### PR TITLE
Qt: Add Chinese (Simplified) translation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ The following people have contributed to the project in some way, and are credit
 - Anderson Cardoso - Portuguese (Br)
 - @bajolzas - Portuguese (Pt)
 - posix - @Richard-L - German
+- @phoe-nix - Chinese (Simplified)
 
 ## Game Compatibility Database
  - @Zet-sensei

--- a/src/duckstation-qt/CMakeLists.txt
+++ b/src/duckstation-qt/CMakeLists.txt
@@ -69,6 +69,7 @@ set(TS_FILES
   translations/duckstation-qt_he.ts
   translations/duckstation-qt_pt-br.ts
   translations/duckstation-qt_pt-pt.ts
+  translations/duckstation-qt_zh-cn.ts
 )
 
 set_source_files_properties(${TS_FILES} PROPERTIES OUTPUT_LOCATION "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/translations")

--- a/src/duckstation-qt/duckstation-qt.vcxproj
+++ b/src/duckstation-qt/duckstation-qt.vcxproj
@@ -201,6 +201,9 @@
     <QtTs Include="translations\duckstation-qt_pt-pt.ts">
       <FileType>Document</FileType>
     </QtTs>
+    <QtTs Include="translations\duckstation-qt_zh-cn.ts">
+      <FileType>Document</FileType>
+    </QtTs>
   </ItemGroup>
   <ItemGroup>
     <QtUi Include="autoupdaterdialog.ui">

--- a/src/duckstation-qt/duckstation-qt.vcxproj.filters
+++ b/src/duckstation-qt/duckstation-qt.vcxproj.filters
@@ -125,5 +125,8 @@
     <None Include="translations\duckstation-qt_he.ts">
       <Filter>translations</Filter>
     </None>
+    <None Include="translations\duckstation-qt_zh-cn.ts">
+      <Filter>translations</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -58,7 +58,8 @@ std::vector<std::pair<QString, QString>> QtHostInterface::getAvailableLanguageLi
           {QStringLiteral("Deutsch"), QStringLiteral("de")},
           {QStringLiteral("עברית"), QStringLiteral("he")},
           {QStringLiteral("português (Pt)"), QStringLiteral("pt-pt")},
-          {QStringLiteral("português (Br)"), QStringLiteral("pt-br")}};
+          {QStringLiteral("português (Br)"), QStringLiteral("pt-br")},
+          {QStringLiteral("简体中文"), QStringLiteral("zh-cn")}};
 }
 
 bool QtHostInterface::Initialize()

