### PR TITLE
Controller: Add Analog Joystick support

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(core
     analog_controller.cpp
     analog_controller.h
+    analog_joystick.cpp
+    analog_joystick.h
     bios.cpp
     bios.h
     bus.cpp

--- a/src/core/analog_controller.cpp
+++ b/src/core/analog_controller.cpp
@@ -24,6 +24,7 @@ void AnalogController::Reset()
 {
   m_analog_mode = false;
   m_rumble_unlocked = false;
+  m_legacy_rumble_unlocked = false;
   m_configuration_mode = false;
   m_command_param = 0;
   m_motor_state.fill(0);
@@ -41,8 +42,10 @@ bool AnalogController::DoState(StateWrapper& sw)
 
   sw.Do(&m_analog_mode);
   sw.Do(&m_rumble_unlocked);
+  sw.DoEx(&m_legacy_rumble_unlocked, 44, false);
   sw.Do(&m_configuration_mode);
   sw.Do(&m_command_param);
+  sw.DoEx(&m_button_state, 44, static_cast<u16>(0xFFFF));
   sw.Do(&m_state);
 
   MotorState motor_state = m_motor_state;

--- a/src/core/analog_joystick.cpp
+++ b/src/core/analog_joystick.cpp
@@ -1,0 +1,311 @@
+#include "analog_joystick.h"
+#include "common/log.h"
+#include "common/state_wrapper.h"
+#include "common/string_util.h"
+#include "host_interface.h"
+#include "system.h"
+#include <cmath>
+Log_SetChannel(AnalogJoystick);
+
+AnalogJoystick::AnalogJoystick(u32 index)
+{
+  m_index = index;
+  m_axis_state.fill(0x80);
+  Reset();
+}
+
+AnalogJoystick::~AnalogJoystick() = default;
+
+ControllerType AnalogJoystick::GetType() const
+{
+  return ControllerType::AnalogJoystick;
+}
+
+void AnalogJoystick::Reset()
+{
+  m_transfer_state = TransferState::Idle;
+}
+
+bool AnalogJoystick::DoState(StateWrapper& sw)
+{
+  if (!Controller::DoState(sw))
+    return false;
+
+  const bool old_analog_mode = m_analog_mode;
+
+  sw.Do(&m_analog_mode);
+  sw.Do(&m_button_state);
+  sw.Do(&m_axis_state);
+  sw.Do(&m_transfer_state);
+
+  if (sw.IsReading() && (old_analog_mode != m_analog_mode))
+  {
+    g_host_interface->AddFormattedOSDMessage(
+      5.0f,
+      m_analog_mode ? g_host_interface->TranslateString("AnalogJoystick", "Controller %u switched to analog mode.") :
+                      g_host_interface->TranslateString("AnalogJoystick", "Controller %u switched to digital mode."),
+      m_index + 1u);
+  }
+  return true;
+}
+
+std::optional<s32> AnalogJoystick::GetAxisCodeByName(std::string_view axis_name) const
+{
+  return StaticGetAxisCodeByName(axis_name);
+}
+
+std::optional<s32> AnalogJoystick::GetButtonCodeByName(std::string_view button_name) const
+{
+  return StaticGetButtonCodeByName(button_name);
+}
+
+void AnalogJoystick::SetAxisState(s32 axis_code, float value)
+{
+  if (axis_code < 0 || axis_code >= static_cast<s32>(Axis::Count))
+    return;
+
+  // -1..1 -> 0..255
+  const float scaled_value = std::clamp(value * m_axis_scale, -1.0f, 1.0f);
+  const u8 u8_value = static_cast<u8>(std::clamp(((scaled_value + 1.0f) / 2.0f) * 255.0f, 0.0f, 255.0f));
+
+  SetAxisState(static_cast<Axis>(axis_code), u8_value);
+}
+
+void AnalogJoystick::SetAxisState(Axis axis, u8 value)
+{
+  m_axis_state[static_cast<u8>(axis)] = value;
+}
+
+void AnalogJoystick::SetButtonState(Button button, bool pressed)
+{
+  if (button == Button::Mode)
+  {
+    if (pressed)
+      ToggleAnalogMode();
+
+    return;
+  }
+
+  if (pressed)
+    m_button_state &= ~(u16(1) << static_cast<u8>(button));
+  else
+    m_button_state |= (u16(1) << static_cast<u8>(button));
+}
+
+void AnalogJoystick::SetButtonState(s32 button_code, bool pressed)
+{
+  if (button_code < 0 || button_code >= static_cast<s32>(Button::Count))
+    return;
+
+  SetButtonState(static_cast<Button>(button_code), pressed);
+}
+
+void AnalogJoystick::ResetTransferState()
+{
+  m_transfer_state = TransferState::Idle;
+}
+
+u16 AnalogJoystick::GetID() const
+{
+  static constexpr u16 DIGITAL_MODE_ID = 0x5A41;
+  static constexpr u16 ANALOG_MODE_ID = 0x5A53;
+
+  return m_analog_mode ? ANALOG_MODE_ID : DIGITAL_MODE_ID;
+}
+
+void AnalogJoystick::ToggleAnalogMode()
+{
+  m_analog_mode = !m_analog_mode;
+
+  Log_InfoPrintf("Joystick %u switched to %s mode.", m_index + 1u, m_analog_mode ? "analog" : "digital");
+  g_host_interface->AddFormattedOSDMessage(
+    5.0f,
+    m_analog_mode ? g_host_interface->TranslateString("AnalogJoystick", "Controller %u switched to analog mode.") :
+                    g_host_interface->TranslateString("AnalogJoystick", "Controller %u switched to digital mode."),
+    m_index + 1u);
+}
+
+bool AnalogJoystick::Transfer(const u8 data_in, u8* data_out)
+{
+  switch (m_transfer_state)
+  {
+    case TransferState::Idle:
+    {
+      // ack when sent 0x01, send ID for 0x42
+      if (data_in == 0x42)
+      {
+        *data_out = Truncate8(GetID());
+        m_transfer_state = TransferState::IDMSB;
+        return true;
+      }
+      else
+      {
+        *data_out = 0xFF;
+        return (data_in == 0x01);
+      }
+    }
+
+    case TransferState::IDMSB:
+    {
+      *data_out = Truncate8(GetID() >> 8);
+      m_transfer_state = TransferState::ButtonsLSB;
+      return true;
+    }
+
+    case TransferState::ButtonsLSB:
+    {
+      *data_out = Truncate8(m_button_state);
+      m_transfer_state = TransferState::ButtonsMSB;
+      return true;
+    }
+
+    case TransferState::ButtonsMSB:
+    {
+      *data_out = Truncate8(m_button_state >> 8);
+
+      m_transfer_state = m_analog_mode ? TransferState::RightAxisX : TransferState::Idle;
+      return m_analog_mode;
+    }
+
+    case TransferState::RightAxisX:
+    {
+      *data_out = Truncate8(m_axis_state[static_cast<u8>(Axis::RightX)]);
+      m_transfer_state = TransferState::RightAxisY;
+      return true;
+    }
+
+    case TransferState::RightAxisY:
+    {
+      *data_out = Truncate8(m_axis_state[static_cast<u8>(Axis::RightY)]);
+      m_transfer_state = TransferState::LeftAxisX;
+      return true;
+    }
+
+    case TransferState::LeftAxisX:
+    {
+      *data_out = Truncate8(m_axis_state[static_cast<u8>(Axis::LeftX)]);
+      m_transfer_state = TransferState::LeftAxisY;
+      return true;
+    }
+
+    case TransferState::LeftAxisY:
+    {
+      *data_out = Truncate8(m_axis_state[static_cast<u8>(Axis::LeftY)]);
+      m_transfer_state = TransferState::Idle;
+      return false;
+    }
+
+    default:
+    {
+      UnreachableCode();
+      return false;
+    }
+  }
+}
+
+std::unique_ptr<AnalogJoystick> AnalogJoystick::Create(u32 index)
+{
+  return std::make_unique<AnalogJoystick>(index);
+}
+
+std::optional<s32> AnalogJoystick::StaticGetAxisCodeByName(std::string_view axis_name)
+{
+#define AXIS(name)                                                                                                     \
+  if (axis_name == #name)                                                                                              \
+  {                                                                                                                    \
+    return static_cast<s32>(ZeroExtend32(static_cast<u8>(Axis::name)));                                                \
+  }
+
+  AXIS(LeftX);
+  AXIS(LeftY);
+  AXIS(RightX);
+  AXIS(RightY);
+
+  return std::nullopt;
+
+#undef AXIS
+}
+
+std::optional<s32> AnalogJoystick::StaticGetButtonCodeByName(std::string_view button_name)
+{
+#define BUTTON(name)                                                                                                   \
+  if (button_name == #name)                                                                                            \
+  {                                                                                                                    \
+    return static_cast<s32>(ZeroExtend32(static_cast<u8>(Button::name)));                                              \
+  }
+
+  BUTTON(Select);
+  BUTTON(L3);
+  BUTTON(R3);
+  BUTTON(Start);
+  BUTTON(Up);
+  BUTTON(Right);
+  BUTTON(Down);
+  BUTTON(Left);
+  BUTTON(L2);
+  BUTTON(R2);
+  BUTTON(L1);
+  BUTTON(R1);
+  BUTTON(Triangle);
+  BUTTON(Circle);
+  BUTTON(Cross);
+  BUTTON(Square);
+  BUTTON(Mode);
+
+  return std::nullopt;
+
+#undef BUTTON
+}
+
+Controller::AxisList AnalogJoystick::StaticGetAxisNames()
+{
+  return {{TRANSLATABLE("AnalogJoystick", "LeftX"), static_cast<s32>(Axis::LeftX), AxisType::Full},
+          {TRANSLATABLE("AnalogJoystick", "LeftY"), static_cast<s32>(Axis::LeftY), AxisType::Full},
+          {TRANSLATABLE("AnalogJoystick", "RightX"), static_cast<s32>(Axis::RightX), AxisType::Full},
+          {TRANSLATABLE("AnalogJoystick", "RightY"), static_cast<s32>(Axis::RightY), AxisType::Full}};
+}
+
+Controller::ButtonList AnalogJoystick::StaticGetButtonNames()
+{
+  return {{TRANSLATABLE("AnalogJoystick", "Up"), static_cast<s32>(Button::Up)},
+          {TRANSLATABLE("AnalogJoystick", "Down"), static_cast<s32>(Button::Down)},
+          {TRANSLATABLE("AnalogJoystick", "Left"), static_cast<s32>(Button::Left)},
+          {TRANSLATABLE("AnalogJoystick", "Right"), static_cast<s32>(Button::Right)},
+          {TRANSLATABLE("AnalogJoystick", "Select"), static_cast<s32>(Button::Select)},
+          {TRANSLATABLE("AnalogJoystick", "Start"), static_cast<s32>(Button::Start)},
+          {TRANSLATABLE("AnalogJoystick", "Triangle"), static_cast<s32>(Button::Triangle)},
+          {TRANSLATABLE("AnalogJoystick", "Cross"), static_cast<s32>(Button::Cross)},
+          {TRANSLATABLE("AnalogJoystick", "Circle"), static_cast<s32>(Button::Circle)},
+          {TRANSLATABLE("AnalogJoystick", "Square"), static_cast<s32>(Button::Square)},
+          {TRANSLATABLE("AnalogJoystick", "L1"), static_cast<s32>(Button::L1)},
+          {TRANSLATABLE("AnalogJoystick", "L2"), static_cast<s32>(Button::L2)},
+          {TRANSLATABLE("AnalogJoystick", "R1"), static_cast<s32>(Button::R1)},
+          {TRANSLATABLE("AnalogJoystick", "R2"), static_cast<s32>(Button::R2)},
+          {TRANSLATABLE("AnalogJoystick", "L3"), static_cast<s32>(Button::L3)},
+          {TRANSLATABLE("AnalogJoystick", "R3"), static_cast<s32>(Button::R3)},
+          {TRANSLATABLE("AnalogJoystick", "Analog"), static_cast<s32>(Button::Mode)}};
+}
+
+u32 AnalogJoystick::StaticGetVibrationMotorCount()
+{
+  return 0;
+}
+
+Controller::SettingList AnalogJoystick::StaticGetSettings()
+{
+  static constexpr std::array<SettingInfo, 1> settings = {
+    {{SettingInfo::Type::Float, "AxisScale", TRANSLATABLE("AnalogJoystick", "Analog Axis Scale"),
+      TRANSLATABLE(
+        "AnalogJoystick",
+        "Sets the analog stick axis scaling factor. A value between 1.30 and 1.40 is recommended when using recent "
+        "controllers, e.g. DualShock 4, Xbox One Controller."),
+      "1.00f", "0.01f", "1.50f", "0.01f"}}};
+
+  return SettingList(settings.begin(), settings.end());
+}
+
+void AnalogJoystick::LoadSettings(const char* section)
+{
+  Controller::LoadSettings(section);
+  m_axis_scale = std::clamp(g_host_interface->GetFloatSettingValue(section, "AxisScale", 1.00f), 0.01f, 1.50f);
+}

--- a/src/core/analog_joystick.h
+++ b/src/core/analog_joystick.h
@@ -1,0 +1,100 @@
+#pragma once
+#include "controller.h"
+#include <array>
+#include <memory>
+#include <optional>
+#include <string_view>
+
+class AnalogJoystick final : public Controller
+{
+public:
+  enum class Axis : u8
+  {
+    LeftX,
+    LeftY,
+    RightX,
+    RightY,
+    Count
+  };
+
+  enum class Button : u8
+  {
+    Select = 0,
+    L3 = 1,
+    R3 = 2,
+    Start = 3,
+    Up = 4,
+    Right = 5,
+    Down = 6,
+    Left = 7,
+    L2 = 8,
+    R2 = 9,
+    L1 = 10,
+    R1 = 11,
+    Triangle = 12,
+    Circle = 13,
+    Cross = 14,
+    Square = 15,
+    Mode = 16,
+    Count
+  };
+
+  AnalogJoystick(u32 index);
+  ~AnalogJoystick() override;
+
+  static std::unique_ptr<AnalogJoystick> Create(u32 index);
+  static std::optional<s32> StaticGetAxisCodeByName(std::string_view axis_name);
+  static std::optional<s32> StaticGetButtonCodeByName(std::string_view button_name);
+  static AxisList StaticGetAxisNames();
+  static ButtonList StaticGetButtonNames();
+  static u32 StaticGetVibrationMotorCount();
+  static SettingList StaticGetSettings();
+
+  ControllerType GetType() const override;
+  std::optional<s32> GetAxisCodeByName(std::string_view axis_name) const override;
+  std::optional<s32> GetButtonCodeByName(std::string_view button_name) const override;
+
+  void Reset() override;
+  bool DoState(StateWrapper& sw) override;
+
+  void SetAxisState(s32 axis_code, float value) override;
+  void SetButtonState(s32 button_code, bool pressed) override;
+
+  void ResetTransferState() override;
+  bool Transfer(const u8 data_in, u8* data_out) override;
+
+  void LoadSettings(const char* section) override;
+
+private:
+  enum class TransferState : u8
+  {
+    Idle,
+    IDMSB,
+    ButtonsLSB,
+    ButtonsMSB,
+    RightAxisX,
+    RightAxisY,
+    LeftAxisX,
+    LeftAxisY
+  };
+
+  void SetAxisState(Axis axis, u8 value);
+  void SetButtonState(Button button, bool pressed);
+
+  u16 GetID() const;
+  void ToggleAnalogMode();
+
+  u32 m_index;
+
+  float m_axis_scale = 1.00f;
+
+  // On original hardware, the mode toggle is a switch rather than a button, so we'll enable Analog Mode by default
+  bool m_analog_mode = true;
+
+  // buttons are active low
+  u16 m_button_state = UINT16_C(0xFFFF);
+
+  std::array<u8, static_cast<u8>(Axis::Count)> m_axis_state{};
+
+  TransferState m_transfer_state = TransferState::Idle;
+};

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -1,5 +1,6 @@
 #include "controller.h"
 #include "analog_controller.h"
+#include "analog_joystick.h"
 #include "common/state_wrapper.h"
 #include "digital_controller.h"
 #include "namco_guncon.h"
@@ -56,6 +57,9 @@ std::unique_ptr<Controller> Controller::Create(ControllerType type, u32 index)
     case ControllerType::AnalogController:
       return AnalogController::Create(index);
 
+    case ControllerType::AnalogJoystick:
+      return AnalogJoystick::Create(index);
+
     case ControllerType::NamcoGunCon:
       return NamcoGunCon::Create();
 
@@ -91,6 +95,9 @@ Controller::AxisList Controller::GetAxisNames(ControllerType type)
     case ControllerType::AnalogController:
       return AnalogController::StaticGetAxisNames();
 
+    case ControllerType::AnalogJoystick:
+      return AnalogJoystick::StaticGetAxisNames();
+
     case ControllerType::NamcoGunCon:
       return NamcoGunCon::StaticGetAxisNames();
 
@@ -115,6 +122,9 @@ Controller::ButtonList Controller::GetButtonNames(ControllerType type)
 
     case ControllerType::AnalogController:
       return AnalogController::StaticGetButtonNames();
+
+    case ControllerType::AnalogJoystick:
+      return AnalogJoystick::StaticGetButtonNames();
 
     case ControllerType::NamcoGunCon:
       return NamcoGunCon::StaticGetButtonNames();
@@ -141,6 +151,9 @@ u32 Controller::GetVibrationMotorCount(ControllerType type)
     case ControllerType::AnalogController:
       return AnalogController::StaticGetVibrationMotorCount();
 
+    case ControllerType::AnalogJoystick:
+      return AnalogJoystick::StaticGetVibrationMotorCount();
+
     case ControllerType::NamcoGunCon:
       return NamcoGunCon::StaticGetVibrationMotorCount();
 
@@ -165,6 +178,9 @@ std::optional<s32> Controller::GetAxisCodeByName(ControllerType type, std::strin
 
     case ControllerType::AnalogController:
       return AnalogController::StaticGetAxisCodeByName(axis_name);
+
+    case ControllerType::AnalogJoystick:
+      return AnalogJoystick::StaticGetAxisCodeByName(axis_name);
 
     case ControllerType::NamcoGunCon:
       return NamcoGunCon::StaticGetAxisCodeByName(axis_name);
@@ -191,6 +207,9 @@ std::optional<s32> Controller::GetButtonCodeByName(ControllerType type, std::str
     case ControllerType::AnalogController:
       return AnalogController::StaticGetButtonCodeByName(button_name);
 
+    case ControllerType::AnalogJoystick:
+      return AnalogJoystick::StaticGetButtonCodeByName(button_name);
+
     case ControllerType::NamcoGunCon:
       return NamcoGunCon::StaticGetButtonCodeByName(button_name);
 
@@ -212,6 +231,9 @@ Controller::SettingList Controller::GetSettings(ControllerType type)
   {
     case ControllerType::AnalogController:
       return AnalogController::StaticGetSettings();
+
+    case ControllerType::AnalogJoystick:
+      return AnalogJoystick::StaticGetSettings();
 
     case ControllerType::NamcoGunCon:
       return NamcoGunCon::StaticGetSettings();

--- a/src/core/core.vcxproj
+++ b/src/core/core.vcxproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="analog_controller.cpp" />
+    <ClCompile Include="analog_joystick.cpp" />
     <ClCompile Include="bios.cpp" />
     <ClCompile Include="bus.cpp" />
     <ClCompile Include="cdrom.cpp" />
@@ -116,6 +117,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="analog_controller.h" />
+    <ClInclude Include="analog_joystick.h" />
     <ClInclude Include="bios.h" />
     <ClInclude Include="bus.h" />
     <ClInclude Include="cdrom.h" />

--- a/src/core/core.vcxproj.filters
+++ b/src/core/core.vcxproj.filters
@@ -49,6 +49,7 @@
     <ClCompile Include="cheats.cpp" />
     <ClCompile Include="shadergen.cpp" />
     <ClCompile Include="memory_card_image.cpp" />
+    <ClCompile Include="analog_joystick.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="types.h" />
@@ -101,5 +102,6 @@
     <ClInclude Include="cheats.h" />
     <ClInclude Include="shadergen.h" />
     <ClInclude Include="memory_card_image.h" />
+    <ClInclude Include="analog_joystick.h" />
   </ItemGroup>
 </Project>

--- a/src/core/pad.cpp
+++ b/src/core/pad.cpp
@@ -67,7 +67,11 @@ bool Pad::DoState(StateWrapper& sw)
 
         m_controllers[i].reset();
         if (state_controller_type != ControllerType::None)
+        {
           m_controllers[i] = Controller::Create(state_controller_type, i);
+          if (!sw.DoMarker("Controller") || !m_controllers[i]->DoState(sw))
+            return false;
+        }
       }
       else
       {

--- a/src/core/save_state_version.h
+++ b/src/core/save_state_version.h
@@ -2,7 +2,7 @@
 #include "types.h"
 
 static constexpr u32 SAVE_STATE_MAGIC = 0x43435544;
-static constexpr u32 SAVE_STATE_VERSION = 43;
+static constexpr u32 SAVE_STATE_VERSION = 44;
 static constexpr u32 SAVE_STATE_MINIMUM_VERSION = 42;
 
 #pragma pack(push, 4)

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -651,12 +651,13 @@ const char* Settings::GetAudioBackendDisplayName(AudioBackend backend)
   return s_audio_backend_display_names[static_cast<int>(backend)];
 }
 
-static std::array<const char*, 6> s_controller_type_names = {
-  {"None", "DigitalController", "AnalogController", "NamcoGunCon", "PlayStationMouse", "NeGcon"}};
-static std::array<const char*, 6> s_controller_display_names = {
+static std::array<const char*, 7> s_controller_type_names = {
+  {"None", "DigitalController", "AnalogController", "AnalogJoystick", "NamcoGunCon", "PlayStationMouse", "NeGcon"}};
+static std::array<const char*, 7> s_controller_display_names = {
   {TRANSLATABLE("ControllerType", "None"), TRANSLATABLE("ControllerType", "Digital Controller"),
-   TRANSLATABLE("ControllerType", "Analog Controller (DualShock)"), TRANSLATABLE("ControllerType", "Namco GunCon"),
-   TRANSLATABLE("ControllerType", "PlayStation Mouse"), TRANSLATABLE("ControllerType", "NeGcon")}};
+   TRANSLATABLE("ControllerType", "Analog Controller (DualShock)"), TRANSLATABLE("ControllerType", "Analog Joystick"),
+   TRANSLATABLE("ControllerType", "Namco GunCon"), TRANSLATABLE("ControllerType", "PlayStation Mouse"),
+   TRANSLATABLE("ControllerType", "NeGcon")}};
 
 std::optional<ControllerType> Settings::ParseControllerTypeName(const char* str)
 {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -114,6 +114,7 @@ enum class ControllerType
   None,
   DigitalController,
   AnalogController,
+  AnalogJoystick,
   NamcoGunCon,
   PlayStationMouse,
   NeGcon,


### PR DESCRIPTION
Allows the use of analog controls for pre-Analog Controller titles such as Descent and MechWarrior 2.