### PR TITLE
Properties: Hide buttons when not in the Properties tab

### DIFF
--- a/src/duckstation-qt/gamepropertiesdialog.cpp
+++ b/src/duckstation-qt/gamepropertiesdialog.cpp
@@ -377,6 +377,12 @@ void GamePropertiesDialog::connectUi()
   connect(m_ui.exportCompatibilityInfo, &QPushButton::clicked, this,
           &GamePropertiesDialog::onExportCompatibilityInfoClicked);
   connect(m_ui.close, &QPushButton::clicked, this, &QDialog::close);
+  connect(m_ui.tabWidget, &QTabWidget::currentChanged, [this](int index) {
+    const bool show_buttons = index == 0;
+    m_ui.computeHashes->setVisible(show_buttons);
+    m_ui.verifyDump->setVisible(show_buttons);
+    m_ui.exportCompatibilityInfo->setVisible(show_buttons);
+  });
 
   connect(m_ui.userAspectRatio, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index) {
     if (index <= 0)


### PR DESCRIPTION
Hides, `Compute Hashes`, `Verify Dump` and `Export Compatibility Info` when the `Properties` tab is not visible, because those buttons are kinda meaningless outside of that tab.

![image](https://user-images.githubusercontent.com/7947461/93257085-9ed5ec00-f79c-11ea-9d1b-d78b6ac0ebe1.png)
