### PR TITLE
playstation_mouse: Amend initial x value

### DIFF
--- a/src/core/playstation_mouse.cpp
+++ b/src/core/playstation_mouse.cpp
@@ -11,7 +11,7 @@ Log_SetChannel(PlayStationMouse);
 
 PlayStationMouse::PlayStationMouse(System* system) : m_system(system)
 {
-  m_last_host_position_y = system->GetHostInterface()->GetDisplay()->GetMousePositionX();
+  m_last_host_position_x = system->GetHostInterface()->GetDisplay()->GetMousePositionX();
   m_last_host_position_y = system->GetHostInterface()->GetDisplay()->GetMousePositionY();
 }
 


### PR DESCRIPTION
Previously the last host y position was being written to twice, which seems like a typo.