### PR TITLE
(libretro/Vulkan) Fix glslang shader-related crashes

### DIFF
--- a/dep/glslang/OGLCompilersDLL/InitializeDll.cpp
+++ b/dep/glslang/OGLCompilersDLL/InitializeDll.cpp
@@ -158,6 +158,7 @@ bool DetachProcess()
 
     OS_FreeTLSIndex(ThreadInitializeIndex);
     ThreadInitializeIndex = OS_INVALID_TLS_INDEX;
+    DeinitializePoolIndex();
 
     return success;
 }

--- a/dep/glslang/glslang/Include/InitializeGlobals.h
+++ b/dep/glslang/glslang/Include/InitializeGlobals.h
@@ -38,6 +38,7 @@
 namespace glslang {
 
 bool InitializePoolIndex();
+bool DeinitializePoolIndex();
 
 } // end namespace glslang
 

--- a/dep/glslang/glslang/MachineIndependent/PoolAlloc.cpp
+++ b/dep/glslang/glslang/MachineIndependent/PoolAlloc.cpp
@@ -65,6 +65,15 @@ bool InitializePoolIndex()
     return true;
 }
 
+bool DeinitializePoolIndex()
+{
+    if (PoolIndex == OS_INVALID_TLS_INDEX)
+        return false;
+    OS_FreeTLSIndex(PoolIndex);
+    PoolIndex = OS_INVALID_TLS_INDEX;
+    return true;
+}
+
 //
 // Implement the functionality of the TPoolAllocator class, which
 // is documented in PoolAlloc.h.

--- a/dep/glslang/glslang/MachineIndependent/ShaderLang.cpp
+++ b/dep/glslang/glslang/MachineIndependent/ShaderLang.cpp
@@ -1429,6 +1429,7 @@ int ShFinalize()
     glslang::HlslScanContext::deleteKeywordMap();
 #endif
 
+    DetachProcess();
     return 1;
 }
 

--- a/src/common/vulkan/shader_compiler.cpp
+++ b/src/common/vulkan/shader_compiler.cpp
@@ -24,6 +24,8 @@ bool InitializeGlslang();
 
 static unsigned s_next_bad_shader_id = 1;
 
+static bool glslang_initialized = false;
+
 static std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage, const char* stage_filename,
                                                          std::string_view source)
 {
@@ -113,7 +115,6 @@ static std::optional<SPIRVCodeVector> CompileShaderToSPV(EShLanguage stage, cons
 
 bool InitializeGlslang()
 {
-  static bool glslang_initialized = false;
   if (glslang_initialized)
     return true;
 
@@ -123,10 +124,21 @@ bool InitializeGlslang()
     return false;
   }
 
+#ifndef LIBRETRO
   std::atexit([]() { glslang::FinalizeProcess(); });
+#endif
 
   glslang_initialized = true;
   return true;
+}
+
+void DeinitializeGlslang()
+{
+  if (!glslang_initialized)
+    return;
+
+  glslang::FinalizeProcess();
+  glslang_initialized = false;
 }
 
 std::optional<SPIRVCodeVector> CompileVertexShader(std::string_view source_code)

--- a/src/common/vulkan/shader_compiler.h
+++ b/src/common/vulkan/shader_compiler.h
@@ -21,6 +21,8 @@ enum class Type
   Compute
 };
 
+void DeinitializeGlslang();
+
 // SPIR-V compiled code type
 using SPIRVCodeType = u32;
 using SPIRVCodeVector = std::vector<SPIRVCodeType>;

--- a/src/duckstation-libretro/libretro_vulkan_host_display.cpp
+++ b/src/duckstation-libretro/libretro_vulkan_host_display.cpp
@@ -136,6 +136,7 @@ void LibretroVulkanHostDisplay::DestroyResources()
   VulkanHostDisplay::DestroyResources();
   Vulkan::Util::SafeDestroyFramebuffer(m_frame_framebuffer);
   m_frame_texture.Destroy();
+  Vulkan::ShaderCompiler::DeinitializeGlslang();
 }
 
 VkRenderPass LibretroVulkanHostDisplay::GetRenderPassForDisplay() const


### PR DESCRIPTION
As reported in #672, the libretro core crashes when loading more than one item of content within a single session when running under Linux with an Intel integrated GPU.

There were actually 2 issues here:

1) `glslang::FinalizeProcess()` is attached via `std::atexit()`. This does not work as intended when running duckstation as a dynamic shared object library... (it only gets called when RetroArch quits, not when the core is unloaded)

2) With Linux + Intel iGPU, I was getting hit by the same 'mysterious' corruption issue that affected RetroArch itself some time ago, and which was fixed in this commit: https://github.com/libretro/RetroArch/commit/4437cd1eac144f1a3b5acda54c128213e59ec0e1

This PR ensures that `glslang::FinalizeProcess()` is called when unloading the core (and not on RetroArch exit), and backports the changes in https://github.com/libretro/RetroArch/commit/4437cd1eac144f1a3b5acda54c128213e59ec0e1. This fixes all crashing issues on my systems.

This closes #672

@stenzek I am by no means an expert in this particular area, so please review this carefully before merging! :)