### PR TITLE
CommonHostInterface: Prevent some potential null pointer dereferences

### DIFF
--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -484,6 +484,9 @@ void QtHostInterface::connectDisplaySignals(QtDisplayWidget* widget)
 
 void QtHostInterface::updateDisplayState()
 {
+  if (!m_display)
+    return;
+
   // this expects the context to get moved back to us afterwards
   m_display->DoneRenderContextCurrent();
 

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -551,13 +551,16 @@ bool CommonHostInterface::ResumeSystemFromMostRecentState()
 
 void CommonHostInterface::UpdateSpeedLimiterState()
 {
+  if (!m_system || !m_audio_stream || !m_display)
+    return;
+
   m_speed_limiter_enabled = m_settings.speed_limiter_enabled && !m_speed_limiter_temp_disabled;
 
   const bool is_non_standard_speed = (std::abs(m_settings.emulation_speed - 1.0f) > 0.05f);
   const bool audio_sync_enabled =
-    !m_system || m_paused || (m_speed_limiter_enabled && m_settings.audio_sync_enabled && !is_non_standard_speed);
+    m_paused || (m_speed_limiter_enabled && m_settings.audio_sync_enabled && !is_non_standard_speed);
   const bool video_sync_enabled =
-    !m_system || m_paused || (m_speed_limiter_enabled && m_settings.video_sync_enabled && !is_non_standard_speed);
+    m_paused || (m_speed_limiter_enabled && m_settings.video_sync_enabled && !is_non_standard_speed);
   Log_InfoPrintf("Syncing to %s%s", audio_sync_enabled ? "audio" : "",
                  (audio_sync_enabled && video_sync_enabled) ? " and video" : (video_sync_enabled ? "video" : ""));
 


### PR DESCRIPTION
This should fix issue #638. 

Might also need to block controller polling for a short period of time or something to that effect to prevent the hotkey functionality from being engaged instantly after being registered, but that's a separate issue from the crash.