### PR TITLE
Qt: Simplify Rebind All behavior

### DIFF
--- a/src/duckstation-qt/controllersettingswidget.cpp
+++ b/src/duckstation-qt/controllersettingswidget.cpp
@@ -124,7 +124,7 @@ void ControllerSettingsWidget::createPortSettingsUi(int index, PortSettingsUI* u
   QPushButton* clear_all_button = new QPushButton(tr("Clear All"), ui->widget);
   clear_all_button->connect(clear_all_button, &QPushButton::clicked, [this, index]() {
     if (QMessageBox::question(this, tr("Clear Bindings"),
-                              tr("Are you sure you want to clear all bound controls? This cannot be reversed.")) !=
+                              tr("Are you sure you want to clear all bound controls? This can not be reversed.")) !=
         QMessageBox::Yes)
     {
       return;
@@ -140,15 +140,19 @@ void ControllerSettingsWidget::createPortSettingsUi(int index, PortSettingsUI* u
 
   QPushButton* rebind_all_button = new QPushButton(tr("Rebind All"), ui->widget);
   rebind_all_button->connect(rebind_all_button, &QPushButton::clicked, [this, index]() {
-    if (QMessageBox::question(this, tr("Clear Bindings"), tr("Do you want to clear all currently-bound controls?")) ==
+    if (QMessageBox::question(this, tr("Rebind All"),
+                              tr("Are you sure you want to rebind all controls? All currently-bound controls will be "
+                                 "irreversibly cleared. Rebinding will begin after confirmation.")) !=
         QMessageBox::Yes)
     {
-      InputBindingWidget* widget = m_port_ui[index].first_button;
-      while (widget)
-      {
-        widget->clearBinding();
-        widget = widget->getNextWidget();
-      }
+      return;
+    }
+
+    InputBindingWidget* widget = m_port_ui[index].first_button;
+    while (widget)
+    {
+      widget->clearBinding();
+      widget = widget->getNextWidget();
     }
 
     if (m_port_ui[index].first_button)

--- a/src/duckstation-qt/settingsdialog.cpp
+++ b/src/duckstation-qt/settingsdialog.cpp
@@ -27,8 +27,9 @@ static constexpr std::array<const char*, static_cast<int>(SettingsDialog::Catego
    "self-explanatory.",
    "<strong>Controller Settings</strong><hr>This page lets you choose the type of controller you wish to simulate for "
    "the console, and rebind the keys or host game controller buttons to your choosing. Clicking a binding will start a "
-   "count-down, in which case you should press the key or controller button/axis you wish to bind. If no button is "
-   "pressed and the timer lapses, the binding will be unchanged. To clear a binding, right-click the button.",
+   "countdown, in which case you should press the key or controller button/axis you wish to bind. (For rumble, press "
+   "any button/axis on the controller you wish to send rumble to.) If no button is pressed and the timer lapses, "
+   "the binding will be unchanged. To clear a binding, right-click the button.",
    "<strong>Memory Card Settings</strong><hr>This page lets you control what mode the memory card emulation will "
    "function in, and where the images for these cards will be stored on disk.",
    "<strong>GPU Settings</strong><hr>These options control the simulation of the GPU in the console. Various "


### PR DESCRIPTION
The current behavior for Rebind All is to unconditionally rebind all buttons regardless of what the user selects in the question message box, with the selection only determining whether or not bindings are cleared before starting the full rebinding process. If Rebind All was pressed unintentionally, it seems that the user has to wait through the timeout process to prevent bindings from being changed.

To make this less prone to user error and more straightforward, Rebind All should first ask for user confirmation (like Clear All does), and if the user confirms, clear all bindings and run the rebinding.