### PR TITLE
CommonHostInterface: Support parsing multiple mappings per binding entry

### DIFF
--- a/src/frontend-common/common_host_interface.h
+++ b/src/frontend-common/common_host_interface.h
@@ -35,6 +35,14 @@ public:
   using InputAxisHandler = std::function<void(float)>;
   using ControllerRumbleCallback = std::function<void(const float*, u32)>;
 
+  struct DeviceSubBindingPair
+  {
+    std::string device;
+    std::string sub_binding;
+  };
+
+  using DeviceSubBindingList = std::vector<DeviceSubBindingPair>;
+
   struct HotkeyInfo
   {
     String category;
@@ -294,6 +302,7 @@ private:
   void UpdateControllerInputMap(SettingsInterface& si);
   void UpdateHotkeyInputMap(SettingsInterface& si);
   void ClearAllControllerBindings(SettingsInterface& si);
+  void SplitBindingIntoList(const std::string& binding, DeviceSubBindingList& splits);
 
 #ifdef WITH_DISCORD_PRESENCE
   void SetDiscordPresenceEnabled(bool enabled);

--- a/src/frontend-common/sdl_controller_interface.cpp
+++ b/src/frontend-common/sdl_controller_interface.cpp
@@ -319,7 +319,7 @@ bool SDLControllerInterface::HandleControllerButtonEvent(const SDL_Event* ev)
   Log_DebugPrintf("controller %d button %d %s", ev->cbutton.which, ev->cbutton.button,
                   ev->cbutton.state == SDL_PRESSED ? "pressed" : "released");
 
-  auto it = GetControllerDataForJoystickId(ev->caxis.which);
+  auto it = GetControllerDataForJoystickId(ev->cbutton.which);
   if (it == m_controllers.end())
     return false;
 


### PR DESCRIPTION
Adds support for multiple mappings per emulated controller axis/button. Format is comma-separated, e.g. `ButtonUp = Keyboard/W,Controller0/Button11`.