### PR TITLE
Add 16:10 Aspect Ratio Option

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -561,10 +561,10 @@ const char* Settings::GetDisplayCropModeDisplayName(DisplayCropMode crop_mode)
   return s_display_crop_mode_display_names[static_cast<int>(crop_mode)];
 }
 
-static std::array<const char*, 7> s_display_aspect_ratio_names = {
-  {"4:3", "16:9", "21:9", "8:7", "2:1 (VRAM 1:1)", "1:1", "PAR 1:1"}};
-static constexpr std::array<float, 7> s_display_aspect_ratio_values = {
-  {4.0f / 3.0f, 16.0f / 9.0f, 21.0f / 9.0f, 8.0f / 7.0f, 2.0f / 1.0f, 1.0f, -1.0f}};
+static std::array<const char*, 8> s_display_aspect_ratio_names = {
+  {"4:3", "16:9", "16:10", "21:9", "8:7", "2:1 (VRAM 1:1)", "1:1", "PAR 1:1"}};
+static constexpr std::array<float, 8> s_display_aspect_ratio_values = {
+  {4.0f / 3.0f, 16.0f / 9.0f, 16.0f / 10.0f, 21.0f / 9.0f, 8.0f / 7.0f, 2.0f / 1.0f, 1.0f, -1.0f}};
 
 std::optional<DisplayAspectRatio> Settings::ParseDisplayAspectRatio(const char* str)
 {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -84,6 +84,7 @@ enum class DisplayAspectRatio : u8
 {
   R4_3,
   R16_9,
+  R16_10,
   R21_9,
   R8_7,
   R2_1,


### PR DESCRIPTION
This time I didn't forget to declare it in `types.h` heh. This change was mostly so I could learn how to make a PR that changes two files, if this PR is unnecessary to due to proposed custom aspect ratio feature as mentioned here https://github.com/stenzek/duckstation/issues/362#issuecomment-686953114, then feel free to drop it.