### PR TITLE
AnalogController: Implement legacy rumble method

### DIFF
--- a/src/core/analog_controller.cpp
+++ b/src/core/analog_controller.cpp
@@ -302,6 +302,10 @@ bool AnalogController::Transfer(const u8 data_in, u8* data_out)
     {
       if (m_rumble_unlocked)
         SetMotorState(1, ((data_in & 0x01) != 0) ? 255 : 0);
+      else if (data_in >= 0x40 && data_in <= 0x7F)
+        m_legacy_rumble_unlocked = true;
+      else
+        SetMotorState(1, 0);
 
       *data_out = Truncate8(m_button_state) & GetExtraButtonMaskLSB();
       m_state = State::GetStateButtonsMSB;
@@ -313,6 +317,11 @@ bool AnalogController::Transfer(const u8 data_in, u8* data_out)
     {
       if (m_rumble_unlocked)
         SetMotorState(0, data_in);
+      else if (m_legacy_rumble_unlocked)
+      {
+        SetMotorState(1, ((data_in & 0x01) != 0) ? 255 : 0);
+        m_legacy_rumble_unlocked = false;
+      }
 
       *data_out = Truncate8(m_button_state >> 8);
       m_state = m_analog_mode ? State::GetStateRightAxisX : State::Idle;

--- a/src/core/analog_controller.h
+++ b/src/core/analog_controller.h
@@ -142,6 +142,7 @@ private:
   bool m_analog_mode = false;
   bool m_analog_locked = false;
   bool m_rumble_unlocked = false;
+  bool m_legacy_rumble_unlocked = false;
   bool m_configuration_mode = false;
   u8 m_command_param = 0;
 


### PR DESCRIPTION
Doesn't seem strictly necessary to save `m_legacy_rumble_unlocked` to state since it's only toggled during pad read sequences. I think the worst that could happen is missing or getting an extra frame of rumble on load state if the state was created very precisely in the middle of transferring the two motor bytes, so it's probably safe to wait for the next save state bump for saving the variable to state.