### PR TITLE
Fix a few path manipulation bugs

### DIFF
--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -75,6 +75,9 @@ void CanonicalizePath(char* Destination, u32 cbDestination, const char* Path, bo
           // remove the previous \, if we have one trailing the dot it'll append it anyway
           if (destinationLength > 0)
             Destination[--destinationLength] = '\0';
+          // if there was no previous \, skip past the next one
+          else if (nextCh != '\0')
+            i++;
 
           continue;
         }
@@ -125,6 +128,10 @@ void CanonicalizePath(char* Destination, u32 cbDestination, const char* Path, bo
     // increment position by one
     i++;
   }
+
+  // if we end up with the empty string, return '.'
+  if (destinationLength == 0)
+    Destination[destinationLength++] = '.';
 
   // ensure nullptr termination
   if (destinationLength < cbDestination)

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -112,7 +112,7 @@ void CanonicalizePath(char* Destination, u32 cbDestination, const char* Path, bo
 
     // fix ospath
     if (OSPath && (currentCh == '\\' || currentCh == '/'))
-      currentCh = FS_OSPATH_SEPERATOR_CHARACTER;
+      currentCh = FS_OSPATH_SEPARATOR_CHARACTER;
 
     // copy character
     if (destinationLength < cbDestination)
@@ -547,7 +547,7 @@ void BuildOSPath(char* Destination, u32 cbDestination, const char* Path)
     for (i = 0; i < pathLength; i++)
     {
       if (Destination[i] == '/')
-        Destination[i] = FS_OSPATH_SEPERATOR_CHARACTER;
+        Destination[i] = FS_OSPATH_SEPARATOR_CHARACTER;
     }
   }
   else
@@ -556,7 +556,7 @@ void BuildOSPath(char* Destination, u32 cbDestination, const char* Path)
     pathLength = std::max(pathLength, cbDestination - 1);
     for (i = 0; i < pathLength; i++)
     {
-      Destination[i] = (Path[i] == '/') ? FS_OSPATH_SEPERATOR_CHARACTER : Path[i];
+      Destination[i] = (Path[i] == '/') ? FS_OSPATH_SEPARATOR_CHARACTER : Path[i];
     }
 
     Destination[pathLength] = '\0';
@@ -576,7 +576,7 @@ void BuildOSPath(String& Destination, const char* Path)
     for (i = 0; i < pathLength; i++)
     {
       if (Destination[i] == '/')
-        Destination[i] = FS_OSPATH_SEPERATOR_CHARACTER;
+        Destination[i] = FS_OSPATH_SEPARATOR_CHARACTER;
     }
   }
   else
@@ -586,7 +586,7 @@ void BuildOSPath(String& Destination, const char* Path)
     Destination.Resize(pathLength);
     for (i = 0; i < pathLength; i++)
     {
-      Destination[i] = (Path[i] == '/') ? FS_OSPATH_SEPERATOR_CHARACTER : Path[i];
+      Destination[i] = (Path[i] == '/') ? FS_OSPATH_SEPARATOR_CHARACTER : Path[i];
     }
   }
 }

--- a/src/common/file_system.h
+++ b/src/common/file_system.h
@@ -10,10 +10,10 @@
 class ByteStream;
 
 #ifdef WIN32
-#define FS_OSPATH_SEPERATOR_CHARACTER '\\'
+#define FS_OSPATH_SEPARATOR_CHARACTER '\\'
 #define FS_OSPATH_SEPARATOR_STR "\\"
 #else
-#define FS_OSPATH_SEPERATOR_CHARACTER '/'
+#define FS_OSPATH_SEPARATOR_CHARACTER '/'
 #define FS_OSPATH_SEPARATOR_STR "/"
 #endif
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -314,17 +314,11 @@ ConsoleRegion GetConsoleRegionForDiscRegion(DiscRegion region)
 
 std::string_view GetTitleForPath(const char* path)
 {
-  const char* extension = std::strrchr(path, '.');
-  if (path == extension)
-    return path;
-
-  const char* path_end = path + std::strlen(path);
-  const char* title_end = extension ? (extension - 1) : (path_end);
-  const char* title_start = std::max(std::strrchr(path, '/'), std::strrchr(path, '\\'));
-  if (!title_start || title_start == path)
-    return std::string_view(path, title_end - title_start);
-  else
-    return std::string_view(title_start + 1, title_end - title_start);
+  std::string_view path_view = path;
+  std::size_t title_start = path_view.find_last_of("/\\");
+  if (title_start != std::string_view::npos)
+    path_view.remove_prefix(title_start + 1);
+  return path_view.substr(0, path_view.find_last_of('.'));
 }
 
 std::string GetGameCodeForPath(const char* image_path)

