### PR TITLE
Memory Card Editor fixes

### DIFF
--- a/src/duckstation-qt/memorycardeditordialog.cpp
+++ b/src/duckstation-qt/memorycardeditordialog.cpp
@@ -33,7 +33,7 @@ MemoryCardEditorDialog::~MemoryCardEditorDialog() = default;
 
 bool MemoryCardEditorDialog::setCardA(const QString& path)
 {
-  const int index = m_ui.cardAPath->findData(QVariant(path));
+  const int index = m_ui.cardAPath->findData(QVariant(QDir::toNativeSeparators(path)));
   if (index < 0)
     return false;
 
@@ -43,7 +43,7 @@ bool MemoryCardEditorDialog::setCardA(const QString& path)
 
 bool MemoryCardEditorDialog::setCardB(const QString& path)
 {
-  const int index = m_ui.cardBPath->findData(QVariant(path));
+  const int index = m_ui.cardBPath->findData(QVariant(QDir::toNativeSeparators(path)));
   if (index < 0)
     return false;
 
@@ -114,7 +114,8 @@ void MemoryCardEditorDialog::loadCardFromComboBox(Card* card, int index)
   QString filename;
   if (index == 1)
   {
-    filename = QFileDialog::getOpenFileName(this, tr("Select Memory Card"), QString(), tr(MEMORY_CARD_IMAGE_FILTER));
+    filename = QDir::toNativeSeparators(
+      QFileDialog::getOpenFileName(this, tr("Select Memory Card"), QString(), tr(MEMORY_CARD_IMAGE_FILTER)));
     if (!filename.isEmpty())
     {
       // add to combo box
@@ -238,8 +239,8 @@ void MemoryCardEditorDialog::newCard(Card* card)
 {
   promptForSave(card);
 
-  QString filename =
-    QFileDialog::getSaveFileName(this, tr("Select Memory Card"), QString(), tr(MEMORY_CARD_IMAGE_FILTER));
+  QString filename = QDir::toNativeSeparators(
+    QFileDialog::getSaveFileName(this, tr("Select Memory Card"), QString(), tr(MEMORY_CARD_IMAGE_FILTER)));
   if (filename.isEmpty())
     return;
 
@@ -264,8 +265,8 @@ void MemoryCardEditorDialog::openCard(Card* card)
 {
   promptForSave(card);
 
-  QString filename =
-    QFileDialog::getOpenFileName(this, tr("Select Memory Card"), QString(), tr(MEMORY_CARD_IMAGE_FILTER));
+  QString filename = QDir::toNativeSeparators(
+    QFileDialog::getOpenFileName(this, tr("Select Memory Card"), QString(), tr(MEMORY_CARD_IMAGE_FILTER)));
   if (filename.isEmpty())
     return;
 

--- a/src/duckstation-qt/memorycardsettingswidget.cpp
+++ b/src/duckstation-qt/memorycardsettingswidget.cpp
@@ -11,7 +11,8 @@
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QLabel>
 
-static constexpr char MEMORY_CARD_IMAGE_FILTER[] = QT_TRANSLATE_NOOP("MemoryCardSettingsWidget", "All Memory Card Types (*.mcd *.mcr *.mc)");
+static constexpr char MEMORY_CARD_IMAGE_FILTER[] =
+  QT_TRANSLATE_NOOP("MemoryCardSettingsWidget", "All Memory Card Types (*.mcd *.mcr *.mc)");
 
 MemoryCardSettingsWidget::MemoryCardSettingsWidget(QtHostInterface* host_interface, QWidget* parent,
                                                    SettingsDialog* dialog)
@@ -104,8 +105,8 @@ void MemoryCardSettingsWidget::createPortSettingsUi(SettingsDialog* dialog, int 
 
 void MemoryCardSettingsWidget::onBrowseMemoryCardPathClicked(int index)
 {
-  QString path =
-    QFileDialog::getOpenFileName(this, tr("Select path to memory card image"), QString(), tr(MEMORY_CARD_IMAGE_FILTER));
+  QString path = QDir::toNativeSeparators(QFileDialog::getOpenFileName(this, tr("Select path to memory card image"),
+                                                                       QString(), tr(MEMORY_CARD_IMAGE_FILTER)));
   if (path.isEmpty())
     return;
 

--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -950,7 +950,7 @@ void QtHostInterface::populateGameListContextMenu(const GameListEntry* entry, QW
 
   QAction* open_memory_cards_action = menu->addAction(tr("Edit Memory Cards..."));
   connect(open_memory_cards_action, &QAction::triggered, [this, entry]() {
-    std::string paths[2];
+    QString paths[2];
     for (u32 i = 0; i < 2; i++)
     {
       MemoryCardType type = g_settings.memory_card_types[i];
@@ -962,21 +962,29 @@ void QtHostInterface::populateGameListContextMenu(const GameListEntry* entry, QW
         case MemoryCardType::None:
           continue;
         case MemoryCardType::Shared:
-          paths[i] =
-            g_settings.memory_card_paths[i].empty() ? GetSharedMemoryCardPath(i) : g_settings.memory_card_paths[i];
+          if (g_settings.memory_card_paths[i].empty())
+          {
+            paths[i] = QString::fromStdString(GetSharedMemoryCardPath(i));
+          }
+          else
+          {
+            QFileInfo path(QString::fromStdString(g_settings.memory_card_paths[i]));
+            path.makeAbsolute();
+            paths[i] = QDir::toNativeSeparators(path.canonicalFilePath());
+          }
           break;
         case MemoryCardType::PerGame:
-          paths[i] = GetGameMemoryCardPath(entry->code.c_str(), i);
+          paths[i] = QString::fromStdString(GetGameMemoryCardPath(entry->code.c_str(), i));
           break;
         case MemoryCardType::PerGameTitle:
-          paths[i] = GetGameMemoryCardPath(entry->title.c_str(), i);
+          paths[i] = QString::fromStdString(GetGameMemoryCardPath(entry->title.c_str(), i));
           break;
         default:
           break;
       }
     }
 
-    m_main_window->openMemoryCardEditor(QString::fromStdString(paths[0]), QString::fromStdString(paths[1]));
+    m_main_window->openMemoryCardEditor(paths[0], paths[1]);
   });
 
   const bool has_any_states = resume_action->isEnabled() || load_state_menu->isEnabled();


### PR DESCRIPTION
Fixes two issues:
1. Forward/backward slashes were inconsistent, leading to mismatches in the combobox. Now native separators are used consistently.
2. Fixes a bug where relative path shared memcard would not be found in the combobox, causing a false positive "could not find the memory card" error.