### PR TITLE
rectangle: Correct assignment of right within SetExtents

### DIFF
--- a/src/common/rectangle.h
+++ b/src/common/rectangle.h
@@ -41,7 +41,7 @@ struct Rectangle
   {
     left = x;
     top = y;
-    left = x + width;
+    right = x + width;
     bottom = y + height;
   }
 


### PR DESCRIPTION
Previously left was being assigned twice in a row.

Thankfully, this function wasn't used anywhere yet, so no code was impacted by this =)