### PR TITLE
GDB server stub for remote debugging

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -163,6 +163,33 @@ std::size_t Strlcpy(char* dst, const std::string_view& src, std::size_t size)
   return len;
 }
 
+std::optional<std::vector<u8>> DecodeHex(const std::string_view& in)
+{
+  std::vector<u8> data;
+  data.reserve(in.size()/2);
+
+  for (int i = 0; i < in.size()-1; i+=2) {
+    auto byte = StringUtil::FromChars<u8>(in.substr(i*2, 2));
+    if (byte) {
+      data.push_back(*byte);
+    }
+    else {
+      return { };
+    }
+  }
+
+  return { data };
+}
+
+std::string EncodeHex(const u8* data, int length)
+{
+  std::stringstream ss;
+  for (int i = 0; i < length; i++) {
+    ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(data[i]);
+  }
+  return ss.str();
+}
+
 #ifdef WIN32
 
 std::wstring UTF8StringToWideString(const std::string_view& str)

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -3,9 +3,11 @@
 #include <cstdarg>
 #include <cstddef>
 #include <cstring>
+#include <iomanip>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #if defined(__has_include) && __has_include(<charconv>)
 #include <charconv>
@@ -53,12 +55,12 @@ static inline int Strncasecmp(const char* s1, const char* s2, std::size_t n)
 
 /// Wrapper arond std::from_chars
 template<typename T>
