### PR TITLE
Make path separators in UI more consistent

### DIFF
--- a/src/common/file_system.h
+++ b/src/common/file_system.h
@@ -11,8 +11,10 @@ class ByteStream;
 
 #ifdef WIN32
 #define FS_OSPATH_SEPERATOR_CHARACTER '\\'
+#define FS_OSPATH_SEPARATOR_STR "\\"
 #else
 #define FS_OSPATH_SEPERATOR_CHARACTER '/'
+#define FS_OSPATH_SEPARATOR_STR "/"
 #endif
 
 enum FILESYSTEM_FILE_ATTRIBUTES

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -410,7 +410,7 @@ void HostInterface::SetDefaultSettings(SettingsInterface& si)
   si.SetBoolValue("Audio", "Sync", true);
   si.SetBoolValue("Audio", "DumpOnBoot", false);
 
-  si.SetStringValue("BIOS", "Path", "bios/scph1001.bin");
+  si.SetStringValue("BIOS", "Path", "bios" FS_OSPATH_SEPARATOR_STR "scph1001.bin");
   si.SetBoolValue("BIOS", "PatchTTYEnable", false);
   si.SetBoolValue("BIOS", "PatchFastBoot", false);
 
@@ -418,9 +418,9 @@ void HostInterface::SetDefaultSettings(SettingsInterface& si)
   si.SetStringValue("Controller2", "Type", Settings::GetControllerTypeName(Settings::DEFAULT_CONTROLLER_2_TYPE));
 
   si.SetStringValue("MemoryCards", "Card1Type", Settings::GetMemoryCardTypeName(Settings::DEFAULT_MEMORY_CARD_1_TYPE));
-  si.SetStringValue("MemoryCards", "Card1Path", "memcards/shared_card_1.mcd");
+  si.SetStringValue("MemoryCards", "Card1Path", "memcards" FS_OSPATH_SEPARATOR_STR "shared_card_1.mcd");
   si.SetStringValue("MemoryCards", "Card2Type", Settings::GetMemoryCardTypeName(Settings::DEFAULT_MEMORY_CARD_2_TYPE));
-  si.SetStringValue("MemoryCards", "Card2Path", "memcards/shared_card_2.mcd");
+  si.SetStringValue("MemoryCards", "Card2Path", "memcards" FS_OSPATH_SEPARATOR_STR "shared_card_2.mcd");
   si.SetBoolValue("MemoryCards", "UsePlaylistTitle", true);
 
   si.SetStringValue("Logging", "LogLevel", Settings::GetLogLevelName(Settings::DEFAULT_LOG_LEVEL));
@@ -639,7 +639,7 @@ std::string HostInterface::GetUserDirectoryRelativePath(const char* format, ...)
   }
   else
   {
-    return StringUtil::StdStringFromFormat("%s%c%s", m_user_directory.c_str(), FS_OSPATH_SEPERATOR_CHARACTER,
+    return StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", m_user_directory.c_str(),
                                            formatted_path.c_str());
   }
 }
@@ -657,7 +657,7 @@ std::string HostInterface::GetProgramDirectoryRelativePath(const char* format, .
   }
   else
   {
-    return StringUtil::StdStringFromFormat("%s%c%s", m_program_directory.c_str(), FS_OSPATH_SEPERATOR_CHARACTER,
+    return StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", m_program_directory.c_str(),
                                            formatted_path.c_str());
   }
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -1,4 +1,5 @@
 #include "settings.h"
+#include "common/file_system.h"
 #include "common/make_array.h"
 #include "common/string_util.h"
 #include "host_interface.h"
@@ -156,7 +157,7 @@ void Settings::Load(SettingsInterface& si)
   gpu_fifo_size = static_cast<u32>(si.GetIntValue("Hacks", "GPUFIFOSize", DEFAULT_GPU_FIFO_SIZE));
   gpu_max_run_ahead = si.GetIntValue("Hacks", "GPUMaxRunAhead", DEFAULT_GPU_MAX_RUN_AHEAD);
 
-  bios_path = si.GetStringValue("BIOS", "Path", "bios/scph1001.bin");
+  bios_path = si.GetStringValue("BIOS", "Path", "bios" FS_OSPATH_SEPARATOR_STR "scph1001.bin");
   bios_patch_tty_enable = si.GetBoolValue("BIOS", "PatchTTYEnable", false);
   bios_patch_fast_boot = si.GetBoolValue("BIOS", "PatchFastBoot", false);
 
