### PR TITLE
(libretro) Fix 'Fast Boot' option

### DIFF
--- a/src/core/bios.cpp
+++ b/src/core/bios.cpp
@@ -35,13 +35,14 @@ std::string Hash::ToString() const
   return str;
 }
 
-static constexpr Hash SCPH_1000_HASH = MakeHashFromString("239665b1a3dade1b5a52c06338011044");
-static constexpr Hash SCPH_1001_HASH = MakeHashFromString("924e392ed05558ffdb115408c263dccf");
-static constexpr Hash SCPH_1002_HASH = MakeHashFromString("54847e693405ffeb0359c6287434cbef");
-static constexpr Hash SCPH_3000_HASH = MakeHashFromString("849515939161e62f6b866f6853006780");
-static constexpr Hash SCPH_5500_HASH = MakeHashFromString("8dd7d5296a650fac7319bce665a6a53c");
-static constexpr Hash SCPH_5501_HASH = MakeHashFromString("490f666e1afb15b7362b406ed1cea246");
-static constexpr Hash SCPH_5502_HASH = MakeHashFromString("32736f17079d0b2b7024407c39bd3050");
+static constexpr Hash SCPH_1000_HASH    = MakeHashFromString("239665b1a3dade1b5a52c06338011044");
+static constexpr Hash SCPH_1001_HASH    = MakeHashFromString("924e392ed05558ffdb115408c263dccf");
+static constexpr Hash SCPH_1002_HASH    = MakeHashFromString("54847e693405ffeb0359c6287434cbef");
+static constexpr Hash SCPH_3000_HASH    = MakeHashFromString("849515939161e62f6b866f6853006780");
+static constexpr Hash SCPH_5500_HASH    = MakeHashFromString("8dd7d5296a650fac7319bce665a6a53c");
+static constexpr Hash SCPH_5501_HASH    = MakeHashFromString("490f666e1afb15b7362b406ed1cea246");
+static constexpr Hash SCPH_5502_HASH    = MakeHashFromString("32736f17079d0b2b7024407c39bd3050");
+static constexpr Hash SCPH_POPS660_HASH = MakeHashFromString("c53ca5908936d412331790f4426c6c33");
 
 Hash GetHash(const Image& image)
 {
@@ -150,7 +151,7 @@ bool PatchBIOSEnableTTY(Image& image, const Hash& hash)
 bool PatchBIOSFastBoot(Image& image, const Hash& hash)
 {
   if (hash != SCPH_1000_HASH && hash != SCPH_1001_HASH && hash != SCPH_1002_HASH && hash != SCPH_3000_HASH &&
-      hash != SCPH_5500_HASH && hash != SCPH_5501_HASH && hash != SCPH_5502_HASH)
+      hash != SCPH_5500_HASH && hash != SCPH_5501_HASH && hash != SCPH_5502_HASH && hash != SCPH_POPS660_HASH)
   {
     Log_WarningPrintf("Incompatible version for fast-boot patch: %s", hash.ToString().c_str());
     return false;

--- a/src/duckstation-libretro/libretro_host_interface.cpp
+++ b/src/duckstation-libretro/libretro_host_interface.cpp
@@ -357,7 +357,7 @@ static std::array<retro_core_option_definition, 23> s_option_definitions = {{
     {"NTSC-U", "NTSC-U (US)"},
     {"PAL", "PAL (Europe, Australia)"}},
    "Auto"},
-  {"BIOS.FastBoot",
+  {"BIOS.PatchFastBoot",
    "Fast Boot",
    "Skips the BIOS shell/intro, booting directly into the game. Usually safe to enable, but some games break.",
    {{"true", "Enabled"}, {"false", "Disabled"}},


### PR DESCRIPTION
At present, the libretro core exposes the `Fast Boot` option - but the setting is ignored due to a typo (`BIOS.FastBoot` <-> `BIOS.PatchFastBoot`). This trivial PR fixes the issue :)

This PR also adds the widely used PSX BIOS included in PSP firmware 6.60 to the list of allowed hash values accepted by `PatchBIOSFastBoot()`