### PR TITLE
CMake: Always run gen_scmversion script on rebuilds

### DIFF
--- a/src/scmversion/CMakeLists.txt
+++ b/src/scmversion/CMakeLists.txt
@@ -1,9 +1,10 @@
+# _scmversion.cpp is a dummy file that will never be created, so the command will always be run
 if(WIN32)
-  add_custom_command(OUTPUT scmversion.cpp
+  add_custom_command(OUTPUT scmversion.cpp _scmversion.cpp
                      COMMAND cmd /k "${CMAKE_CURRENT_SOURCE_DIR}/gen_scmversion.bat"
                      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 else()
-  add_custom_command(OUTPUT scmversion.cpp
+  add_custom_command(OUTPUT scmversion.cpp _scmversion.cpp
                      COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gen_scmversion.sh")
 endif()
 


### PR DESCRIPTION
Another small housekeeping fix for an issue mentioned in Discord. I think it's also possible to use a CMake script for generating the scmversion file instead of using separate batch and shell scripts, but that's probably unnecessary right now.