@@ -173,12 +174,14 @@ void Settings::Load(SettingsInterface& si)
     ParseMemoryCardTypeName(
       si.GetStringValue("MemoryCards", "Card1Type", GetMemoryCardTypeName(DEFAULT_MEMORY_CARD_1_TYPE)).c_str())
       .value_or(DEFAULT_MEMORY_CARD_1_TYPE);
-  memory_card_paths[0] = si.GetStringValue("MemoryCards", "Card1Path", "memcards/shared_card_1.mcd");
+  memory_card_paths[0] =
+    si.GetStringValue("MemoryCards", "Card1Path", "memcards" FS_OSPATH_SEPARATOR_STR "shared_card_1.mcd");
   memory_card_types[1] =
     ParseMemoryCardTypeName(
       si.GetStringValue("MemoryCards", "Card2Type", GetMemoryCardTypeName(DEFAULT_MEMORY_CARD_2_TYPE)).c_str())
       .value_or(DEFAULT_MEMORY_CARD_2_TYPE);
-  memory_card_paths[1] = si.GetStringValue("MemoryCards", "Card2Path", "memcards/shared_card_2.mcd");
+  memory_card_paths[1] =
+    si.GetStringValue("MemoryCards", "Card2Path", "memcards" FS_OSPATH_SEPARATOR_STR "shared_card_2.mcd");
   memory_card_use_playlist_title = si.GetBoolValue("MemoryCards", "UsePlaylistTitle", true);
 
   log_level = ParseLogLevelName(si.GetStringValue("Logging", "LogLevel", GetLogLevelName(DEFAULT_LOG_LEVEL)).c_str())
@@ -637,4 +640,3 @@ const char* Settings::GetMemoryCardTypeDisplayName(MemoryCardType type)
 {
   return s_memory_card_type_display_names[static_cast<int>(type)];
 }
-

--- a/src/duckstation-libretro/libretro_host_interface.cpp
+++ b/src/duckstation-libretro/libretro_host_interface.cpp
@@ -146,13 +146,13 @@ static const char* GetSaveDirectory()
 
 std::string LibretroHostInterface::GetSharedMemoryCardPath(u32 slot) const
 {
-  return StringUtil::StdStringFromFormat("%s%cduckstation_shared_card_%d.mcd", GetSaveDirectory(),
-                                         FS_OSPATH_SEPERATOR_CHARACTER, slot + 1);
+  return StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "duckstation_shared_card_%d.mcd",
+                                         GetSaveDirectory(), slot + 1);
 }
 
 std::string LibretroHostInterface::GetGameMemoryCardPath(const char* game_code, u32 slot) const
 {
-  return StringUtil::StdStringFromFormat("%s%c%s_%d.mcd", GetSaveDirectory(), FS_OSPATH_SEPERATOR_CHARACTER, game_code,
+  return StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s_%d.mcd", GetSaveDirectory(), game_code,
                                          slot + 1);
 }
 
@@ -662,8 +662,7 @@ void LibretroHostInterface::LoadSettings()
   const char* system_directory = nullptr;
   if (!g_retro_environment_callback(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &system_directory) || !system_directory)
     system_directory = "bios";
-  g_settings.bios_path =
-    StringUtil::StdStringFromFormat("%s%cscph1001.bin", system_directory, FS_OSPATH_SEPERATOR_CHARACTER);
+  g_settings.bios_path = StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "scph1001.bin", system_directory);
 
   // Ensure we don't use the standalone memcard directory in shared mode.
   for (u32 i = 0; i < NUM_CONTROLLER_AND_CARD_PORTS; i++)

