### PR TITLE
Qt: Add about dialog

### DIFF
--- a/src/duckstation-qt/CMakeLists.txt
+++ b/src/duckstation-qt/CMakeLists.txt
@@ -4,6 +4,8 @@ set(CMAKE_AUTOUIC ON)
 
 add_executable(duckstation-qt
   resources/icons.qrc
+  aboutdialog.cpp
+  aboutdialog.h
   advancedsettingswidget.cpp
   advancedsettingswidget.h
   advancedsettingswidget.ui

--- a/src/duckstation-qt/aboutdialog.cpp
+++ b/src/duckstation-qt/aboutdialog.cpp
@@ -1,0 +1,17 @@
+#include "aboutdialog.h"
+#include "qtutils.h"
+#include "scmversion/scmversion.h"
+#include <QtCore/QString>
+#include <QtWidgets/QDialog>
+
+AboutDialog::AboutDialog(QWidget* parent /* = nullptr */) : QDialog(parent)
+{
+  m_ui.setupUi(this);
+
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+  setFixedSize(geometry().width(), geometry().height());
+
+  m_ui.scmversion->setText(tr("%1 (%2)").arg(QString(g_scm_tag_str)).arg(QString(g_scm_branch_str)));
+}
+
+AboutDialog::~AboutDialog() = default;

--- a/src/duckstation-qt/aboutdialog.cpp
+++ b/src/duckstation-qt/aboutdialog.cpp
@@ -12,6 +12,9 @@ AboutDialog::AboutDialog(QWidget* parent /* = nullptr */) : QDialog(parent)
   setFixedSize(geometry().width(), geometry().height());
 
   m_ui.scmversion->setText(tr("%1 (%2)").arg(QString(g_scm_tag_str)).arg(QString(g_scm_branch_str)));
+
+  m_ui.description->setTextInteractionFlags(Qt::TextBrowserInteraction);
+  m_ui.description->setOpenExternalLinks(true);
 }
 
 AboutDialog::~AboutDialog() = default;

--- a/src/duckstation-qt/aboutdialog.h
+++ b/src/duckstation-qt/aboutdialog.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "ui_aboutdialog.h"
+#include <QtWidgets/QDialog>
+
+class AboutDialog final : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit AboutDialog(QWidget* parent = nullptr);
+  ~AboutDialog();
+
+private:
+  Ui::AboutDialog m_ui;
+
+};

--- a/src/duckstation-qt/aboutdialog.ui
+++ b/src/duckstation-qt/aboutdialog.ui
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AboutDialog</class>
+ <widget class="QDialog" name="AboutDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>About DuckStation</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="resources/icons.qrc">
+    <normaloff>:/icons/duck.png</normaloff>:/icons/duck.png</iconset>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QWidget" name="iconWidget" native="true">
+     <layout class="QVBoxLayout" name="iconLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetDefaultConstraint</enum>
+      </property>
+      <property name="leftMargin">
+       <number>1</number>
+      </property>
+      <property name="topMargin">
+       <number>1</number>
+      </property>
+      <property name="rightMargin">
+       <number>1</number>
+      </property>
+      <property name="bottomMargin">
+       <number>1</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="icon">
+        <property name="maximumSize">
+         <size>
+          <width>260</width>
+          <height>260</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="resources/icons.qrc">:/icons/duck.png</pixmap>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="iconSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>17</width>
+          <height>156</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="textLayout">
+     <property name="spacing">
+      <number>9</number>
+     </property>
+     <property name="leftMargin">
+      <number>9</number>
+     </property>
+     <property name="topMargin">
+      <number>9</number>
+     </property>
+     <property name="rightMargin">
+      <number>9</number>
+     </property>
+     <property name="bottomMargin">
+      <number>9</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="title">
+       <property name="font">
+        <font>
+         <pointsize>14</pointsize>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>DuckStation</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="scmversion">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="description">
+       <property name="text">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;DuckStation is a free and open-source simulator/emulator of the Sony PlayStation&lt;span style=&quot; vertical-align:super;&quot;&gt;TM&lt;/span&gt; console, focusing on playability, speed, and long-term maintainability.&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Authors&lt;/span&gt;:&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  Connor McLaughlin &amp;lt;stenzek@gmail.com&amp;gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Duck icon by &lt;a href=&quot;https://icons8.com/icon/74847/platforms.undefined.short-title&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;icons8&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/blob/master/LICENSE&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;License&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/stenzek/duckstation&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;GitHub&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://discord.gg/Buktv3t&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0057ae;&quot;&gt;Discord&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="resources/icons.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/duckstation-qt/aboutdialog.ui
+++ b/src/duckstation-qt/aboutdialog.ui
@@ -115,7 +115,7 @@
         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;DuckStation is a free and open-source simulator/emulator of the Sony PlayStation&lt;span style=&quot; vertical-align:super;&quot;&gt;TM&lt;/span&gt; console, focusing on playability, speed, and long-term maintainability.&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Authors&lt;/span&gt;:&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  Connor McLaughlin &amp;lt;stenzek@gmail.com&amp;gt;&lt;/p&gt;

--- a/src/duckstation-qt/duckstation-qt.vcxproj
+++ b/src/duckstation-qt/duckstation-qt.vcxproj
@@ -35,6 +35,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="aboutdialog.cpp" />
     <ClCompile Include="advancedsettingswidget.cpp" />
     <ClCompile Include="audiosettingswidget.cpp" />
     <ClCompile Include="consolesettingswidget.cpp" />
@@ -60,6 +61,7 @@
     <ClCompile Include="settingsdialog.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <QtMoc Include="aboutdialog.h" />
     <QtMoc Include="audiosettingswidget.h" />
     <QtMoc Include="controllersettingswidget.h" />
     <QtMoc Include="memorycardsettingswidget.h" />
@@ -108,6 +110,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <QtUi Include="aboutdialog.ui">
+      <FileType>Document</FileType>
+    </QtUi>
     <QtUi Include="audiosettingswidget.ui">
       <FileType>Document</FileType>
     </QtUi>
@@ -142,6 +147,7 @@
     </QtResource>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="$(IntDir)moc_aboutdialog.cpp" />
     <ClCompile Include="$(IntDir)moc_audiosettingswidget.cpp" />
     <ClCompile Include="$(IntDir)moc_advancedsettingswidget.cpp" />
     <ClCompile Include="$(IntDir)moc_consolesettingswidget.cpp" />

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -3,6 +3,7 @@
 #include "core/game_list.h"
 #include "core/settings.h"
 #include "core/system.h"
+#include "aboutdialog.h"
 #include "gamelistsettingswidget.h"
 #include "gamelistwidget.h"
 #include "gamepropertiesdialog.h"
@@ -296,7 +297,11 @@ void MainWindow::onDiscordServerActionTriggered()
   QtUtils::OpenURL(this, "https://discord.gg/Buktv3t");
 }
 
-void MainWindow::onAboutActionTriggered() {}
+void MainWindow::onAboutActionTriggered()
+{
+  AboutDialog about(this);
+  about.exec();
+}
 
 void MainWindow::onGameListEntrySelected(const GameListEntry* entry)
 {


### PR DESCRIPTION
Figured might as well, since `Help -> About` in the Qt frontend wasn't doing anything yet. I'm no UI guy by any means, so any feedback is greatly appreciated!