### PR TITLE
AppImage: Add zsync support

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -67,11 +67,23 @@ jobs:
         name: "linux-x64-appimage-sdl"
         path: "build/duckstation-sdl-x64.AppImage"
 
+    - name: Upload SDL AppImage zsync
+      uses: actions/upload-artifact@v1
+      with:
+        name: "linux-x64-appimage-sdl-zsync"
+        path: "build/duckstation-sdl-x64.AppImage.zsync"
+
     - name: Upload Qt AppImage
       uses: actions/upload-artifact@v1
       with:
         name: "linux-x64-appimage-qt"
         path: "build/duckstation-qt-x64.AppImage"
+
+    - name: Upload Qt AppImage zsync
+      uses: actions/upload-artifact@v1
+      with:
+        name: "linux-x64-appimage-qt-zsync"
+        path: "build/duckstation-qt-x64.AppImage.zsync"
 
   create-release:
     needs: [windows-build, linux-build]
@@ -87,10 +99,20 @@ jobs:
         with:
           name: "linux-x64-appimage-sdl"
 
+      - name: Download SDL AppImage zsync Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: "linux-x64-appimage-sdl-zsync"
+
       - name: Download Qt AppImage Artifact
         uses: actions/download-artifact@v1
         with:
           name: "linux-x64-appimage-qt"
+
+      - name: Download Qt AppImage zsync Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: "linux-x64-appimage-qt-zsync"
 
       - name: Create release
         uses: "marvinpinto/action-automatic-releases@latest"
@@ -101,5 +123,6 @@ jobs:
           files: |
             windows-x64/duckstation-windows-x64-release.7z
             linux-x64-appimage-sdl/duckstation-sdl-x64.AppImage
+            linux-x64-appimage-sdl-zsync/duckstation-sdl-x64.AppImage.zsync
             linux-x64-appimage-qt/duckstation-qt-x64.AppImage
-            
+            linux-x64-appimage-qt-zsync/duckstation-qt-x64.AppImage.zsync

--- a/appimage/generate-appimages.sh
+++ b/appimage/generate-appimages.sh
@@ -48,27 +48,27 @@ for frontend in ${FRONTENDS[@]}; do
   cp -av ${DATA_DIR}/* ${CURRENT_APPDIR}/usr/bin
 done
 
-# Outputted file from linuxdeploy is named based on the .desktop file Name key;
-# We rename it to something generic that buildbot or CI scripts can modify
-# as they wish outside of this script, e.g. to distinguish between Release or
-# Debug builds, since we don't have awareness of that inside this script
+# Pass UPDATE_INFORMATION and OUTPUT variables (used by linuxdeploy-plugin-appimage)
+# to the environment of the linuxdeploy commands
 
+UPDATE_INFORMATION="zsync|https://github.com/stenzek/duckstation/releases/download/latest/duckstation-qt-x64.AppImage.zsync" \
+OUTPUT="duckstation-qt-x64.AppImage" \
 ${BUILD_DIR}/linuxdeploy-x86_64.AppImage \
   --appdir=${BUILD_DIR}/AppDir-duckstation-qt \
   --executable=${BUILD_DIR}/bin/duckstation-qt \
   --desktop-file=${APPIMAGE_RESOURCES_DIR}/duckstation-qt.desktop \
   ${ICONS_QT[@]/#/--icon-file=} \
   --plugin=qt \
-  --output=appimage \
-  && mv DuckStation_Qt*.AppImage ${BUILD_DIR}/duckstation-qt-x64.AppImage
+  --output=appimage
 
+UPDATE_INFORMATION="zsync|https://github.com/stenzek/duckstation/releases/download/latest/duckstation-sdl-x64.AppImage.zsync" \
+OUTPUT="duckstation-sdl-x64.AppImage" \
 ${BUILD_DIR}/linuxdeploy-x86_64.AppImage \
   --appdir=${BUILD_DIR}/AppDir-duckstation-sdl \
   --executable=${BUILD_DIR}/bin/duckstation-sdl \
   --desktop-file=${APPIMAGE_RESOURCES_DIR}/duckstation-sdl.desktop \
   ${ICONS_SDL[@]/#/--icon-file=} \
-  --output=appimage \
-  && mv DuckStation_SDL*.AppImage ${BUILD_DIR}/duckstation-sdl-x64.AppImage
+  --output=appimage
 
-# Resulting AppImages will be created in the directory this script is called from;
+# Resulting AppImages and zsync files will be created in the directory this script is called from;
 # move them into the user's specified build directory


### PR DESCRIPTION
The embedded update information in the AppImages is hardcoded to use GitHub rolling releases. The URLs used [shouldn't be changed](https://github.com/AppImage/AppImageSpec/blob/da2633c082fcd83a60aa3a28381e5c0b49ef7bed/draft.md#update-information) unless absolutely necessary I believe, e.g. if migrating to an organization repository.