### PR TITLE
Add ForceDigitalController for a handful of games

### DIFF
--- a/data/database/gamesettings.ini
+++ b/data/database/gamesettings.ini
@@ -78,3 +78,63 @@ DisplayActiveEndOffset = 68
 DisableUpscaling = true
 DisablePGXP = true
 ForceDigitalController = true
+
+
+# SCUS-94302 (Destruction Derby (USA))
+[SCUS-94302]
+ForceDigitalController = true
+
+
+# SCUS-94900 (Crash Bandicoot (USA))
+[SCUS-94900]
+ForceDigitalController = true
+
+
+# SCUS-94350 (Destruction Derby 2 (USA))
+[SCUS-94350]
+ForceDigitalController = true
+
+
+# PCPX-96085 (Gran Turismo (Japan) (Demo 1))
+[PCPX-96085]
+ForceDigitalController = true
+
+
+# SLUS-00106 (Grand Theft Auto (USA))
+[SLUS-00106]
+ForceDigitalController = true
+
+
+# SLUS-00590 (Need for Speed - V-Rally (USA))
+[SLUS-00590]
+ForceDigitalController = true
+
+
+# SLUS-00403 (Rage Racer (USA))
+[SLUS-00403]
+ForceDigitalController = true
+
+
+# SCUS-94300 (Ridge Racer (USA))
+[SCUS-94300]
+ForceDigitalController = true
+
+
+# SLUS-00214 (Ridge Racer Revolution (USA))
+[SLUS-00214]
+ForceDigitalController = true
+
+
+# SLUS-00204 (Road & Track Presents - The Need for Speed (USA))
+[SLUS-00204]
+ForceDigitalController = true
+
+
+# SLUS-00006 (Tekken (USA))
+[SLUS-00006]
+ForceDigitalController = true
+
+
+# SLUS-00213 (Tekken 2 (USA))
+[SLUS-00213]
+ForceDigitalController = true


### PR DESCRIPTION
Adds `ForceDigitalController` for a few games. I have verified that analog controller doesn't work not only in menus, but also during the gameplay (races, fights etc.).