### PR TITLE
AnalogController: Disallow analog-to-dpad in config mode

### DIFF
--- a/src/core/analog_controller.cpp
+++ b/src/core/analog_controller.cpp
@@ -216,7 +216,7 @@ void AnalogController::SetMotorState(u8 motor, u8 value)
 
 u8 AnalogController::GetExtraButtonMaskLSB() const
 {
-  if (!m_analog_dpad_in_digital_mode || m_analog_mode)
+  if (!m_analog_dpad_in_digital_mode || m_analog_mode || m_configuration_mode)
     return 0xFF;
 
   static constexpr u8 NEG_THRESHOLD = static_cast<u8>(128.0f - (127.0 * 0.5f));


### PR DESCRIPTION
Since pad reads in config mode get the full analog mode response regardless of actual digital/analog mode, this feature should be disabled in config mode. Don't remember at the moment which games do pad reads in config mode to test this, but this change should be safe.