### PR TITLE
HostInterface: Fix PAL BIOS path not being read from settings

### DIFF
--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -219,7 +219,7 @@ std::optional<std::vector<u8>> HostInterface::GetBIOSImage(ConsoleRegion region)
       break;
 
     case ConsoleRegion::PAL:
-      bios_name = GetStringSettingValue("BIOS", "PAL", "");
+      bios_name = GetStringSettingValue("BIOS", "PathPAL", "");
       break;
 
     case ConsoleRegion::NTSC_U:


### PR DESCRIPTION
Fixes #1019.