--- a/src/duckstation-qt/translations/duckstation-qt_zh-cn.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_zh-cn.ts
@@ -1,0 +1,2046 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../aboutdialog.ui" line="14"/>
+        <source>About DuckStation</source>
+        <translation>关于Duckstation</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.ui" line="101"/>
+        <source>DuckStation</source>
+        <translation>DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="14"/>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="29"/>
+        <source>DuckStation is a free and open-source simulator/emulator of the Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt; console, focusing on playability, speed, and long-term maintainability.</source>
+        <translation>DuckStation是索尼PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt;主机的免费开源仿真器/模拟器, 注重可玩性、速度和长期可维护性。</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="32"/>
+        <source>Authors</source>
+        <translation>作者</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="33"/>
+        <source>Icon by</source>
+        <translation>图标制作</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="34"/>
+        <source>License</source>
+        <translation>License</translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedSettingsWidget</name>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="32"/>
+        <source>Logging</source>
+        <translation>记日志</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="40"/>
+        <source>Log Level:</source>
+        <translation>日志级别:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="50"/>
+        <source>Log Filters:</source>
+        <translation>日志筛选器:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="64"/>
+        <source>Log To System Console</source>
+        <translation>记录系统控制台</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="71"/>
+        <source>Log To Window</source>
+        <translation>记录窗口</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="78"/>
+        <source>Log To Debug Console</source>
+        <translation>记录调试控制台</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="85"/>
+        <source>Log To File</source>
+        <translation>记录文件</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="97"/>
+        <source>Tweaks/Hacks</source>
+        <translation>Tweaks/Hacks</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="103"/>
+        <source>These options are tweakable to improve performance/game compatibility. Use at your own risk, modified values will not be supported.</source>
+        <translation>这些选项可以调整以提高性能/游戏兼容性。使用风险自负, 将不支持修改后的值。</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="113"/>
+        <source>DMA Max Slice Ticks:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="133"/>
+        <source>DMA Halt Ticks:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="166"/>
+        <source>GPU FIFO Size:</source>
+        <translation>GPU FIFO大小:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="173"/>
+        <source>GPU Max Run-Ahead:</source>
+        <translation>GPU最大前进速度:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="190"/>
+        <source>Reset To Default</source>
+        <translation>重置为默认值</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="197"/>
+        <source>Enable Recompiler Memory Exceptions</source>
+        <translation>启用重新编译内存异常</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="207"/>
+        <source>System Settings</source>
+        <translation>系统设置</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="213"/>
+        <location filename="../advancedsettingswidget.cpp" line="34"/>
+        <source>Use Debug Host GPU Device</source>
+        <translation>使用调试主机GPU设备</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="34"/>
+        <source>Unchecked</source>
+        <translation>不勾选</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="35"/>
+        <source>Enables the usage of debug devices and shaders for rendering APIs which support them. Should only be used when debugging the emulator.</source>
+        <translation>允许使用调试设备和着色器渲染支持它们的API。只应在调试模拟器时使用。</translation>
+    </message>
+</context>
+<context>
+    <name>AudioSettingsWidget</name>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="32"/>
+        <source>Configuration</source>
+        <translation>设置</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="38"/>
+        <source>Backend:</source>
+        <translation>后端:</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="48"/>
+        <source>Buffer Size:</source>
+        <translation>缓存大小:</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="93"/>
+        <source>Maximum latency: 0 frames (0.00ms)</source>
+        <translation>最大延迟: 0帧 (0.00ms)</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="103"/>
+        <source>Sync To Output</source>
+        <translation>同步到输出</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="110"/>
+        <source>Start Dumping On Boot</source>
+        <translation>启动时开始转储</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="120"/>
+        <source>Controls</source>
+        <translation>控制</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="126"/>
+        <source>Volume:</source>
+        <translation>音量:</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="152"/>
+        <location filename="../audiosettingswidget.cpp" line="53"/>
+        <source>Mute</source>
+        <translation>静音</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="159"/>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="34"/>
+        <source>Audio Backend</source>
+        <translation>音频后端</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="35"/>
+        <source>The audio backend determines how frames produced by the emulator are submitted to the host. Cubeb provides the lowest latency, if you encounter issues, try the SDL backend. The null backend disables all host audio output.</source>
+        <translation>音频后端决定如何将模拟器生成的帧提交到主机。Cubeb提供了最低的延迟, 如果遇到问题, 请尝试SDL后端。空后端禁用所有主机音频输出。</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="39"/>
+        <source>Buffer Size</source>
+        <translation>缓存大小</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="40"/>
+        <source>The buffer size determines the size of the chunks of audio which will be pulled by the host. Smaller values reduce the output latency, but may cause hitches if the emulation speed is inconsistent. Note that the Cubeb backend uses smaller chunks regardless of this value, so using a low value here may not significantly change latency.</source>
+        <translation>缓冲区大小决定主机将要拉入的音频块的大小。较小的值可减少输出延迟, 但如果仿真速度不一致, 则可能会导致挂起。请注意, Cubeb后端使用更小的块, 而不管这个值如何, 因此在这里使用较低的值可能不会显著改变延迟。</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="45"/>
+        <source>Checked</source>
+        <translation>勾选</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="46"/>
+        <source>Throttles the emulation speed based on the audio backend pulling audio frames. Sync will automatically be disabled if not running at 100% speed.</source>
+        <translation>根据音频后端拉取音频帧来限制模拟速度。如果没有以100%的速度运行, 同步将自动禁用。</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="49"/>
+        <location filename="../audiosettingswidget.cpp" line="53"/>
+        <source>Unchecked</source>
+        <translation>不勾选</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="50"/>
+        <source>Start dumping audio to file as soon as the emulator is started. Mainly useful as a debug option.</source>
+        <translation>一旦模拟器启动, 就开始将音频转储到文件中。主要用作调试选项。</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="51"/>
+        <source>Volume</source>
+        <translation>音量</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="52"/>
+        <source>Controls the volume of the audio played on the host. Values are in percentage.</source>
+        <translation>控制主机上播放的音频的音量。值以百分比表示。</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="54"/>
+        <source>Prevents the emulator from producing any audible sound.</source>
+        <translation>防止模拟器产生任何可听见的声音。</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="64"/>
+        <source>Maximum latency: %1 frames (%2ms)</source>
+        <translation>最大延迟: %1帧 (%2ms)</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="69"/>
+        <source>%1%</source>
+        <translation>%1%</translation>
+    </message>
+</context>
+<context>
+    <name>AutoUpdaterDialog</name>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="17"/>
+        <location filename="../autoupdaterdialog.cpp" line="147"/>
+        <location filename="../autoupdaterdialog.cpp" line="234"/>
+        <source>Automatic Updater</source>
+        <translation>自动更新程序</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="33"/>
+        <source>Update Available</source>
+        <translation>可用更新</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="40"/>
+        <source>Current Version: </source>
+        <translation>当前版本: </translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="47"/>
+        <source>New Version: </source>
+        <translation>新版本: </translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="54"/>
+        <source>Update Notes:</source>
+        <translation>更新内容:</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="83"/>
+        <source>Download and Install...</source>
+        <translation>下载并安装</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="90"/>
+        <source>Skip This Update</source>
+        <translation>跳过这个更新</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="97"/>
+        <source>Remind Me Later</source>
+        <translation>稍后提醒我</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="81"/>
+        <source>Updater Error</source>
+        <translation>更新错误</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="148"/>
+        <source>No updates are currently available. Please try again later.</source>
+        <translation>当前没有可用的更新。请稍后再试。</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="199"/>
+        <source>Current Version: %1 (%2)</source>
+        <translation>当前版本: %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="201"/>
+        <source>New Version: %1 (%2)</source>
+        <translation>新版本: %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="233"/>
+        <source>Downloading %1...</source>
+        <translation>下载中 %1...</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="233"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+</context>
+<context>
+    <name>ConsoleSettingsWidget</name>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="32"/>
+        <source>Console</source>
+        <translation>主机</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="38"/>
+        <source>Region:</source>
+        <translation>区域:</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="48"/>
+        <source>BIOS Image Path:</source>
+        <translation>BIOS文件路径:</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="55"/>
+        <location filename="../consolesettingswidget.cpp" line="35"/>
+        <source>Fast Boot</source>
+        <translation>快速启动</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="62"/>
+        <source>Enable TTY Output</source>
+        <translation>启用TTY输出</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="74"/>
+        <source>...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="86"/>
+        <source>CPU Emulation</source>
+        <translation>CPU模拟</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="92"/>
+        <source>Execution Mode:</source>
+        <translation>执行方式:</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="105"/>
+        <source>CDROM Emulation</source>
+        <translation>光盘模拟</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="111"/>
+        <source>Use Read Thread (Asynchronous)</source>
+        <translation>使用读取线程 (异步)</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="118"/>
+        <source>Enable Region Check</source>
+        <translation>启用区域检查</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="125"/>
+        <source>Preload Image To RAM</source>
+        <translation>将图像预加载到内存</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="35"/>
+        <location filename="../consolesettingswidget.cpp" line="39"/>
+        <source>Unchecked</source>
+        <translation>不勾选</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="36"/>
+        <source>Patches the BIOS to skip the console&apos;s boot animation. Does not work with all games, but usually safe to enabled.</source>
+        <translation>对BIOS应用补丁以跳过主机的启动动画, 不适用于所有游戏, 但通常可以安全启用。</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="39"/>
+        <source>Preload Image to RAM</source>
+        <translation>将图像预加载到内存</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="40"/>
+        <source>Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay.</source>
+        <translation>将游戏图像加载到内存中。对于可能在游戏过程中变得不可靠的网络路径非常有用。</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="47"/>
+        <source>Select BIOS Image</source>
+        <translation>选择BIOS文件</translation>
+    </message>
+</context>
+<context>
+    <name>ControllerSettingsWidget</name>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="82"/>
+        <source>Controller Type:</source>
+        <translation>控制器类型:</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="113"/>
+        <source>Load Profile</source>
+        <translation>读取配置</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="117"/>
+        <source>Save Profile</source>
+        <translation>保存配置</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="123"/>
+        <source>Clear All</source>
+        <translation>清除全部</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="125"/>
+        <source>Clear Bindings</source>
+        <translation>清除绑定</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="126"/>
+        <source>Are you sure you want to clear all bound controls? This can not be reversed.</source>
+        <translation>确实要清除所有绑定控件吗？这是无法撤消的。</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="140"/>
+        <location filename="../controllersettingswidget.cpp" line="142"/>
+        <source>Rebind All</source>
+        <translation>全部重新绑定</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="143"/>
+        <source>Are you sure you want to rebind all controls? All currently-bound controls will be irreversibly cleared. Rebinding will begin after confirmation.</source>
+        <translation>是否确实要重新绑定所有控件？所有当前绑定的控件都将被不可逆转地清除。确认后将开始重新绑定。</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="167"/>
+        <source>Port %1</source>
+        <translation>接口%1</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="183"/>
+        <source>Button Bindings:</source>
+        <translation>按钮绑定:</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="220"/>
+        <source>Axis Bindings:</source>
+        <translation>轴绑定:</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="259"/>
+        <source>Rumble</source>
+        <translation>Rumble</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="345"/>
+        <location filename="../controllersettingswidget.cpp" line="394"/>
+        <location filename="../controllersettingswidget.cpp" line="435"/>
+        <source>Browse...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="349"/>
+        <source>Select File</source>
+        <translation>选择文件</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="397"/>
+        <location filename="../controllersettingswidget.cpp" line="437"/>
+        <source>Select path to input profile ini</source>
+        <translation>选择输入配置文件ini的路径</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="421"/>
+        <source>New...</source>
+        <translation>新建...</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="423"/>
+        <location filename="../controllersettingswidget.cpp" line="424"/>
+        <source>Enter Input Profile Name</source>
+        <translation>输入输入配置文件名</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="427"/>
+        <location filename="../controllersettingswidget.cpp" line="441"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="428"/>
+        <source>No name entered, input profile was not saved.</source>
+        <translation>未输入名称, 未保存输入配置文件。</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="442"/>
+        <source>No path selected, input profile was not saved.</source>
+        <translation>未选择路径, 未保存输入配置文件。</translation>
+    </message>
+</context>
+<context>
+    <name>GPUSettingsWidget</name>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="47"/>
+        <source>Basic</source>
+        <translation>基本</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="53"/>
+        <source>Renderer:</source>
+        <translation>渲染器:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="63"/>
+        <source>Adapter:</source>
+        <translation>适配器:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="76"/>
+        <source>Screen Display</source>
+        <translation>屏幕显示</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="82"/>
+        <source>Aspect Ratio:</source>
+        <translation>纵横比:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="92"/>
+        <source>Crop:</source>
+        <translation>裁剪:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="102"/>
+        <location filename="../gpusettingswidget.cpp" line="88"/>
+        <source>Linear Upscaling</source>
+        <translation>线性放大</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="109"/>
+        <location filename="../gpusettingswidget.cpp" line="93"/>
+        <source>Integer Upscaling</source>
+        <translation>整数放大</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="116"/>
+        <location filename="../gpusettingswidget.cpp" line="97"/>
+        <source>VSync</source>
+        <translation>垂直同步</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="126"/>
+        <source>Enhancements</source>
+        <translation>增强功能</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="132"/>
+        <source>Resolution Scale:</source>
+        <translation>分辨率缩放:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="142"/>
+        <location filename="../gpusettingswidget.cpp" line="107"/>
+        <source>True Color Rendering (24-bit, disables dithering)</source>
+        <translation type="unfinished">真彩色渲染 (24位, 禁用色彩抖动)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="149"/>
+        <location filename="../gpusettingswidget.cpp" line="114"/>
+        <source>Scaled Dithering (scale dither pattern to resolution)</source>
+        <translation type="unfinished">缩放色彩抖动 (按分辨率缩放模式)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="156"/>
+        <location filename="../gpusettingswidget.cpp" line="83"/>
+        <source>Disable Interlacing (force progressive render/scan)</source>
+        <translation>禁用隔行扫描 (强制渐进式渲染/扫描)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="163"/>
+        <location filename="../gpusettingswidget.cpp" line="118"/>
+        <source>Force NTSC Timings (60hz-on-PAL)</source>
+        <translation>强制NTSC制式(60hz-PAL)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="170"/>
+        <location filename="../gpusettingswidget.cpp" line="124"/>
+        <source>Bilinear Texture Filtering</source>
+        <translation>双线性纹理过滤</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="177"/>
+        <location filename="../gpusettingswidget.cpp" line="128"/>
+        <source>Widescreen Hack</source>
+        <translation>宽屏补丁</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="187"/>
+        <source>PGXP</source>
+        <translation>PGXP</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="193"/>
+        <location filename="../gpusettingswidget.cpp" line="133"/>
+        <source>Geometry Correction</source>
+        <translation>几何校正</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="200"/>
+        <location filename="../gpusettingswidget.cpp" line="136"/>
+        <source>Culling Correction</source>
+        <translation>剔除校正</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="207"/>
+        <location filename="../gpusettingswidget.cpp" line="139"/>
+        <source>Texture Correction</source>
+        <translation>纹理校正</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="214"/>
+        <location filename="../gpusettingswidget.cpp" line="142"/>
+        <source>Vertex Cache</source>
+        <translation>顶点缓存</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="63"/>
+        <source>Renderer</source>
+        <translation>渲染器</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="64"/>
+        <source>Chooses the backend to use for rendering tasks for the the console GPU. Depending on your system and hardware, Direct3D 11 and OpenGL hardware backends may be available. The software renderer offers the best compatibility, but is the slowest and does not offer any enhancements.</source>
+        <translation>选择用于呈现控制台GPU任务的后端。根据您的系统和硬件, Direct3D 11和OpenGL硬件后端可能可用。软件渲染器提供了最好的兼容性, 但速度最慢, 并且不提供任何增强功能。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="69"/>
+        <source>Adapter</source>
+        <translation>适配器</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="69"/>
+        <location filename="../gpusettingswidget.cpp" line="224"/>
+        <source>(Default)</source>
+        <translation>(默认)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="70"/>
+        <source>If your system contains multiple GPUs or adapters, you can select which GPU you wish to use for the hardware renderers. This option is only supported in Direct3D and Vulkan, OpenGL will always use the default device.</source>
+        <translation>如果系统包含多个GPU或适配器, 则可以选择要将哪个GPU用于硬件渲染器。此选项仅在Direct3D和Vulkan中受支持, OpenGL将始终使用默认设备。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="73"/>
+        <source>Aspect Ratio</source>
+        <translation>高宽比</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="74"/>
+        <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is 4:3 which matches a typical TV of the era.</source>
+        <translation>更改用于在屏幕上显示控制台输出的纵横比。默认值是4:3, 与那个时代的典型电视相匹配。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="77"/>
+        <source>Crop Mode</source>
+        <translation>裁剪模式</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="77"/>
+        <source>Only Overscan Area</source>
+        <translation>仅限过扫描区域</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="78"/>
+        <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide. Some games display content in the overscan area, or use it for screen effects and may not display correctly with the All Borders setting. Only Overscan offers a good compromise between stability and hiding black borders.</source>
+        <translation>确定用户电视机上通常不可见的区域有多少要裁剪/隐藏。有些游戏在“过扫描”区域显示内容, 或将其用于屏幕效果, 在“所有边框”设置下可能无法正确显示。只有过度扫描才能在稳定和隐藏黑边界之间提供一个很好的折衷方案。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="83"/>
+        <location filename="../gpusettingswidget.cpp" line="93"/>
+        <location filename="../gpusettingswidget.cpp" line="107"/>
+        <location filename="../gpusettingswidget.cpp" line="118"/>
+        <location filename="../gpusettingswidget.cpp" line="124"/>
+        <location filename="../gpusettingswidget.cpp" line="128"/>
+        <location filename="../gpusettingswidget.cpp" line="133"/>
+        <location filename="../gpusettingswidget.cpp" line="142"/>
+        <source>Unchecked</source>
+        <translation>不勾选</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="84"/>
+        <source>Forces the rendering and display of frames to progressive mode. This removes the &quot;combing&quot; effect seen in 480i games by rendering them in 480p. Not all games are compatible with this option, some require interlaced rendering or render interlaced internally. Usually safe to enable.</source>
+        <translation>强制以渐进模式渲染和显示帧。这将通过在480p中渲染480i游戏中的效果来移除它们。并非所有的游戏都与此选项兼容, 有些游戏需要隔行渲染或内部渲染。通常可以安全启用。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="88"/>
+        <location filename="../gpusettingswidget.cpp" line="97"/>
+        <location filename="../gpusettingswidget.cpp" line="114"/>
+        <location filename="../gpusettingswidget.cpp" line="136"/>
+        <location filename="../gpusettingswidget.cpp" line="139"/>
+        <source>Checked</source>
+        <translation>勾选</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="89"/>
+        <source>Uses bilinear texture filtering when displaying the console&apos;s framebuffer to the screen. Disabling filtering will producer a sharper, blockier/pixelated image. Enabling will smooth out the image. The option will be less noticable the higher the resolution scale.</source>
+        <translation>在将控制台帧缓冲区显示到屏幕时使用双线性纹理过滤。禁用过滤将生成更清晰、更块状/像素化的图像。启用将使图像平滑。分辨率越高, 选项就越不引人注意。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="94"/>
+        <source>Adds padding to the display area to ensure that the ratio between pixels on the host to pixels in the console is an integer number. May result in a sharper image in some 2D games.</source>
+        <translation>向显示区域添加填充, 以确保主机上的像素与控制台中的像素之间的比率为整数。在一些2D游戏中可能会产生更清晰的图像。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="98"/>
+        <source>Enables synchronization with the host display when possible. Enabling this option will provide better frame pacing and smoother motion with fewer duplicated frames. VSync is automatically disabled when it is not possible (e.g. running at non-100% speed).</source>
+        <translation>如果可能, 启用与主机显示的同步。启用此选项将以更少的重复帧提供更好的帧间距和更平滑的运动。当不可能时(例如, 以非100%速度运行), 垂直同步将自动禁用。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="102"/>
+        <source>Resolution Scale</source>
+        <translation>分辨率缩放</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="103"/>
+        <source>Enables the upscaling of 3D objects rendered to the console&apos;s framebuffer. Only applies to the hardware backends. This option is usually safe, with most games looking fine at higher resolutions. Higher resolutions require a more powerful GPU.</source>
+        <translation>允许放大渲染到控制台帧缓冲区的三维对象。仅适用于硬件后端。这个选项通常是安全的, 大多数游戏在更高的分辨率下看起来很好。更高的分辨率需要更强大的GPU。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="108"/>
+        <source>Forces the precision of colours output to the console&apos;s framebuffer to use the full 8 bits of precision per channel. This produces nicer looking gradients at the cost of making some colours look slightly different. Disabling the option also enables dithering, which makes the transition between colours less sharp by applying a pattern around those pixels. Most games are compatible with this option, but there is a number which aren&apos;t and will have broken effects with it enabled. Only applies to the hardware renderers.</source>
+        <translation type="unfinished">强制输出到控制台的帧缓冲区的颜色精度使用每个通道的全部8位精度。这会产生更好看的渐变, 但代价是使某些颜色看起来稍有不同。禁用该选项也会启用色彩抖动, 这会通过在这些像素周围应用图案来减少颜色之间的过渡。大多数游戏都与此选项兼容, 但也有一部分游戏不支持此选项, 并且在启用该选项后会产生中断效果。仅适用于硬件渲染器。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="115"/>
+        <source>Scales the dither pattern to the resolution scale of the emulated GPU. This makes the dither pattern much less obvious at higher resolutions. Usually safe to enable, and only supported by the hardware renderers.</source>
+        <translation type="unfinished">将着色彩抖动式缩放到模拟GPU的分辨率级别。这使得着色彩抖动式在更高分辨率下变得不那么明显。通常可以安全启用, 并且仅由硬件渲染器支持。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="119"/>
+        <source>Uses NTSC frame timings when the console is in PAL mode, forcing PAL games to run at 60hz. For most games which have a speed tied to the framerate, this will result in the game running approximately 17% faster. For variable frame rate games, it may not affect the speed.</source>
+        <translation>当游戏机处于PAL模式时使用NTSC帧计时, 强制PAL游戏以60hz运行。对于大多数速度与帧速率相关的游戏, 这将导致游戏运行速度大约快17%。对于可变帧速率游戏, 它可能不会影响速度。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="125"/>
+        <source>Smooths out the blockyness of magnified textures on 3D object by using bilinear filtering. Will have a greater effect on higher resolution scales. Only applies to the hardware renderers.</source>
+        <translation>利用双线性滤波消除三维物体上放大纹理的块状。会对更高分辨率的尺度产生更大的影响。目前, 在许多游戏中, 这个选项会在对象周围产生瑕疵, 需要进一步的工作。仅适用于硬件渲染器。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="129"/>
+        <source>Scales vertex positions in screen-space to a widescreen aspect ratio, essentially increasing the field of view from 4:3 to 16:9 in 3D games. &lt;br&gt;For 2D games, or games which use pre-rendered backgrounds, this enhancement will not work as expected. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
+        <translation>将屏幕空间中的顶点位置缩放到宽屏幕的纵横比, 基本上将3D游戏中的视野从4:3增加到16:9。&lt;br&gt;对于2D游戏, 或使用预渲染背景的游戏, 此增强将无法按预期工作。&lt;b&gt;&lt;u&gt;可能不兼容所有游戏。&lt;/u&gt;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="134"/>
+        <source>Reduces &quot;wobbly&quot; polygons and &quot;warping&quot; textures that are common in PS1 games. &lt;br&gt;Only works with the hardware renderers. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
+        <translation>减少在PS1游戏中常见的&quot;抖动&quot;多边形和扭曲纹理。&lt;br&gt;仅适用于硬件渲染器。&lt;b&gt;&lt;u&gt;可能不兼容所有游戏。&lt;/u&gt;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="137"/>
+        <source>Increases the precision of polygon culling, reducing the number of holes in geometry. Requires geometry correction enabled.</source>
+        <translation>提高多边形剔除的精度, 减少几何体中的孔数。需要启用几何校正。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="140"/>
+        <source>Uses perspective-correct interpolation for texture coordinates and colors, straightening out warped textures. Requires geometry correction enabled.</source>
+        <translation>使用透视校正插值纹理坐标和颜色, 矫直扭曲的纹理。需要启用几何校正。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="143"/>
+        <source>Uses screen coordinates as a fallback when tracking vertices through memory fails. May improve PGXP compatibility.</source>
+        <translation>当通过内存跟踪顶点失败时, 使用屏幕坐标作为备用。可提高PGXP兼容性。</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="178"/>
+        <source> (for 720p)</source>
+        <translation> (适合720p)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="180"/>
+        <source> (for 1080p)</source>
+        <translation> (适合1080p)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="181"/>
+        <source> (for 1440p)</source>
+        <translation> (适合1440p)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="184"/>
+        <source> (for 4K)</source>
+        <translation> (适合4K)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="194"/>
+        <source>Automatic based on window size</source>
+        <translation>自动根据窗口大小</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="196"/>
+        <source>%1x%2</source>
+        <translation>%1x%2</translation>
+    </message>
+</context>
+<context>
+    <name>GameListModel</name>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="289"/>
+        <source>Type</source>
+        <translation>类型</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="290"/>
+        <source>Code</source>
+        <translation>编号</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="291"/>
+        <source>Title</source>
+        <translation>标题</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="292"/>
+        <source>File Title</source>
+        <translation>文件标题</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="293"/>
+        <source>Size</source>
+        <translation>大小</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="294"/>
+        <source>Region</source>
+        <translation>区域</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="295"/>
+        <source>Compatibility</source>
+        <translation>兼容性</translation>
+    </message>
+</context>
+<context>
+    <name>GameListSearchDirectoriesModel</name>
+    <message>
+        <location filename="../gamelistsearchdirectoriesmodel.cpp" line="29"/>
+        <source>Path</source>
+        <translation>路径</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsearchdirectoriesmodel.cpp" line="31"/>
+        <source>Recursive</source>
+        <translation>深度搜索</translation>
+    </message>
+</context>
+<context>
+    <name>GameListSettingsWidget</name>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="34"/>
+        <source>Search Directories</source>
+        <translation><byte value="x1e"/>搜索目录</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="46"/>
+        <source>Add</source>
+        <translation>添加</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="57"/>
+        <location filename="../gamelistsettingswidget.cpp" line="85"/>
+        <source>Remove</source>
+        <translation>移除</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="81"/>
+        <source>Scan New</source>
+        <translation>搜索新的</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="92"/>
+        <source>Rescan All</source>
+        <translation>全部重新搜索</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="103"/>
+        <source>Update Redump Database</source>
+        <translation>更新Redump数据库</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="87"/>
+        <source>Open Directory...</source>
+        <translation>打开目录...</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="95"/>
+        <source>Select Search Directory</source>
+        <translation>选择搜索目录</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="101"/>
+        <source>Scan Recursively?</source>
+        <translation>深度扫描?</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="102"/>
+        <source>Would you like to scan the directory &quot;%1&quot; recursively?
+
+Scanning recursively takes more time, but will identify files in subdirectories.</source>
+        <translation>是否要深度扫描 &quot;%1&quot; 目录?
+
+深度扫描需要更多时间, 但会识别子目录中的文件。</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="140"/>
+        <source>Download database from redump.org?</source>
+        <translation>从redump.org下载数据库?</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="141"/>
+        <source>Do you wish to download the disc database from redump.org?
+
+This will download approximately 4 megabytes over your current internet connection.</source>
+        <translation>您想从redump.org下载光盘数据库吗? 
+
+这将通过您当前的网络连接下载大约4MB。</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="248"/>
+        <source>Downloading %1...</source>
+        <translation>下载中 %1...</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="248"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="259"/>
+        <source>Download failed</source>
+        <translation>下载失败</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="266"/>
+        <source>Extracting...</source>
+        <translation>解压中...</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="272"/>
+        <source>Extract failed</source>
+        <translation>解压失败</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="272"/>
+        <source>Extracting game database failed.</source>
+        <translation>解压游戏数据库失败。</translation>
+    </message>
+</context>
+<context>
+    <name>GamePropertiesDialog</name>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="14"/>
+        <source>Dialog</source>
+        <translation>Dialog</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="24"/>
+        <source>Image Path:</source>
+        <translation>文件路径:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="38"/>
+        <source>Game Code:</source>
+        <translation>游戏编号:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="52"/>
+        <source>Title:</source>
+        <translation>标题:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="66"/>
+        <source>Region:</source>
+        <translation>区域:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="80"/>
+        <source>Compatibility:</source>
+        <translation>兼容性:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="90"/>
+        <source>Upscaling Issues:</source>
+        <translation>放大错误:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="100"/>
+        <source>Comments:</source>
+        <translation>备注:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="110"/>
+        <source>Version Tested:</source>
+        <translation>已测试版本:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="122"/>
+        <source>Set to Current</source>
+        <translation>设置为当前</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="131"/>
+        <source>Tracks:</source>
+        <translation>轨道:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="148"/>
+        <source>#</source>
+        <translation>#</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="153"/>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="158"/>
+        <source>Start</source>
+        <translation>开始</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="163"/>
+        <source>Length</source>
+        <translation>长度</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="168"/>
+        <source>Hash</source>
+        <translation>哈希</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="191"/>
+        <source>Compute Hashes</source>
+        <translation>计算哈希</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="198"/>
+        <source>Verify Dump</source>
+        <translation>验证转储</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="205"/>
+        <source>Export Compatibility Info</source>
+        <translation>导出兼容性信息</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="212"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="53"/>
+        <source>Game Properties - %1</source>
+        <translation>游戏属性 - %1</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="150"/>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="154"/>
+        <source>&lt;not computed&gt;</source>
+        <translation>&lt;不兼容&gt;</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="244"/>
+        <source>Not yet implemented</source>
+        <translation>尚未实施</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="258"/>
+        <source>Compatibility Info Export</source>
+        <translation>兼容性信息导出</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="258"/>
+        <source>Press OK to copy to clipboard.</source>
+        <translation>按“确定”复制到剪贴板。</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralSettingsWidget</name>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="32"/>
+        <source>Behaviour</source>
+        <translation>行为</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="38"/>
+        <location filename="../generalsettingswidget.cpp" line="52"/>
+        <source>Pause On Start</source>
+        <translation>开始时暂停</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="45"/>
+        <location filename="../generalsettingswidget.cpp" line="40"/>
+        <source>Confirm Power Off</source>
+        <translation>确认关机</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="52"/>
+        <location filename="../generalsettingswidget.cpp" line="43"/>
+        <source>Save State On Exit</source>
+        <translation>退出时保存即时存档</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="59"/>
+        <location filename="../generalsettingswidget.cpp" line="55"/>
+        <source>Load Devices From Save States</source>
+        <translation>从即时存档读取设备</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="66"/>
+        <location filename="../generalsettingswidget.cpp" line="46"/>
+        <source>Start Fullscreen</source>
+        <translation>全屏启动</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="73"/>
+        <location filename="../generalsettingswidget.cpp" line="49"/>
+        <source>Render To Main Window</source>
+        <translation>渲染到主窗口</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="83"/>
+        <location filename="../generalsettingswidget.cpp" line="68"/>
+        <source>Emulation Speed</source>
+        <translation>模拟速度</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="119"/>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="128"/>
+        <location filename="../generalsettingswidget.cpp" line="60"/>
+        <source>Enable Speed Limiter</source>
+        <translation>启用限速</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="135"/>
+        <location filename="../generalsettingswidget.cpp" line="64"/>
+        <source>Increase Timer Resolution</source>
+        <translation>提高计时器分辨率</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="145"/>
+        <source>On-Screen Display</source>
+        <translation>屏幕显示</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="151"/>
+        <source>Show Messages</source>
+        <translation>显示消息</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="158"/>
+        <location filename="../generalsettingswidget.cpp" line="74"/>
+        <source>Show FPS</source>
+        <translation>显示FPS</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="165"/>
+        <source>Show Emulation Speed</source>
+        <translation>显示模拟速度</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="172"/>
+        <location filename="../generalsettingswidget.cpp" line="76"/>
+        <source>Show VPS</source>
+        <translation>显示VPS</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="40"/>
+        <location filename="../generalsettingswidget.cpp" line="43"/>
+        <location filename="../generalsettingswidget.cpp" line="49"/>
+        <location filename="../generalsettingswidget.cpp" line="60"/>
+        <location filename="../generalsettingswidget.cpp" line="64"/>
+        <location filename="../generalsettingswidget.cpp" line="71"/>
+        <location filename="../generalsettingswidget.cpp" line="101"/>
+        <source>Checked</source>
+        <translation>勾选</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="41"/>
+        <source>Determines whether a prompt will be displayed to confirm shutting down the emulator/game when the hotkey is pressed.</source>
+        <translation>确定按下热键时是否显示确认关闭模拟器/游戏的提示。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="44"/>
+        <source>Automatically saves the emulator state when powering down or exiting. You can then resume directly from where you left off next time.</source>
+        <translation>关闭或退出时自动保存模拟器状态。然后你可以直接从你下次离开的地方继续。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="46"/>
+        <location filename="../generalsettingswidget.cpp" line="52"/>
+        <location filename="../generalsettingswidget.cpp" line="55"/>
+        <location filename="../generalsettingswidget.cpp" line="74"/>
+        <location filename="../generalsettingswidget.cpp" line="76"/>
+        <location filename="../generalsettingswidget.cpp" line="80"/>
+        <location filename="../generalsettingswidget.cpp" line="91"/>
+        <source>Unchecked</source>
+        <translation>不勾选</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="47"/>
+        <source>Automatically switches to fullscreen mode when a game is started.</source>
+        <translation>游戏开始时自动切换到全屏模式。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="50"/>
+        <source>Renders the display of the simulated console to the main window of the application, over the game list. If unchecked, the display will render in a separate window.</source>
+        <translation>将模拟控制台的显示渲染到应用程序的主窗口, 显示在游戏列表上。如果未选中, 则显示将在单独的窗口中渲染。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="53"/>
+        <source>Pauses the emulator when a game is started.</source>
+        <translation>游戏开始时暂停模拟器。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="56"/>
+        <source>When enabled, memory cards and controllers will be overwritten when save states are loaded. This can result in lost saves, and controller type mismatches. For deterministic save states, enable this option, otherwise leave disabled.</source>
+        <translation>启用后, 记忆卡和控制器将在加载即时存档时被覆盖。这可能导致保存丢失, 以及控制器类型不匹配。对于确定性保存状态, 请启用此选项, 否则保持禁用状态。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="61"/>
+        <source>Throttles the emulation speed to the chosen speed above. If unchecked, the emulator will run as fast as possible, which may not be playable.</source>
+        <translation>将模拟速度调节到上述选定速度。如果未选中, 模拟器将以最快的速度运行, 这可能无法播放。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="65"/>
+        <source>Increases the system timer resolution when emulation is started to provide more accurate frame pacing. May increase battery usage on laptops.</source>
+        <translation>在开始模拟时增加系统计时器分辨率, 以提供更精确的帧间距。可能会增加笔记本电脑的电池使用量。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="69"/>
+        <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached, and if not, the emulator will run as fast as it can manage.</source>
+        <translation>设置目标模拟速度。不能保证达到这个速度, 如果不能, 模拟器将以它能管理的速度运行。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="71"/>
+        <source>Show OSD Messages</source>
+        <translation>显示屏幕消息</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="72"/>
+        <source>Shows on-screen-display messages when events occur such as save states being created/loaded, screenshots being taken, etc.</source>
+        <translation>在发生事件(如正在创建/读取即时存档、正在拍摄屏幕截图等)时显示屏幕显示消息。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="75"/>
+        <source>Shows the internal frame rate of the game in the top-right corner of the display.</source>
+        <translation>在显示屏的右上角显示游戏的内部帧速率。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="77"/>
+        <source>Shows the number of frames (or v-syncs) displayed per second by the system in the top-right corner of the display.</source>
+        <translation>在显示屏右上角显示系统每秒显示的帧数(或垂直同步)。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="80"/>
+        <source>Show Speed</source>
+        <translation>显示速度</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="81"/>
+        <source>Shows the current emulation speed of the system in the top-right corner of the display as a percentage.</source>
+        <translation>在显示屏右上角以百分比显示系统的当前模拟速度。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="87"/>
+        <location filename="../generalsettingswidget.cpp" line="91"/>
+        <source>Enable Discord Presence</source>
+        <translation>启用Discord Presence</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="92"/>
+        <source>Shows the game you are currently playing as part of your profile in Discord.</source>
+        <translation>在Discord中显示您当前正在玩的游戏。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="97"/>
+        <location filename="../generalsettingswidget.cpp" line="101"/>
+        <source>Enable Automatic Update Check</source>
+        <translation>启用自动更新检查</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="102"/>
+        <source>Automatically checks for updates to the program on startup. Updates can be deferred until later or skipped entirely.</source>
+        <translation>启动时自动检查程序的更新, 可以选择稍后更新或完全跳过。</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="116"/>
+        <source>%1%</source>
+        <translation>%1%</translation>
+    </message>
+</context>
+<context>
+    <name>InputBindingDialog</name>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="17"/>
+        <source>Edit Bindings</source>
+        <translation>编辑绑定</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="26"/>
+        <source>Bindings for Controller0/ButtonCircle</source>
+        <translation>控制器0/按钮圈绑定</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="45"/>
+        <source>Add Binding</source>
+        <translation>添加绑定</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="52"/>
+        <source>Remove Binding</source>
+        <translation>移除绑定</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="59"/>
+        <source>Clear Bindings</source>
+        <translation>清除绑定</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.cpp" line="21"/>
+        <source>Bindings for %1 %2</source>
+        <translation>为%1 %2绑定</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.cpp" line="57"/>
+        <location filename="../inputbindingdialog.cpp" line="69"/>
+        <source>Push Button/Axis... [%1]</source>
+        <translation>按钮/轴... [%1]</translation>
+    </message>
+</context>
+<context>
+    <name>InputBindingWidget</name>
+    <message>
+        <location filename="../inputbindingwidgets.cpp" line="38"/>
+        <source>%1 bindings</source>
+        <translation>%1 绑定</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingwidgets.cpp" line="140"/>
+        <location filename="../inputbindingwidgets.cpp" line="152"/>
+        <source>Push Button/Axis... [%1]</source>
+        <translation>按钮/轴... [%1]</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.ui" line="14"/>
+        <location filename="../mainwindow.cpp" line="60"/>
+        <location filename="../mainwindow.cpp" line="71"/>
+        <location filename="../mainwindow.cpp" line="482"/>
+        <source>DuckStation</source>
+        <translation>DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="38"/>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="42"/>
+        <location filename="../mainwindow.cpp" line="403"/>
+        <source>Change Disc</source>
+        <translation>换碟</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="54"/>
+        <source>Load State</source>
+        <translation>即时读档</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="63"/>
+        <source>Save State</source>
+        <translation>即时存档</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="86"/>
+        <source>S&amp;ettings</source>
+        <translation>设置(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="90"/>
+        <source>Theme</source>
+        <translation>主题</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="95"/>
+        <source>Language</source>
+        <translation>语言</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="119"/>
+        <source>&amp;Help</source>
+        <translation>帮助(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="131"/>
+        <source>&amp;Debug</source>
+        <translation>调试(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="135"/>
+        <source>Switch GPU Renderer</source>
+        <translation>切换到GPU渲染器</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="140"/>
+        <source>Switch CPU Emulation Mode</source>
+        <translation>切换到CPU模拟模式</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="164"/>
+        <source>toolBar</source>
+        <translation>工具栏</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="203"/>
+        <source>Start &amp;Disc...</source>
+        <translation>启动光盘(&amp;D)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="212"/>
+        <source>Start &amp;BIOS</source>
+        <translation>启动BIOS(&amp;B)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="221"/>
+        <source>&amp;Scan For New Games</source>
+        <translation>扫描新游戏(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="230"/>
+        <source>&amp;Rescan All Games</source>
+        <translation>重新扫描所有游戏(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="239"/>
+        <source>Power &amp;Off</source>
+        <translation>关机(&amp;O)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="248"/>
+        <source>&amp;Reset</source>
+        <translation>重启(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="260"/>
+        <source>&amp;Pause</source>
+        <translation>暂停(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="269"/>
+        <source>&amp;Load State</source>
+        <translation>即时读档(&amp;L)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="278"/>
+        <source>&amp;Save State</source>
+        <translation>即时存档(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="283"/>
+        <source>E&amp;xit</source>
+        <translation>退出(&amp;X)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="292"/>
+        <source>C&amp;onsole Settings...</source>
+        <translation>主机设置(&amp;O)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="301"/>
+        <source>&amp;Controller Settings...</source>
+        <translation>控制器设置(&amp;C)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="310"/>
+        <source>&amp;Hotkey Settings...</source>
+        <translation>快捷键设置(&amp;H)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="319"/>
+        <source>&amp;GPU Settings...</source>
+        <translation>视频设置(&amp;G)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="328"/>
+        <source>Fullscreen</source>
+        <translation>全屏</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="333"/>
+        <source>Resolution Scale</source>
+        <translation>分辨率缩放</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="338"/>
+        <source>&amp;GitHub Repository...</source>
+        <translation>GitHub库(&amp;G)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="343"/>
+        <source>&amp;Issue Tracker...</source>
+        <translation>问题反馈(&amp;I)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="348"/>
+        <source>&amp;Discord Server...</source>
+        <translation>Discord服务器(&amp;D)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="353"/>
+        <source>Check for &amp;Updates...</source>
+        <translation>检查更新(&amp;U)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="358"/>
+        <source>&amp;About...</source>
+        <translation>关于(&amp;A)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="367"/>
+        <source>Change Disc...</source>
+        <translation>换碟...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="376"/>
+        <source>Audio Settings...</source>
+        <translation>音频设置...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="385"/>
+        <source>Game List Settings...</source>
+        <translation>游戏列表设置...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="394"/>
+        <source>General Settings...</source>
+        <translation>常规设置...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="403"/>
+        <source>Advanced Settings...</source>
+        <translation>高级设置...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="412"/>
+        <source>Add Game Directory...</source>
+        <translation>添加游戏路径...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="421"/>
+        <source>&amp;Settings...</source>
+        <translation>设置(&amp;S)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="426"/>
+        <source>From File...</source>
+        <translation>从文件...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="431"/>
+        <source>From Game List...</source>
+        <translation>从列表...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="436"/>
+        <source>Remove Disc</source>
+        <translation>取出光盘</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="441"/>
+        <source>Resume State</source>
+        <translation>恢复状态</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="446"/>
+        <source>Global State</source>
+        <translation>全局状态</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="454"/>
+        <source>Show VRAM</source>
+        <translation>显示显存</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="462"/>
+        <source>Dump CPU to VRAM Copies</source>
+        <translation>将CPU转存到显存拷贝</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="470"/>
+        <source>Dump VRAM to CPU Copies</source>
+        <translation>将显存转存到CPU拷贝</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="478"/>
+        <source>Dump Audio</source>
+        <translation>导出音频</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="486"/>
+        <source>Show GPU State</source>
+        <translation>显示GPU状态</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="494"/>
+        <source>Show CDROM State</source>
+        <translation>显示光盘状态</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="502"/>
+        <source>Show SPU State</source>
+        <translation>显示SPU状态</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="510"/>
+        <source>Show Timers State</source>
+        <translation>显示计时器状态</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="518"/>
+        <source>Show MDEC State</source>
+        <translation>显示MDEC状态</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="527"/>
+        <source>&amp;Screenshot</source>
+        <translation>截图(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="536"/>
+        <source>&amp;Memory Card Settings...</source>
+        <translation>记忆卡设置(&amp;M)...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="545"/>
+        <source>Resume</source>
+        <translation>恢复</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="548"/>
+        <source>Resumes the last save state created.</source>
+        <translation>恢复上次创建的保存状态。</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="116"/>
+        <source>Failed to create host display device context.</source>
+        <translation>无法创建主机显示设备内容。</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="266"/>
+        <location filename="../mainwindow.cpp" line="284"/>
+        <source>Select Disc Image</source>
+        <translation>选择光盘镜像</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="368"/>
+        <source>Properties...</source>
+        <translation>属性...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="371"/>
+        <source>Open Containing Directory...</source>
+        <translation>打开所在目录...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <source>Default Boot</source>
+        <translation>默认启动</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="389"/>
+        <source>Fast Boot</source>
+        <translation>快速启动</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="395"/>
+        <source>Full Boot</source>
+        <translation>完全启动</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="413"/>
+        <source>Add Search Directory...</source>
+        <translation>添加搜索目录...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="483"/>
+        <source>Language changed. Please restart the application to apply.</source>
+        <translation>语言已更改, 请重新启动应用程序以应用。</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="660"/>
+        <source>Default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="661"/>
+        <source>DarkFusion</source>
+        <translation>黑色</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="662"/>
+        <source>QDarkStyle</source>
+        <translation>深色</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="835"/>
+        <source>Updater Error</source>
+        <translation>更新程序错误</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="841"/>
+        <source>&lt;p&gt;Sorry, you are trying to update a DuckStation version which is not an official GitHub release. To prevent incompatibilities, the auto-updater is only enabled on official builds.&lt;/p&gt;&lt;p&gt;To obtain an official build, please follow the instructions under &quot;Downloading and Running&quot; at the link below:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/&quot;&gt;https://github.com/stenzek/duckstation/&lt;/a&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;抱歉, 您正在尝试更新非GitHub官方版本的DuckStation版本。为防止不兼容, 自动更新程序仅在正式版本上启用。&lt;/p&gt;&lt;p&gt;要获取正式版本,请按照下面链接中的&quot;下载并运行&quot;下的说明进行操作：&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/&quot;&gt;https://github.com/stenzek/duckstation/&lt;/a&gt;lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="847"/>
+        <source>Automatic updating is not supported on the current platform.</source>
+        <translation>当前平台不支持自动更新。</translation>
+    </message>
+</context>
+<context>
+    <name>MemoryCardSettingsWidget</name>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="38"/>
+        <source>If one of the &quot;separate card per game&quot; memory card modes is chosen, these memory cards will be saved to the memcards directory.</source>
+        <translation>如果选择了&quot;每个游戏独立记忆卡&quot;的存储卡模式, 这些存储卡将保存到memcards目录中。</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="44"/>
+        <source>Open...</source>
+        <translation>打开...</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="57"/>
+        <source>Memory Card %1</source>
+        <translation>记忆卡%1</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="71"/>
+        <source>Memory Card Type:</source>
+        <translation>记忆卡类型:</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="80"/>
+        <source>Browse...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="84"/>
+        <source>Shared Memory Card Path:</source>
+        <translation>共用记忆卡路径:</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="93"/>
+        <source>Select path to memory card image</source>
+        <translation>选择记忆卡文件的路径</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="32"/>
+        <source>DuckStation Error</source>
+        <translation>DuckStation错误</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="33"/>
+        <source>Failed to initialize host interface. Cannot continue.</source>
+        <translation>初始化主机接口失败, 无法继续。</translation>
+    </message>
+    <message>
+        <location filename="../qtutils.cpp" line="628"/>
+        <source>Failed to open URL</source>
+        <translation>无法打开URL</translation>
+    </message>
+    <message>
+        <location filename="../qtutils.cpp" line="629"/>
+        <source>Failed to open URL.
+
+The URL was: %1</source>
+        <translation>无法打开URL
+
+URL: %1</translation>
+    </message>
+</context>
+<context>
+    <name>QtHostInterface</name>
+    <message>
+        <location filename="../qthostinterface.cpp" line="856"/>
+        <source>Resume</source>
+        <translation>恢复</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="859"/>
+        <source>Load State</source>
+        <translation>即时读档</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="877"/>
+        <source>Resume (%1)</source>
+        <translation>恢复(%1)</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="884"/>
+        <source>%1 Save %2 (%3)</source>
+        <translation>&quot;%1保存%2 (%3)</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="884"/>
+        <source>Game</source>
+        <translation>游戏</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="891"/>
+        <source>Delete Save States...</source>
+        <translation>删除即时存档...</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="898"/>
+        <source>Confirm Save State Deletion</source>
+        <translation>确认删除即时存档</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="899"/>
+        <source>Are you sure you want to delete all save states for %1?
+
+The saves will not be recoverable.</source>
+        <translation>确定要删除%1的所有即时存档吗？
+
+即时存档将无法恢复。</translation>
+    </message>
+</context>
+<context>
+    <name>QtProgressCallback</name>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="10"/>
+        <source>DuckStation</source>
+        <translation>DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="29"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="82"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="87"/>
+        <source>Question</source>
+        <translation>问题</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="93"/>
+        <source>Information</source>
+        <translation>信息</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../settingsdialog.ui" line="23"/>
+        <source>DuckStation Settings</source>
+        <translation>DuckStation设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="63"/>
+        <source>General Settings</source>
+        <translation>常规设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="72"/>
+        <source>Console Settings</source>
+        <translation>主机设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="81"/>
+        <source>Game List Settings</source>
+        <translation>游戏列表设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="90"/>
+        <source>Hotkey Settings</source>
+        <translation>快捷键设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="99"/>
+        <source>Controller Settings</source>
+        <translation>控制器设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="108"/>
+        <source>Memory Card Settings</source>
+        <translation>记忆卡设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="117"/>
+        <source>GPU Settings</source>
+        <translation>视频设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="126"/>
+        <source>Audio Settings</source>
+        <translation>音频设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="135"/>
+        <source>Advanced Settings</source>
+        <translation>高级设置</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="54"/>
+        <source>&lt;strong&gt;General Settings&lt;/strong&gt;&lt;hr&gt;These options control how the emulator looks and behaves.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;常规设置&lt;/strong&gt;&lt;hr&gt;这些选项控制模拟器的外观和行为。&lt;br&gt;&lt;br&gt;将鼠标悬停在某个选项上以获取其他信息。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="58"/>
+        <source>&lt;strong&gt;Console Settings&lt;/strong&gt;&lt;hr&gt;These options determine the configuration of the simulated console.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;主机设置&lt;/strong&gt;&lt;hr&gt;这些选项决定了模拟主机的配置。&lt;br&gt;&lt;br&gt;将鼠标悬停在某个选项上以获取其他信息。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="61"/>
+        <source>&lt;strong&gt;Game List Settings&lt;/strong&gt;&lt;hr&gt;The list above shows the directories which will be searched by DuckStation to populate the game list. Search directories can be added, removed, and switched to recursive/non-recursive. Additionally, the redump.org database can be downloaded or updated to provide titles for discs, as the discs themselves do not provide title information.</source>
+        <translation>&lt;strong&gt;游戏列表设置&lt;/strong&gt;&lt;hr&gt;上面的列表显示了由DuckStation搜索以添加游戏列表的目录, 可以添加、删除搜索目录, 并将其切换到深度搜索/非深度搜索目录。此外redump.org网站可以下载或更新数据库以提供光盘的标题, 因为光盘本身不提供标题信息。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="66"/>
+        <source>&lt;strong&gt;Hotkey Settings&lt;/strong&gt;&lt;hr&gt;Binding a hotkey allows you to trigger events such as a resetting or taking screenshots at the press of a key/controller button. Hotkey titles are self-explanatory. Clicking a binding will start a countdown, in which case you should press the key or controller button/axis you wish to bind. If no button  is pressed and the timer lapses, the binding will be unchanged. To clear a binding, right-click the button. To  bind multiple buttons, hold Shift and click the button.</source>
+        <translation>&lt;strong&gt;快捷键设置&lt;/strong&gt;&lt;hr&gt;绑定热键可以触发事件, 例如按下键/控制器按钮时重置或截屏。热键标题是不言而喻的。单击绑定将开始倒计时, 在这种情况下, 您应该按要绑定的键或控制器按钮/轴。如果没有按下任何按钮, 计时器过期, 绑定将保持不变。要清除绑定, 请右键单击该按钮。若要绑定多个按钮, 请按住Shift键并单击该按钮。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="72"/>
+        <source>&lt;strong&gt;Controller Settings&lt;/strong&gt;&lt;hr&gt;This page lets you choose the type of controller you wish to simulate for the console, and rebind the keys or host game controller buttons to your choosing. Clicking a binding will start a countdown, in which case you should press the key or controller button/axis you wish to bind. (For rumble, press any button/axis on the controller you wish to send rumble to.) If no button is pressed and the timer lapses, the binding will be unchanged. To clear a binding, right-click the button. To bind multiple buttons, hold Shift and click the button.</source>
+        <translation>&lt;strong&gt;控制器设置&lt;/strong&gt;&lt;hr&gt;此页允许您选择要为控制台模拟的控制器类型, 并将按键或主机游戏控制器按钮重新绑定到您选择的位置。单击绑定将开始倒计时, 在这种情况下, 您应该按要绑定的键或控制器按钮/轴。（对于rumble, 请按您要发送rumble的控制器上的任何按钮/轴。）如果没有按下任何按钮并且计时器过期, 绑定将保持不变。要清除绑定, 请右键单击该按钮。若要绑定多个按钮, 请按住Shift键并单击该按钮。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="80"/>
+        <source>&lt;strong&gt;Memory Card Settings&lt;/strong&gt;&lt;hr&gt;This page lets you control what mode the memory card emulation will function in, and where the images for these cards will be stored on disk.</source>
+        <translation>&lt;strong&gt;记忆卡设置&lt;/strong&gt;&lt;hr&gt;此页允许您控制记忆卡的工作模式, 以及这些记忆卡的文件将存储在磁盘上的位置。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="83"/>
+        <source>&lt;strong&gt;GPU Settings&lt;/strong&gt;&lt;hr&gt;These options control the simulation of the GPU in the console. Various enhancements are available, mouse over each for additional information.</source>
+        <translation>&lt;strong&gt;视频设置&lt;/strong&gt;&lt;hr&gt;这些选项控制主机中GPU的模拟。提供了各种增强功能, 将鼠标悬停在每个功能上可获得更多信息。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="86"/>
+        <source>&lt;strong&gt;Audio Settings&lt;/strong&gt;&lt;hr&gt;These options control the audio output of the console. Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;音频设置&lt;/strong&gt;&lt;hr&gt;这些选项控制主机的音频输出。将鼠标悬停在某个选项上以获取其他信息。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="88"/>
+        <source>&lt;strong&gt;Advanced Settings&lt;/strong&gt;&lt;hr&gt;These options control logging and internal behavior of the emulator. Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;高级设置&lt;/strong&gt;&lt;hr&gt;这些选项控制模拟器的日志记录和内部行为。将鼠标悬停在某个选项上以获取其他信息。</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="115"/>
+        <source>Recommended Value</source>
+        <translation>推荐</translation>
+    </message>
+</context>
+</TS>

--- a/src/duckstation-qt/update_translations.bat
+++ b/src/duckstation-qt/update_translations.bat
@@ -2,4 +2,5 @@
 ..\..\dep\msvc\qt\5.15.0\msvc2017_64\bin\lupdate.exe ./ -ts translations\duckstation-qt_he.ts
 ..\..\dep\msvc\qt\5.15.0\msvc2017_64\bin\lupdate.exe ./ -ts translations\duckstation-qt_pt-br.ts
 ..\..\dep\msvc\qt\5.15.0\msvc2017_64\bin\lupdate.exe ./ -ts translations\duckstation-qt_pt-pt.ts
+..\..\dep\msvc\qt\5.15.0\msvc2017_64\bin\lupdate.exe ./ -ts translations\duckstation-qt_zh-cn.ts
 pause


### PR DESCRIPTION
This is an edited version of @phoe-nix's translation, with various formatting and typo fixes plus build integration.

In particular, 着色器 was changed to 色彩抖动 where applicable since the former refers to shaders while the latter refers specifically to color dithering.