### PR TITLE
Add SDL_Joystick support

### DIFF
--- a/src/core/negcon.cpp
+++ b/src/core/negcon.cpp
@@ -63,9 +63,8 @@ void NeGcon::SetAxisState(s32 axis_code, float value)
     return;
   }
 
-  // I, II, L: 0..1 -> 0..255 or -1..0 -> 0..255 to support negative axis ranges,
-  // e.g. if bound to analog stick instead of trigger
-  const u8 u8_value = static_cast<u8>(std::clamp(std::abs(value) * 255.0f, 0.0f, 255.0f));
+  // I, II, L: -1..1 -> 0..255
+  const u8 u8_value = static_cast<u8>(std::clamp(((value + 1.0f) / 2.0f) * 255.0f, 0.0f, 255.0f));
 
   SetAxisState(static_cast<Axis>(axis_code), u8_value);
 }

--- a/src/duckstation-qt/CMakeLists.txt
+++ b/src/duckstation-qt/CMakeLists.txt
@@ -55,6 +55,8 @@ set(SRCS
   inputbindingdialog.cpp
   inputbindingdialog.h
   inputbindingdialog.ui
+  inputbindingmonitor.cpp
+  inputbindingmonitor.h
   inputbindingwidgets.cpp
   inputbindingwidgets.h
   main.cpp

--- a/src/duckstation-qt/duckstation-qt.vcxproj
+++ b/src/duckstation-qt/duckstation-qt.vcxproj
@@ -66,6 +66,7 @@
     <ClCompile Include="displaysettingswidget.cpp" />
     <ClCompile Include="hotkeysettingswidget.cpp" />
     <ClCompile Include="inputbindingdialog.cpp" />
+    <ClCompile Include="inputbindingmonitor.cpp" />
     <ClCompile Include="inputbindingwidgets.cpp" />
     <ClCompile Include="qtdisplaywidget.cpp" />
     <ClCompile Include="gamelistsettingswidget.cpp" />
@@ -105,6 +106,7 @@
     <QtMoc Include="gamelistmodel.h" />
     <QtMoc Include="gamelistsearchdirectoriesmodel.h" />
     <QtMoc Include="autoupdaterdialog.h" />
+    <ClInclude Include="inputbindingmonitor.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="settingwidgetbinder.h" />
     <QtMoc Include="consolesettingswidget.h" />

--- a/src/duckstation-qt/duckstation-qt.vcxproj.filters
+++ b/src/duckstation-qt/duckstation-qt.vcxproj.filters
@@ -60,11 +60,13 @@
     <ClCompile Include="$(IntDir)moc_postprocessingchainconfigwidget.cpp" />
     <ClCompile Include="$(IntDir)moc_postprocessingshaderconfigwidget.cpp" />
     <ClCompile Include="$(IntDir)moc_postprocessingsettingswidget.cpp" />
+    <ClCompile Include="inputbindingmonitor.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="qtutils.h" />
     <ClInclude Include="settingwidgetbinder.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="inputbindingmonitor.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="resources">

--- a/src/duckstation-qt/inputbindingdialog.cpp
+++ b/src/duckstation-qt/inputbindingdialog.cpp
@@ -3,6 +3,7 @@
 #include "common/string_util.h"
 #include "core/settings.h"
 #include "frontend-common/controller_interface.h"
+#include "inputbindingmonitor.h"
 #include "qthostinterface.h"
 #include "qtutils.h"
 #include <QtCore/QTimer>
@@ -210,27 +211,7 @@ void InputButtonBindingDialog::hookControllerInput()
   if (!controller_interface)
     return;
 
-  controller_interface->SetHook([this](const ControllerInterface::Hook& ei) {
-    if (ei.type == ControllerInterface::Hook::Type::Axis)
-    {
-      // wait until it's at least half pushed so we don't get confused between axises with small movement
-      if (std::abs(ei.value) < 0.5f)
-        return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
-
-      // TODO: this probably should consider the "last value"
-      QMetaObject::invokeMethod(this, "bindToControllerAxis", Q_ARG(int, ei.controller_index),
-                                Q_ARG(int, ei.button_or_axis_number), Q_ARG(std::optional<bool>, ei.value > 0));
-      return ControllerInterface::Hook::CallbackResult::StopMonitoring;
-    }
-    else if (ei.type == ControllerInterface::Hook::Type::Button && ei.value > 0.0f)
-    {
-      QMetaObject::invokeMethod(this, "bindToControllerButton", Q_ARG(int, ei.controller_index),
-                                Q_ARG(int, ei.button_or_axis_number));
-      return ControllerInterface::Hook::CallbackResult::StopMonitoring;
-    }
-
-    return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
-  });
+  controller_interface->SetHook(InputButtonBindingMonitor(this));
 }
 
 void InputButtonBindingDialog::unhookControllerInput()
