### PR TITLE
Fix an outstanding forward slash showing in the UI

### DIFF
--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -673,12 +673,12 @@ TinyString HostInterface::GetTimestampStringForFileName()
 
 std::string HostInterface::GetSharedMemoryCardPath(u32 slot) const
 {
-  return GetUserDirectoryRelativePath("memcards/shared_card_%d.mcd", slot + 1);
+  return GetUserDirectoryRelativePath("memcards" FS_OSPATH_SEPARATOR_STR "shared_card_%u.mcd", slot + 1);
 }
 
 std::string HostInterface::GetGameMemoryCardPath(const char* game_code, u32 slot) const
 {
-  return GetUserDirectoryRelativePath("memcards/%s_%d.mcd", game_code, slot + 1);
+  return GetUserDirectoryRelativePath("memcards" FS_OSPATH_SEPARATOR_STR "%s_%u.mcd", game_code, slot + 1);
 }
 
 bool HostInterface::GetBoolSettingValue(const char* section, const char* key, bool default_value /*= false*/)


### PR DESCRIPTION
Missed a slash, so messages like `Memory card X could not be read` and `Saved memory card X` still had forward slashes showing in the UI on Windows.

Also changed `%d` to `%u` because the parameter is unsigned - the compiler could have warned about it, but I guess it lacks some annotations `printf` and alike have.