### PR TITLE
Update BIOS image handling

### DIFF
--- a/src/core/bios.cpp
+++ b/src/core/bios.cpp
@@ -101,9 +101,11 @@ std::optional<Image> LoadImageFromFile(const char* filename)
   const u32 size = static_cast<u32>(std::ftell(fp.get()));
   std::fseek(fp.get(), 0, SEEK_SET);
 
-  if (size != BIOS_SIZE)
+  // Apparently some PS1/PS2 BIOS revisions found on the PS3 are neither 512KB nor 4MB, so just check within this range
+  if (size < BIOS_SIZE || size > BIOS_SIZE_PS2)
   {
-    Log_ErrorPrintf("BIOS image '%s' mismatch, expecting %u bytes, got %u bytes", filename, BIOS_SIZE, size);
+    Log_ErrorPrintf("BIOS image '%s' mismatch, expecting between %u and %u bytes, got %u bytes", filename, BIOS_SIZE,
+                    BIOS_SIZE_PS2, size);
     return std::nullopt;
   }
 

--- a/src/core/bios.cpp
+++ b/src/core/bios.cpp
@@ -37,46 +37,49 @@ std::string Hash::ToString() const
   return str;
 }
 
-static constexpr std::array<ImageInfo, 26> s_image_infos = {{
-  {"SCPH-1000, DTL-H1000 (v1.0)", ConsoleRegion::NTSC_J, MakeHashFromString("239665b1a3dade1b5a52c06338011044")},
-  {"SCPH-1001, 5003, DTL-H1201, H3001 (v2.2 12-04-95 A)", ConsoleRegion::NTSC_U,
-   MakeHashFromString("924e392ed05558ffdb115408c263dccf")},
-  {"SCPH-1002, DTL-H1002 (v2.0 05-10-95 E)", ConsoleRegion::PAL,
-   MakeHashFromString("54847e693405ffeb0359c6287434cbef")},
-  {"SCPH-1002, DTL-H1102 (v2.1 07-17-95 E)", ConsoleRegion::PAL,
-   MakeHashFromString("417b34706319da7cf001e76e40136c23")},
-  {"SCPH-1002, DTL-H1202, H3002 (v2.2 12-04-95 E)", ConsoleRegion::PAL,
-   MakeHashFromString("e2110b8a2b97a8e0b857a45d32f7e187")},
-  {"DTL-H1100 (v2.2 03-06-96 D)", ConsoleRegion::NTSC_J, MakeHashFromString("ca5cfc321f916756e3f0effbfaeba13b")},
-  {"SCPH-3000, DTL-H1000H (v1.1 01-22-95)", ConsoleRegion::NTSC_J,
-   MakeHashFromString("849515939161e62f6b866f6853006780")},
-  {"SCPH-1001, DTL-H1001 (v2.0 05-07-95 A)", ConsoleRegion::NTSC_U,
-   MakeHashFromString("dc2b9bf8da62ec93e868cfd29f0d067d")},
-  {"SCPH-3500 (v2.1 07-17-95 J)", ConsoleRegion::NTSC_J, MakeHashFromString("cba733ceeff5aef5c32254f1d617fa62")},
-  {"SCPH-1001, DTL-H1101 (v2.1 07-17-95 A)", ConsoleRegion::NTSC_U,
-   MakeHashFromString("da27e8b6dab242d8f91a9b25d80c63b8")},
-  {"SCPH-5000, DTL-H1200, H3000 (v2.2 12-04-95 J)", ConsoleRegion::NTSC_J,
-   MakeHashFromString("57a06303dfa9cf9351222dfcbb4a29d9")},
-  {"SCPH-5500 (v3.0 09-09-96 J)", ConsoleRegion::NTSC_J, MakeHashFromString("8dd7d5296a650fac7319bce665a6a53c")},
-  {"SCPH-5501, 5503, 7003 (v3.0 11-18-96 A)", ConsoleRegion::NTSC_U,
-   MakeHashFromString("490f666e1afb15b7362b406ed1cea246")},
-  {"SCPH-5502, 5552 (v3.0 01-06-97 E)", ConsoleRegion::PAL, MakeHashFromString("32736f17079d0b2b7024407c39bd3050")},
-  {"SCPH-7000, 7500, 9000 (v4.0 08-18-97 J)", ConsoleRegion::NTSC_J,
-   MakeHashFromString("8e4c14f567745eff2f0408c8129f72a6")},
-  {"SCPH-7000W (v4.1 11-14-97 A)", ConsoleRegion::NTSC_J, MakeHashFromString("b84be139db3ee6cbd075630aa20a6553")},
-  {"SCPH-7001, 7501, 7503, 9001, 9003, 9903 (v4.1 12-16-97 A)", ConsoleRegion::NTSC_U,
-   MakeHashFromString("1e68c231d0896b7eadcad1d7d8e76129")},
-  {"SCPH-7002, 7502, 9002 (v4.1 12-16-97 E)", ConsoleRegion::PAL,
-   MakeHashFromString("b9d9a0286c33dc6b7237bb13cd46fdee")},
-  {"SCPH-100 (v4.3 03-11-00 J)", ConsoleRegion::NTSC_J, MakeHashFromString("8abc1b549a4a80954addc48ef02c4521")},
-  {"SCPH-101 (v4.4 03-24-00 A)", ConsoleRegion::NTSC_U, MakeHashFromString("9a09ab7e49b422c007e6d54d7c49b965")},
-  {"SCPH-101 (v4.5 05-25-00 A)", ConsoleRegion::NTSC_U, MakeHashFromString("6e3735ff4c7dc899ee98981385f6f3d0")},
-  {"SCPH-102 (v4.4 03-24-00 E)", ConsoleRegion::PAL, MakeHashFromString("b10f5e0e3d9eb60e5159690680b1e774")},
-  {"SCPH-102 (v4.5 05-25-00 E)", ConsoleRegion::PAL, MakeHashFromString("de93caec13d1a141a40a79f5c86168d6")},
-  {"PSP, SCPH-1000R (v4.5 05-25-00 J)", ConsoleRegion::Auto, MakeHashFromString("c53ca5908936d412331790f4426c6c33")},
-  {"SCPH-1000R (v4.5 05-25-00 J)", ConsoleRegion::NTSC_J, MakeHashFromString("476d68a94ccec3b9c8303bbd1daf2810")},
-  {"PS3 (v5.0 06-23-03 A)", ConsoleRegion::Auto, MakeHashFromString("81bbe60ba7a3d1cea1d48c14cbcc647b")}
-}};
+static constexpr std::array<ImageInfo, 26> s_image_infos = {
+  {{"SCPH-1000, DTL-H1000 (v1.0)", ConsoleRegion::NTSC_J, MakeHashFromString("239665b1a3dade1b5a52c06338011044"), true},
+   {"SCPH-1001, 5003, DTL-H1201, H3001 (v2.2 12-04-95 A)", ConsoleRegion::NTSC_U,
+    MakeHashFromString("924e392ed05558ffdb115408c263dccf"), true},
+   {"SCPH-1002, DTL-H1002 (v2.0 05-10-95 E)", ConsoleRegion::PAL,
+    MakeHashFromString("54847e693405ffeb0359c6287434cbef"), true},
+   {"SCPH-1002, DTL-H1102 (v2.1 07-17-95 E)", ConsoleRegion::PAL,
+    MakeHashFromString("417b34706319da7cf001e76e40136c23"), true},
+   {"SCPH-1002, DTL-H1202, H3002 (v2.2 12-04-95 E)", ConsoleRegion::PAL,
+    MakeHashFromString("e2110b8a2b97a8e0b857a45d32f7e187"), true},
+   {"DTL-H1100 (v2.2 03-06-96 D)", ConsoleRegion::NTSC_J, MakeHashFromString("ca5cfc321f916756e3f0effbfaeba13b"), true},
+   {"SCPH-3000, DTL-H1000H (v1.1 01-22-95)", ConsoleRegion::NTSC_J,
+    MakeHashFromString("849515939161e62f6b866f6853006780"), true},
+   {"SCPH-1001, DTL-H1001 (v2.0 05-07-95 A)", ConsoleRegion::NTSC_U,
+    MakeHashFromString("dc2b9bf8da62ec93e868cfd29f0d067d"), true},
+   {"SCPH-3500 (v2.1 07-17-95 J)", ConsoleRegion::NTSC_J, MakeHashFromString("cba733ceeff5aef5c32254f1d617fa62"), true},
+   {"SCPH-1001, DTL-H1101 (v2.1 07-17-95 A)", ConsoleRegion::NTSC_U,
+    MakeHashFromString("da27e8b6dab242d8f91a9b25d80c63b8"), true},
+   {"SCPH-5000, DTL-H1200, H3000 (v2.2 12-04-95 J)", ConsoleRegion::NTSC_J,
+    MakeHashFromString("57a06303dfa9cf9351222dfcbb4a29d9"), true},
+   {"SCPH-5500 (v3.0 09-09-96 J)", ConsoleRegion::NTSC_J, MakeHashFromString("8dd7d5296a650fac7319bce665a6a53c"), true},
+   {"SCPH-5501, 5503, 7003 (v3.0 11-18-96 A)", ConsoleRegion::NTSC_U,
+    MakeHashFromString("490f666e1afb15b7362b406ed1cea246"), true},
+   {"SCPH-5502, 5552 (v3.0 01-06-97 E)", ConsoleRegion::PAL, MakeHashFromString("32736f17079d0b2b7024407c39bd3050"),
+    true},
+   {"SCPH-7000, 7500, 9000 (v4.0 08-18-97 J)", ConsoleRegion::NTSC_J,
+    MakeHashFromString("8e4c14f567745eff2f0408c8129f72a6"), true},
+   {"SCPH-7000W (v4.1 11-14-97 A)", ConsoleRegion::NTSC_J, MakeHashFromString("b84be139db3ee6cbd075630aa20a6553"),
+    true},
+   {"SCPH-7001, 7501, 7503, 9001, 9003, 9903 (v4.1 12-16-97 A)", ConsoleRegion::NTSC_U,
+    MakeHashFromString("1e68c231d0896b7eadcad1d7d8e76129"), true},
+   {"SCPH-7002, 7502, 9002 (v4.1 12-16-97 E)", ConsoleRegion::PAL,
+    MakeHashFromString("b9d9a0286c33dc6b7237bb13cd46fdee"), true},
+   {"SCPH-100 (v4.3 03-11-00 J)", ConsoleRegion::NTSC_J, MakeHashFromString("8abc1b549a4a80954addc48ef02c4521"), true},
+   {"SCPH-101 (v4.4 03-24-00 A)", ConsoleRegion::NTSC_U, MakeHashFromString("9a09ab7e49b422c007e6d54d7c49b965"), true},
+   {"SCPH-101 (v4.5 05-25-00 A)", ConsoleRegion::NTSC_U, MakeHashFromString("6e3735ff4c7dc899ee98981385f6f3d0"), true},
+   {"SCPH-102 (v4.4 03-24-00 E)", ConsoleRegion::PAL, MakeHashFromString("b10f5e0e3d9eb60e5159690680b1e774"), true},
+   {"SCPH-102 (v4.5 05-25-00 E)", ConsoleRegion::PAL, MakeHashFromString("de93caec13d1a141a40a79f5c86168d6"), true},
+   {"PSP, SCPH-1000R (v4.5 05-25-00 J)", ConsoleRegion::Auto, MakeHashFromString("c53ca5908936d412331790f4426c6c33"),
+    true},
+   {"SCPH-1000R (v4.5 05-25-00 J)", ConsoleRegion::NTSC_J, MakeHashFromString("476d68a94ccec3b9c8303bbd1daf2810"),
+    true},
+   {"PS3 (v5.0 06-23-03 A)", ConsoleRegion::Auto, MakeHashFromString("81bbe60ba7a3d1cea1d48c14cbcc647b"), false}}};
 
 Hash GetHash(const Image& image)
 {
@@ -168,7 +171,7 @@ void PatchBIOS(u8* image, u32 image_size, u32 address, u32 value, u32 mask /*= U
 bool PatchBIOSEnableTTY(u8* image, u32 image_size, const Hash& hash)
 {
   const ImageInfo* ii = GetImageInfoForHash(hash);
-  if (!ii)
+  if (!ii || !ii->patch_compatible)
   {
     Log_WarningPrintf("Incompatible version for TTY patch: %s", hash.ToString().c_str());
     return false;
@@ -183,7 +186,7 @@ bool PatchBIOSEnableTTY(u8* image, u32 image_size, const Hash& hash)
 bool PatchBIOSFastBoot(u8* image, u32 image_size, const Hash& hash)
 {
   const ImageInfo* ii = GetImageInfoForHash(hash);
-  if (!ii)
+  if (!ii || !ii->patch_compatible)
   {
     Log_WarningPrintf("Incompatible version for fast-boot patch: %s", hash.ToString().c_str());
     return false;

--- a/src/core/bios.h
+++ b/src/core/bios.h
@@ -9,7 +9,8 @@ namespace BIOS {
 enum : u32
 {
   BIOS_BASE = 0x1FC00000,
-  BIOS_SIZE = 0x80000
+  BIOS_SIZE = 0x80000,
+  BIOS_SIZE_PS2 = 0x400000
 };
 
 using Image = std::vector<u8>;

--- a/src/core/bios.h
+++ b/src/core/bios.h
@@ -30,6 +30,7 @@ struct ImageInfo
   const char* description;
   ConsoleRegion region;
   Hash hash;
+  bool patch_compatible;
 };
 
 #pragma pack(push, 1)

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -374,7 +374,7 @@ HostInterface::FindBIOSImagesInDirectory(const char* directory)
 bool HostInterface::HasAnyBIOSImages()
 {
   const std::string dir = GetBIOSDirectory();
-  return (FindBIOSImageInDirectory(ConsoleRegion::NTSC_U, dir.c_str()).has_value());
+  return (FindBIOSImageInDirectory(ConsoleRegion::Auto, dir.c_str()).has_value());
 }
 
 bool HostInterface::LoadState(const char* filename)

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -304,7 +304,7 @@ std::optional<std::vector<u8>> HostInterface::FindBIOSImageInDirectory(ConsoleRe
 
   for (const FILESYSTEM_FIND_DATA& fd : results)
   {
-    if (fd.Size != BIOS::BIOS_SIZE)
+    if (fd.Size < BIOS::BIOS_SIZE || fd.Size > BIOS::BIOS_SIZE_PS2)
     {
       Log_WarningPrintf("Skipping '%s': incorrect size", fd.FileName.c_str());
       continue;
@@ -353,7 +353,7 @@ HostInterface::FindBIOSImagesInDirectory(const char* directory)
 
   for (FILESYSTEM_FIND_DATA& fd : files)
   {
-    if (fd.Size != BIOS::BIOS_SIZE)
+    if (fd.Size < BIOS::BIOS_SIZE || fd.Size > BIOS::BIOS_SIZE_PS2)
       continue;
 
     std::string full_path(

--- a/src/core/host_interface.h
+++ b/src/core/host_interface.h
@@ -126,7 +126,7 @@ public:
   std::optional<std::vector<u8>> GetBIOSImage(ConsoleRegion region);
 
   /// Searches for a BIOS image for the specified region in the specified directory. If no match is found, the first
-  /// 512KB BIOS image will be used.
+  /// BIOS image within 512KB and 4MB will be used.
   std::optional<std::vector<u8>> FindBIOSImageInDirectory(ConsoleRegion region, const char* directory);
 
   /// Returns a list of filenames and descriptions for BIOS images in a directory.


### PR DESCRIPTION
For #1247.

Turns out that the 512KB PS1 BIOS on PS3 is incompatible with the fast boot patch and seems to get stuck in an invalid bus read/write loop. TTY patch doesn't look like it works either. Disabling patching for it should be fine, since it's effectively a fastboot BIOS anyways.