@@ -274,27 +255,7 @@ void InputAxisBindingDialog::hookControllerInput()
   if (!controller_interface)
     return;
 
-  controller_interface->SetHook([this](const ControllerInterface::Hook& ei) {
-    if (ei.type == ControllerInterface::Hook::Type::Axis)
-    {
-      // wait until it's at least half pushed so we don't get confused between axises with small movement
-      if (std::abs(ei.value) < 0.5f)
-        return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
-
-      QMetaObject::invokeMethod(this, "bindToControllerAxis", Q_ARG(int, ei.controller_index),
-                                Q_ARG(int, ei.button_or_axis_number), Q_ARG(std::optional<bool>, std::nullopt));
-      return ControllerInterface::Hook::CallbackResult::StopMonitoring;
-    }
-    else if (ei.type == ControllerInterface::Hook::Type::Button && m_axis_type == Controller::AxisType::Half &&
-             ei.value > 0.0f)
-    {
-      QMetaObject::invokeMethod(this, "bindToControllerButton", Q_ARG(int, ei.controller_index),
-                                Q_ARG(int, ei.button_or_axis_number));
-      return ControllerInterface::Hook::CallbackResult::StopMonitoring;
-    }
-
-    return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
-  });
+  controller_interface->SetHook(InputAxisBindingMonitor(this, m_axis_type));
 }
 
 void InputAxisBindingDialog::unhookControllerInput()

--- a/src/duckstation-qt/inputbindingdialog.cpp
+++ b/src/duckstation-qt/inputbindingdialog.cpp
@@ -128,16 +128,18 @@ void InputBindingDialog::addNewBinding(std::string new_binding)
   saveListToSettings();
 }
 
-void InputBindingDialog::bindToControllerAxis(int controller_index, int axis_index, std::optional<bool> positive)
+void InputBindingDialog::bindToControllerAxis(int controller_index, int axis_index, bool inverted,
+                                              std::optional<bool> half_axis_positive)
 {
+  const char* invert_char = inverted ? "-" : "";
   const char* sign_char = "";
-  if (positive)
+  if (half_axis_positive)
   {
-    sign_char = *positive ? "+" : "-";
+    sign_char = *half_axis_positive ? "+" : "-";
   }
 
   std::string binding =
-    StringUtil::StdStringFromFormat("Controller%d/%sAxis%d", controller_index, sign_char, axis_index);
+    StringUtil::StdStringFromFormat("Controller%d/%sAxis%d%s", controller_index, sign_char, axis_index, invert_char);
   addNewBinding(std::move(binding));
   stopListeningForInput();
 }
