### PR TITLE
Hack: Shader Interface Block INI setting

### DIFF
--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -507,6 +507,7 @@ void HostInterface::SetDefaultSettings(SettingsInterface& si)
   si.SetIntValue("GPU", "ResolutionScale", 1);
   si.SetIntValue("GPU", "Multisamples", 1);
   si.SetBoolValue("GPU", "UseDebugDevice", false);
+  si.SetBoolValue("GPU", "AllowShaderInterfaceBlock", true);
   si.SetBoolValue("GPU", "PerSampleShading", false);
   si.SetBoolValue("GPU", "UseThread", true);
   si.SetBoolValue("GPU", "ThreadedPresentation", true);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -149,6 +149,7 @@ void Settings::Load(SettingsInterface& si)
   gpu_resolution_scale = static_cast<u32>(si.GetIntValue("GPU", "ResolutionScale", 1));
   gpu_multisamples = static_cast<u32>(si.GetIntValue("GPU", "Multisamples", 1));
   gpu_use_debug_device = si.GetBoolValue("GPU", "UseDebugDevice", false);
+  gpu_allow_shader_interface_block = si.GetBoolValue("GPU", "AllowShaderInterfaceBlock", true);
   gpu_per_sample_shading = si.GetBoolValue("GPU", "PerSampleShading", false);
   gpu_use_thread = si.GetBoolValue("GPU", "UseThread", true);
   gpu_threaded_presentation = si.GetBoolValue("GPU", "ThreadedPresentation", true);
@@ -319,6 +320,7 @@ void Settings::Save(SettingsInterface& si) const
   si.SetIntValue("GPU", "ResolutionScale", static_cast<long>(gpu_resolution_scale));
   si.SetIntValue("GPU", "Multisamples", static_cast<long>(gpu_multisamples));
   si.SetBoolValue("GPU", "UseDebugDevice", gpu_use_debug_device);
+  si.SetBoolValue("GPU", "AllowShaderInterfaceBlock", gpu_allow_shader_interface_block);
   si.SetBoolValue("GPU", "PerSampleShading", gpu_per_sample_shading);
   si.SetBoolValue("GPU", "UseThread", gpu_use_thread);
   si.SetBoolValue("GPU", "ThreadedPresentation", gpu_threaded_presentation);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -108,6 +108,7 @@ struct Settings
   bool gpu_use_thread = true;
   bool gpu_threaded_presentation = true;
   bool gpu_use_debug_device = false;
+  bool gpu_allow_shader_interface_block = true;
   bool gpu_per_sample_shading = false;
   bool gpu_true_color = true;
   bool gpu_scaled_dithering = false;

--- a/src/core/shadergen.cpp
+++ b/src/core/shadergen.cpp
@@ -1,6 +1,7 @@
 #include "shadergen.h"
 #include "common/assert.h"
 #include "common/log.h"
+#include "core/settings.h"
 #include <cstdio>
 #include <glad.h>
 Log_SetChannel(ShaderGen);
@@ -14,7 +15,7 @@ ShaderGen::ShaderGen(HostDisplay::RenderAPI render_api, bool supports_dual_sourc
     if (m_render_api == HostDisplay::RenderAPI::OpenGL || m_render_api == HostDisplay::RenderAPI::OpenGLES)
       SetGLSLVersionString();
 
-    m_use_glsl_interface_blocks = (IsVulkan() || GLAD_GL_ES_VERSION_3_2 || GLAD_GL_VERSION_3_2);
+    m_use_glsl_interface_blocks = (IsVulkan() || GLAD_GL_ES_VERSION_3_2 || GLAD_GL_VERSION_3_2) && g_settings.gpu_allow_shader_interface_block;
     m_use_glsl_binding_layout = (IsVulkan() || UseGLSLBindingLayout());
   }
 }


### PR DESCRIPTION
As found in #1026, old Radeon OGL driver has issues with the qualifier used for SSAA and Interface Blocks. This PR adds an INI setting that allows to disable shader Interface Blocks from being used and avoid the bug.

Currently, I've been just making custom builds with the interface blocks disabled so I decided to try and make a setting for it. It's the least invasive way I found, although it exposes global settings to the shader generator. No UI settings either, too hacky for "advanced" even. 