--- a/src/duckstation-qt/consolesettingswidget.cpp
+++ b/src/duckstation-qt/consolesettingswidget.cpp
@@ -41,16 +41,19 @@ ConsoleSettingsWidget::ConsoleSettingsWidget(QtHostInterface* host_interface, QW
   dialog->registerWidgetHelp(m_ui.fastBoot, tr("Fast Boot"), tr("Unchecked"),
                              tr("Patches the BIOS to skip the console's boot animation. Does not work with all games, "
                                 "but usually safe to enabled."));
-  
-  dialog->registerWidgetHelp(m_ui.cdromLoadImageToRAM, tr("Preload Image to RAM"), tr("Unchecked"),
-                             tr("Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some cases also eliminates stutter when games initiate audio track playback."));
+
+  dialog->registerWidgetHelp(
+    m_ui.cdromLoadImageToRAM, tr("Preload Image to RAM"), tr("Unchecked"),
+    tr("Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some "
+       "cases also eliminates stutter when games initiate audio track playback."));
 }
 
 ConsoleSettingsWidget::~ConsoleSettingsWidget() = default;
 
 void ConsoleSettingsWidget::onBrowseBIOSPathButtonClicked()
 {
-  QString path = QFileDialog::getOpenFileName(this, tr("Select BIOS Image"), QString(), tr(BIOS_IMAGE_FILTER));
+  QString path = QDir::toNativeSeparators(
+    QFileDialog::getOpenFileName(this, tr("Select BIOS Image"), QString(), tr(BIOS_IMAGE_FILTER)));
   if (path.isEmpty())
     return;
 

--- a/src/duckstation-qt/gamepropertiesdialog.cpp
+++ b/src/duckstation-qt/gamepropertiesdialog.cpp
@@ -456,8 +456,9 @@ void GamePropertiesDialog::connectUi()
     saveGameSettings();
   });
   connect(m_ui.userMemoryCard1SharedPathBrowse, &QPushButton::clicked, [this]() {
-    QString path = QFileDialog::getOpenFileName(this, tr("Select path to memory card image"), QString(),
-                                                qApp->translate("MemoryCardSettingsWidget", MEMORY_CARD_IMAGE_FILTER));
+    QString path = QDir::toNativeSeparators(
+      QFileDialog::getOpenFileName(this, tr("Select path to memory card image"), QString(),
+                                   qApp->translate("MemoryCardSettingsWidget", MEMORY_CARD_IMAGE_FILTER)));
     if (path.isEmpty())
       return;
 
@@ -478,8 +479,9 @@ void GamePropertiesDialog::connectUi()
     saveGameSettings();
   });
   connect(m_ui.userMemoryCard2SharedPathBrowse, &QPushButton::clicked, [this]() {
-    QString path = QFileDialog::getOpenFileName(this, tr("Select path to memory card image"), QString(),
-                                                qApp->translate("MemoryCardSettingsWidget", MEMORY_CARD_IMAGE_FILTER));
+    QString path = QDir::toNativeSeparators(
+      QFileDialog::getOpenFileName(this, tr("Select path to memory card image"), QString(),
+                                   qApp->translate("MemoryCardSettingsWidget", MEMORY_CARD_IMAGE_FILTER)));
     if (path.isEmpty())
       return;
 

--- a/src/duckstation-qt/memorycardeditordialog.cpp
+++ b/src/duckstation-qt/memorycardeditordialog.cpp
@@ -78,7 +78,7 @@ void MemoryCardEditorDialog::populateComboBox(QComboBox* cb)
   for (FILESYSTEM_FIND_DATA& fd : results)
   {
     std::string real_filename(
-      StringUtil::StdStringFromFormat("%s%c%s", base_path.c_str(), FS_OSPATH_SEPERATOR_CHARACTER, fd.FileName.c_str()));
+      StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", base_path.c_str(), fd.FileName.c_str()));
     std::string::size_type pos = fd.FileName.rfind('.');
     if (pos != std::string::npos)
       fd.FileName.erase(pos);

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -637,12 +637,12 @@ void CommonHostInterface::SetUserDirectory()
 
   std::fprintf(stdout, "Program directory \"%s\"\n", m_program_directory.c_str());
 
-  if (FileSystem::FileExists(StringUtil::StdStringFromFormat("%s%c%s", m_program_directory.c_str(),
-                                                             FS_OSPATH_SEPERATOR_CHARACTER, "portable.txt")
-                               .c_str()) ||
-      FileSystem::FileExists(StringUtil::StdStringFromFormat("%s%c%s", m_program_directory.c_str(),
-                                                             FS_OSPATH_SEPERATOR_CHARACTER, "settings.ini")
-                               .c_str()))
+  if (FileSystem::FileExists(
+        StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", m_program_directory.c_str(), "portable.txt")
+          .c_str()) ||
+      FileSystem::FileExists(
+        StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", m_program_directory.c_str(), "settings.ini")
+          .c_str()))
   {
     std::fprintf(stdout, "portable.txt or old settings.ini found, using program directory as user directory.\n");
     m_user_directory = m_program_directory;
@@ -657,8 +657,8 @@ void CommonHostInterface::SetUserDirectory()
       const std::string documents_directory_str(StringUtil::WideStringToUTF8String(documents_directory));
       if (!documents_directory_str.empty())
       {
-        m_user_directory = StringUtil::StdStringFromFormat("%s%c%s", documents_directory_str.c_str(),
-                                                           FS_OSPATH_SEPERATOR_CHARACTER, "DuckStation");
+        m_user_directory = StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s",
+                                                           documents_directory_str.c_str(), "DuckStation");
       }
       CoTaskMemFree(documents_directory);
     }
@@ -1594,7 +1594,7 @@ void CommonHostInterface::FindInputProfiles(const std::string& base_path, InputP
     }
 
     std::string filename(
-      StringUtil::StdStringFromFormat("%s%c%s", base_path.c_str(), FS_OSPATH_SEPERATOR_CHARACTER, it.FileName.c_str()));
+      StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", base_path.c_str(), it.FileName.c_str()));
     out_list->push_back(InputProfileEntry{std::move(name), std::move(filename)});
   }
 }