@@ -145,6 +147,14 @@ void InputBindingDialog::bindToControllerAxis(int controller_index, int axis_ind
 void InputBindingDialog::bindToControllerButton(int controller_index, int button_index)
 {
   std::string binding = StringUtil::StdStringFromFormat("Controller%d/Button%d", controller_index, button_index);
+  addNewBinding(std::move(binding));
+  stopListeningForInput();
+}
+
+void InputBindingDialog::bindToControllerHat(int controller_index, int hat_index, const QString& hat_direction)
+{
+  std::string binding = StringUtil::StdStringFromFormat("Controller%d/Hat%d %s", controller_index, hat_index,
+                                                        hat_direction.toLatin1().constData());
   addNewBinding(std::move(binding));
   stopListeningForInput();
 }

--- a/src/duckstation-qt/inputbindingdialog.h
+++ b/src/duckstation-qt/inputbindingdialog.h
@@ -19,8 +19,10 @@ public:
   ~InputBindingDialog();
 
 protected Q_SLOTS:
-  void bindToControllerAxis(int controller_index, int axis_index, std::optional<bool> positive);
+  void bindToControllerAxis(int controller_index, int axis_index, bool inverted,
+                            std::optional<bool> half_axis_positive);
   void bindToControllerButton(int controller_index, int button_index);
+  void bindToControllerHat(int controller_index, int hat_index, const QString& hat_direction);
   void onAddBindingButtonClicked();
   void onRemoveBindingButtonClicked();
   void onClearBindingsButtonClicked();

--- a/src/duckstation-qt/inputbindingmonitor.cpp
+++ b/src/duckstation-qt/inputbindingmonitor.cpp
@@ -1,4 +1,5 @@
 #include "inputbindingmonitor.h"
+#include <cmath>
 
 ControllerInterface::Hook::CallbackResult
 InputButtonBindingMonitor::operator()(const ControllerInterface::Hook& ei) const
@@ -6,19 +7,31 @@ InputButtonBindingMonitor::operator()(const ControllerInterface::Hook& ei) const
   if (ei.type == ControllerInterface::Hook::Type::Axis)
   {
     // wait until it's at least half pushed so we don't get confused between axises with small movement
-    if (std::abs(ei.value) < 0.5f)
+    if (std::abs(std::get<float>(ei.value)) < 0.5f)
       return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
 
     // TODO: this probably should consider the "last value"
     QMetaObject::invokeMethod(m_parent, "bindToControllerAxis", Q_ARG(int, ei.controller_index),
-                              Q_ARG(int, ei.button_or_axis_number), Q_ARG(std::optional<bool>, ei.value > 0));
+                              Q_ARG(int, ei.button_or_axis_number), Q_ARG(bool, false),
+                              Q_ARG(std::optional<bool>, std::get<float>(ei.value) > 0));
     return ControllerInterface::Hook::CallbackResult::StopMonitoring;
   }
-  else if (ei.type == ControllerInterface::Hook::Type::Button && ei.value > 0.0f)
+  else if (ei.type == ControllerInterface::Hook::Type::Button && std::get<float>(ei.value) > 0.0f)
   {
     QMetaObject::invokeMethod(m_parent, "bindToControllerButton", Q_ARG(int, ei.controller_index),
                               Q_ARG(int, ei.button_or_axis_number));
     return ControllerInterface::Hook::CallbackResult::StopMonitoring;
+  }
+  else if (ei.type == ControllerInterface::Hook::Type::Hat)
+  {
+    const std::string_view hat_position = std::get<std::string_view>(ei.value);
+    if (!hat_position.empty())
+    {
+      QString str = QString::fromLatin1(hat_position.data(), static_cast<int>(hat_position.size()));
+      QMetaObject::invokeMethod(m_parent, "bindToControllerHat", Q_ARG(int, ei.controller_index),
+                                Q_ARG(int, ei.button_or_axis_number), Q_ARG(QString, std::move(str)));
+      return ControllerInterface::Hook::CallbackResult::StopMonitoring;
+    }
   }
 
   return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
