### PR TITLE
Prefix libretro core options with core name.

### DIFF
--- a/src/duckstation-libretro/libretro_host_interface.cpp
+++ b/src/duckstation-libretro/libretro_host_interface.cpp
@@ -150,7 +150,7 @@ std::string LibretroHostInterface::GetStringSettingValue(const char* section, co
                                                          const char* default_value /*= ""*/)
 {
   TinyString name;
-  name.Format("%s.%s", section, key);
+  name.Format("duckstation_%s.%s", section, key);
   retro_variable var{name, default_value};
   if (g_retro_environment_callback(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
     return var.value;
@@ -353,7 +353,7 @@ void LibretroHostInterface::OnSystemDestroyed()
 }
 
 static std::array<retro_core_option_definition, 29> s_option_definitions = {{
-  {"Console.Region",
+  {"duckstation_Console.Region",
    "Console Region",
    "Determines which region/hardware to emulate. Auto-Detect will use the region of the disc inserted.",
    {{"Auto", "Auto-Detect"},
@@ -361,34 +361,34 @@ static std::array<retro_core_option_definition, 29> s_option_definitions = {{
     {"NTSC-U", "NTSC-U (US)"},
     {"PAL", "PAL (Europe, Australia)"}},
    "Auto"},
-  {"BIOS.PatchFastBoot",
+  {"duckstation_BIOS.PatchFastBoot",
    "Fast Boot",
    "Skips the BIOS shell/intro, booting directly into the game. Usually safe to enable, but some games break.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"CDROM.RegionCheck",
+  {"duckstation_CDROM.RegionCheck",
    "CD-ROM Region Check",
    "Prevents discs from incorrect regions being read by the emulator. Usually safe to disable.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"CDROM.ReadThread",
+  {"duckstation_CDROM.ReadThread",
    "CD-ROM Read Thread",
    "Reads CD-ROM sectors ahead asynchronously, reducing the risk of frame time spikes.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "true"},
-  {"CDROM.LoadImageToRAM",
+  {"duckstation_CDROM.LoadImageToRAM",
    "Preload CD-ROM Image To RAM",
    "Loads the disc image to RAM before starting emulation. May reduce hitching if you are running off a network share, "
    "at a cost of a greater startup time. As libretro provides no way to draw overlays, the emulator will appear to "
    "lock up while the image is preloaded.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"CPU.ExecutionMode",
+  {"duckstation_CPU.ExecutionMode",
    "CPU Execution Mode",
    "Which mode to use for CPU emulation. Recompiler provides the best performance.",
    {{"Interpreter", "Interpreter"}, {"CachedIntepreter", "Cached Interpreter"}, {"Recompiler", "Recompiler"}},
    "Recompiler"},
-  {"GPU.Renderer",
+  {"duckstation_GPU.Renderer",
    "GPU Renderer",
    "Which renderer to use to emulate the GPU",
    {
@@ -404,7 +404,7 @@ static std::array<retro_core_option_definition, 29> s_option_definitions = {{
    "OpenGL"
 #endif
   },
-  {"GPU.ResolutionScale",
+  {"duckstation_GPU.ResolutionScale",
    "Internal Resolution Scale",
    "Scales internal VRAM resolution by the specified multiplier. Larger values are slower. Some games require "
    "1x VRAM resolution or they will have rendering issues.",
@@ -425,81 +425,81 @@ static std::array<retro_core_option_definition, 29> s_option_definitions = {{
     {"15", "15x"},
     {"16", "16x"}},
    "1"},
-  {"GPU.TrueColor",
+  {"duckstation_GPU.TrueColor",
    "True Color Rendering",
    "Disables dithering and uses the full 8 bits per channel of color information. May break rendering in some games.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"GPU.ScaledDithering",
+  {"duckstation_GPU.ScaledDithering",
    "Scaled Dithering",
    "Scales the dithering pattern with the internal rendering resolution, making it less noticeable. Usually safe to "
    "enable.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "true"},
-  {"GPU.DisableInterlacing",
+  {"duckstation_GPU.DisableInterlacing",
    "Disable Interlacing",
    "Disables interlaced rendering and display in the GPU. Some games can render in 480p this way, but others will "
    "break.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"GPU.ForceNTSCTimings",
+  {"duckstation_GPU.ForceNTSCTimings",
    "Force NTSC Timings",
    "Forces PAL games to run at NTSC timings, i.e. 60hz. Some PAL games will run at their \"normal\" speeds, while "
    "others will break.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"GPU.TextureFiltering",
+  {"duckstation_GPU.TextureFiltering",
    "Bilinear Texture Filtering",
    "Smooths out the blockyness of magnified textures on 3D object by using bilinear filtering. Will have a "
    "greater effect on higher resolution scales. Only applies to the hardware renderers.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"GPU.WidescreenHack",
+  {"duckstation_GPU.WidescreenHack",
    "Widescreen Hack",
    "Increases the field of view from 4:3 to 16:9 in 3D games. For 2D games, or games which use pre-rendered "
    "backgrounds, this enhancement will not work as expected.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"GPU.PGXPEnable",
+  {"duckstation_GPU.PGXPEnable",
    "PGXP Geometry Correction",
    "Reduces \"wobbly\" polygons by attempting to preserve the fractional component through memory transfers. Only "
    "works with the hardware renderers, and may not be compatible with all games.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"GPU.PGXPCulling",
+  {"duckstation_GPU.PGXPCulling",
    "PGXP Culling Correction",
    "Increases the precision of polygon culling, reducing the number of holes in geometry. Requires geometry correction "
    "enabled.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "true"},
-  {"GPU.PGXPTextureCorrection",
+  {"duckstation_GPU.PGXPTextureCorrection",
    "PGXP Texture Correction",
    "Uses perspective-correct interpolation for texture coordinates and colors, straightening out warped textures. "
    "Requires geometry correction enabled.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "true"},
-  {"GPU.PGXPVertexCache",
+  {"duckstation_GPU.PGXPVertexCache",
    "PGXP Vertex Cache",
    "Uses screen coordinates as a fallback when tracking vertices through memory fails. May improve PGXP compatibility.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"Display.CropMode",
+  {"duckstation_Display.CropMode",
    "Crop Mode",
    "Changes how much of the image is cropped. Some games display garbage in the overscan area which is typically "
    "hidden.",
    {{"None", "None"}, {"Overscan", "Only Overscan Area"}, {"Borders", "All Borders"}},
    "Overscan"},
-  {"Display.AspectRatio",
+  {"duckstation_Display.AspectRatio",
    "Aspect Ratio",
    "Sets the core-provided aspect ratio.",
    {{"4:3", "4:3"}, {"16:9", "16:9"}, {"2:1", "2:1 (VRAM 1:1)"}, {"1:1", "1:1"}},
    "4:3"},
-  {"MemoryCards.LoadFromSaveStates",
+  {"duckstation_MemoryCards.LoadFromSaveStates",
    "Load Memory Cards From Save States",
    "Sets whether the contents of memory cards will be loaded when a save state is loaded.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"MemoryCards.Card1Type",
+  {"duckstation_MemoryCards.Card1Type",
    "Memory Card 1 Type",
    "Sets the type of memory card for Slot 1.",
    {{"None", "No Memory Card"},
@@ -507,7 +507,7 @@ static std::array<retro_core_option_definition, 29> s_option_definitions = {{
     {"PerGame", "Separate Card Per Game (Game Code)"},
     {"PerGameTitle", "Separate Card Per Game (Game Title)"}},
    "PerGameTitle"},
-  {"MemoryCards.Card2Type",
+  {"duckstation_MemoryCards.Card2Type",
    "Memory Card 2 Type",
    "Sets the type of memory card for Slot 2.",
    {{"None", "No Memory Card"},
@@ -515,7 +515,7 @@ static std::array<retro_core_option_definition, 29> s_option_definitions = {{
     {"PerGame", "Separate Card Per Game (Game Code)"},
     {"PerGameTitle", "Separate Card Per Game (Game Title)"}},
    "None"},
-  {"Controller1.Type",
+  {"duckstation_Controller1.Type",
    "Controller 1 Type",
    "Sets the type of controller for Slot 1.",
    {{"None", "None"},
@@ -525,12 +525,12 @@ static std::array<retro_core_option_definition, 29> s_option_definitions = {{
     {"PlayStationMouse", "PlayStation Mouse"},
     {"NeGcon", "NeGcon"}},
    "DigitalController"},
-  {"Controller1.AutoEnableAnalog",
+  {"duckstation_Controller1.AutoEnableAnalog",
    "Controller 1 Auto Analog Mode",
    "Automatically enables analog mode in supported controllers at start/reset.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"Controller2.Type",
+  {"duckstation_Controller2.Type",
    "Controller 2 Type",
    "Sets the type of controller for Slot 2.",
    {{"None", "None"},
@@ -540,12 +540,12 @@ static std::array<retro_core_option_definition, 29> s_option_definitions = {{
     {"PlayStationMouse", "PlayStation Mouse"},
     {"NeGcon", "NeGcon"}},
    "None"},
-  {"Controller2.AutoEnableAnalog",
+  {"duckstation_Controller2.AutoEnableAnalog",
    "Controller 2 Auto Analog Mode",
    "Automatically enables analog mode in supported controllers at start/reset.",
    {{"true", "Enabled"}, {"false", "Disabled"}},
    "false"},
-  {"Logging.LogLevel",
+  {"duckstation_Logging.LogLevel",
    "Log Level",
    "Sets the level of information logged by the core.",
    {{"None", "None"},
@@ -788,7 +788,7 @@ static std::optional<GPURenderer> RenderAPIToRenderer(HostDisplay::RenderAPI api
 bool LibretroHostInterface::RequestHardwareRendererContext()
 {
   GPURenderer renderer = Settings::DEFAULT_GPU_RENDERER;
-  retro_variable renderer_variable{"GPU.Renderer", Settings::GetRendererName(Settings::DEFAULT_GPU_RENDERER)};
+  retro_variable renderer_variable{"duckstation_GPU.Renderer", Settings::GetRendererName(Settings::DEFAULT_GPU_RENDERER)};
   if (g_retro_environment_callback(RETRO_ENVIRONMENT_GET_VARIABLE, &renderer_variable) && renderer_variable.value)
     renderer = Settings::ParseRendererName(renderer_variable.value).value_or(Settings::DEFAULT_GPU_RENDERER);
 

--- a/src/duckstation-libretro/libretro_settings_interface.cpp
+++ b/src/duckstation-libretro/libretro_settings_interface.cpp
@@ -8,8 +8,9 @@ Log_SetChannel(LibretroSettingsInterface);
 template<typename T, typename DefaultValueType>
 static T GetVariable(const char* section, const char* key, DefaultValueType default_value)
 {
+
   TinyString full_key;
-  full_key.Format("%s.%s", section, key);
+  full_key.Format("duckstation_%s.%s", section, key);
 
   retro_variable rv = {full_key.GetCharArray(), nullptr};
   if (!g_retro_environment_callback(RETRO_ENVIRONMENT_GET_VARIABLE, &rv) || !rv.value)


### PR DESCRIPTION
Until [only recently](https://github.com/libretro/RetroArch/commit/d9673b8c8fd86d8e2fdcfac503e3da2cd53af6e3) RetroArch's default behaviour was to save all core options for the installed cores in one global .cfg file. Now it defaults to splitting them out into individual files per-core, but the user may still configure it to use a global file via `global_core_options = "true"`. The latter is the behavior of my concern, the RetroPie project. 

To that end, it's suggested for libretro cores to prefix all core options with the name of the core, so they can be grouped and easily identified within a global .cfg. see https://github.com/libretro/RetroArch/blob/master/libretro-common/include/libretro.h#L1150-L1152

Eg:
```
beetle_psx_analog_calibration = "disabled"
beetle_psx_analog_toggle = "disabled"
beetle_psx_aspect_ratio = "corrected"
beetle_psx_cd_access_method = "async"
beetle_psx_cd_fastload = "2x(native)"
```
I have introduced the same behaviour here. Obviously any setting changes made before this change will be left as clutter in the file, and not retrieved. Could put some code in to pick up the previous settings (and subsequently save them under the new format) but you may consider that clutter in the code.

**NOTE:** I do see this in the logs:
```
[libretro WARN] [retro_set_environment] Failed to set core options, settings will not be changeable.
```
...however the new core options seem to save and load anyway :man_shrugging:. I might have missed something...