### PR TITLE
spu: Make use of logical AND within IsPitchModulationEnabled()

### DIFF
--- a/src/core/spu.h
+++ b/src/core/spu.h
@@ -350,7 +350,7 @@ private:
   }
   ALWAYS_INLINE bool IsPitchModulationEnabled(u32 i) const
   {
-    return ((i > 0) & ConvertToBoolUnchecked((m_pitch_modulation_enable_register >> i) & u32(1)));
+    return ((i > 0) && ConvertToBoolUnchecked((m_pitch_modulation_enable_register >> i) & u32(1)));
   }
   ALWAYS_INLINE s16 GetVoiceNoiseLevel() const { return static_cast<s16>(static_cast<u16>(m_noise_level)); }
 


### PR DESCRIPTION
It seems awfully suspect to use a bitwise AND here.