@@ -1755,17 +1755,17 @@ std::string CommonHostInterface::GetSettingsFileName() const
 std::string CommonHostInterface::GetGameSaveStateFileName(const char* game_code, s32 slot) const
 {
   if (slot < 0)
-    return GetUserDirectoryRelativePath("savestates/%s_resume.sav", game_code);
+    return GetUserDirectoryRelativePath("savestates" FS_OSPATH_SEPARATOR_STR "%s_resume.sav", game_code);
   else
-    return GetUserDirectoryRelativePath("savestates/%s_%d.sav", game_code, slot);
+    return GetUserDirectoryRelativePath("savestates" FS_OSPATH_SEPARATOR_STR "%s_%d.sav", game_code, slot);
 }
 
 std::string CommonHostInterface::GetGlobalSaveStateFileName(s32 slot) const
 {
   if (slot < 0)
-    return GetUserDirectoryRelativePath("savestates/resume.sav");
+    return GetUserDirectoryRelativePath("savestates" FS_OSPATH_SEPARATOR_STR "resume.sav");
   else
-    return GetUserDirectoryRelativePath("savestates/savestate_%d.sav", slot);
+    return GetUserDirectoryRelativePath("savestates" FS_OSPATH_SEPARATOR_STR "savestate_%d.sav", slot);
 }
 
 std::vector<CommonHostInterface::SaveStateInfo> CommonHostInterface::GetAvailableSaveStates(const char* game_code) const
