### PR TITLE
ControllerInterface: Customizable axis scaling and deadzone size

### DIFF
--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1033,6 +1033,9 @@ void CommonHostInterface::UpdateControllerInputMap(SettingsInterface& si)
 
     const float axis_scale = si.GetFloatValue(category, "AxisScale", 1.00f);
     m_controller_interface->SetControllerAxisScale(controller_index, axis_scale);
+
+    const float deadzone_size = si.GetFloatValue(category, "Deadzone", 0.25f);
+    m_controller_interface->SetControllerDeadzone(controller_index, deadzone_size);
   }
 }
 

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1030,6 +1030,9 @@ void CommonHostInterface::UpdateControllerInputMap(SettingsInterface& si)
       for (const std::string& binding : bindings)
         AddRumbleToInputMap(binding, controller_index, num_motors);
     }
+
+    const float axis_scale = si.GetFloatValue(category, "AxisScale", 1.00f);
+    m_controller_interface->SetControllerAxisScale(controller_index, axis_scale);
   }
 }
 

--- a/src/frontend-common/controller_interface.h
+++ b/src/frontend-common/controller_interface.h
@@ -46,6 +46,9 @@ public:
   // Set scaling that will be applied on axis-to-axis mappings
   virtual bool SetControllerAxisScale(int controller_index, float scale) = 0;
 
+  // Set deadzone that will be applied on axis-to-button mappings
+  virtual bool SetControllerDeadzone(int controller_index, float size) = 0;
+
   // Input monitoring for external access.
   struct Hook
   {

--- a/src/frontend-common/controller_interface.h
+++ b/src/frontend-common/controller_interface.h
@@ -43,6 +43,9 @@ public:
   virtual u32 GetControllerRumbleMotorCount(int controller_index) = 0;
   virtual void SetControllerRumbleStrength(int controller_index, const float* strengths, u32 num_motors) = 0;
 
+  // Set scaling that will be applied on axis-to-axis mappings
+  virtual bool SetControllerAxisScale(int controller_index, float scale) = 0;
+
   // Input monitoring for external access.
   struct Hook
   {

--- a/src/frontend-common/sdl_controller_interface.cpp
+++ b/src/frontend-common/sdl_controller_interface.cpp
@@ -289,7 +289,8 @@ bool SDLControllerInterface::HandleControllerAxisEvent(const SDL_Event* ev)
   const AxisCallback& cb = it->axis_mapping[ev->caxis.axis];
   if (cb)
   {
-    cb(value);
+    // Apply axis scaling only when controller axis is mapped to an axis
+    cb(std::clamp(it->axis_scale * value, -1.0f, 1.0f));
     return true;
   }
 
@@ -385,4 +386,15 @@ void SDLControllerInterface::SetControllerRumbleStrength(int controller_index, c
     else
       SDL_HapticRumbleStop(haptic);
   }
+}
+
+bool SDLControllerInterface::SetControllerAxisScale(int controller_index, float scale /* = 1.00f */)
+{
+  auto it = GetControllerDataForPlayerId(controller_index);
+  if (it == m_controllers.end())
+    return false;
+
+  it->axis_scale = std::clamp(std::abs(scale), 0.01f, 1.50f);
+  Log_InfoPrintf("Controller %d axis scale set to %f", controller_index, it->axis_scale);
+  return true;
 }

--- a/src/frontend-common/sdl_controller_interface.h
+++ b/src/frontend-common/sdl_controller_interface.h
@@ -32,6 +32,9 @@ public:
   // Set scaling that will be applied on axis-to-axis mappings
   bool SetControllerAxisScale(int controller_index, float scale = 1.00f) override;
 
+  // Set deadzone that will be applied on axis-to-button mappings
+  bool SetControllerDeadzone(int controller_index, float size = 0.25f) override;
+
   void PollEvents() override;
 
   bool ProcessSDLEvent(const SDL_Event* event);
@@ -47,6 +50,7 @@ private:
 
     // Scaling value of 1.30f to 1.40f recommended when using recent controllers
     float axis_scale = 1.00f;
+    float deadzone = 0.25f;
 
     std::array<AxisCallback, MAX_NUM_AXISES> axis_mapping;
     std::array<ButtonCallback, MAX_NUM_BUTTONS> button_mapping;

--- a/src/frontend-common/sdl_controller_interface.h
+++ b/src/frontend-common/sdl_controller_interface.h
@@ -29,6 +29,9 @@ public:
   u32 GetControllerRumbleMotorCount(int controller_index) override;
   void SetControllerRumbleStrength(int controller_index, const float* strengths, u32 num_motors) override;
 
+  // Set scaling that will be applied on axis-to-axis mappings
+  bool SetControllerAxisScale(int controller_index, float scale = 1.00f) override;
+
   void PollEvents() override;
 
   bool ProcessSDLEvent(const SDL_Event* event);
@@ -41,6 +44,9 @@ private:
     int haptic_left_right_effect;
     int joystick_id;
     int player_id;
+
+    // Scaling value of 1.30f to 1.40f recommended when using recent controllers
+    float axis_scale = 1.00f;
 
     std::array<AxisCallback, MAX_NUM_AXISES> axis_mapping;
     std::array<ButtonCallback, MAX_NUM_BUTTONS> button_mapping;


### PR DESCRIPTION
Feature/workaround to accommodate for differences between the logical range of reporting on the analog sticks of modern controllers and original PS1 analog controllers. Ballpark for a good scaling value is somewhere around 1.30~1.40 but every controller is a bit different so it'll be mostly up to user preference.