### PR TITLE
Seek before reading save state screenshot

### DIFF
--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1820,6 +1820,7 @@ CommonHostInterface::GetExtendedSaveStateInfo(const char* game_code, s32 slot)
   if (header.screenshot_width > 0 && header.screenshot_height > 0 && header.screenshot_size > 0 &&
       (static_cast<u64>(header.offset_to_screenshot) + static_cast<u64>(header.screenshot_size)) <= stream->GetSize())
   {
+    stream->SeekAbsolute(header.offset_to_screenshot);
     ssi.screenshot_data.resize((header.screenshot_size + 3u) / 4u);
     if (stream->Read2(ssi.screenshot_data.data(), header.screenshot_size))
     {


### PR DESCRIPTION
Fixes corrupted thumbnails in the save state UI.

Before:
![image](https://user-images.githubusercontent.com/7947461/92312996-b48e2900-efc6-11ea-8897-e5c5e5d840c5.png)

After:
![image](https://user-images.githubusercontent.com/7947461/92312967-76910500-efc6-11ea-942e-72155675d4f9.png)