### PR TITLE
More path fixes

### DIFF
--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -1,4 +1,5 @@
 #include "image.h"
+#include "file_system.h"
 #include "log.h"
 #include "stb_image.h"
 Log_SetChannel(Common::Image);
@@ -6,8 +7,14 @@ Log_SetChannel(Common::Image);
 namespace Common {
 bool LoadImageFromFile(Common::RGBA8Image* image, const char* filename)
 {
+  auto fp = FileSystem::OpenManagedCFile(filename, "rb");
+  if (!fp)
+  {
+    return false;
+  }
+
   int width, height, file_channels;
-  u8* pixel_data = stbi_load(filename, &width, &height, &file_channels, 4);
+  u8* pixel_data = stbi_load_from_file(fp.get(), &width, &height, &file_channels, 4);
   if (!pixel_data)
   {
     const char* error_reason = stbi_failure_reason();

--- a/src/frontend-common/game_list.cpp
+++ b/src/frontend-common/game_list.cpp
@@ -740,8 +740,12 @@ void GameList::LoadDatabase()
   if (m_database_filename.empty())
     return;
 
+  auto fp = FileSystem::OpenManagedCFile(m_database_filename.c_str(), "rb");
+  if (!fp)
+    return;
+
   tinyxml2::XMLDocument doc;
-  tinyxml2::XMLError error = doc.LoadFile(m_database_filename.c_str());
+  tinyxml2::XMLError error = doc.LoadFile(fp.get());
   if (error != tinyxml2::XML_SUCCESS)
   {
     Log_ErrorPrintf("Failed to parse redump dat '%s': %s", m_database_filename.c_str(),
@@ -858,8 +862,12 @@ void GameList::LoadCompatibilityList()
   if (m_compatibility_list_filename.empty())
     return;
 
+  auto fp = FileSystem::OpenManagedCFile(m_compatibility_list_filename.c_str(), "rb");
+  if (!fp)
+    return;
+
   tinyxml2::XMLDocument doc;
-  tinyxml2::XMLError error = doc.LoadFile(m_compatibility_list_filename.c_str());
+  tinyxml2::XMLError error = doc.LoadFile(fp.get());
   if (error != tinyxml2::XML_SUCCESS)
   {
     Log_ErrorPrintf("Failed to parse compatibility list '%s': %s", m_compatibility_list_filename.c_str(),
@@ -989,11 +997,12 @@ bool GameList::SaveCompatibilityDatabaseForEntry(const GameListCompatibilityEntr
   if (m_compatibility_list_filename.empty())
     return false;
 
-  if (!FileSystem::FileExists(m_compatibility_list_filename.c_str()))
+  auto fp = FileSystem::OpenManagedCFile(m_compatibility_list_filename.c_str(), "rb");
+  if (!fp)
     return SaveCompatibilityDatabase();
 
   tinyxml2::XMLDocument doc;
-  tinyxml2::XMLError error = doc.LoadFile(m_compatibility_list_filename.c_str());
+  tinyxml2::XMLError error = doc.LoadFile(fp.get());
   if (error != tinyxml2::XML_SUCCESS)
   {
     Log_ErrorPrintf("Failed to parse compatibility list '%s': %s", m_compatibility_list_filename.c_str(),


### PR DESCRIPTION
XML loading and screenshot/texture saving **still** couldn't handle UTF-8 on Windows.

~~**NOTE:** For screenshot saving, I had to define `STBI_WINDOWS_UTF8` in multiple places (incl. stb project), is there a better way to do that? I probably also need to add the define to CMake somewhere?~~