--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -767,7 +767,7 @@ void QtHostInterface::saveInputProfile(const QString& profile_name)
 QString QtHostInterface::getUserDirectoryRelativePath(const QString& arg) const
 {
   QString result = QString::fromStdString(m_user_directory);
-  result += FS_OSPATH_SEPERATOR_CHARACTER;
+  result += FS_OSPATH_SEPARATOR_CHARACTER;
   result += arg;
   return result;
 }
@@ -775,7 +775,7 @@ QString QtHostInterface::getUserDirectoryRelativePath(const QString& arg) const
 QString QtHostInterface::getProgramDirectoryRelativePath(const QString& arg) const
 {
   QString result = QString::fromStdString(m_program_directory);
-  result += FS_OSPATH_SEPERATOR_CHARACTER;
+  result += FS_OSPATH_SEPARATOR_CHARACTER;
   result += arg;
   return result;
 }

--- a/src/frontend-common/game_list.cpp
+++ b/src/frontend-common/game_list.cpp
@@ -1157,9 +1157,9 @@ std::string GameList::GetCoverImagePathForEntry(const GameListEntry* entry) cons
     {
       cover_path.Clear();
       cover_path.AppendString(g_host_interface->GetUserDirectory().c_str());
-      cover_path.AppendCharacter(FS_OSPATH_SEPERATOR_CHARACTER);
+      cover_path.AppendCharacter(FS_OSPATH_SEPARATOR_CHARACTER);
       cover_path.AppendString("covers");
-      cover_path.AppendCharacter(FS_OSPATH_SEPERATOR_CHARACTER);
+      cover_path.AppendCharacter(FS_OSPATH_SEPARATOR_CHARACTER);
       cover_path.AppendString(file_title.data(), static_cast<u32>(file_title.size()));
       cover_path.AppendCharacter('.');
       cover_path.AppendString(extension);

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -98,15 +98,15 @@ bool Updater::ParseZip()
     for (size_t i = 0; i < len; i++)
     {
       if (zip_filename_buffer[i] == '/' || zip_filename_buffer[i] == '\\')
-        zip_filename_buffer[i] = FS_OSPATH_SEPERATOR_CHARACTER;
+        zip_filename_buffer[i] = FS_OSPATH_SEPARATOR_CHARACTER;
     }
 
     // should never have a leading slash. just in case.
-    while (zip_filename_buffer[0] == FS_OSPATH_SEPERATOR_CHARACTER)
+    while (zip_filename_buffer[0] == FS_OSPATH_SEPARATOR_CHARACTER)
       std::memmove(&zip_filename_buffer[1], &zip_filename_buffer[0], --len);
 
     // skip directories (we sort them out later)
-    if (len > 0 && zip_filename_buffer[len - 1] != FS_OSPATH_SEPERATOR_CHARACTER)
+    if (len > 0 && zip_filename_buffer[len - 1] != FS_OSPATH_SEPARATOR_CHARACTER)
     {
       // skip updater itself, since it was already pre-extracted.
       if (StringUtil::Strcasecmp(zip_filename_buffer, "updater.exe") != 0)
@@ -138,10 +138,10 @@ bool Updater::ParseZip()
     const size_t len = ftu.destination_filename.length();
     for (size_t i = 0; i < len; i++)
     {
-      if (ftu.destination_filename[i] == FS_OSPATH_SEPERATOR_CHARACTER)
+      if (ftu.destination_filename[i] == FS_OSPATH_SEPARATOR_CHARACTER)
       {
         std::string dir(ftu.destination_filename.begin(), ftu.destination_filename.begin() + i);
-        while (!dir.empty() && dir[dir.length() - 1] == FS_OSPATH_SEPERATOR_CHARACTER)
+        while (!dir.empty() && dir[dir.length() - 1] == FS_OSPATH_SEPARATOR_CHARACTER)
           dir.erase(dir.length() - 1);
 
         if (std::find(m_update_directories.begin(), m_update_directories.end(), dir) == m_update_directories.end())


### PR DESCRIPTION
I noticed these when trying to load a file from the current directory. When I tried `file.m3u`, I got a  `std::bad_alloc` exception, and when I tried `./file.m3u`, it tried to load items from `/`.