### PR TITLE
Added universal Spanish translation

### DIFF
--- a/src/duckstation-qt/translations/duckstation-qt_es.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_es.ts
@@ -1,0 +1,2044 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../aboutdialog.ui" line="14"/>
+        <source>About DuckStation</source>
+        <translation>Acerca de DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.ui" line="101"/>
+        <source>DuckStation</source>
+        <translation>DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="14"/>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="29"/>
+        <source>DuckStation is a free and open-source simulator/emulator of the Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt; console, focusing on playability, speed, and long-term maintainability.</source>
+        <translation>DuckStation es un emulador/simulador gratuito y de código abierto de la consola Sony PlayStation, haciendo foco en jugabilidad, velocidad y mantenimiento a largo plazo.</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="32"/>
+        <source>Authors</source>
+        <translation>Autores</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="33"/>
+        <source>Icon by</source>
+        <translation>Icono por</translation>
+    </message>
+    <message>
+        <location filename="../aboutdialog.cpp" line="34"/>
+        <source>License</source>
+        <translation>Licencia</translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedSettingsWidget</name>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="32"/>
+        <source>Logging</source>
+        <translation>Registro</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="40"/>
+        <source>Log Level:</source>
+        <translation>Nivel de registro:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="50"/>
+        <source>Log Filters:</source>
+        <translation>Filtros de registro:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="64"/>
+        <source>Log To System Console</source>
+        <translation>Registrar a consola del sistema</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="71"/>
+        <source>Log To Window</source>
+        <translation>Registrar a ventana</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="78"/>
+        <source>Log To Debug Console</source>
+        <translation>Registrar a consola de depuración</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="85"/>
+        <source>Log To File</source>
+        <translation>Registrar a archivo</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="97"/>
+        <source>Tweaks/Hacks</source>
+        <translation>Modificaciones/Hacks</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="103"/>
+        <source>These options are tweakable to improve performance/game compatibility. Use at your own risk, modified values will not be supported.</source>
+        <translation>Estas opciones se pueden modificar para mejorar el rendimiento y compatibilidad. Úsalas bajo tu propio riesgo, no se dará soporte al cambio de estos valores.</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="113"/>
+        <source>DMA Max Slice Ticks:</source>
+        <translation>DMA Max Slice Ticks:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="133"/>
+        <source>DMA Halt Ticks:</source>
+        <translation>DMA Halt Ticks:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="166"/>
+        <source>GPU FIFO Size:</source>
+        <translation>GPU FIFO Size:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="173"/>
+        <source>GPU Max Run-Ahead:</source>
+        <translation>GPU Max Run-Ahead:</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="190"/>
+        <source>Reset To Default</source>
+        <translation>Restablecer predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="197"/>
+        <source>Enable Recompiler Memory Exceptions</source>
+        <translation>Habilitar excepciones de memoria del recompilador</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="207"/>
+        <source>System Settings</source>
+        <translation>Opciones del Sistema</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.ui" line="213"/>
+        <location filename="../advancedsettingswidget.cpp" line="34"/>
+        <source>Use Debug Host GPU Device</source>
+        <translation>Usar dispositivo gráfico de depuración</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="34"/>
+        <source>Unchecked</source>
+        <translation>Deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="35"/>
+        <source>Enables the usage of debug devices and shaders for rendering APIs which support them. Should only be used when debugging the emulator.</source>
+        <translation>Habilita el uso de dispositivos y shaders de depuración para las APIs de renderizado que lo soporten. Sólo se debe usar para depuración.</translation>
+    </message>
+</context>
+<context>
+    <name>AudioSettingsWidget</name>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="32"/>
+        <source>Configuration</source>
+        <translation>Configuración</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="38"/>
+        <source>Backend:</source>
+        <translation>Motor:</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="48"/>
+        <source>Buffer Size:</source>
+        <translation>Tamaño de búfer:</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="93"/>
+        <source>Maximum latency: 0 frames (0.00ms)</source>
+        <translation>Latencia máxima: 0 fotogramas (0.00ms)</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="103"/>
+        <source>Sync To Output</source>
+        <translation>Sincronizar a salida</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="110"/>
+        <source>Start Dumping On Boot</source>
+        <translation>Comenzar volcado en inicio</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="120"/>
+        <source>Controls</source>
+        <translation>Controles</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="126"/>
+        <source>Volume:</source>
+        <translation>Volumen:</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="152"/>
+        <location filename="../audiosettingswidget.cpp" line="53"/>
+        <source>Mute</source>
+        <translation>Silenciar</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="159"/>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="34"/>
+        <source>Audio Backend</source>
+        <translation>Motor de audio</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="35"/>
+        <source>The audio backend determines how frames produced by the emulator are submitted to the host. Cubeb provides the lowest latency, if you encounter issues, try the SDL backend. The null backend disables all host audio output.</source>
+        <translation>El motor de audio determina como se envían los fotogramas producidos por el emulador al anfitrión. Cubeb provee la menor latencia, si encuentras problemas prueba con el motor SDL. El motor nulo deshabilita cualquier salida de audio.</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="39"/>
+        <source>Buffer Size</source>
+        <translation>Tamaño de búfer</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="40"/>
+        <source>The buffer size determines the size of the chunks of audio which will be pulled by the host. Smaller values reduce the output latency, but may cause hitches if the emulation speed is inconsistent. Note that the Cubeb backend uses smaller chunks regardless of this value, so using a low value here may not significantly change latency.</source>
+        <translation>El tamaño de búfer determina el tamaño de los trozos de audio que serán enviados por el anfitrión. Valores más pequeños reducen la latencia de salida, pero puede causar imperfecciones si la emulación no es consistente. Ten en cuenta que el motor Cubeb usa trozos más pequeños a pesar de este valor, por lo que usar valores más pequeños en este caso puede no cambiar mucho la latencia.</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="45"/>
+        <source>Checked</source>
+        <translation>Habilitado</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="46"/>
+        <source>Throttles the emulation speed based on the audio backend pulling audio frames. Sync will automatically be disabled if not running at 100% speed.</source>
+        <translation>Acelera la velocidad de la emulación basado en los fotogramas de audio enviados por el motor de audio. La sincronización se desabilitará automáticamente si la velocidad no es del 100%.</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="49"/>
+        <location filename="../audiosettingswidget.cpp" line="53"/>
+        <source>Unchecked</source>
+        <translation>Deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="50"/>
+        <source>Start dumping audio to file as soon as the emulator is started. Mainly useful as a debug option.</source>
+        <translation>Comenzar a volcar audio en archivos tan pronto se inicia el emulador. Principalmente útil para depuración.</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="51"/>
+        <source>Volume</source>
+        <translation>Volumen</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="52"/>
+        <source>Controls the volume of the audio played on the host. Values are in percentage.</source>
+        <translation>Controla el volúmen de reproducción de audio. Los valores están en porcentaje.</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="54"/>
+        <source>Prevents the emulator from producing any audible sound.</source>
+        <translation>Previene al emulador de producir cualquier sonido.</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="64"/>
+        <source>Maximum latency: %1 frames (%2ms)</source>
+        <translation>Latencia máxima: %1 fotogramas (%2ms)</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="69"/>
+        <source>%1%</source>
+        <translation>%1%</translation>
+    </message>
+</context>
+<context>
+    <name>AutoUpdaterDialog</name>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="17"/>
+        <location filename="../autoupdaterdialog.cpp" line="147"/>
+        <location filename="../autoupdaterdialog.cpp" line="234"/>
+        <source>Automatic Updater</source>
+        <translation>Actualizador</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="33"/>
+        <source>Update Available</source>
+        <translation>Actualización Disponible</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="40"/>
+        <source>Current Version: </source>
+        <translation>Versión actual: </translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="47"/>
+        <source>New Version: </source>
+        <translation>Nueva versión: </translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="54"/>
+        <source>Update Notes:</source>
+        <translation>Notas de actualización:</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="83"/>
+        <source>Download and Install...</source>
+        <translation>Descargar e instalar...</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="90"/>
+        <source>Skip This Update</source>
+        <translation>Saltar actualización</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.ui" line="97"/>
+        <source>Remind Me Later</source>
+        <translation>Recordar más tarde</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="81"/>
+        <source>Updater Error</source>
+        <translation>Error de actualización</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="148"/>
+        <source>No updates are currently available. Please try again later.</source>
+        <translation>Actualmente no hay actualizaciones disponibles. Intenta más tarde.</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="199"/>
+        <source>Current Version: %1 (%2)</source>
+        <translation>Versión actual: %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="201"/>
+        <source>New Version: %1 (%2)</source>
+        <translation>Nueva versión: %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="233"/>
+        <source>Downloading %1...</source>
+        <translation>Descargando %1...</translation>
+    </message>
+    <message>
+        <location filename="../autoupdaterdialog.cpp" line="233"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>ConsoleSettingsWidget</name>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="32"/>
+        <source>Console</source>
+        <translation>Consola</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="38"/>
+        <source>Region:</source>
+        <translation>Región:</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="48"/>
+        <source>BIOS Image Path:</source>
+        <translation>Dirección de BIOS:</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="55"/>
+        <location filename="../consolesettingswidget.cpp" line="35"/>
+        <source>Fast Boot</source>
+        <translation>Inicio rápido</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="62"/>
+        <source>Enable TTY Output</source>
+        <translation>Habilitar salida por terminal</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="74"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="86"/>
+        <source>CPU Emulation</source>
+        <translation>Emulación de CPU</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="92"/>
+        <source>Execution Mode:</source>
+        <translation>Modo de ejecución:</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="105"/>
+        <source>CDROM Emulation</source>
+        <translation>Emulación de CDROM</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="111"/>
+        <source>Use Read Thread (Asynchronous)</source>
+        <translation>Usar hilo de lectura (asincrónico)</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="118"/>
+        <source>Enable Region Check</source>
+        <translation>Habilitar chequeo regional</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.ui" line="125"/>
+        <source>Preload Image To RAM</source>
+        <translation>Precargar imagen a RAM</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="35"/>
+        <location filename="../consolesettingswidget.cpp" line="39"/>
+        <source>Unchecked</source>
+        <translation>Deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="36"/>
+        <source>Patches the BIOS to skip the console&apos;s boot animation. Does not work with all games, but usually safe to enabled.</source>
+        <translation>Parchea el BIOS para saltar la animación de inicio de la consola. No funciona con todos los juegos, pero es generalmente seguro de activar.</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="39"/>
+        <source>Preload Image to RAM</source>
+        <translation>Precargar imagen a RAM</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="40"/>
+        <source>Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay.</source>
+        <translation>Carga la imagen del juego en la RAM. Útil para cuando se usan directorios a través de una red.</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="47"/>
+        <source>Select BIOS Image</source>
+        <translation>Selecciona una imagen BIOS</translation>
+    </message>
+</context>
+<context>
+    <name>ControllerSettingsWidget</name>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="82"/>
+        <source>Controller Type:</source>
+        <translation>Tipo de control:</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="113"/>
+        <source>Load Profile</source>
+        <translation>Cargar perfil</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="117"/>
+        <source>Save Profile</source>
+        <translation>Guardar perfil</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="123"/>
+        <source>Clear All</source>
+        <translation>Limpiar todo</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="125"/>
+        <source>Clear Bindings</source>
+        <translation>Limpiar asignados</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="126"/>
+        <source>Are you sure you want to clear all bound controls? This can not be reversed.</source>
+        <translation>¿Estás seguro que quieres borrar todos los controles asignados? No se puede revertir.</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="140"/>
+        <location filename="../controllersettingswidget.cpp" line="142"/>
+        <source>Rebind All</source>
+        <translation>Reasignar todo</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="143"/>
+        <source>Are you sure you want to rebind all controls? All currently-bound controls will be irreversibly cleared. Rebinding will begin after confirmation.</source>
+        <translation>¿Estás seguro que quieres reasignar todos los controles? Todos los controles ya asignados se van a borrar. La reasignación va a comenzar después de confirmar.</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="167"/>
+        <source>Port %1</source>
+        <translation>Puerto %1</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="183"/>
+        <source>Button Bindings:</source>
+        <translation>Asignación de botones:</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="220"/>
+        <source>Axis Bindings:</source>
+        <translation>Asignación de axis:</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="259"/>
+        <source>Rumble</source>
+        <translation>Vibración</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="345"/>
+        <location filename="../controllersettingswidget.cpp" line="394"/>
+        <location filename="../controllersettingswidget.cpp" line="435"/>
+        <source>Browse...</source>
+        <translation>Buscar...</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="349"/>
+        <source>Select File</source>
+        <translation>Seleccionar archivo</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="397"/>
+        <location filename="../controllersettingswidget.cpp" line="437"/>
+        <source>Select path to input profile ini</source>
+        <translation>Seleccionar archivo de perfil de control</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="421"/>
+        <source>New...</source>
+        <translation>Nuevo...</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="423"/>
+        <location filename="../controllersettingswidget.cpp" line="424"/>
+        <source>Enter Input Profile Name</source>
+        <translation>Ingresar nombre de perfil</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="427"/>
+        <location filename="../controllersettingswidget.cpp" line="441"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="428"/>
+        <source>No name entered, input profile was not saved.</source>
+        <translation>No se indicó un nombre, el perfil de control no se guardó.</translation>
+    </message>
+    <message>
+        <location filename="../controllersettingswidget.cpp" line="442"/>
+        <source>No path selected, input profile was not saved.</source>
+        <translation>No se indicó un directorio, el perfil de control no se guardó.</translation>
+    </message>
+</context>
+<context>
+    <name>GPUSettingsWidget</name>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="47"/>
+        <source>Basic</source>
+        <translation>Básico</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="53"/>
+        <source>Renderer:</source>
+        <translation>Renderizador:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="63"/>
+        <source>Adapter:</source>
+        <translation>Adaptador:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="76"/>
+        <source>Screen Display</source>
+        <translation>Pantalla</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="82"/>
+        <source>Aspect Ratio:</source>
+        <translation>Relación de aspecto:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="92"/>
+        <source>Crop:</source>
+        <translation>Cortar:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="102"/>
+        <location filename="../gpusettingswidget.cpp" line="88"/>
+        <source>Linear Upscaling</source>
+        <translation>Escalado lineal</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="109"/>
+        <location filename="../gpusettingswidget.cpp" line="93"/>
+        <source>Integer Upscaling</source>
+        <translation>Escalado entero</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="116"/>
+        <location filename="../gpusettingswidget.cpp" line="97"/>
+        <source>VSync</source>
+        <translation>Sincronización vertical</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="126"/>
+        <source>Enhancements</source>
+        <translation>Mejoras</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="132"/>
+        <source>Resolution Scale:</source>
+        <translation>Escala de resolución:</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="142"/>
+        <location filename="../gpusettingswidget.cpp" line="107"/>
+        <source>True Color Rendering (24-bit, disables dithering)</source>
+        <translation>Renderizado de color verdadero (24-bit, deshabilita el tramado)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="149"/>
+        <location filename="../gpusettingswidget.cpp" line="114"/>
+        <source>Scaled Dithering (scale dither pattern to resolution)</source>
+        <translation>Escalado de tramado (patrón a resolución)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="156"/>
+        <location filename="../gpusettingswidget.cpp" line="83"/>
+        <source>Disable Interlacing (force progressive render/scan)</source>
+        <translation>Deshabilitar entrelazado (forzar escaneo progresivo)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="163"/>
+        <location filename="../gpusettingswidget.cpp" line="118"/>
+        <source>Force NTSC Timings (60hz-on-PAL)</source>
+        <translation>Forzar tiempos NTSC (60Hz en PAL)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="170"/>
+        <location filename="../gpusettingswidget.cpp" line="124"/>
+        <source>Bilinear Texture Filtering</source>
+        <translation>Filtrado de texturas bilineal</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="177"/>
+        <location filename="../gpusettingswidget.cpp" line="128"/>
+        <source>Widescreen Hack</source>
+        <translation>Hack de pantalla panorámica</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="187"/>
+        <source>PGXP</source>
+        <translation>PGXP (Parallel/Precision Geometry Transform Pipeline)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="193"/>
+        <location filename="../gpusettingswidget.cpp" line="133"/>
+        <source>Geometry Correction</source>
+        <translation>Correción de geometría</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="200"/>
+        <location filename="../gpusettingswidget.cpp" line="136"/>
+        <source>Culling Correction</source>
+        <translation>Corrección de culling</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="207"/>
+        <location filename="../gpusettingswidget.cpp" line="139"/>
+        <source>Texture Correction</source>
+        <translation>Corrección de texturas</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.ui" line="214"/>
+        <location filename="../gpusettingswidget.cpp" line="142"/>
+        <source>Vertex Cache</source>
+        <translation>Caché de vértices</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="63"/>
+        <source>Renderer</source>
+        <translation>Renderizador</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="64"/>
+        <source>Chooses the backend to use for rendering tasks for the the console GPU. Depending on your system and hardware, Direct3D 11 and OpenGL hardware backends may be available. The software renderer offers the best compatibility, but is the slowest and does not offer any enhancements.</source>
+        <translation>Elije el motor a usar para las tareas de renderizado para la GPU de la consola. Dependiendo en tu hardware y sistema, los motores Direct3D 11 y OpenGL podrán estar disponibles. El renderizador por software ofrece la mejor compatibilidad, pero es el más lento y no permite seleccionar ninguna mejora.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="69"/>
+        <source>Adapter</source>
+        <translation>Adaptador</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="69"/>
+        <location filename="../gpusettingswidget.cpp" line="224"/>
+        <source>(Default)</source>
+        <translation>(Predeterminado)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="70"/>
+        <source>If your system contains multiple GPUs or adapters, you can select which GPU you wish to use for the hardware renderers. This option is only supported in Direct3D and Vulkan, OpenGL will always use the default device.</source>
+        <translation>Si tu sistema tiene múltiples GPUs o adaptadores, puedes elegir cual quieres usar para los renderizadores. Esta opción sólo está disponible en Direct3D y Vulkan, OpenGL siempre usa el dispositivo por defecto.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="73"/>
+        <source>Aspect Ratio</source>
+        <translation>Relación de aspecto</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="74"/>
+        <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is 4:3 which matches a typical TV of the era.</source>
+        <translation>Cambia la relación de aspecto usada para mostrar la salida de la consola en la pantalla. La opción por defecto es 4:3, la cual coincide con una televisión de la época.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="77"/>
+        <source>Crop Mode</source>
+        <translation>Modo de corte</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="77"/>
+        <source>Only Overscan Area</source>
+        <translation>Sólo area de sobreescaneo</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="78"/>
+        <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide. Some games display content in the overscan area, or use it for screen effects and may not display correctly with the All Borders setting. Only Overscan offers a good compromise between stability and hiding black borders.</source>
+        <translation>Determina cuanto del área generalmente no visible en un televisor cortar/ocultar. Algunos juegos muestran contenido en el área de sobreescaneo, o la usan para efectos y pueden no mostrarse correctamente si se ocultan todos los bordes. Sólo sobreescaneo ofrece un buen balance entre estabilidad y ocultar bordes.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="83"/>
+        <location filename="../gpusettingswidget.cpp" line="93"/>
+        <location filename="../gpusettingswidget.cpp" line="107"/>
+        <location filename="../gpusettingswidget.cpp" line="118"/>
+        <location filename="../gpusettingswidget.cpp" line="124"/>
+        <location filename="../gpusettingswidget.cpp" line="128"/>
+        <location filename="../gpusettingswidget.cpp" line="133"/>
+        <location filename="../gpusettingswidget.cpp" line="142"/>
+        <source>Unchecked</source>
+        <translation>Deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="84"/>
+        <source>Forces the rendering and display of frames to progressive mode. This removes the &quot;combing&quot; effect seen in 480i games by rendering them in 480p. Not all games are compatible with this option, some require interlaced rendering or render interlaced internally. Usually safe to enable.</source>
+        <translation>Fuerza el renderizado y visualización de fotogramas en modo progresivo. Esto elimina el efecto peine producido por el entrelazado en juegos que usan el modo 480i renderizándolos en 480p. No todos los juegos son compatibles, algunos requieren el renderizado entrelazado o renderizan entrelazado internamente. Usualmente es seguro habilitarlo.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="88"/>
+        <location filename="../gpusettingswidget.cpp" line="97"/>
+        <location filename="../gpusettingswidget.cpp" line="114"/>
+        <location filename="../gpusettingswidget.cpp" line="136"/>
+        <location filename="../gpusettingswidget.cpp" line="139"/>
+        <source>Checked</source>
+        <translation>Habilitado</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="89"/>
+        <source>Uses bilinear texture filtering when displaying the console&apos;s framebuffer to the screen. Disabling filtering will producer a sharper, blockier/pixelated image. Enabling will smooth out the image. The option will be less noticable the higher the resolution scale.</source>
+        <translation>Usa el filtrado de texturas bilineal cuando se muestra el búfer de fotograma en la pantalla. Deshabilitar el filtrado va a producir una imagen más nítida y pixelada/cúbica. Activarlo va a suavizar la imagen. Este efecto se va a percibir menos mientras mayor sea la escala de resolución.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="94"/>
+        <source>Adds padding to the display area to ensure that the ratio between pixels on the host to pixels in the console is an integer number. May result in a sharper image in some 2D games.</source>
+        <translation>Rellena la imagen mostrada para asegurarse que la relación entre los pixeles de la consola y del anfitrión es un número entero. Puede resultar en una imagen más nítida en algunos juegos 2D.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="98"/>
+        <source>Enables synchronization with the host display when possible. Enabling this option will provide better frame pacing and smoother motion with fewer duplicated frames. VSync is automatically disabled when it is not possible (e.g. running at non-100% speed).</source>
+        <translation>Habilita la sincronización con la pantalla del anfitrión cuando sea posible. Habilitar esta opción permite un mejor ritmo de fotogramas y un movimiento más suave y fluido con menos fotogramas duplicados. La sincronización vertical se deshabilita automáticamente cuando no sea posible (como velocidad menor al 100%).</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="102"/>
+        <source>Resolution Scale</source>
+        <translation>Escala de resolución</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="103"/>
+        <source>Enables the upscaling of 3D objects rendered to the console&apos;s framebuffer. Only applies to the hardware backends. This option is usually safe, with most games looking fine at higher resolutions. Higher resolutions require a more powerful GPU.</source>
+        <translation>Habilita el escalado de los objetos 3D renderizados al búfer de fotogramas. Sólo se aplica a los renderizadores por hardware. Usualmente activar esta opción es seguro. Resoluciones más altas requieren una GPU más potente.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="108"/>
+        <source>Forces the precision of colours output to the console&apos;s framebuffer to use the full 8 bits of precision per channel. This produces nicer looking gradients at the cost of making some colours look slightly different. Disabling the option also enables dithering, which makes the transition between colours less sharp by applying a pattern around those pixels. Most games are compatible with this option, but there is a number which aren&apos;t and will have broken effects with it enabled. Only applies to the hardware renderers.</source>
+        <translation>Fuerza la precisión de la salida de colores al búfer de fotogramas para que use la totalidad de los 8 bits de precisión por canal. Esto produce mejores gradientes al costo de hacer algunos colores diferentes. Deshabilitar esta opción también activa el tramado, que hace la transición entre colores menos definida al aplicar un patrón sobre los pixeles. La mayoría de los juegos son compatibles con esta opción, aunque hay algunos que no y pueden presentar efectos incorrectamente. Sólo se aplica a los renderizadores por hardware.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="115"/>
+        <source>Scales the dither pattern to the resolution scale of the emulated GPU. This makes the dither pattern much less obvious at higher resolutions. Usually safe to enable, and only supported by the hardware renderers.</source>
+        <translation>Escala el patrón del tramado a la escala de resolución de la GPU emulada. Esto disimula el tramado en altas resoluciones. Usualmente es seguro habilitarlo, y sólo está soportado por los renderizadores por hardware.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="119"/>
+        <source>Uses NTSC frame timings when the console is in PAL mode, forcing PAL games to run at 60hz. For most games which have a speed tied to the framerate, this will result in the game running approximately 17% faster. For variable frame rate games, it may not affect the speed.</source>
+        <translation>Usa los tiempos de fotograma del modo NTSC cuando la consola está en modo PAL, forzando los juegos PAL a correr a 60Hz. Para la mayoría de los juegos que tienen su velocidad relacionada a los cuadros por segundo, esto va a resultar en el juego corriendo aproximadamente un 17% más rápido. Para juegos con velocidad de fotogramas variable, este problema no debería afectarles.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="125"/>
+        <source>Smooths out the blockyness of magnified textures on 3D object by using bilinear filtering. Will have a greater effect on higher resolution scales. Only applies to the hardware renderers.</source>
+        <translation>Suaviza el efecto pixelado de las texturas magnificadas en objetos 3D usando el filtro bilineal. Va a tener mayor efecto a mayor escala de resolución. Actualmente esta opción produce imperfecciones al rededor de objetos en muchos juegos y necesita más trabajo. Sólo se aplica a los renderizadores por hardware.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="129"/>
+        <source>Scales vertex positions in screen-space to a widescreen aspect ratio, essentially increasing the field of view from 4:3 to 16:9 in 3D games. &lt;br&gt;For 2D games, or games which use pre-rendered backgrounds, this enhancement will not work as expected. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
+        <translation>Escala las posiciones de vértices en pantalla a una relación de aspecto panorámica, incrementando el campo de visión de 4:3 a 16:9 en juegos 3D. En juegos 2D o con fondos pre-renderizados, esta mejora no va a funcionar como se espera.&lt;b&gt;&lt;u&gt;Tal vez no sea compatible con todos los juegos.&lt;/u&gt;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="134"/>
+        <source>Reduces &quot;wobbly&quot; polygons and &quot;warping&quot; textures that are common in PS1 games. &lt;br&gt;Only works with the hardware renderers. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
+        <translation>Reduce el efecto tembloroso de los polígonos y la deformación de texturas que son comunes en los juegos de PlayStation. &lt;br&gt;Sólo funciona con los renderizadores por hardware. &lt;b&gt;&lt;u&gt;Tal vez no sea compatible con todos los juegos.&lt;/u&gt;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="137"/>
+        <source>Increases the precision of polygon culling, reducing the number of holes in geometry. Requires geometry correction enabled.</source>
+        <translation>Incrementa la precisión del culling de polígonos, reduciendo el número de huecos en la geometría. Requiere la correción de geometría activada.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="140"/>
+        <source>Uses perspective-correct interpolation for texture coordinates and colors, straightening out warped textures. Requires geometry correction enabled.</source>
+        <translation>Usa interpolación con perspectiva correcta para las coordenadas de texturas y colores, enderezando texturas deformadas. Requiere la correción de geometría activada.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="143"/>
+        <source>Uses screen coordinates as a fallback when tracking vertices through memory fails. May improve PGXP compatibility.</source>
+        <translation>Usa coordinadas en pantalla como respaldo cuando el rastreo de vértices por memoria falla. Puede mejorar la compatibilidad con PGXP.</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="178"/>
+        <source> (for 720p)</source>
+        <translation> (para 720p)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="180"/>
+        <source> (for 1080p)</source>
+        <translation> (para 1080p)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="181"/>
+        <source> (for 1440p)</source>
+        <translation> (para 1440p)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="184"/>
+        <source> (for 4K)</source>
+        <translation> (para 4K)</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="194"/>
+        <source>Automatic based on window size</source>
+        <translation>Automático basado en el tamaño de la ventana</translation>
+    </message>
+    <message>
+        <location filename="../gpusettingswidget.cpp" line="196"/>
+        <source>%1x%2</source>
+        <translation>%1x%2</translation>
+    </message>
+</context>
+<context>
+    <name>GameListModel</name>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="289"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="290"/>
+        <source>Code</source>
+        <translation>Código</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="291"/>
+        <source>Title</source>
+        <translation>Título</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="292"/>
+        <source>File Title</source>
+        <translation>Título de archivo</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="293"/>
+        <source>Size</source>
+        <translation>Tamaño</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="294"/>
+        <source>Region</source>
+        <translation>Región</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="295"/>
+        <source>Compatibility</source>
+        <translation>Compatibilidad</translation>
+    </message>
+</context>
+<context>
+    <name>GameListSearchDirectoriesModel</name>
+    <message>
+        <location filename="../gamelistsearchdirectoriesmodel.cpp" line="29"/>
+        <source>Path</source>
+        <translation>Directorio</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsearchdirectoriesmodel.cpp" line="31"/>
+        <source>Recursive</source>
+        <translation>Recursivo</translation>
+    </message>
+</context>
+<context>
+    <name>GameListSettingsWidget</name>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="34"/>
+        <source>Search Directories</source>
+        <translation>Buscar en directorios</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="46"/>
+        <source>Add</source>
+        <translation>Añadir</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="57"/>
+        <location filename="../gamelistsettingswidget.cpp" line="85"/>
+        <source>Remove</source>
+        <translation>Borrar</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="81"/>
+        <source>Scan New</source>
+        <translation>Escanear nuevo</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="92"/>
+        <source>Rescan All</source>
+        <translation>Reescanear</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.ui" line="103"/>
+        <source>Update Redump Database</source>
+        <translation>Actualizar Redump</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="87"/>
+        <source>Open Directory...</source>
+        <translation>Abrir directorio...</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="95"/>
+        <source>Select Search Directory</source>
+        <translation>Seleccionar directorio para buscar</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="101"/>
+        <source>Scan Recursively?</source>
+        <translation>¿Escanear recursivamente?</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="102"/>
+        <source>Would you like to scan the directory &quot;%1&quot; recursively?
+
+Scanning recursively takes more time, but will identify files in subdirectories.</source>
+        <translation>¿Quieres escanear el directorio &quot;%1&quot; recursivamente?
+
+Escanear recursivamente lleva más tiempo, pero identifica archivos en subdirectorios.</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="140"/>
+        <source>Download database from redump.org?</source>
+        <translation>¿Descargar base de datos de redump.org?</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="141"/>
+        <source>Do you wish to download the disc database from redump.org?
+
+This will download approximately 4 megabytes over your current internet connection.</source>
+        <translation>¿Quieres descargar la base de datos de discos desde redump.org?
+
+Esto descargará aproximadamente 4MB a través de tu conexión de internet.</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="248"/>
+        <source>Downloading %1...</source>
+        <translation>Descargando %1...</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="248"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="259"/>
+        <source>Download failed</source>
+        <translation>Descarga fallida</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="266"/>
+        <source>Extracting...</source>
+        <translation>Extrayendo...</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="272"/>
+        <source>Extract failed</source>
+        <translation>Extracción fallida</translation>
+    </message>
+    <message>
+        <location filename="../gamelistsettingswidget.cpp" line="272"/>
+        <source>Extracting game database failed.</source>
+        <translation>Extracción de base de datos fallida.</translation>
+    </message>
+</context>
+<context>
+    <name>GamePropertiesDialog</name>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="14"/>
+        <source>Dialog</source>
+        <translation>Diálogo</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="24"/>
+        <source>Image Path:</source>
+        <translation>Dirección de imagen:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="38"/>
+        <source>Game Code:</source>
+        <translation>Código de juego:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="52"/>
+        <source>Title:</source>
+        <translation>Título:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="66"/>
+        <source>Region:</source>
+        <translation>Región:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="80"/>
+        <source>Compatibility:</source>
+        <translation>Compatibilidad:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="90"/>
+        <source>Upscaling Issues:</source>
+        <translation>Problemas de escalado:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="100"/>
+        <source>Comments:</source>
+        <translation>Comentarios:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="110"/>
+        <source>Version Tested:</source>
+        <translation>Versión testeada:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="122"/>
+        <source>Set to Current</source>
+        <translation>Establecer actual</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="131"/>
+        <source>Tracks:</source>
+        <translation>Pistas:</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="148"/>
+        <source>#</source>
+        <translation>#</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="153"/>
+        <source>Mode</source>
+        <translation>Modo</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="158"/>
+        <source>Start</source>
+        <translation>Inicio</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="163"/>
+        <source>Length</source>
+        <translation>Duración</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="168"/>
+        <source>Hash</source>
+        <translation>Hash</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="191"/>
+        <source>Compute Hashes</source>
+        <translation>Calcular hashes</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="198"/>
+        <source>Verify Dump</source>
+        <translation>Verificar volcado</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="205"/>
+        <source>Export Compatibility Info</source>
+        <translation>Exportar información de compatibilidad</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.ui" line="212"/>
+        <source>Close</source>
+        <translation>Cerrar</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="53"/>
+        <source>Game Properties - %1</source>
+        <translation>Propiedades - %1</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="150"/>
+        <source>%1</source>
+        <translation>%1</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="154"/>
+        <source>&lt;not computed&gt;</source>
+        <translation>&lt;sin calcular&gt;</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="244"/>
+        <source>Not yet implemented</source>
+        <translation>Sin implementar</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="258"/>
+        <source>Compatibility Info Export</source>
+        <translation>Exportar información de compatibilidad</translation>
+    </message>
+    <message>
+        <location filename="../gamepropertiesdialog.cpp" line="258"/>
+        <source>Press OK to copy to clipboard.</source>
+        <translation>Presiona Ok para copiar al portapapeles.</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralSettingsWidget</name>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="32"/>
+        <source>Behaviour</source>
+        <translation>Comportamiento</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="38"/>
+        <location filename="../generalsettingswidget.cpp" line="52"/>
+        <source>Pause On Start</source>
+        <translation>Pausar en inicio</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="45"/>
+        <location filename="../generalsettingswidget.cpp" line="40"/>
+        <source>Confirm Power Off</source>
+        <translation>Confirmar apagado</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="52"/>
+        <location filename="../generalsettingswidget.cpp" line="43"/>
+        <source>Save State On Exit</source>
+        <translation>Guardar estado al salir</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="59"/>
+        <location filename="../generalsettingswidget.cpp" line="55"/>
+        <source>Load Devices From Save States</source>
+        <translation>Cargar dispositivos en estados guardados</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="66"/>
+        <location filename="../generalsettingswidget.cpp" line="46"/>
+        <source>Start Fullscreen</source>
+        <translation>Iniciar en pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="73"/>
+        <location filename="../generalsettingswidget.cpp" line="49"/>
+        <source>Render To Main Window</source>
+        <translation>Renderizar a ventana principal</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="83"/>
+        <location filename="../generalsettingswidget.cpp" line="68"/>
+        <source>Emulation Speed</source>
+        <translation>Velocidad de Emulación</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="119"/>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="128"/>
+        <location filename="../generalsettingswidget.cpp" line="60"/>
+        <source>Enable Speed Limiter</source>
+        <translation>Habilitar límite de velocidad</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="135"/>
+        <location filename="../generalsettingswidget.cpp" line="64"/>
+        <source>Increase Timer Resolution</source>
+        <translation>Incrementar la resolución del temporizador</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="145"/>
+        <source>On-Screen Display</source>
+        <translation>Mensajes en Pantalla</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="151"/>
+        <source>Show Messages</source>
+        <translation>Mostrar mensajes</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="158"/>
+        <location filename="../generalsettingswidget.cpp" line="74"/>
+        <source>Show FPS</source>
+        <translation>Mostrar FPS</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="165"/>
+        <source>Show Emulation Speed</source>
+        <translation>Mostrar velocidad de emulación</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.ui" line="172"/>
+        <location filename="../generalsettingswidget.cpp" line="76"/>
+        <source>Show VPS</source>
+        <translation>Mostrar VPS</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="40"/>
+        <location filename="../generalsettingswidget.cpp" line="43"/>
+        <location filename="../generalsettingswidget.cpp" line="49"/>
+        <location filename="../generalsettingswidget.cpp" line="60"/>
+        <location filename="../generalsettingswidget.cpp" line="64"/>
+        <location filename="../generalsettingswidget.cpp" line="71"/>
+        <location filename="../generalsettingswidget.cpp" line="101"/>
+        <source>Checked</source>
+        <translation>Habilitado</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="41"/>
+        <source>Determines whether a prompt will be displayed to confirm shutting down the emulator/game when the hotkey is pressed.</source>
+        <translation>Determina si se mostrará un mensaje de confirmación para cerrar el emulador/juego al presionar un atajo.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="44"/>
+        <source>Automatically saves the emulator state when powering down or exiting. You can then resume directly from where you left off next time.</source>
+        <translation>Guarda automáticamente el estado del emulador al apagar o salir. Después puedes continuar desde donde dejaste la última vez.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="46"/>
+        <location filename="../generalsettingswidget.cpp" line="52"/>
+        <location filename="../generalsettingswidget.cpp" line="55"/>
+        <location filename="../generalsettingswidget.cpp" line="74"/>
+        <location filename="../generalsettingswidget.cpp" line="76"/>
+        <location filename="../generalsettingswidget.cpp" line="80"/>
+        <location filename="../generalsettingswidget.cpp" line="91"/>
+        <source>Unchecked</source>
+        <translation>Deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="47"/>
+        <source>Automatically switches to fullscreen mode when a game is started.</source>
+        <translation>Cambia automáticamente a modo en pantalla completa cuando se inicia un juego.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="50"/>
+        <source>Renders the display of the simulated console to the main window of the application, over the game list. If unchecked, the display will render in a separate window.</source>
+        <translation>Renderiza la imagen de la consola emulada en la ventana principal de la aplicación, sobre la lista de juegos. Si no se activa, la imagen se renderizará en una ventana separada.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="53"/>
+        <source>Pauses the emulator when a game is started.</source>
+        <translation>Pausa el emulador cuando se inicia un juego.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="56"/>
+        <source>When enabled, memory cards and controllers will be overwritten when save states are loaded. This can result in lost saves, and controller type mismatches. For deterministic save states, enable this option, otherwise leave disabled.</source>
+        <translation>Cuando se habilita, los controles y tarjetas de memoria se sobreescribirán cuando se cargar estados guardados. Esto puede resultar en guardados perdidos e incoherencias con el tipo de control. Para estados guardados consistentes, activar esta opción.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="61"/>
+        <source>Throttles the emulation speed to the chosen speed above. If unchecked, the emulator will run as fast as possible, which may not be playable.</source>
+        <translation>Acelera la velocidad de la emulación a la indicada arriba. Si se deshabilita, el emulador funcionará lo más rápido posible, lo cual puede no ser jugable.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="65"/>
+        <source>Increases the system timer resolution when emulation is started to provide more accurate frame pacing. May increase battery usage on laptops.</source>
+        <translation>Incrementa la resolución del temporizador del sistema cuando se inicia la emulación para dar un ritmo de fotogramas más preciso. Puede incrementar el uso de batería en portátiles.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="69"/>
+        <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached, and if not, the emulator will run as fast as it can manage.</source>
+        <translation>Establece la velocidad de emulación de destino. No se asegura que esa velocidad se vaya a alcanzar, y de no hacerlo, el emulador va a correr lo más rápido que pueda.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="71"/>
+        <source>Show OSD Messages</source>
+        <translation>Mostrar mensajes en pantalla</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="72"/>
+        <source>Shows on-screen-display messages when events occur such as save states being created/loaded, screenshots being taken, etc.</source>
+        <translation>Muestra mensajes en pantalla cuando ocurren eventos como crear o cargar estados guardados, tomar capturas, etc.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="75"/>
+        <source>Shows the internal frame rate of the game in the top-right corner of the display.</source>
+        <translation>Muestra la velocidad de fotogramas interna del juego en la esquina superior derecha de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="77"/>
+        <source>Shows the number of frames (or v-syncs) displayed per second by the system in the top-right corner of the display.</source>
+        <translation>Muestra el número de fotogramas (o sincronizaciones verticales) mostradas por segundo por el sistema en la esquina superior derecha de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="80"/>
+        <source>Show Speed</source>
+        <translation>Mostrar velocidad</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="81"/>
+        <source>Shows the current emulation speed of the system in the top-right corner of the display as a percentage.</source>
+        <translation>Muestra la velocidad de emulación actual del sistema en la esquina superior derecha de la pantalla como porcentaje.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="87"/>
+        <location filename="../generalsettingswidget.cpp" line="91"/>
+        <source>Enable Discord Presence</source>
+        <translation>Habilitar Discord Rich Presence</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="92"/>
+        <source>Shows the game you are currently playing as part of your profile in Discord.</source>
+        <translation>Muestra el juego que estás jugando actualmente en tu perfil de Discord.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="97"/>
+        <location filename="../generalsettingswidget.cpp" line="101"/>
+        <source>Enable Automatic Update Check</source>
+        <translation>Habilitar chequeo de actualizaciones automáticas</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="102"/>
+        <source>Automatically checks for updates to the program on startup. Updates can be deferred until later or skipped entirely.</source>
+        <translation>Chequea automáticamente por actualizaciones al iniciar el programa. Pueden posponerse para más adelante o directamente evitarse.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="116"/>
+        <source>%1%</source>
+        <translation>%1%</translation>
+    </message>
+</context>
+<context>
+    <name>InputBindingDialog</name>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="17"/>
+        <source>Edit Bindings</source>
+        <translation>Editar asignaciones</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="26"/>
+        <source>Bindings for Controller0/ButtonCircle</source>
+        <translation>Asignaciones para Controller0/ButtonCircle</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="45"/>
+        <source>Add Binding</source>
+        <translation>Añadir</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="52"/>
+        <source>Remove Binding</source>
+        <translation>Borrar</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.ui" line="59"/>
+        <source>Clear Bindings</source>
+        <translation>Limpiar</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.cpp" line="21"/>
+        <source>Bindings for %1 %2</source>
+        <translation>Asignaciones para %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingdialog.cpp" line="57"/>
+        <location filename="../inputbindingdialog.cpp" line="69"/>
+        <source>Push Button/Axis... [%1]</source>
+        <translation>Presiona un botón/axis [%1]</translation>
+    </message>
+</context>
+<context>
+    <name>InputBindingWidget</name>
+    <message>
+        <location filename="../inputbindingwidgets.cpp" line="38"/>
+        <source>%1 bindings</source>
+        <translation>%1 asignaciones</translation>
+    </message>
+    <message>
+        <location filename="../inputbindingwidgets.cpp" line="140"/>
+        <location filename="../inputbindingwidgets.cpp" line="152"/>
+        <source>Push Button/Axis... [%1]</source>
+        <translation>Presiona un botón/axis [%1]</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../mainwindow.ui" line="14"/>
+        <location filename="../mainwindow.cpp" line="60"/>
+        <location filename="../mainwindow.cpp" line="71"/>
+        <location filename="../mainwindow.cpp" line="482"/>
+        <source>DuckStation</source>
+        <translation>DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="38"/>
+        <source>System</source>
+        <translation>&amp;Sistema</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="42"/>
+        <location filename="../mainwindow.cpp" line="403"/>
+        <source>Change Disc</source>
+        <translation>Cambiar disco</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="54"/>
+        <source>Load State</source>
+        <translation>Cargar estado</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="63"/>
+        <source>Save State</source>
+        <translation>Guardar estado</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="86"/>
+        <source>S&amp;ettings</source>
+        <translation>&amp;Configuración</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="90"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="95"/>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="119"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Ayuda</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="131"/>
+        <source>&amp;Debug</source>
+        <translation>&amp;Depuración</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="135"/>
+        <source>Switch GPU Renderer</source>
+        <translation>Cambiar renderizador de GPU</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="140"/>
+        <source>Switch CPU Emulation Mode</source>
+        <translation>Cambiar modo de emulación de GPU</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="164"/>
+        <source>toolBar</source>
+        <translation>toolBar</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="203"/>
+        <source>Start &amp;Disc...</source>
+        <translation>Iniciar &amp;Disco...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="212"/>
+        <source>Start &amp;BIOS</source>
+        <translation>Iniciar &amp;BIOS</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="221"/>
+        <source>&amp;Scan For New Games</source>
+        <translation>&amp;Escanear por juegos nuevos</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="230"/>
+        <source>&amp;Rescan All Games</source>
+        <translation>&amp;Reescanear todos los juegos</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="239"/>
+        <source>Power &amp;Off</source>
+        <translation>&amp;Apagar</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="248"/>
+        <source>&amp;Reset</source>
+        <translation>&amp;Reiniciar</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="260"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Pausar</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="269"/>
+        <source>&amp;Load State</source>
+        <translation>&amp;Cargar Estado</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="278"/>
+        <source>&amp;Save State</source>
+        <translation>&amp;Guardar Estado</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="283"/>
+        <source>E&amp;xit</source>
+        <translation>&amp;Salir</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="292"/>
+        <source>C&amp;onsole Settings...</source>
+        <translation>Configuración de C&amp;onsola...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="301"/>
+        <source>&amp;Controller Settings...</source>
+        <translation>Configuración de &amp;Controles...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="310"/>
+        <source>&amp;Hotkey Settings...</source>
+        <translation>Configuración de Ata&amp;jos...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="319"/>
+        <source>&amp;GPU Settings...</source>
+        <translation>Configuración de &amp;GPU...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="328"/>
+        <source>Fullscreen</source>
+        <translation>Pantalla Completa</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="333"/>
+        <source>Resolution Scale</source>
+        <translation>Escala de resolución</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="338"/>
+        <source>&amp;GitHub Repository...</source>
+        <translation>Repositorio en &amp;GitHub...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="343"/>
+        <source>&amp;Issue Tracker...</source>
+        <translation>&amp;Rastreador de problemas...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="348"/>
+        <source>&amp;Discord Server...</source>
+        <translation>Servidor de &amp;Discord...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="353"/>
+        <source>Check for &amp;Updates...</source>
+        <translation>&amp;Buscar actualizaciones...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="358"/>
+        <source>&amp;About...</source>
+        <translation>&amp;Acerca de...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="367"/>
+        <source>Change Disc...</source>
+        <translation>Cambiar Disco...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="376"/>
+        <source>Audio Settings...</source>
+        <translation>Configuración de &amp;Audio...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="385"/>
+        <source>Game List Settings...</source>
+        <translation>Configuración de &amp;Lista de Juegos...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="394"/>
+        <source>General Settings...</source>
+        <translation>Configuración &amp;General...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="403"/>
+        <source>Advanced Settings...</source>
+        <translation>Configuración A&amp;vanzada...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="412"/>
+        <source>Add Game Directory...</source>
+        <translation>Añadir directorio de juegos...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="421"/>
+        <source>&amp;Settings...</source>
+        <translation>&amp;Configuración...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="426"/>
+        <source>From File...</source>
+        <translation>Desde archivo...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="431"/>
+        <source>From Game List...</source>
+        <translation>Desde lista de juegos...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="436"/>
+        <source>Remove Disc</source>
+        <translation>Remover disco</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="441"/>
+        <source>Resume State</source>
+        <translation>Resumir estado</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="446"/>
+        <source>Global State</source>
+        <translation>Estado global</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="454"/>
+        <source>Show VRAM</source>
+        <translation>Mostrar VRAM</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="462"/>
+        <source>Dump CPU to VRAM Copies</source>
+        <translation>Volcar copias de CPU a VRAM</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="470"/>
+        <source>Dump VRAM to CPU Copies</source>
+        <translation>Volcar copias de VRAM a CPU</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="478"/>
+        <source>Dump Audio</source>
+        <translation>Volcar audio</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="486"/>
+        <source>Show GPU State</source>
+        <translation>Mostrar estado del GPU</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="494"/>
+        <source>Show CDROM State</source>
+        <translation>Mostrar estado del CDROM</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="502"/>
+        <source>Show SPU State</source>
+        <translation>Mostrar estado del SPU</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="510"/>
+        <source>Show Timers State</source>
+        <translation>Mostrar estado de los temporizadores</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="518"/>
+        <source>Show MDEC State</source>
+        <translation>Mostrar estado del MDEC</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="527"/>
+        <source>&amp;Screenshot</source>
+        <translation>&amp;Captura</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="536"/>
+        <source>&amp;Memory Card Settings...</source>
+        <translation>Configuración de &amp;Memorias</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="545"/>
+        <source>Resume</source>
+        <translation>Continuar</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="548"/>
+        <source>Resumes the last save state created.</source>
+        <translation>Continúa desde el último estado guardado hecho.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="116"/>
+        <source>Failed to create host display device context.</source>
+        <translation>Fallo al crear el contexto del dispositivo de visualización del host.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="266"/>
+        <location filename="../mainwindow.cpp" line="284"/>
+        <source>Select Disc Image</source>
+        <translation>Seleccionar imagen de disco</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="368"/>
+        <source>Properties...</source>
+        <translation>Propiedades...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="371"/>
+        <source>Open Containing Directory...</source>
+        <translation>Abrir directorio contenedor...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <source>Default Boot</source>
+        <translation>Inicio predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="389"/>
+        <source>Fast Boot</source>
+        <translation>Inicio rápido</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="395"/>
+        <source>Full Boot</source>
+        <translation>Inicio completo</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="413"/>
+        <source>Add Search Directory...</source>
+        <translation>Añadir directorio de búsqueda...</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="483"/>
+        <source>Language changed. Please restart the application to apply.</source>
+        <translation>Se ha cambiado el idioma. Reinicia la aplicación para que tenga efecto.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="660"/>
+        <source>Default</source>
+        <translation>Predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="661"/>
+        <source>DarkFusion</source>
+        <translation>DarkFusion</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="662"/>
+        <source>QDarkStyle</source>
+        <translation>QDarkStyle</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="835"/>
+        <source>Updater Error</source>
+        <translation>Error de actualización</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="841"/>
+        <source>&lt;p&gt;Sorry, you are trying to update a DuckStation version which is not an official GitHub release. To prevent incompatibilities, the auto-updater is only enabled on official builds.&lt;/p&gt;&lt;p&gt;To obtain an official build, please follow the instructions under &quot;Downloading and Running&quot; at the link below:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/&quot;&gt;https://github.com/stenzek/duckstation/&lt;/a&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Estás intentando actualizar una versión de DuckStation no oficial de GitHub. Para prevenir incompatibilidades, el actualizador sólo está habilitado en compilaciones oficiales.&lt;/p&gt;&lt;p&gt;Para obtener una versión oficial, sigue las instrucciones en el apartado &quot;Downloading and Running&quot; (Descargando y Corriendo) en el siguiente enlace:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/&quot;&gt;https://github.com/stenzek/duckstation/&lt;/a&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="847"/>
+        <source>Automatic updating is not supported on the current platform.</source>
+        <translation>Las actualizaciones automáticas no son compatibles con la plataforma actual.</translation>
+    </message>
+</context>
+<context>
+    <name>MemoryCardSettingsWidget</name>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="38"/>
+        <source>If one of the &quot;separate card per game&quot; memory card modes is chosen, these memory cards will be saved to the memcards directory.</source>
+        <translation>Si alguno de los modos &quot;Separar tarjeta por juego&quot; es seleccionado, las tarjetas de memoria se guardarán el el directorio &quot;memcards&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="44"/>
+        <source>Open...</source>
+        <translation>Abrir...</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="57"/>
+        <source>Memory Card %1</source>
+        <translation>Tarjeta de memoria %1</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="71"/>
+        <source>Memory Card Type:</source>
+        <translation>Tipo de tarjeta de memoria:</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="80"/>
+        <source>Browse...</source>
+        <translation>Buscar...</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="84"/>
+        <source>Shared Memory Card Path:</source>
+        <translation>Dirección de tarjeta de memoria compartida:</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="93"/>
+        <source>Select path to memory card image</source>
+        <translation>Seleccionar imagen de tarjeta de memoria</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../main.cpp" line="32"/>
+        <source>DuckStation Error</source>
+        <translation>Error de DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="33"/>
+        <source>Failed to initialize host interface. Cannot continue.</source>
+        <translation>Fallo al inicializar la interfaz del anfitrión. No se puede continuar.</translation>
+    </message>
+    <message>
+        <location filename="../qtutils.cpp" line="628"/>
+        <source>Failed to open URL</source>
+        <translation>Fallo al abrir URL.</translation>
+    </message>
+    <message>
+        <location filename="../qtutils.cpp" line="629"/>
+        <source>Failed to open URL.
+
+The URL was: %1</source>
+        <translation>Fallo al abrir URL. La URL era: %1</translation>
+    </message>
+</context>
+<context>
+    <name>QtHostInterface</name>
+    <message>
+        <location filename="../qthostinterface.cpp" line="855"/>
+        <source>Resume</source>
+        <translation>Continuar</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="858"/>
+        <source>Load State</source>
+        <translation>Cargar estado</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="876"/>
+        <source>Resume (%1)</source>
+        <translation>Continuar (%1)</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="883"/>
+        <source>%1 Save %2 (%3)</source>
+        <translation>%1 Guardar %2 (%3)</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="883"/>
+        <source>Game</source>
+        <translation>Juego</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="890"/>
+        <source>Delete Save States...</source>
+        <translation>Borrar estados guardados...</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="897"/>
+        <source>Confirm Save State Deletion</source>
+        <translation>Confirmar borrado de estados guardados</translation>
+    </message>
+    <message>
+        <location filename="../qthostinterface.cpp" line="898"/>
+        <source>Are you sure you want to delete all save states for %1?
+
+The saves will not be recoverable.</source>
+        <translation>¿Estás seguro que quieres borrar todos los estados guardados para %1?
+
+Estos guardados no se podrán recuperar.</translation>
+    </message>
+</context>
+<context>
+    <name>QtProgressCallback</name>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="10"/>
+        <source>DuckStation</source>
+        <translation>DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="29"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="82"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="87"/>
+        <source>Question</source>
+        <translation>Pregunta</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="93"/>
+        <source>Information</source>
+        <translation>Información</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../settingsdialog.ui" line="23"/>
+        <source>DuckStation Settings</source>
+        <translation>Configuración de DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="63"/>
+        <source>General Settings</source>
+        <translation>Configuración General</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="72"/>
+        <source>Console Settings</source>
+        <translation>Configuración de Consola</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="81"/>
+        <source>Game List Settings</source>
+        <translation>Configuración de Lista de Juegos</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="90"/>
+        <source>Hotkey Settings</source>
+        <translation>Configuración de Atajos</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="99"/>
+        <source>Controller Settings</source>
+        <translation>Configuración de Controles</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="108"/>
+        <source>Memory Card Settings</source>
+        <translation>Configuración de Memorias</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="117"/>
+        <source>GPU Settings</source>
+        <translation>Configuración de GPU</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="126"/>
+        <source>Audio Settings</source>
+        <translation>Configuración de Audio</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.ui" line="135"/>
+        <source>Advanced Settings</source>
+        <translation>Configuración Avanzada</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="54"/>
+        <source>&lt;strong&gt;General Settings&lt;/strong&gt;&lt;hr&gt;These options control how the emulator looks and behaves.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;Configuración General&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan como se ve y comporta el emulador.&lt;br&gt;&lt;br&gt;Pasa el puntero sobre alguna opción para más información.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="58"/>
+        <source>&lt;strong&gt;Console Settings&lt;/strong&gt;&lt;hr&gt;These options determine the configuration of the simulated console.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;Configuración de Consola&lt;/strong&gt;&lt;hr&gt;Estas opciones determinan la configuración de la consola emulada.&lt;br&gt;&lt;br&gt;Pasa el puntero sobre alguna opción para más información.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="61"/>
+        <source>&lt;strong&gt;Game List Settings&lt;/strong&gt;&lt;hr&gt;The list above shows the directories which will be searched by DuckStation to populate the game list. Search directories can be added, removed, and switched to recursive/non-recursive. Additionally, the redump.org database can be downloaded or updated to provide titles for discs, as the discs themselves do not provide title information.</source>
+        <translation>&lt;strong&gt;Configuración de Lista de Juegos&lt;/strong&gt;&lt;hr&gt;La lista de arriba indica los directorios en los cuales se buscarán los juegos a aparecer en la lista. Se pueden añadir y quitar directorios, y buscar tanto de forma recursiva como no. Adicionalmente, la base de datos de redump.org se puede descargar/actualizar para mostrar los títulos de cada disco, ya que estos no almacenan esta información por su cuenta.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="66"/>
+        <source>&lt;strong&gt;Hotkey Settings&lt;/strong&gt;&lt;hr&gt;Binding a hotkey allows you to trigger events such as a resetting or taking screenshots at the press of a key/controller button. Hotkey titles are self-explanatory. Clicking a binding will start a countdown, in which case you should press the key or controller button/axis you wish to bind. If no button  is pressed and the timer lapses, the binding will be unchanged. To clear a binding, right-click the button. To  bind multiple buttons, hold Shift and click the button.</source>
+        <translation>&lt;strong&gt;Configuración de Atajos&lt;/strong&gt;&lt;hr&gt;Configurar un atajo permite ejecutar eventos como reiniciar o tomar capturas al presionar una tecla o botón. Haciendo clic sobre el botón de mapeo comenzará una cuenta regresiva, dentro de la cual se debe presionar la tecla o botón que quieras asignar. Si no se presiona ninguna tecla para cuando se termine el tiempo, se mantendrá la configuración existente. Para limpiar la configuración, hacer clic derecho en el botón. Para configurar múltiples botones, mantener la tecla Shift y hacer clic en el botón.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="72"/>
+        <source>&lt;strong&gt;Controller Settings&lt;/strong&gt;&lt;hr&gt;This page lets you choose the type of controller you wish to simulate for the console, and rebind the keys or host game controller buttons to your choosing. Clicking a binding will start a countdown, in which case you should press the key or controller button/axis you wish to bind. (For rumble, press any button/axis on the controller you wish to send rumble to.) If no button is pressed and the timer lapses, the binding will be unchanged. To clear a binding, right-click the button. To bind multiple buttons, hold Shift and click the button.</source>
+        <translation>&lt;strong&gt;Configuración de Controles&lt;/strong&gt;&lt;hr&gt;Esta página permite elegir el tipo de control a emular, y configurar los botones como quieras. Haciendo clic sobre el botón de mapeo comenzará una cuenta regresiva, dentro de la cual se debe presionar la tecla o botón que quieras asignar. (Para vibración, presionar cualquier botón/axis en el control al que se desee enviar las vibraciones). Si no se presiona ninguna tecla para cuando se termine el tiempo, se mantendrá la configuración existente. Para limpiar la configuración, hacer clic derecho en el botón. Para configurar múltiples botones, mantener la tecla Shift y hacer clic en el botón.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="80"/>
+        <source>&lt;strong&gt;Memory Card Settings&lt;/strong&gt;&lt;hr&gt;This page lets you control what mode the memory card emulation will function in, and where the images for these cards will be stored on disk.</source>
+        <translation>&lt;strong&gt;Configuración de Memorias&lt;/strong&gt;&lt;hr&gt;Esta página te permite controlar en que modo funcionará la emulación de tarjetas de memoria, y dónde se guardarán los archivos en disco.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="83"/>
+        <source>&lt;strong&gt;GPU Settings&lt;/strong&gt;&lt;hr&gt;These options control the simulation of the GPU in the console. Various enhancements are available, mouse over each for additional information.</source>
+        <translation>&lt;strong&gt;Configuración de GPU&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan la simulación de la GPU en la consola. Hay disponibles varias mejoras, pasa el puntero sobre cada una para más información.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="86"/>
+        <source>&lt;strong&gt;Audio Settings&lt;/strong&gt;&lt;hr&gt;These options control the audio output of the console. Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;Configuración de Audio&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan la salida de audio de la consola.&lt;br&gt;&lt;br&gt;Pasa el puntero sobre alguna opción para más información.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="88"/>
+        <source>&lt;strong&gt;Advanced Settings&lt;/strong&gt;&lt;hr&gt;These options control logging and internal behavior of the emulator. Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;Configuración Avanzada&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan los registros y el comportamiento interno del emulador.&lt;br&gt;&lt;br&gt;Pasa el puntero sobre alguna opción para más información.</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="115"/>
+        <source>Recommended Value</source>
+        <translation>Valor recomendado</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
"Universal" because is intended to be neutral. I'd strongly suggest to keep just one spanish translation, no "es-es" or "es-us"/"es-mx", it may cause unnecessary confusion.