### PR TITLE
Qt/GameListSettings: Use native path separators

### DIFF
--- a/src/duckstation-qt/gamelistsettingswidget.cpp
+++ b/src/duckstation-qt/gamelistsettingswidget.cpp
@@ -248,7 +248,9 @@ void GameListSettingsWidget::onDirectoryListItemClicked(const QModelIndex& index
 
 void GameListSettingsWidget::addSearchDirectory(QWidget* parent_widget)
 {
-  QString dir = QFileDialog::getExistingDirectory(parent_widget, tr("Select Search Directory"));
+  QString dir =
+    QDir::toNativeSeparators(QFileDialog::getExistingDirectory(parent_widget, tr("Select Search Directory")));
+
   if (dir.isEmpty())
     return;
 


### PR DESCRIPTION
`QFileDialog::getExistingDirectory()` returns paths with forward slash by default. This path string eventually gets passed to `FileSystem::FindFiles()` which constructs the rest of the path string using native path separators. This means that for example if on Windows we had added `C:/path/to/game` non-recursively and `C:/path/to` recursively through Qt, we would find `C:/path/to/game\x.cue` and `C:/path/to\game\x.cue`, resulting in the same game appearing twice on the game list.