### PR TITLE
Register more glyph ranges supported by Roboto

### DIFF
--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -1442,12 +1442,6 @@ static bool AddImGuiFont(const std::string& language, float size, float framebuf
     path = GetFontPath("msgothic.ttc");
     range = ImGui::GetIO().Fonts->GetGlyphRangesJapanese();
   }
-  else if (language == "ru")
-  {
-    path = GetFontPath("segoeui.ttf");
-    range = ImGui::GetIO().Fonts->GetGlyphRangesCyrillic();
-    size *= 1.15f;
-  }
   else if (language == "zh-cn")
   {
     path = GetFontPath("msyh.ttc");

--- a/src/frontend-common/imgui_styles.cpp
+++ b/src/frontend-common/imgui_styles.cpp
@@ -61,6 +61,26 @@ void ImGui::StyleColorsDarker(ImGuiStyle* dst)
 
 void ImGui::AddRobotoRegularFont(float size /*= 15.0f*/)
 {
+  static const ImWchar ranges[] = {
+    // Basic Latin + Latin Supplement + Central European diacritics
+    0x0020,
+    0x017F,
+
+    // Cyrillic + Cyrillic Supplement
+    0x0400,
+    0x052F,
+
+    // Cyrillic Extended-A
+    0x2DE0,
+    0x2DFF,
+
+    // Cyrillic Extended-B
+    0xA640,
+    0xA69F,
+
+    0,
+  };
+
   ImGui::GetIO().Fonts->AddFontFromMemoryCompressedTTF(s_font_roboto_regular_compressed_data,
-                                                       s_font_roboto_regular_compressed_size, size);
+                                                       s_font_roboto_regular_compressed_size, size, nullptr, ranges);
 }


### PR DESCRIPTION
Adds support for Polish (and, for the future, other Central and Eastern European Latin languages), makes Russian use a default font.

![image](https://user-images.githubusercontent.com/7947461/103677389-845d9380-4f82-11eb-93be-6b47c4c32004.png)
![image](https://user-images.githubusercontent.com/7947461/103677424-92131900-4f82-11eb-9922-7e0d7c730589.png)
