### PR TITLE
Fix Discord RPC not reporting the game title

### DIFF
--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -2371,7 +2371,7 @@ void CommonHostInterface::UpdateDiscordPresence()
   rp.startTimestamp = std::time(nullptr);
 
   SmallString details_string;
-  if (System::IsValid())
+  if (!System::IsShutdown())
   {
     details_string.AppendFormattedString("%s (%s)", System::GetRunningTitle().c_str(),
                                          System::GetRunningCode().c_str());


### PR DESCRIPTION
When Discord RPC is updating, the system is in `Starting` state and has the game's path/name/code set properly already.