### PR TITLE
Settings: Add 8:7 DAR and 1:1 PAR modes

### DIFF
--- a/src/core/host_display.cpp
+++ b/src/core/host_display.cpp
@@ -61,6 +61,7 @@ void HostDisplay::CalculateDrawRect(s32 window_width, s32 window_height, s32* ou
                                     s32* out_height, s32* out_left_padding, s32* out_top_padding, float* out_scale,
                                     float* out_y_scale, bool apply_aspect_ratio) const
 {
+  apply_aspect_ratio = (m_display_aspect_ratio > 0) ? apply_aspect_ratio : false;
   const float y_scale =
     apply_aspect_ratio ?
       ((static_cast<float>(m_display_width) / static_cast<float>(m_display_height)) / m_display_aspect_ratio) :
@@ -262,6 +263,8 @@ bool HostDisplay::WriteDisplayTextureToFile(const char* filename, bool full_reso
 {
   if (!m_display_texture_handle)
     return false;
+
+  apply_aspect_ratio = (m_display_aspect_ratio > 0) ? apply_aspect_ratio : false;
 
   s32 resize_width = 0;
   s32 resize_height = 0;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -437,10 +437,10 @@ const char* Settings::GetDisplayCropModeDisplayName(DisplayCropMode crop_mode)
   return s_display_crop_mode_display_names[static_cast<int>(crop_mode)];
 }
 
-static std::array<const char*, 5> s_display_aspect_ratio_names =
-  {{"4:3", "16:9", "8:7", "2:1 (VRAM 1:1)", "1:1"}};
-static constexpr std::array<float, 5> s_display_aspect_ratio_values =
-  {{4.0f / 3.0f, 16.0f / 9.0f, 8.0f / 7.0f, 2.0f / 1.0f, 1.0f}};
+static std::array<const char*, 6> s_display_aspect_ratio_names =
+  {{"4:3", "16:9", "8:7", "2:1 (VRAM 1:1)", "1:1", "PAR 1:1"}};
+static constexpr std::array<float, 6> s_display_aspect_ratio_values =
+  {{4.0f / 3.0f, 16.0f / 9.0f, 8.0f / 7.0f, 2.0f / 1.0f, 1.0f, -1.0f}};
 
 std::optional<DisplayAspectRatio> Settings::ParseDisplayAspectRatio(const char* str)
 {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -437,8 +437,10 @@ const char* Settings::GetDisplayCropModeDisplayName(DisplayCropMode crop_mode)
   return s_display_crop_mode_display_names[static_cast<int>(crop_mode)];
 }
 
-static std::array<const char*, 4> s_display_aspect_ratio_names = {{"4:3", "16:9", "2:1 (VRAM 1:1)", "1:1"}};
-static constexpr std::array<float, 4> s_display_aspect_ratio_values = {{4.0f / 3.0f, 16.0f / 9.0f, 2.0f / 1.0f, 1.0f}};
+static std::array<const char*, 5> s_display_aspect_ratio_names =
+  {{"4:3", "16:9", "8:7", "2:1 (VRAM 1:1)", "1:1"}};
+static constexpr std::array<float, 5> s_display_aspect_ratio_values =
+  {{4.0f / 3.0f, 16.0f / 9.0f, 8.0f / 7.0f, 2.0f / 1.0f, 1.0f}};
 
 std::optional<DisplayAspectRatio> Settings::ParseDisplayAspectRatio(const char* str)
 {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -71,6 +71,7 @@ enum class DisplayAspectRatio : u8
 {
   R4_3,
   R16_9,
+  R8_7,
   R2_1,
   R1_1,
   Count

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -74,6 +74,7 @@ enum class DisplayAspectRatio : u8
   R8_7,
   R2_1,
   R1_1,
+  PAR1_1,
   Count
 };
 

--- a/src/duckstation-sdl/sdl_host_interface.cpp
+++ b/src/duckstation-sdl/sdl_host_interface.cpp
@@ -1225,7 +1225,7 @@ void SDLHostInterface::DrawSettingsWindow()
         ImGui::SameLine(indent);
         int display_aspect_ratio = static_cast<int>(m_settings_copy.display_aspect_ratio);
         if (ImGui::Combo(
-              "##display_pixel_aspect_ratio", &display_aspect_ratio,
+              "##display_aspect_ratio", &display_aspect_ratio,
               [](void*, int index, const char** out_text) {
                 *out_text = Settings::GetDisplayAspectRatioName(static_cast<DisplayAspectRatio>(index));
                 return true;


### PR DESCRIPTION
Implementation for 1:1 PAR mode just exploits the idea that we shouldn't be applying any non-positive aspect ratios. We could also have a settings check in `UpdateDisplay()` in `GPU_SW` and the `GPU_HW`s like what is already being done to override aspect ratios when Show VRAM is enabled.

We might also be able to deprecate the 2:1 (VRAM 1:1) DAR mode since Show VRAM already does aspect ratio overriding and there most likely isn't much use of that mode other than viewing VRAM.