### PR TITLE
QtUtils: Improve QTableView column resizing

### DIFF
--- a/src/duckstation-qt/qtutils.h
+++ b/src/duckstation-qt/qtutils.h
@@ -20,7 +20,7 @@ QFrame* CreateHorizontalLine(QWidget* parent);
 /// Returns the greatest parent of a widget, i.e. its dialog/window.
 QWidget* GetRootWidget(QWidget* widget, bool stop_at_window_or_dialog = true);
 
-/// Resizes columns of the table view to at the specified widths. A width of -1 will stretch the column to use the
+/// Resizes columns of the table view to at the specified widths. A negative width will stretch the column to use the
 /// remaining space.
 void ResizeColumnsForTableView(QTableView* view, const std::initializer_list<int>& widths);
 


### PR DESCRIPTION
This avoids use of hard-coded padding values and properly considers minimum and maximum column widths when calculating the remaining flexible width. Fixes unnecessary horizontal scroll bar showing up by default.

Before:
![image](https://user-images.githubusercontent.com/45282415/89934464-779c6580-dbc5-11ea-9da0-ca5ce8236702.png)

With patch:
![image](https://user-images.githubusercontent.com/45282415/89934897-20e35b80-dbc6-11ea-8925-722661b5d8ec.png)
