### PR TITLE
Disable Interlacing default as "Unchecked"

### DIFF
--- a/src/duckstation-qt/gpusettingswidget.cpp
+++ b/src/duckstation-qt/gpusettingswidget.cpp
@@ -73,7 +73,7 @@ GPUSettingsWidget::GPUSettingsWidget(QtHostInterface* host_interface, QWidget* p
                              "Some games display content in the overscan area, or use it for screen effects and may "
                              "not display correctly with the All Borders setting. Only Overscan offers a good "
                              "compromise between stability and hiding black borders.");
-  dialog->registerWidgetHelp(m_ui.disableInterlacing, "Disable Interlacing (force progressive render/scan)", "Checked",
+  dialog->registerWidgetHelp(m_ui.disableInterlacing, "Disable Interlacing (force progressive render/scan)", "Unchecked",
                              "Forces the display of frames to progressive mode. This only affects the displayed image, "
                              "the console will be unaware of the setting. If the game is internally producing "
                              "interlaced frames, this option may not have any effect. Usually safe to enable.");


### PR DESCRIPTION
As noted by Kurayami6, Disable Interlacing should show "Unchecked" as the default option for this enhancement.