@@ -28,16 +41,17 @@ ControllerInterface::Hook::CallbackResult InputAxisBindingMonitor::operator()(co
 {
   if (ei.type == ControllerInterface::Hook::Type::Axis)
   {
-    // wait until it's at least half pushed so we don't get confused between axises with small movement
-    if (std::abs(ei.value) < 0.5f)
+    std::optional<bool> half_axis_positive, inverted;
+    if (!ProcessAxisInput(ei, half_axis_positive, inverted))
       return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
 
     QMetaObject::invokeMethod(m_parent, "bindToControllerAxis", Q_ARG(int, ei.controller_index),
-                              Q_ARG(int, ei.button_or_axis_number), Q_ARG(std::optional<bool>, std::nullopt));
+                              Q_ARG(int, ei.button_or_axis_number), Q_ARG(bool, inverted.value_or(false)),
+                              Q_ARG(std::optional<bool>, half_axis_positive));
     return ControllerInterface::Hook::CallbackResult::StopMonitoring;
   }
   else if (ei.type == ControllerInterface::Hook::Type::Button && m_axis_type == Controller::AxisType::Half &&
-           ei.value > 0.0f)
+           std::get<float>(ei.value) > 0.0f)
   {
     QMetaObject::invokeMethod(m_parent, "bindToControllerButton", Q_ARG(int, ei.controller_index),
                               Q_ARG(int, ei.button_or_axis_number));
@@ -47,10 +61,84 @@ ControllerInterface::Hook::CallbackResult InputAxisBindingMonitor::operator()(co
   return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
 }
 
+bool InputAxisBindingMonitor::ProcessAxisInput(const ControllerInterface::Hook& ei,
+                                               std::optional<bool>& half_axis_positive,
+                                               std::optional<bool>& inverted) const
+{
+  const float value = std::get<float>(ei.value);
+
+  if (!ei.track_history) // Keyboard, mouse, game controller
+  {
+    // wait until it's at least half pushed so we don't get confused between axises with small movement
+    if (std::abs(value) < 0.5f)
+      return false;
+
+    return true;
+  }
+  else // Joystick
+  {
+    auto& history = m_context->m_inputs_history;
+    // Reject inputs coming from multiple sources
+    if (!history.empty())
+    {
+      const auto& item = history.front();
+      if (ei.controller_index != item.controller_index || ei.button_or_axis_number != item.axis_number)
+        return false;
+    }
+    history.push_back({ei.controller_index, ei.button_or_axis_number, value});
+    return AnalyzeInputHistory(half_axis_positive, inverted);
+  }
+}
+
+bool InputAxisBindingMonitor::AnalyzeInputHistory(std::optional<bool>& half_axis_positive,
+                                                  std::optional<bool>& inverted) const
+{
+  const auto& history = m_context->m_inputs_history;
+  const auto [min, max] = std::minmax_element(
+    history.begin(), history.end(), [](const auto& left, const auto& right) { return left.value < right.value; });
+
+  // Ignore small input magnitudes
+  if (std::abs(max->value - min->value) < 0.5f)
+    return false;
+
+  // Used heuristics:
+  // * If history contains inputs with both - and + sign (ignoring 0), bind a full axis
+  // * If history contains only 0 and inputs of the same sign AND maxes out at 1.0/-1.0, bind a half axis
+  // * Use the direction of input changes to determine whether the axis is inverted or not
+  if (std::signbit(min->value) != std::signbit(max->value))
+  {
+    if (min->value != 0.0f && max->value != 0.0f)
+    {
+      // If max value comes before the min value, invert the half axis
+      if (m_axis_type == Controller::AxisType::Half)
+      {
+        inverted = std::distance(min, max) < 0;
+      }
+
+      return true;
+    }
+  }
+  else
+  {
+    if ((std::abs(min->value) > 0.99f || std::abs(max->value) > 0.99f) &&
+        (std::abs(min->value) < 0.01f || std::abs(max->value) < 0.01f))
+    {
+
+      if (m_axis_type == Controller::AxisType::Half)
+      {
+        half_axis_positive = max->value > 0.0f;
+      }
+      return true;
+    }
+  }
+
+  return false;
+}
+
 ControllerInterface::Hook::CallbackResult
 InputRumbleBindingMonitor::operator()(const ControllerInterface::Hook& ei) const
 {
-  if (ei.type == ControllerInterface::Hook::Type::Button && ei.value > 0.0f)
+  if (ei.type == ControllerInterface::Hook::Type::Button && std::get<float>(ei.value) > 0.0f)
   {
     QMetaObject::invokeMethod(m_parent, "bindToControllerRumble", Q_ARG(int, ei.controller_index));
     return ControllerInterface::Hook::CallbackResult::StopMonitoring;

--- a/src/duckstation-qt/inputbindingmonitor.cpp
+++ b/src/duckstation-qt/inputbindingmonitor.cpp
@@ -1,0 +1,60 @@
+#include "inputbindingmonitor.h"
+
+ControllerInterface::Hook::CallbackResult
+InputButtonBindingMonitor::operator()(const ControllerInterface::Hook& ei) const
+{
+  if (ei.type == ControllerInterface::Hook::Type::Axis)
+  {
+    // wait until it's at least half pushed so we don't get confused between axises with small movement
+    if (std::abs(ei.value) < 0.5f)
+      return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
+
+    // TODO: this probably should consider the "last value"
+    QMetaObject::invokeMethod(m_parent, "bindToControllerAxis", Q_ARG(int, ei.controller_index),
+                              Q_ARG(int, ei.button_or_axis_number), Q_ARG(std::optional<bool>, ei.value > 0));
+    return ControllerInterface::Hook::CallbackResult::StopMonitoring;
+  }
+  else if (ei.type == ControllerInterface::Hook::Type::Button && ei.value > 0.0f)
+  {
+    QMetaObject::invokeMethod(m_parent, "bindToControllerButton", Q_ARG(int, ei.controller_index),
+                              Q_ARG(int, ei.button_or_axis_number));
+    return ControllerInterface::Hook::CallbackResult::StopMonitoring;
+  }
+
+  return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
+}
+
+ControllerInterface::Hook::CallbackResult InputAxisBindingMonitor::operator()(const ControllerInterface::Hook& ei) const
+{
+  if (ei.type == ControllerInterface::Hook::Type::Axis)
+  {
+    // wait until it's at least half pushed so we don't get confused between axises with small movement
+    if (std::abs(ei.value) < 0.5f)
+      return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
+
+    QMetaObject::invokeMethod(m_parent, "bindToControllerAxis", Q_ARG(int, ei.controller_index),
+                              Q_ARG(int, ei.button_or_axis_number), Q_ARG(std::optional<bool>, std::nullopt));
+    return ControllerInterface::Hook::CallbackResult::StopMonitoring;
+  }
+  else if (ei.type == ControllerInterface::Hook::Type::Button && m_axis_type == Controller::AxisType::Half &&
+           ei.value > 0.0f)
+  {
+    QMetaObject::invokeMethod(m_parent, "bindToControllerButton", Q_ARG(int, ei.controller_index),
+                              Q_ARG(int, ei.button_or_axis_number));
+    return ControllerInterface::Hook::CallbackResult::StopMonitoring;
+  }
+
+  return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
+}
+
+ControllerInterface::Hook::CallbackResult
+InputRumbleBindingMonitor::operator()(const ControllerInterface::Hook& ei) const
+{
+  if (ei.type == ControllerInterface::Hook::Type::Button && ei.value > 0.0f)
+  {
+    QMetaObject::invokeMethod(m_parent, "bindToControllerRumble", Q_ARG(int, ei.controller_index));
+    return ControllerInterface::Hook::CallbackResult::StopMonitoring;
+  }
+
+  return ControllerInterface::Hook::CallbackResult::ContinueMonitoring;
+}

--- a/src/duckstation-qt/inputbindingmonitor.h
+++ b/src/duckstation-qt/inputbindingmonitor.h
@@ -2,6 +2,8 @@
 
 #include "frontend-common/controller_interface.h"
 #include <QtCore/QObject>
+#include <memory>
+#include <vector>
 
 // NOTE: Those Monitor classes must be copyable to meet the requirements of std::function, but at the same time we want
 // copies to be opaque to the caling code and share context. Therefore, all mutable context of the monitor (if required)
@@ -29,8 +31,25 @@ public:
   ControllerInterface::Hook::CallbackResult operator()(const ControllerInterface::Hook& ei) const;
 
 private:
+  bool ProcessAxisInput(const ControllerInterface::Hook& ei, std::optional<bool>& half_axis_positive,
+                        std::optional<bool>& inverted) const;
+  bool AnalyzeInputHistory(std::optional<bool>& half_axis_positive, std::optional<bool>& inverted) const;
+
+  struct Context
+  {
+    struct History
+    {
+      int controller_index;
+      int axis_number;
+      float value;
+    };
+
+    std::vector<History> m_inputs_history;
+  };
+
   QObject* m_parent;
   Controller::AxisType m_axis_type;
+  std::shared_ptr<Context> m_context = std::make_shared<Context>();
 };
 
 class InputRumbleBindingMonitor

--- a/src/duckstation-qt/inputbindingmonitor.h
+++ b/src/duckstation-qt/inputbindingmonitor.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "frontend-common/controller_interface.h"
+#include <QtCore/QObject>
+
+// NOTE: Those Monitor classes must be copyable to meet the requirements of std::function, but at the same time we want
+// copies to be opaque to the caling code and share context. Therefore, all mutable context of the monitor (if required)
+// must be enclosed in a std::shared_ptr. m_parent/m_axis_type don't mutate so they don't need to be stored as such.
+
+class InputButtonBindingMonitor
+{
+public:
+  explicit InputButtonBindingMonitor(QObject* parent) : m_parent(parent) {}
+
+  ControllerInterface::Hook::CallbackResult operator()(const ControllerInterface::Hook& ei) const;
+
+private:
+  QObject* m_parent;
+};
+
+class InputAxisBindingMonitor
+{
+public:
+  explicit InputAxisBindingMonitor(QObject* parent, Controller::AxisType axis_type)
+    : m_parent(parent), m_axis_type(axis_type)
+  {
+  }
+
+  ControllerInterface::Hook::CallbackResult operator()(const ControllerInterface::Hook& ei) const;
+
+private:
+  QObject* m_parent;
+  Controller::AxisType m_axis_type;
+};
+
+class InputRumbleBindingMonitor
+{
+public:
+  explicit InputRumbleBindingMonitor(QObject* parent) : m_parent(parent) {}
+
+  ControllerInterface::Hook::CallbackResult operator()(const ControllerInterface::Hook& ei) const;
+
+private:
+  QObject* m_parent;
+};

--- a/src/duckstation-qt/inputbindingwidgets.cpp
+++ b/src/duckstation-qt/inputbindingwidgets.cpp
@@ -41,16 +41,18 @@ void InputBindingWidget::updateText()
     setText(QString::fromStdString(m_bindings[0]));
 }
 
-void InputBindingWidget::bindToControllerAxis(int controller_index, int axis_index, std::optional<bool> positive)
+void InputBindingWidget::bindToControllerAxis(int controller_index, int axis_index, bool inverted,
+                                              std::optional<bool> half_axis_positive)
 {
+  const char* invert_char = inverted ? "-" : "";
   const char* sign_char = "";
-  if (positive)
+  if (half_axis_positive)
   {
-    sign_char = *positive ? "+" : "-";
+    sign_char = *half_axis_positive ? "+" : "-";
   }
 
   m_new_binding_value =
-    StringUtil::StdStringFromFormat("Controller%d/%sAxis%d", controller_index, sign_char, axis_index);
+    StringUtil::StdStringFromFormat("Controller%d/%sAxis%d%s", controller_index, sign_char, axis_index, invert_char);
   setNewBinding();
   stopListeningForInput();
 }
@@ -58,6 +60,14 @@ void InputBindingWidget::bindToControllerAxis(int controller_index, int axis_ind
 void InputBindingWidget::bindToControllerButton(int controller_index, int button_index)
 {
   m_new_binding_value = StringUtil::StdStringFromFormat("Controller%d/Button%d", controller_index, button_index);
+  setNewBinding();
+  stopListeningForInput();
+}
+
+void InputBindingWidget::bindToControllerHat(int controller_index, int hat_index, const QString& hat_direction)
+{
+  m_new_binding_value = StringUtil::StdStringFromFormat("Controller%d/Hat%d %s", controller_index, hat_index,
+                                                        hat_direction.toLatin1().constData());
   setNewBinding();
   stopListeningForInput();
 }

--- a/src/duckstation-qt/inputbindingwidgets.h
+++ b/src/duckstation-qt/inputbindingwidgets.h
@@ -20,8 +20,10 @@ public:
   ALWAYS_INLINE void setNextWidget(InputBindingWidget* widget) { m_next_widget = widget; }
 
 public Q_SLOTS:
-  void bindToControllerAxis(int controller_index, int axis_index, std::optional<bool> positive);
+  void bindToControllerAxis(int controller_index, int axis_index, bool inverted,
+                            std::optional<bool> half_axis_positive);
   void bindToControllerButton(int controller_index, int button_index);
+  void bindToControllerHat(int controller_index, int hat_index, const QString& hat_direction);
   void beginRebindAll();
   void clearBinding();
   void reloadBinding();

--- a/src/frontend-common/controller_interface.cpp
+++ b/src/frontend-common/controller_interface.cpp
@@ -36,13 +36,14 @@ void ControllerInterface::ClearHook()
     m_event_intercept_callback = {};
 }
 
-bool ControllerInterface::DoEventHook(Hook::Type type, int controller_index, int button_or_axis_number, float value)
+bool ControllerInterface::DoEventHook(Hook::Type type, int controller_index, int button_or_axis_number,
+                                      std::variant<float, std::string_view> value, bool track_history)
 {
   std::unique_lock<std::mutex> lock(m_event_intercept_mutex);
   if (!m_event_intercept_callback)
     return false;
 
-  const Hook ei{type, controller_index, button_or_axis_number, value};
+  const Hook ei{type, controller_index, button_or_axis_number, std::move(value), track_history};
   const Hook::CallbackResult action = m_event_intercept_callback(ei);
   if (action == Hook::CallbackResult::StopMonitoring)
     m_event_intercept_callback = {};
@@ -64,7 +65,8 @@ void ControllerInterface::OnControllerDisconnected(int host_id)
 
 void ControllerInterface::ClearBindings() {}
 
-bool ControllerInterface::BindControllerAxis(int controller_index, int axis_number, AxisCallback callback)
+bool ControllerInterface::BindControllerAxis(int controller_index, int axis_number, AxisSide axis_side,
+                                             AxisCallback callback)
 {
   return false;
 }

--- a/src/frontend-common/sdl_controller_interface.h
+++ b/src/frontend-common/sdl_controller_interface.h
@@ -6,8 +6,6 @@
 #include <mutex>
 #include <vector>
 
-union SDL_Event;
-
 class SDLControllerInterface final : public ControllerInterface
 {
 public:
@@ -42,7 +40,7 @@ public:
 
   void PollEvents() override;
 
-  bool ProcessSDLEvent(const SDL_Event* event);
+  bool ProcessSDLEvent(const union SDL_Event* event);
 
 private:
   struct ControllerData
@@ -72,8 +70,8 @@ private:
 
   bool OpenGameController(int index);
   bool CloseGameController(int joystick_index, bool notify);
-  bool HandleControllerAxisEvent(const SDL_Event* event);
-  bool HandleControllerButtonEvent(const SDL_Event* event);
+  bool HandleControllerAxisEvent(const struct SDL_ControllerAxisEvent* event);
+  bool HandleControllerButtonEvent(const struct SDL_ControllerButtonEvent* event);
 
   bool OpenJoystick(int index);
   bool HandleJoystickAxisEvent(const struct SDL_JoyAxisEvent* event);

--- a/src/frontend-common/xinput_controller_interface.h
+++ b/src/frontend-common/xinput_controller_interface.h
@@ -22,10 +22,12 @@ public:
   void ClearBindings() override;
 
   // Binding to events. If a binding for this axis/button already exists, returns false.
-  bool BindControllerAxis(int controller_index, int axis_number, AxisCallback callback) override;
+  bool BindControllerAxis(int controller_index, int axis_number, AxisSide axis_side, AxisCallback callback) override;
   bool BindControllerButton(int controller_index, int button_number, ButtonCallback callback) override;
   bool BindControllerAxisToButton(int controller_index, int axis_number, bool direction,
                                   ButtonCallback callback) override;
+  bool BindControllerHatToButton(int controller_index, int hat_number, std::string_view hat_position,
+                                 ButtonCallback callback) override;
   bool BindControllerButtonToAxis(int controller_index, int button_number, AxisCallback callback) override;
 
   // Changing rumble strength.
@@ -61,7 +63,7 @@ private:
 
     float deadzone = 0.25f;
 
-    std::array<AxisCallback, MAX_NUM_AXISES> axis_mapping;
+    std::array<std::array<AxisCallback, 3>, MAX_NUM_AXISES> axis_mapping;
     std::array<ButtonCallback, MAX_NUM_BUTTONS> button_mapping;
     std::array<std::array<ButtonCallback, 2>, MAX_NUM_AXISES> axis_button_mapping;
     std::array<AxisCallback, MAX_NUM_BUTTONS> button_axis_mapping;


### PR DESCRIPTION
**This PR needs testing with libretro and NeGcon controllers! The range of I/II buttons has been modified so I can't guarantee there are no regressions.**

This PR refactors and extends the SDL controller interface to not only support GameController peripherals, but also Joystick ones. This allows users to use various peripherals which don't fit the standardized game controller interface.

This PR was only tested with a steering wheel, but in theory it should make it possible to use e.g. flight sticks or other devices matching the official ones for PS1.

It's possible that the new extended mapping heuristics don't cover all possible cases, but I have verified that mapping works as expected e.g. with both separate pedal axes as well as combined axes. Inverted axes are also now supported.