### PR TITLE
Star Wars - Dark Forces (SLUS-00297) gameini

### DIFF
--- a/data/database/gamesettings.ini
+++ b/data/database/gamesettings.ini
@@ -73,3 +73,8 @@ EnableInterlacing = true
 DisplayActiveStartOffset = 64
 DisplayActiveEndOffset = 68
 
+# SLUS-00297 (Star Wars - Dark Forces (USA))
+[SLUS-00297]
+DisableUpscaling = true
+DisablePGXP = true
+ForceDigitalController = true


### PR DESCRIPTION
>DisableUpscaling = true
>DisablePGXP = true

Much like Doom the game is 2.5D so both Upscaling and PGXP cause garbage graphics.

>ForceDigitalController = true

If Analog is used the game pauses until you switch it off so no point in using it.