-inline std::optional<T> FromChars(const std::string_view& str)
+inline std::optional<T> FromChars(const std::string_view& str, int base = 10)
 {
   T value;
 
 #if defined(__has_include) && __has_include(<charconv>)
-  const std::from_chars_result result = std::from_chars(str.data(), str.data() + str.length(), value);
+  const std::from_chars_result result = std::from_chars(str.data(), str.data() + str.length(), value, base);
   if (result.ec != std::errc())
     return std::nullopt;
 #else
@@ -74,7 +76,7 @@ inline std::optional<T> FromChars(const std::string_view& str)
 
 /// Explicit override for booleans
 template<>
-inline std::optional<bool> FromChars(const std::string_view& str)
+inline std::optional<bool> FromChars(const std::string_view& str, int base)
 {
   if (Strncasecmp("true", str.data(), str.length()) == 0 || Strncasecmp("yes", str.data(), str.length()) == 0 ||
       Strncasecmp("on", str.data(), str.length()) == 0 || Strncasecmp("1", str.data(), str.length()) == 0)
@@ -94,18 +96,22 @@ inline std::optional<bool> FromChars(const std::string_view& str)
 #ifndef _MSC_VER
 /// from_chars doesn't seem to work with floats on gcc
 template<>
-inline std::optional<float> FromChars(const std::string_view& str)
+inline std::optional<float> FromChars(const std::string_view& str, int base)
 {
   float value;
   std::string temp(str);
   std::istringstream ss(temp);
-  ss >> value;
+  ss >> std::setbase(base) >> value;
   if (ss.fail())
     return std::nullopt;
   else
     return value;
 }
 #endif
+
+/// Encode/decode hexadecimal byte buffers
+std::optional<std::vector<u8>> DecodeHex(const std::string_view& str);
+std::string EncodeHex(const u8* data, int length);
 
 /// starts_with from C++20
 ALWAYS_INLINE static bool StartsWith(const std::string_view& str, const char* prefix)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(core
     digital_controller.h
     dma.cpp
     dma.h
+    gdb_protocol.cpp
+    gdb_protocol.h
     gpu.cpp
     gpu.h
     gpu_backend.cpp

--- a/src/core/bus.h
+++ b/src/core/bus.h
@@ -149,4 +149,8 @@ ALWAYS_INLINE TickCount GetDMARAMTickCount(u32 word_count)
   return static_cast<TickCount>(word_count + ((word_count + 15) / 16));
 }
 
+/// Bus access for debugging.
+void Peek(VirtualMemoryAddress address, u32 size, u8* values);
+void Poke(VirtualMemoryAddress address, u32 size, u8* values);
+
 } // namespace Bus

--- a/src/core/gdb_protocol.cpp
+++ b/src/core/gdb_protocol.cpp
@@ -1,0 +1,394 @@
+#include "gdb_protocol.h"
+#include "bus.h"
+#include "common/log.h"
+#include "common/string_util.h"
+#include "cpu_core.h"
+#include "frontend-common/common_host_interface.h"
+#include "system.h"
+#include <functional>
+#include <iomanip>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <string>
+Log_SetChannel(GDBProtocol);
+
+namespace GDBProtocol
+{
+
+static void WatchpointHelper(bool insert, const std::string_view& data, CPU::InstrumentedAddresses& byteMap, CPU::InstrumentedAddresses& halfwordMap, CPU::InstrumentedAddresses& wordMap)
+{
+  std::stringstream ss{std::string{data}};
+  std::string dataAddress, dataLength;
+
+  std::getline(ss, dataAddress, ',');
+  std::getline(ss, dataLength, '\0');
+
+  auto address = StringUtil::FromChars<VirtualMemoryAddress>(dataAddress, 16).value_or(0);
+  auto length = StringUtil::FromChars<u32>(dataLength, 16).value_or(0);
+
+  bool ok = true;
+  if (insert) {
+    switch (length) {
+     case 1:
+        byteMap.insert(address);
+        break;
+     case 2:
+        halfwordMap.insert(address);
+        break;
+     case 4:
+        byteMap.insert(address);
+        break;
+      default:
+        Log_ErrorPrintf("Unsupported watchpoint insertion of size %d at 0x%08x", length, address);
+        ok = false;
+        break;
+    }
+  }
+  else {
+    switch (length) {
+     case 1:
+        byteMap.erase(address);
+        break;
+     case 2:
+        halfwordMap.erase(address);
+        break;
+     case 4:
+        wordMap.erase(address);
+        break;
+      default:
+        Log_ErrorPrintf("Unsupported watchpoint removal of size %d at 0x%08x", length, address);
+        ok = false;
+        break;
+    }
+  }
+
+  if (ok) {
+    CPU::DebugUpdatedInstrumentation();
+    Log_InfoPrintf("%s watchpoint at 0x%08x (size %d)", insert ? "Inserted" : "Cleared", address, length);
+  }
+}
+
+static u8 ComputeChecksum(const std::string_view& str)
+{
+  u8 checksum = 0;
+  for (char c : str) {
+    checksum = (checksum + c) % 256;
+  }
+  return checksum;
+}
+
+static std::optional<std::string_view> DeserializePacket(const std::string_view& in)
+{
+  if ((in.size() < 4) || (in[0] != '$') || (in[in.size()-3] != '#')) {
+    return { };
+  }
+  std::string_view data = in.substr(1, in.size()-4);
+
+  u8 packetChecksum = StringUtil::FromChars<u8>(in.substr(in.size()-2, 2), 16).value_or(0);
+  u8 computedChecksum = ComputeChecksum(data);
+
+  if (packetChecksum == computedChecksum) {
+    return { data };
+  }
+  else {
+    return { };
+  }
+}
+
+static std::string SerializePacket(const std::string_view& in)
+{
+  std::stringstream ss;
+  ss << '$' << in << '#' << StringUtil::StdStringFromFormat("%02x", ComputeChecksum(in));
+  return ss.str();
+}
+
+/// List of GDB remote protocol registers for MIPS III (excluding FP).
+static const std::array<u32*, 38> REGISTERS {
+  &CPU::g_state.regs.r[0],
+  &CPU::g_state.regs.r[1],
+  &CPU::g_state.regs.r[2],
+  &CPU::g_state.regs.r[3],
+  &CPU::g_state.regs.r[4],
+  &CPU::g_state.regs.r[5],
+  &CPU::g_state.regs.r[6],
+  &CPU::g_state.regs.r[7],
+  &CPU::g_state.regs.r[8],
+  &CPU::g_state.regs.r[9],
+  &CPU::g_state.regs.r[10],
+  &CPU::g_state.regs.r[11],
+  &CPU::g_state.regs.r[12],
+  &CPU::g_state.regs.r[13],
+  &CPU::g_state.regs.r[14],
+  &CPU::g_state.regs.r[15],
+  &CPU::g_state.regs.r[16],
+  &CPU::g_state.regs.r[17],
+  &CPU::g_state.regs.r[18],
+  &CPU::g_state.regs.r[19],
+  &CPU::g_state.regs.r[20],
+  &CPU::g_state.regs.r[21],
+  &CPU::g_state.regs.r[22],
+  &CPU::g_state.regs.r[23],
+  &CPU::g_state.regs.r[24],
+  &CPU::g_state.regs.r[25],
+  &CPU::g_state.regs.r[26],
+  &CPU::g_state.regs.r[27],
+  &CPU::g_state.regs.r[28],
+  &CPU::g_state.regs.r[29],
+  &CPU::g_state.regs.r[30],
+  &CPU::g_state.regs.r[31],
+
+  &CPU::g_state.cop0_regs.sr.bits,
+  &CPU::g_state.regs.lo,
+  &CPU::g_state.regs.hi,
+  &CPU::g_state.cop0_regs.BadVaddr,
+  &CPU::g_state.cop0_regs.cause.bits,
+  &CPU::g_state.regs.pc,
+};
+
+/// Number of registers in GDB remote protocol for MIPS III.
+constexpr int NUM_GDB_REGISTERS = 73;
+
+/// Get stop reason.
+static std::optional<std::string> Cmd$_questionMark(const std::string_view& data)
+{
+  return { "S02" };
+}
+
+/// Continue execution.
+static std::optional<std::string> Cmd$c(const std::string_view& data)
+{
+  CPU::DebugReleaseCPU();
+  return { };
+}
+
+/// Get general registers.
+static std::optional<std::string> Cmd$g(const std::string_view& data)
+{
+  std::stringstream ss;
+
+  for (u32* reg : REGISTERS) {
+    // Data is in host order (little endian).
+    ss << StringUtil::EncodeHex(reinterpret_cast<u8*>(reg), 4);
+  }
+
+  // Pad with dummy data (FP registers stuff).
+  for (int i = 0; i < NUM_GDB_REGISTERS - REGISTERS.size(); i++) {
+    ss << "00000000";
+  }
+
+  return { ss.str() };
+}
+
+/// Set general registers.
+static std::optional<std::string> Cmd$G(const std::string_view& data)
+{
+  if (data.size() == NUM_GDB_REGISTERS*8) {
+    int offset = 0;
+
+    for (u32* reg : REGISTERS) {
+      // Data is in host order (little endian).
+      auto value = StringUtil::DecodeHex({data.data()+offset, 8});
+      if (value) {
+        *reg = *reinterpret_cast<u32*>(&(*value)[0]);
+      }
+      offset += 8;
+    }
+  }
+  else {
+    Log_ErrorPrintf("Wrong payload size for 'G' command, expected %d got %d", NUM_GDB_REGISTERS*8, data.size());
+  }
+
+  return { "" };
+}
+
+/// Get memory.
+static std::optional<std::string> Cmd$m(const std::string_view& data)
+{
+  std::stringstream ss{std::string{data}};
+  std::string dataAddress, dataLength;
+
+  std::getline(ss, dataAddress, ',');
+  std::getline(ss, dataLength, '\0');
+
+  auto address = StringUtil::FromChars<VirtualMemoryAddress>(dataAddress, 16).value_or(0);
+  auto length = StringUtil::FromChars<u32>(dataLength, 16).value_or(0);
+  auto payload = std::vector<u8>(length, 0xFF);
+
+  Bus::Peek(address, length, &payload[0]);
+
+  return { StringUtil::EncodeHex(&payload[0], length) };
+}
+
+/// Set memory.
+static std::optional<std::string> Cmd$M(const std::string_view& data)
+{
+  std::stringstream ss{std::string{data}};
+  std::string dataAddress, dataLength, dataPayload;
+
+  std::getline(ss, dataAddress, ',');
+  std::getline(ss, dataLength, ':');
+  std::getline(ss, dataPayload, '\0');
+
+  auto address = StringUtil::FromChars<VirtualMemoryAddress>(dataAddress, 16).value_or(0);
+  auto length = StringUtil::FromChars<u32>(dataLength, 16).value_or(0);
+  auto payload = StringUtil::DecodeHex(dataPayload);
+
+  if (payload) {
+    Bus::Poke(address, length, &payload.value()[0]);
+  }
+
+  return { "OK" };
+}
+
+/// Remove hardware breakpoint.
+static std::optional<std::string> Cmd$z1(const std::string_view& data)
+{
+  auto address = StringUtil::FromChars<VirtualMemoryAddress>(data, 16).value_or(0);
+  CPU::g_state.debug_breakpoints.erase(address);
+  Log_InfoPrintf("Cleared breakpoint 0x%08x", address);
+  CPU::DebugUpdatedInstrumentation();
+
+  return { "OK" };
+}
+
+/// Insert hardware breakpoint.
+static std::optional<std::string> Cmd$Z1(const std::string_view& data)
+{
+  auto address = StringUtil::FromChars<VirtualMemoryAddress>(data, 16).value_or(0);
+  CPU::g_state.debug_breakpoints.insert(address);
+  Log_InfoPrintf("Inserted breakpoint at 0x%08x", address);
+  CPU::DebugUpdatedInstrumentation();
+
+  return { "OK" };
+}
+
+/// Remove write watchpoint.
+static std::optional<std::string> Cmd$z2(const std::string_view& data)
+{
+  WatchpointHelper(false, data, CPU::g_state.debug_watchpoints_write_byte, CPU::g_state.debug_watchpoints_write_halfword, CPU::g_state.debug_watchpoints_write_word);
+  return { "OK" };
+}
+
+/// Insert hardware breakpoint.
+static std::optional<std::string> Cmd$Z2(const std::string_view& data)
+{
+  WatchpointHelper(true, data, CPU::g_state.debug_watchpoints_write_byte, CPU::g_state.debug_watchpoints_write_halfword, CPU::g_state.debug_watchpoints_write_word);
+  return { "OK" };
+}
+
+/// Remove read watchpoint.
+static std::optional<std::string> Cmd$z3(const std::string_view& data)
+{
+  WatchpointHelper(false, data, CPU::g_state.debug_watchpoints_read_byte, CPU::g_state.debug_watchpoints_read_halfword, CPU::g_state.debug_watchpoints_read_word);
+  return { "OK" };
+}
+
+/// Insert read breakpoint.
+static std::optional<std::string> Cmd$Z3(const std::string_view& data)
+{
+  WatchpointHelper(true, data, CPU::g_state.debug_watchpoints_read_byte, CPU::g_state.debug_watchpoints_read_halfword, CPU::g_state.debug_watchpoints_read_word);
+  return { "OK" };
+}
+
+/// Remove access watchpoint.
+static std::optional<std::string> Cmd$z4(const std::string_view& data)
+{
+  WatchpointHelper(false, data, CPU::g_state.debug_watchpoints_access_byte, CPU::g_state.debug_watchpoints_access_halfword, CPU::g_state.debug_watchpoints_access_word);
+  return { "OK" };
+}
+
+/// Insert access breakpoint.
+static std::optional<std::string> Cmd$Z4(const std::string_view& data)
+{
+  WatchpointHelper(true, data, CPU::g_state.debug_watchpoints_access_byte, CPU::g_state.debug_watchpoints_access_halfword, CPU::g_state.debug_watchpoints_access_word);
+  return { "OK" };
+}
+
+static std::optional<std::string> Cmd$vMustReplyEmpty(const std::string_view& data)
+{
+  return { "" };
+}
+
+static std::optional<std::string> Cmd$qSupported(const std::string_view& data)
+{
+  return { "" };
+}
+
+/// List of all GDB remote protocol packets supported by us.
+static const std::map<const char*, std::function<std::optional<std::string>(const std::string_view&)>> COMMANDS
+{
+  { "?", Cmd$_questionMark },
+  { "c", Cmd$c },
+  { "g", Cmd$g },
+  { "G", Cmd$G },
+  { "m", Cmd$m },
+  { "M", Cmd$M },
+  { "z0,", Cmd$z1 },
+  { "Z0,", Cmd$Z1 },
+  { "z1,", Cmd$z1 },
+  { "Z1,", Cmd$Z1 },
+  { "z2,", Cmd$z2 },
+  { "Z2,", Cmd$Z2 },
+  { "z3,", Cmd$z3 },
+  { "Z3,", Cmd$Z3 },
+  { "z4,", Cmd$z4 },
+  { "Z4,", Cmd$Z4 },
+  { "vMustReplyEmpty", Cmd$vMustReplyEmpty },
+  { "qSupported", Cmd$qSupported },
+};
+
+bool IsPacketComplete(const std::string_view& data)
+{
+  return ((data.size() == 1) && (data[0] == '\003')) ||
+    ((data.size() > 3) && (*(data.end()-3) == '#'));
+}
+
+std::string ProcessPacket(const std::string_view& data)
+{
+  std::string_view trimmedData = data;
+
+  // Eat ACKs.
+  while (!trimmedData.empty() && (trimmedData[0] == '+' || trimmedData[0] == '-')) {
+    if (trimmedData[0] == '-') {
+      Log_ErrorPrint("Received negative ack");
+    }
+    trimmedData = trimmedData.substr(1);
+  }
+
+  // Interrupt request.
+  if (trimmedData.size() == 1 && trimmedData[0] == '\003') {
+    CPU::g_state.debug_pause = true;
+    CPU::DebugUpdatedInstrumentation();
+    return "";
+  }
+
+  // Validate packet.
+  auto packet = DeserializePacket(trimmedData);
+  if (!packet) {
+    Log_ErrorPrintf("Malformed packet '%*s'", trimmedData.size(), trimmedData.data());
+    return "-";
+  }
+
+  std::optional<std::string> reply = { "" };
+
+  // Try to invoke packet command.
+  bool processed = false;
+  for (const auto& command : COMMANDS) {
+    if (StringUtil::StartsWith(packet->data(), command.first)) {
+      Log_DebugPrintf("Processing command '%s'", command.first);
+
+      // Invoke command, remove command name from payload.
+      reply = command.second(packet->substr(strlen(command.first)));
+      processed = true;
+      break;
+    }
+  }
+
+  if (!processed) {
+    Log_WarningPrintf("Failed to process packet '%*s'", trimmedData.size(), trimmedData.data());
+  }
+  return reply ? "+"+SerializePacket(*reply) : "+";
+}
+
+} // namespace GDBProtocol

--- a/src/core/gdb_protocol.h
+++ b/src/core/gdb_protocol.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <string_view>
+
+namespace GDBProtocol
+{
+
+  bool IsPacketComplete(const std::string_view& data);
+  std::string ProcessPacket(const std::string_view& data);
+
+} // namespace GDBProtocol

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -403,6 +403,10 @@ void HostInterface::OnSystemDestroyed() {}
 
 void HostInterface::OnSystemPerformanceCountersUpdated() {}
 
+void HostInterface::OnDebugPaused() {}
+
+void HostInterface::OnDebugResumed() {}
+
 void HostInterface::OnSystemStateSaved(bool global, s32 slot) {}
 
 void HostInterface::OnRunningGameChanged() {}

--- a/src/core/host_interface.h
+++ b/src/core/host_interface.h
@@ -140,6 +140,10 @@ public:
   virtual void OnRunningGameChanged();
   virtual void OnSystemPerformanceCountersUpdated();
 
+  /// Notifications when core wants to pause/resume for debugging reasons.
+  virtual void OnDebugPaused();
+  virtual void OnDebugResumed();
+
 protected:
   virtual bool AcquireHostDisplay() = 0;
   virtual void ReleaseHostDisplay() = 0;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -244,6 +244,8 @@ void Settings::Load(SettingsInterface& si)
   debugging.show_vram = si.GetBoolValue("Debug", "ShowVRAM");
   debugging.dump_cpu_to_vram_copies = si.GetBoolValue("Debug", "DumpCPUToVRAMCopies");
   debugging.dump_vram_to_cpu_copies = si.GetBoolValue("Debug", "DumpVRAMToCPUCopies");
+  debugging.enable_gdb_server = si.GetBoolValue("Debug", "EnableGDBServer");
+  debugging.gdb_server_port = si.GetIntValue("Debug", "GDBServerPort");
   debugging.show_gpu_state = si.GetBoolValue("Debug", "ShowGPUState");
   debugging.show_cdrom_state = si.GetBoolValue("Debug", "ShowCDROMState");
   debugging.show_spu_state = si.GetBoolValue("Debug", "ShowSPUState");

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -160,6 +160,9 @@ struct Settings
     bool dump_cpu_to_vram_copies = false;
     bool dump_vram_to_cpu_copies = false;
 
+    bool enable_gdb_server = false;
+    u16 gdb_server_port = 1234;
+
     // Mutable because the imgui window can close itself.
     mutable bool show_gpu_state = false;
     mutable bool show_cdrom_state = false;

--- a/src/duckstation-qt/CMakeLists.txt
+++ b/src/duckstation-qt/CMakeLists.txt
@@ -47,6 +47,10 @@ set(SRCS
   gamepropertiesdialog.cpp
   gamepropertiesdialog.h
   gamepropertiesdialog.ui
+  gdbconnection.cpp
+  gdbconnection.h
+  gdbserver.cpp
+  gdbserver.h
   generalsettingswidget.cpp
   generalsettingswidget.h
   generalsettingswidget.ui

--- a/src/duckstation-qt/gdbconnection.cpp
+++ b/src/duckstation-qt/gdbconnection.cpp
@@ -1,0 +1,69 @@
+#include "gdbconnection.h"
+#include "common/log.h"
+#include "core/cpu_core.h"
+#include "core/gdb_protocol.h"
+Log_SetChannel(GDBConnection);
+
+GDBConnection::GDBConnection(QObject *parent, int descriptor)
+  : QThread(parent), m_descriptor(descriptor)
+{
+  Log_InfoPrintf("(%u) Accepted new connection on GDB server", m_descriptor);
+
+  connect(&m_socket, SIGNAL(readyRead()), this, SLOT(receivedData()));
+  connect(&m_socket, SIGNAL(disconnected()), this, SLOT(gotDisconnected()));
+
+  if (!m_socket.setSocketDescriptor(m_descriptor)) {
+    Log_ErrorPrintf("(%u) Failed to set socket descriptor: %s", m_descriptor, m_socket.errorString().toUtf8().constData());
+  }
+
+  CPU::g_state.debug_pause = true;
+  CPU::DebugUpdatedInstrumentation();
+}
+
+void GDBConnection::gotDisconnected()
+{
+  Log_InfoPrintf("(%u) Client disconnected", m_descriptor);
+  this->exit(0);
+}
+
+void GDBConnection::receivedData()
+{
+  qint64 bytesRead;
+  char buffer[256];
+
+  while ((bytesRead = m_socket.read(buffer, sizeof(buffer))) > 0) {
+    for (char c : std::string_view(buffer, bytesRead)) {
+      m_readBuffer.push_back(c);
+      if (GDBProtocol::IsPacketComplete(m_readBuffer)) {
+        Log_DebugPrintf("(%u) > %s", m_descriptor, m_readBuffer.c_str());
+        writePacket(GDBProtocol::ProcessPacket(m_readBuffer));
+        m_readBuffer.erase();
+      }
+    }
+  }
+  if (bytesRead == -1) {
+    Log_ErrorPrintf("(%u) Failed to read from socket: %s", m_descriptor, m_socket.errorString().toUtf8().constData());
+  }
+}
+
+void GDBConnection::onDebugPaused()
+{
+  if (m_seen_resume) {
+    m_seen_resume = false;
+    // Generate a stop reply packet, insert '?' command to generate it.
+    writePacket(GDBProtocol::ProcessPacket("$?#3f"));
+  }
+}
+
+void GDBConnection::onDebugResumed()
+{
+  m_seen_resume = true;
+}
+
+void GDBConnection::writePacket(std::string_view packet)
+{
+  Log_DebugPrintf("(%u) < %*s", m_descriptor, packet.length(), packet.data());
+  if (m_socket.write(packet.data(), packet.length()) == -1) {
+    Log_ErrorPrintf("(%u) Failed to write to socket: %s", m_descriptor, m_socket.errorString().toUtf8().constData());
+  }
+}

--- a/src/duckstation-qt/gdbconnection.h
+++ b/src/duckstation-qt/gdbconnection.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "core/types.h"
+#include <QtCore/QThread>
+#include <QtNetwork/QTcpSocket>
+
+class GDBConnection : public QThread
+{
+  Q_OBJECT
+
+public:
+  GDBConnection(QObject *parent, int descriptor);
+
+public Q_SLOTS:
+  void gotDisconnected();
+  void receivedData();
+  void onDebugPaused();
+  void onDebugResumed();
+
+private:
+  void writePacket(std::string_view data);
+
+  int m_descriptor;
+  QTcpSocket m_socket;
+  std::string m_readBuffer;
+  bool m_seen_resume;
+};

--- a/src/duckstation-qt/gdbserver.cpp
+++ b/src/duckstation-qt/gdbserver.cpp
@@ -1,0 +1,45 @@
+#include "gdbserver.h"
+#include "gdbconnection.h"
+#include "common/log.h"
+Log_SetChannel(GDBServer);
+
+GDBServer::GDBServer(QObject *parent, u16 port)
+    : QTcpServer(parent)
+{
+  if (listen(QHostAddress::LocalHost, port)) {
+    Log_InfoPrintf("GDB server listening on TCP port %u", port);
+  }
+  else {
+    Log_InfoPrintf("Failed to listen on TCP port %u for GDB server: %s", port, errorString().toUtf8().constData());
+  }
+}
+
+GDBServer::~GDBServer()
+{
+  Log_InfoPrint("GDB server stopped");
+  for (auto* thread : m_connections) {
+    thread->quit();
+    thread->wait();
+    delete thread;
+  }
+}
+
+void GDBServer::onDebugPaused()
+{
+  emit debugPause();
+}
+
+void GDBServer::onDebugResumed()
+{
+  emit debugResume();
+}
+
+void GDBServer::incomingConnection(qintptr descriptor)
+{
+  Log_InfoPrint("Accepted connection on GDB server");
+  GDBConnection *thread = new GDBConnection(this, descriptor);
+  connect(this, &GDBServer::debugPause, thread, &GDBConnection::onDebugPaused);
+  connect(this, &GDBServer::debugResume, thread, &GDBConnection::onDebugResumed);
+  thread->start();
+  m_connections.push_back(thread);
+}

--- a/src/duckstation-qt/gdbserver.h
+++ b/src/duckstation-qt/gdbserver.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "core/types.h"
+#include "gdbconnection.h"
+#include <QtNetwork/QTcpServer>
+
+class GDBServer : public QTcpServer
+{
+  Q_OBJECT
+
+public:
+  GDBServer(QObject* parent, u16 port);
+  ~GDBServer();
+
+public Q_SLOTS:
+  void onDebugPaused();
+  void onDebugResumed();
+
+Q_SIGNALS:
+  void debugPause();
+  void debugResume();
+
+protected:
+  void incomingConnection(qintptr socketDescriptor) override;
+
+private:
+  std::list<GDBConnection*> m_connections;
+};

--- a/src/duckstation-qt/mainwindow.h
+++ b/src/duckstation-qt/mainwindow.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <QtCore/QThread>
+#include <QtNetwork/QtNetwork>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QMainWindow>
 #include <memory>
@@ -19,6 +20,8 @@ class CheatManagerDialog;
 
 class HostDisplay;
 struct GameListEntry;
+
+class GDBServer;
 
 class MainWindow final : public QMainWindow
 {
@@ -93,6 +96,9 @@ private Q_SLOTS:
   void checkForUpdates(bool display_message);
   void onUpdateCheckComplete();
 
+  void onDebugPaused();
+  void onDebugResumed();
+
 protected:
   void closeEvent(QCloseEvent* event) override;
   void changeEvent(QEvent* event) override;
@@ -140,4 +146,6 @@ private:
 
   bool m_emulation_running = false;
   bool m_was_paused_by_focus_loss = false;
+
+  GDBServer* m_gdb_server = nullptr;
 };

--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -16,6 +16,7 @@
 #include "frontend-common/sdl_audio_stream.h"
 #include "frontend-common/sdl_controller_interface.h"
 #include "frontend-common/vulkan_host_display.h"
+#include "gdbserver.h"
 #include "imgui.h"
 #include "mainwindow.h"
 #include "qtdisplaywidget.h"
@@ -696,6 +697,16 @@ void QtHostInterface::OnRunningGameChanged()
 void QtHostInterface::OnSystemStateSaved(bool global, s32 slot)
 {
   emit stateSaved(QString::fromStdString(System::GetRunningCode()), global, slot);
+}
+
+void QtHostInterface::OnDebugPaused()
+{
+  emit debugPaused();
+}
+
+void QtHostInterface::OnDebugResumed()
+{
+  emit debugResumed();
 }
 
 void QtHostInterface::LoadSettings()

--- a/src/duckstation-qt/qthostinterface.h
+++ b/src/duckstation-qt/qthostinterface.h
@@ -138,6 +138,8 @@ Q_SIGNALS:
   void runningGameChanged(const QString& filename, const QString& game_code, const QString& game_title);
   void exitRequested();
   void inputProfileLoaded();
+  void debugPaused();
+  void debugResumed();
 
 public Q_SLOTS:
   void setDefaultSettings();
@@ -196,6 +198,9 @@ protected:
   void OnSystemPerformanceCountersUpdated() override;
   void OnRunningGameChanged() override;
   void OnSystemStateSaved(bool global, s32 slot) override;
+
+  void OnDebugPaused() override;
+  void OnDebugResumed() override;
 
   void LoadSettings() override;
   void SetDefaultSettings(SettingsInterface& si) override;


### PR DESCRIPTION
I'm currently in the process of reverse-engineering a PS1 game and I need a good, modern PS1 emulator with a decent debugger. This is surprisingly hard to come by, so I've settled for a good, modern PS1 emulator and stick a GDB stub in it.

To use this, you need a GDB with MIPS support (I use gdb-multiarch with `set architecture mips:3000`). Enable the GDB server in the settings file, start the Qt frontend, boot something and connect to the server with `target remote :1234`.

Settings to enable the GDB server:
```
[Debug]
EnableGDBServer = true
GDBServerPort = 1234
```

This is extremely bare-bones at the moment, but it can peek/poke memory. My main concern so far is handling instruction-level breakpoints/watchpoints, since it appears the emulator can only be paused at frame intervals (which would be a couple million instructions too late).

TODO:
- [X] GDB server settings in configuration file
- [ ] GDB server settings in Qt UI
- [X] GDB server for Qt frontend
- [ ] GDB server for SDL frontend
- [X] Basic GDB server infrastructure
- [X] Read/write memory
- [X] Read/write general registers
- [X] Hackish frame-level interrupt/continue
- [x] Proper instruction-level interrupt/continue
- [ ] Instruction step
- [x] Breakpoints
- [ ] Watchpoints