@@ -2153,12 +2153,12 @@ bool CommonHostInterface::SaveScreenshot(const char* filename /* = nullptr */, b
     const char* extension = "png";
     if (code.empty())
     {
-      auto_filename =
-        GetUserDirectoryRelativePath("screenshots/%s.%s", GetTimestampStringForFileName().GetCharArray(), extension);
+      auto_filename = GetUserDirectoryRelativePath("screenshots" FS_OSPATH_SEPARATOR_STR "%s.%s",
+                                                   GetTimestampStringForFileName().GetCharArray(), extension);
     }
     else
     {
-      auto_filename = GetUserDirectoryRelativePath("screenshots/%s_%s.%s", code.c_str(),
+      auto_filename = GetUserDirectoryRelativePath("screenshots" FS_OSPATH_SEPARATOR_STR "%s_%s.%s", code.c_str(),
                                                    GetTimestampStringForFileName().GetCharArray(), extension);
     }
 

--- a/src/frontend-common/postprocessing_chain.cpp
+++ b/src/frontend-common/postprocessing_chain.cpp
@@ -13,8 +13,8 @@ static bool TryLoadingShader(PostProcessingShader* shader, const std::string_vie
 {
   std::string shader_name_str(shader_name);
 
-  std::string filename = g_host_interface->GetUserDirectoryRelativePath(
-    "shaders%c%s.glsl", FS_OSPATH_SEPERATOR_CHARACTER, shader_name_str.c_str());
+  std::string filename = g_host_interface->GetUserDirectoryRelativePath("shaders" FS_OSPATH_SEPARATOR_STR "%s.glsl",
+                                                                        shader_name_str.c_str());
   if (FileSystem::FileExists(filename.c_str()))
   {
     if (!shader->LoadFromFile(std::move(shader_name_str), filename.c_str()))
@@ -25,7 +25,7 @@ static bool TryLoadingShader(PostProcessingShader* shader, const std::string_vie
   }
   else
   {
-    filename = g_host_interface->GetProgramDirectoryRelativePath("shaders%c%s.glsl", FS_OSPATH_SEPERATOR_CHARACTER,
+    filename = g_host_interface->GetProgramDirectoryRelativePath("shaders" FS_OSPATH_SEPARATOR_STR "%s.glsl",
                                                                  shader_name_str.c_str());
     if (FileSystem::FileExists(filename.c_str()))
     {

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -30,15 +30,15 @@ Updater::~Updater()
 bool Updater::Initialize(std::string destination_directory)
 {
   m_destination_directory = std::move(destination_directory);
-  m_staging_directory = StringUtil::StdStringFromFormat("%s%c%s", m_destination_directory.c_str(),
-                                                        FS_OSPATH_SEPERATOR_CHARACTER, "UPDATE_STAGING");
+  m_staging_directory = StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s",
+                                                        m_destination_directory.c_str(), "UPDATE_STAGING");
   m_progress->DisplayFormattedInformation("Destination directory: '%s'", m_destination_directory.c_str());
   m_progress->DisplayFormattedInformation("Staging directory: '%s'", m_staging_directory.c_str());
 
   // log everything to file as well
-  Log::SetFileOutputParams(true, StringUtil::StdStringFromFormat("%s%cupdater.log", m_destination_directory.c_str(),
-                                                                 FS_OSPATH_SEPERATOR_CHARACTER)
-                                   .c_str());
+  Log::SetFileOutputParams(
+    true, StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "updater.log", m_destination_directory.c_str())
+            .c_str());
 
   return true;
 }
@@ -180,8 +180,8 @@ bool Updater::PrepareStagingDirectory()
   {
     m_progress->DisplayFormattedInformation("Creating subdirectory in staging: %s", subdir.c_str());
 
-    const std::string staging_subdir = StringUtil::StdStringFromFormat("%s%c%s", m_staging_directory.c_str(),
-                                                                       FS_OSPATH_SEPERATOR_CHARACTER, subdir.c_str());
+    const std::string staging_subdir =
+      StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", m_staging_directory.c_str(), subdir.c_str());
     if (!FileSystem::CreateDirectory(staging_subdir.c_str(), false))
     {
       m_progress->DisplayFormattedModalError("Failed to create staging subdirectory %s", staging_subdir.c_str());
@@ -215,7 +215,7 @@ bool Updater::StageUpdate()
     m_progress->DisplayFormattedInformation("Extracting '%s'...", ftu.destination_filename.c_str());
 
     const std::string destination_file = StringUtil::StdStringFromFormat(
-      "%s%c%s", m_staging_directory.c_str(), FS_OSPATH_SEPERATOR_CHARACTER, ftu.destination_filename.c_str());
+      "%s" FS_OSPATH_SEPARATOR_STR "%s", m_staging_directory.c_str(), ftu.destination_filename.c_str());
     std::FILE* fp = FileSystem::OpenCFile(destination_file.c_str(), "wb");
     if (!fp)
     {
@@ -268,8 +268,8 @@ bool Updater::CommitUpdate()
   // create directories in target
   for (const std::string& subdir : m_update_directories)
   {
-    const std::string dest_subdir = StringUtil::StdStringFromFormat("%s%c%s", m_destination_directory.c_str(),
-                                                                    FS_OSPATH_SEPERATOR_CHARACTER, subdir.c_str());
+    const std::string dest_subdir = StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s",
+                                                                    m_destination_directory.c_str(), subdir.c_str());
 
     if (!FileSystem::DirectoryExists(dest_subdir.c_str()) && !FileSystem::CreateDirectory(dest_subdir.c_str(), false))
     {
@@ -282,9 +282,9 @@ bool Updater::CommitUpdate()
   for (const FileToUpdate& ftu : m_update_paths)
   {
     const std::string staging_file_name = StringUtil::StdStringFromFormat(
-      "%s%c%s", m_staging_directory.c_str(), FS_OSPATH_SEPERATOR_CHARACTER, ftu.destination_filename.c_str());
+      "%s" FS_OSPATH_SEPARATOR_STR "%s", m_staging_directory.c_str(), ftu.destination_filename.c_str());
     const std::string dest_file_name = StringUtil::StdStringFromFormat(
-      "%s%c%s", m_destination_directory.c_str(), FS_OSPATH_SEPERATOR_CHARACTER, ftu.destination_filename.c_str());
+      "%s" FS_OSPATH_SEPARATOR_STR "%s", m_destination_directory.c_str(), ftu.destination_filename.c_str());
     m_progress->DisplayFormattedInformation("Moving '%s' to '%s'", staging_file_name.c_str(), dest_file_name.c_str());
 #ifdef WIN32
     const bool result =


### PR DESCRIPTION
Before that, BIOS and memory card selection still used a `/` separator on Windows, and various imgui popups would mix `\` and `/` in their messages.

Now separators are consistent, and I replaced runtime `%c` formatters with compile time string literal concatenation, as there is really no reason for separators to be concatenated on runtime.
![image](https://user-images.githubusercontent.com/7947461/93689238-d6120900-facc-11ea-8392-e0b76f99e633.png)
