### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -88,6 +88,7 @@ jobs:
   create-release:
     needs: [windows-build, linux-build]
     runs-on: "ubuntu-latest"
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Download Windows x64 Artifact
         uses: actions/download-artifact@v1


### PR DESCRIPTION
This change should stop PRs from running and failing the create-release job. Checkout action v2 should also be faster than v1 due to its default single commit fetching behavior and would probably be helpful as the repository grows.