### PR TITLE
System: Limit maximum loadable save state version

### DIFF
--- a/src/core/save_state_version.h
+++ b/src/core/save_state_version.h
@@ -5,6 +5,8 @@ static constexpr u32 SAVE_STATE_MAGIC = 0x43435544;
 static constexpr u32 SAVE_STATE_VERSION = 45;
 static constexpr u32 SAVE_STATE_MINIMUM_VERSION = 42;
 
+static_assert(SAVE_STATE_VERSION >= SAVE_STATE_MINIMUM_VERSION);
+
 #pragma pack(push, 4)
 struct SAVE_STATE_HEADER
 {

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -951,12 +951,13 @@ bool DoLoadState(ByteStream* state, bool force_software_renderer, bool update_di
   if (header.magic != SAVE_STATE_MAGIC)
     return false;
 
-  if (header.version < SAVE_STATE_MINIMUM_VERSION)
+  if (header.version < SAVE_STATE_MINIMUM_VERSION || header.version > SAVE_STATE_VERSION)
   {
     g_host_interface->ReportFormattedError(
       g_host_interface->TranslateString("System",
-                                        "Save state is incompatible: minimum version is %u but state is version %u."),
-      SAVE_STATE_MINIMUM_VERSION, header.version);
+                                        "Save state is incompatible: %s version is %u but state is version %u."),
+      header.version > SAVE_STATE_VERSION ? "maximum" : "minimum",
+      header.version > SAVE_STATE_VERSION ? SAVE_STATE_VERSION : SAVE_STATE_MINIMUM_VERSION, header.version);
     return false;
   }
 

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1986,11 +1986,12 @@ CommonHostInterface::GetExtendedSaveStateInfo(const char* game_code, s32 slot)
   ssi.slot = slot;
   ssi.global = global;
 
-  if (header.version < SAVE_STATE_MINIMUM_VERSION)
+  if (header.version < SAVE_STATE_MINIMUM_VERSION || header.version > SAVE_STATE_VERSION)
   {
-    ssi.title =
-      StringUtil::StdStringFromFormat(TranslateString("CommonHostInterface", "Invalid version %u (minimum version %u)"),
-                                      header.version, SAVE_STATE_MINIMUM_VERSION);
+    ssi.title = StringUtil::StdStringFromFormat(
+      TranslateString("CommonHostInterface", "Invalid version %u (%s version %u)"), header.version,
+      header.version > SAVE_STATE_VERSION ? "maximum" : "minimum",
+      header.version > SAVE_STATE_VERSION ? SAVE_STATE_VERSION : SAVE_STATE_MINIMUM_VERSION);
     return ssi;
   }
 


### PR DESCRIPTION
Kind of silly, but figured might as well since loading newer states when testing older builds returns the wrong kind of error.