### PR TITLE
Fix D3D11 resource leaks

### DIFF
--- a/src/common/d3d11/staging_texture.cpp
+++ b/src/common/d3d11/staging_texture.cpp
@@ -84,8 +84,8 @@ bool AutoStagingTexture::EnsureSize(ID3D11DeviceContext* context, u32 width, u32
   if (m_texture && m_width >= width && m_height >= height && m_format == format)
     return true;
 
-  ID3D11Device* device;
-  context->GetDevice(&device);
+  ComPtr<ID3D11Device> device;
+  context->GetDevice(device.GetAddressOf());
 
   CD3D11_TEXTURE2D_DESC new_desc(format, width, height, 1, 1, 0,
                                  for_uploading ? D3D11_USAGE_DYNAMIC : D3D11_USAGE_STAGING,

--- a/src/frontend-common/d3d11_host_display.cpp
+++ b/src/frontend-common/d3d11_host_display.cpp
@@ -156,15 +156,15 @@ bool D3D11HostDisplay::DownloadTexture(const void* texture_handle, u32 x, u32 y,
 {
   ID3D11ShaderResourceView* srv =
     const_cast<ID3D11ShaderResourceView*>(static_cast<const ID3D11ShaderResourceView*>(texture_handle));
-  ID3D11Resource* srv_resource;
+  ComPtr<ID3D11Resource> srv_resource;
   D3D11_SHADER_RESOURCE_VIEW_DESC srv_desc;
-  srv->GetResource(&srv_resource);
+  srv->GetResource(srv_resource.GetAddressOf());
   srv->GetDesc(&srv_desc);
 
   if (!m_readback_staging_texture.EnsureSize(m_context.Get(), width, height, srv_desc.Format, false))
     return false;
 
-  m_readback_staging_texture.CopyFromTexture(m_context.Get(), srv_resource, 0, x, y, 0, 0, width, height);
+  m_readback_staging_texture.CopyFromTexture(m_context.Get(), srv_resource.Get(), 0, x, y, 0, 0, width, height);
   return m_readback_staging_texture.ReadPixels<u32>(m_context.Get(), 0, 0, width, height, out_data_stride / sizeof(u32),
                                                     static_cast<u32*>(out_data));
 }


### PR DESCRIPTION
Fixes strange leaks in `AutoStagingTexture::EnsureSize` and `D3D11HostDisplay::DownloadTexture`. I say "strange" because in other places managed COM pointers were used, but those two were erroneously defined as naked pointers, as if the functions getting them did not increase their refcount.

`GetDevice` and `GetResource` both increase the refcount of the object they return, as described here:
https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicechild-getdevice
https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11view-getresource