### PR TITLE
Fix a crash when changing controller backends as rumble changes

### DIFF
--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1247,9 +1247,15 @@ bool CommonHostInterface::AddRumbleToInputMap(const std::string& binding, u32 co
       return false;
     }
 
-    AddControllerRumble(controller_index, num_motors,
-                        std::bind(&ControllerInterface::SetControllerRumbleStrength, m_controller_interface.get(),
-                                  host_controller_index.value(), std::placeholders::_1, std::placeholders::_2));
+    AddControllerRumble(
+      controller_index, num_motors,
+      [index = host_controller_index.value(),
+       ci = std::weak_ptr<ControllerInterface>(m_controller_interface)](const float* strengths, u32 num_motors) {
+        if (auto controller = ci.lock(); controller)
+        {
+          controller->SetControllerRumbleStrength(index, strengths, num_motors);
+        }
+      });
 
     return true;
   }

--- a/src/frontend-common/common_host_interface.h
+++ b/src/frontend-common/common_host_interface.h
@@ -277,7 +277,7 @@ protected:
 
   std::unique_ptr<GameList> m_game_list;
 
-  std::unique_ptr<ControllerInterface> m_controller_interface;
+  std::shared_ptr<ControllerInterface> m_controller_interface;
 
   std::deque<OSDMessage> m_osd_messages;
   std::mutex m_osd_messages_lock;

--- a/src/frontend-common/controller_interface.cpp
+++ b/src/frontend-common/controller_interface.cpp
@@ -125,15 +125,15 @@ ControllerInterface::Backend ControllerInterface::GetDefaultBackend()
 #include "xinput_controller_interface.h"
 #endif
 
-std::unique_ptr<ControllerInterface> ControllerInterface::Create(Backend type)
+std::shared_ptr<ControllerInterface> ControllerInterface::Create(Backend type)
 {
 #ifdef WITH_SDL2
   if (type == Backend::SDL)
-    return std::make_unique<SDLControllerInterface>();
+    return std::make_shared<SDLControllerInterface>();
 #endif
 #ifdef WIN32
   if (type == Backend::XInput)
-    return std::make_unique<XInputControllerInterface>();
+    return std::make_shared<XInputControllerInterface>();
 #endif
 
   return {};

--- a/src/frontend-common/controller_interface.h
+++ b/src/frontend-common/controller_interface.h
@@ -40,7 +40,7 @@ public:
   static std::optional<Backend> ParseBackendName(const char* name);
   static const char* GetBackendName(Backend type);
   static Backend GetDefaultBackend();
-  static std::unique_ptr<ControllerInterface> Create(Backend type);
+  static std::shared_ptr<ControllerInterface> Create(Backend type);
 
   virtual Backend GetBackend() const = 0;
   virtual bool Initialize(CommonHostInterface* host_interface);


### PR DESCRIPTION
This PR promotes `m_controller_interface` from `std::unique_ptr` to `std::shared_ptr` to allow the rumble update callback not to call back to the interface if it has expired by holding onto a weak pointer.

This fixes a crash when changing controller backends as rumble is being updated. Rumble update callback attempted to call to a destroyed class, causing a crash. By holding onto a weak pointer instead, the callback can attempt to lock the weak pointer and gracefully handle failure.

Fixes #784