### PR TITLE
CI: Add manual Actions workflow trigger

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -2,9 +2,17 @@ name: Create rolling release
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'appveyor.yml'
+      - 'scripts/*'
   push:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
+      - 'appveyor.yml'
+      - 'scripts/*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   windows-build:


### PR DESCRIPTION
Works mostly as expected from testing on my fork. As long as this specific line for the workflow dispatch event trigger exists in the workflow file on the main branch, we can manually run the workflow by going to Actions tab -> Create rolling release -> Run workflow. It lets you pick any branch in the repo, but branches will run using their own version of the workflow file so they'll have to be rebased on top of this change for the manual trigger to actually do anything.