### PR TITLE
AnalogController: Expose axis scale setting to frontend

### DIFF
--- a/src/core/analog_controller.cpp
+++ b/src/core/analog_controller.cpp
@@ -481,9 +481,13 @@ u32 AnalogController::StaticGetVibrationMotorCount()
 
 Controller::SettingList AnalogController::StaticGetSettings()
 {
-  static constexpr std::array<SettingInfo, 1> settings = {
+  static constexpr std::array<SettingInfo, 2> settings = {
     {{SettingInfo::Type::Boolean, "AutoEnableAnalog", "Enable Analog Mode on Reset",
-      "Automatically enables analog mode when the console is reset/powered on.", "false"}}};
+      "Automatically enables analog mode when the console is reset/powered on.", "false"},
+     {SettingInfo::Type::Float, "AxisScale", "Analog Axis Scale",
+      "Sets the analog stick axis scaling factor. A value between 1.30 and 1.40 is recommended when using recent "
+      "controllers, e.g. DualShock 4, Xbox One Controller.",
+      "1.00f", "0.01f", "1.50f", "0.01f"}}};
 
   return SettingList(settings.begin(), settings.end());
 }

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1059,7 +1059,8 @@ void CommonHostInterface::UpdateControllerInputMap(SettingsInterface& si)
     }
 
     const float axis_scale = si.GetFloatValue(category, "AxisScale", 1.00f);
-    m_controller_interface->SetControllerAxisScale(controller_index, axis_scale);
+    m_controller_interface->SetControllerAxisScale(controller_index,
+                                                   (ctype == ControllerType::AnalogController) ? axis_scale : 1.00f);
 
     const float deadzone_size = si.GetFloatValue(category, "Deadzone", 0.25f);
     m_controller_interface->SetControllerDeadzone(controller_index, deadzone_size);


### PR DESCRIPTION
This also locks the axis scale setting exclusively to the Analog Controller for now. I'll have to run some hardware tests on the NeGcon to see what axes require scaling for it and do the necessary refactoring based on those results.