### PR TITLE
Changed debugger "Enter memory address" to accept hex only

### DIFF
--- a/src/duckstation-qt/cheatmanagerdialog.cpp
+++ b/src/duckstation-qt/cheatmanagerdialog.cpp
@@ -644,7 +644,7 @@ void CheatManagerDialog::addToWatchClicked()
 
 void CheatManagerDialog::addManualWatchAddressClicked()
 {
-  std::optional<unsigned> address = QtUtils::PromptForAddress(this, windowTitle(), tr("Enter memory address:"));
+  std::optional<unsigned> address = QtUtils::PromptForAddress(this, windowTitle(), tr("Enter manual address:"), false);
   if (!address.has_value())
     return;
 

--- a/src/duckstation-qt/debuggerwindow.cpp
+++ b/src/duckstation-qt/debuggerwindow.cpp
@@ -104,7 +104,7 @@ void DebuggerWindow::onGoToPCTriggered()
 void DebuggerWindow::onGoToAddressTriggered()
 {
   std::optional<VirtualMemoryAddress> address =
-    QtUtils::PromptForAddress(this, windowTitle(), tr("Enter code address:"));
+    QtUtils::PromptForAddress(this, windowTitle(), tr("Enter code address:"), true);
   if (!address.has_value())
     return;
 
@@ -114,7 +114,7 @@ void DebuggerWindow::onGoToAddressTriggered()
 void DebuggerWindow::onDumpAddressTriggered()
 {
   std::optional<VirtualMemoryAddress> address =
-    QtUtils::PromptForAddress(this, windowTitle(), tr("Enter memory address:"));
+    QtUtils::PromptForAddress(this, windowTitle(), tr("Enter memory address:"), false);
   if (!address.has_value())
     return;
 
@@ -129,7 +129,7 @@ void DebuggerWindow::onFollowAddressTriggered()
 void DebuggerWindow::onAddBreakpointTriggered()
 {
   std::optional<VirtualMemoryAddress> address =
-    QtUtils::PromptForAddress(this, windowTitle(), tr("Enter code address:"));
+    QtUtils::PromptForAddress(this, windowTitle(), tr("Enter code address:") , true);
   if (!address.has_value())
     return;
 

--- a/src/duckstation-qt/qtutils.cpp
+++ b/src/duckstation-qt/qtutils.cpp
@@ -737,7 +737,7 @@ void FillComboBoxWithEmulationSpeeds(QComboBox* cb)
   }
 }
 
-std::optional<unsigned> PromptForAddress(QWidget* parent, const QString& title, const QString& label)
+std::optional<unsigned> PromptForAddress(QWidget* parent, const QString& title, const QString& label, bool code)
 {
   const QString address_str(
     QInputDialog::getText(parent, title, qApp->translate("DebuggerWindow", "Enter memory address:")));
@@ -749,8 +749,9 @@ std::optional<unsigned> PromptForAddress(QWidget* parent, const QString& title, 
   if (address_str.startsWith("0x"))
     address = address_str.midRef(2).toUInt(&ok, 16);
   else
-    address = address_str.toUInt(&ok, 16);  
-  address = address & 0xFFFFFFFC; //address should be divisible by 4 so make sure
+    address = address_str.toUInt(&ok, 16);
+  if ( code == true )
+    address = address & 0xFFFFFFFC; //disassembly address should be divisible by 4 so make sure
   
   if (!ok)
   {

--- a/src/duckstation-qt/qtutils.cpp
+++ b/src/duckstation-qt/qtutils.cpp
@@ -748,16 +748,15 @@ std::optional<unsigned> PromptForAddress(QWidget* parent, const QString& title, 
   uint address;
   if (address_str.startsWith("0x"))
     address = address_str.midRef(2).toUInt(&ok, 16);
-  else if (address_str[0] == '0' && address_str.length() > 1)
-    address = address_str.midRef(1).toUInt(&ok, 8);
   else
-    address = address_str.toUInt(&ok, 10);
-
+    address = address_str.toUInt(&ok, 16);  
+  address = address & 0xFFFFFFFC; //address should be divisible by 4 so make sure
+  
   if (!ok)
   {
     QMessageBox::critical(
       parent, title,
-      qApp->translate("DebuggerWindow", "Invalid address. It should be in hex (0x12345678) or decimal (12345678)"));
+      qApp->translate("DebuggerWindow", "Invalid address. It should be in hex (0x12345678 or 12345678)"));
     return std::nullopt;
   }
 

--- a/src/duckstation-qt/qtutils.h
+++ b/src/duckstation-qt/qtutils.h
@@ -71,7 +71,7 @@ void FillComboBoxWithMSAAModes(QComboBox* cb);
 /// Fills a combo box with emulation speed options.
 void FillComboBoxWithEmulationSpeeds(QComboBox* cb);
 
-/// Prompts for an address in decimal, octal, or hex.
-std::optional<unsigned> PromptForAddress(QWidget* parent, const QString& title, const QString& label);
+/// Prompts for an address in hex.
+std::optional<unsigned> PromptForAddress(QWidget* parent, const QString& title, const QString& label, bool code);
 
 } // namespace QtUtils

--- a/src/duckstation-qt/translations/duckstation-qt_fr.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_fr.ts
@@ -2156,7 +2156,7 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     </message>
     <message>
         <location filename="../qtutils.cpp" line="760"/>
-        <source>Invalid address. It should be in hex (0x12345678) or decimal (12345678)</source>
+        <source>Invalid address. It should be in hex (0x12345678 or 12345678)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/duckstation-qt/translations/duckstation-qt_pt-br.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_pt-br.ts
@@ -2252,8 +2252,8 @@ This warning will only be shown once.</source>
     </message>
     <message>
         <location filename="../qtutils.cpp" line="760"/>
-        <source>Invalid address. It should be in hex (0x12345678) or decimal (12345678)</source>
-        <translation>Endereço inválido! Valores devem ser: hexa (0x12345678) ou decimal (12345678)</translation>
+        <source>Invalid address. It should be in hex (0x12345678 or 12345678)</source>
+        <translation>Endereço inválido! Valores devem ser: hexa (0x12345678 ou 12345678)</translation>
     </message>
 </context>
 <context>

--- a/src/duckstation-qt/translations/duckstation-qt_zh-cn.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_zh-cn.ts
@@ -2213,8 +2213,8 @@ This warning will only be shown once.</source>
     </message>
     <message>
         <location filename="../qtutils.cpp" line="760"/>
-        <source>Invalid address. It should be in hex (0x12345678) or decimal (12345678)</source>
-        <translation>无效的地址。它应该是十六进制(0x12345678)或十进制(12345678)</translation>
+        <source>Invalid address. It should be in hex (0x12345678 or 12345678)</source>
+        <translation>无效的地址。它应该是十六进制(0x12345678或12345678)</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
The "Enter memory address" prompt by default expects a decimal address unless it's preceded by 0x. Or it expects an number starting with 0 is an octal.
The disassembly address should be hexadecimal regardless as that is how it it displays the address.
Also changed it so that it changes any address entered to be divisible by 4 as there was an observed issue that would cause the disassembly addresses to get locked to a address that was not divisible by 4