### PR TITLE
SDLControllerInterface: Add support for optional game controller database

### DIFF
--- a/src/frontend-common/sdl_controller_interface.h
+++ b/src/frontend-common/sdl_controller_interface.h
@@ -17,6 +17,9 @@ public:
   bool Initialize(CommonHostInterface* host_interface) override;
   void Shutdown() override;
 
+  /// Returns the path of the optional game controller database file.
+  std::string GetGameControllerDBFileName() const;
+
   // Removes all bindings. Call before setting new bindings.
   void ClearBindings() override;
 


### PR DESCRIPTION
At present, DuckStation's SDL input interface (i.e. used by the Qt frontend) is using SDL2's GameController API, which requires devices to have known controller mappings. SDL2 provides an embedded database of recognised controllers in its [own source code](https://github.com/spurious/SDL-mirror/blob/master/src/joystick/SDL_gamecontrollerdb.h), however it is rather small and thus limited in practice.

This trivial PR improves game controller compatibility out of the box by implementing support for loading an optional game controller database file. If an optional `gamecontrollerdb.txt` file exists in the user directory, then SDL game controller mappings will be loaded from it. In portable mode, the database can be placed alongside the DS executable.

There is an officially endorsed community sourced database in https://github.com/gabomdq/SDL_GameControllerDB
Users can also create their own custom controller mappings using readily available tools (see community repository).

I followed the existing code style as much as possible, but let me know if you want something implemented in a different way.

Note: The mappings are loaded *before* initialising the game controller subsystem because otherwise already connected controllers present in the database file do not trigger `SDL_CONTROLLERDEVICEADDED` events on application startup.

Fixes #731 (more context there as well)