### PR TITLE
Fix issues with a -resume parameter

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -41,14 +41,9 @@ Log_SetChannel(System);
 
 SystemBootParameters::SystemBootParameters() = default;
 
-SystemBootParameters::SystemBootParameters(std::string filename_) : filename(filename_) {}
+SystemBootParameters::SystemBootParameters(SystemBootParameters&& other) = default;
 
-SystemBootParameters::SystemBootParameters(const SystemBootParameters& copy)
-  : filename(copy.filename), override_fast_boot(copy.override_fast_boot), override_fullscreen(copy.override_fullscreen)
-{
-  // only exists for qt, we can't copy the state stream
-  Assert(!copy.state_stream);
-}
+SystemBootParameters::SystemBootParameters(std::string filename_) : filename(std::move(filename_)) {}
 
 SystemBootParameters::~SystemBootParameters() = default;
 

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -19,8 +19,8 @@ class CheatList;
 struct SystemBootParameters
 {
   SystemBootParameters();
+  SystemBootParameters(SystemBootParameters&& other);
   SystemBootParameters(std::string filename_);
-  SystemBootParameters(const SystemBootParameters& copy);
   ~SystemBootParameters();
 
   std::string filename;

--- a/src/duckstation-qt/main.cpp
+++ b/src/duckstation-qt/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
 
   std::unique_ptr<QtHostInterface> host_interface = std::make_unique<QtHostInterface>();
   std::unique_ptr<SystemBootParameters> boot_params;
-  if (!host_interface->parseCommandLineParameters(argc, argv, &boot_params))
+  if (!host_interface->ParseCommandLineParameters(argc, argv, &boot_params))
     return EXIT_FAILURE;
 
   if (!host_interface->Initialize())
@@ -48,8 +48,7 @@ int main(int argc, char* argv[])
 
   if (boot_params)
   {
-    host_interface->bootSystem(*boot_params);
-    boot_params.reset();
+    host_interface->bootSystem(std::move(boot_params));
   }
   else
   {

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -269,15 +269,12 @@ void MainWindow::onStartDiscActionTriggered()
   if (filename.isEmpty())
     return;
 
-  SystemBootParameters boot_params;
-  boot_params.filename = filename.toStdString();
-  m_host_interface->bootSystem(boot_params);
+  m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(filename.toStdString()));
 }
 
 void MainWindow::onStartBIOSActionTriggered()
 {
-  SystemBootParameters boot_params;
-  m_host_interface->bootSystem(boot_params);
+  m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>());
 }
 
 void MainWindow::onChangeDiscFromFileActionTriggered()
@@ -391,9 +388,7 @@ void MainWindow::onGameListEntryDoubleClicked(const GameListEntry* entry)
     }
     else
     {
-      SystemBootParameters boot_params;
-      boot_params.filename = path.toStdString();
-      m_host_interface->bootSystem(boot_params);
+      m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(path.toStdString()));
     }
   }
   else
@@ -429,19 +424,20 @@ void MainWindow::onGameListContextMenuRequested(const QPoint& point, const GameL
         menu.addSeparator();
       }
 
-      connect(menu.addAction(tr("Default Boot")), &QAction::triggered,
-              [this, entry]() { m_host_interface->bootSystem(SystemBootParameters(entry->path)); });
+      connect(menu.addAction(tr("Default Boot")), &QAction::triggered, [this, entry]() {
+        m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(entry->path));
+      });
 
       connect(menu.addAction(tr("Fast Boot")), &QAction::triggered, [this, entry]() {
-        SystemBootParameters boot_params(entry->path);
-        boot_params.override_fast_boot = true;
-        m_host_interface->bootSystem(boot_params);
+        auto boot_params = std::make_shared<SystemBootParameters>(entry->path);
+        boot_params->override_fast_boot = true;
+        m_host_interface->bootSystem(std::move(boot_params));
       });
 
       connect(menu.addAction(tr("Full Boot")), &QAction::triggered, [this, entry]() {
-        SystemBootParameters boot_params(entry->path);
-        boot_params.override_fast_boot = false;
-        m_host_interface->bootSystem(boot_params);
+        auto boot_params = std::make_shared<SystemBootParameters>(entry->path);
+        boot_params->override_fast_boot = false;
+        m_host_interface->bootSystem(std::move(boot_params));
       });
     }
     else

--- a/src/duckstation-qt/qthostinterface.h
+++ b/src/duckstation-qt/qthostinterface.h
@@ -30,7 +30,7 @@ class INISettingsInterface;
 class MainWindow;
 class QtDisplayWidget;
 
-Q_DECLARE_METATYPE(SystemBootParameters);
+Q_DECLARE_METATYPE(std::shared_ptr<const SystemBootParameters>);
 
 class QtHostInterface final : public QObject, public CommonHostInterface
 {
@@ -48,8 +48,6 @@ public:
   void ReportError(const char* message) override;
   void ReportMessage(const char* message) override;
   bool ConfirmMessage(const char* message) override;
-
-  bool parseCommandLineParameters(int argc, char* argv[], std::unique_ptr<SystemBootParameters>* out_boot_params);
 
   /// Thread-safe settings access.
   std::string GetStringSettingValue(const char* section, const char* key, const char* default_value = "") override;
@@ -141,7 +139,7 @@ public Q_SLOTS:
   void onDisplayWindowKeyEvent(int key, bool pressed);
   void onDisplayWindowMouseMoveEvent(int x, int y);
   void onDisplayWindowMouseButtonEvent(int button, bool pressed);
-  void bootSystem(const SystemBootParameters& params);
+  void bootSystem(std::shared_ptr<const SystemBootParameters> params);
   void resumeSystemFromState(const QString& filename, bool boot_on_failure);
   void resumeSystemFromMostRecentState();
   void powerOffSystem();

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -374,8 +374,15 @@ bool CommonHostInterface::ParseCommandLineParameters(int argc, char* argv[],
           state_filename = GetGameSaveStateFileName(game_code.c_str(), *state_index);
           if (state_filename.empty() || !FileSystem::FileExists(state_filename.c_str()))
           {
-            Log_ErrorPrintf("Could not find file for game '%s' save state %d", game_code.c_str(), *state_index);
-            return false;
+            if (state_index >= 0) // Do not exit if -resume is specified, but resume save state does not exist
+            {
+              Log_ErrorPrintf("Could not find file for game '%s' save state %d", game_code.c_str(), *state_index);
+              return false;
+            }
+            else
+            {
+              state_filename.clear();
+            }
           }
         }
       }


### PR DESCRIPTION
This PR fixes two issues related to the `-resume` parameter:

1. When DuckStation is launched with any of the parameters indicating that a save state should be loaded **and** this save state didn't exist, it would exit quietly. This makes sense when an explicit path to the save state is passed, but not when resuming. A resume save state has been special cased not to terminate DS if it doesn't exist.
2. The case where `-resume` was passed and a save state exists would hit an assertion in the copy constructor of `SystemBootParameters` because an attempt to copy a byte stream pointer was being made. This comes from an `invokeMethod` function used to marshal the call to a Qt worker thread, which as per Qt rules ends up serializing parameters by value, even if they were passed by reference. As a result, `SystemBootParameters` was being copied around, even though it's been clearly designed to be a non-copyable class. I have modified `bootSystem` to operate on a `std::shared_ptr<SystemBootParameters>`, which avoids any copies on the object itself. It's technically also more correct, because this object **does** have to be copied around, and thus a shared pointer makes sense.

As a nice side-effect of those two changes, I tidied up `SystemBootParameters` constructors to move a string instead of copying it, and also made the object truly non-copyable.

Fixes #827