### PR TITLE
system: Correct error dialog in PSF load case

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -223,7 +223,7 @@ bool System::Boot(const SystemBootParameters& params)
   }
   else if (psf_boot && !LoadPSF(params.filename.c_str(), *bios_image))
   {
-    m_host_interface->ReportFormattedError("Failed to load EXE file '%s'", params.filename.c_str());
+    m_host_interface->ReportFormattedError("Failed to load PSF file '%s'", params.filename.c_str());
     return false;
   }
 


### PR DESCRIPTION
Corrects the error message to state that the PSF couldn't be loaded rather than EXE.