### PR TITLE
Controller: Add method for reading analog input bytes

### DIFF
--- a/src/core/analog_controller.cpp
+++ b/src/core/analog_controller.cpp
@@ -151,6 +151,12 @@ u32 AnalogController::GetButtonStateBits() const
   return m_button_state ^ 0xFFFF;
 }
 
+std::optional<u32> AnalogController::GetAnalogInputBytes() const
+{
+  return m_axis_state[static_cast<size_t>(Axis::LeftY)] << 24 | m_axis_state[static_cast<size_t>(Axis::LeftX)] << 16 |
+         m_axis_state[static_cast<size_t>(Axis::RightY)] << 8 | m_axis_state[static_cast<size_t>(Axis::RightX)];
+}
+
 u32 AnalogController::GetVibrationMotorCount() const
 {
   return NUM_MOTORS;

--- a/src/core/analog_controller.h
+++ b/src/core/analog_controller.h
@@ -62,6 +62,7 @@ public:
   void SetAxisState(s32 axis_code, float value) override;
   void SetButtonState(s32 button_code, bool pressed) override;
   u32 GetButtonStateBits() const override;
+  std::optional<u32> GetAnalogInputBytes() const override;
 
   void ResetTransferState() override;
   bool Transfer(const u8 data_in, u8* data_out) override;

--- a/src/core/analog_joystick.cpp
+++ b/src/core/analog_joystick.cpp
@@ -115,6 +115,12 @@ u32 AnalogJoystick::GetButtonStateBits() const
   return m_button_state ^ 0xFFFF;
 }
 
+std::optional<u32> AnalogJoystick::GetAnalogInputBytes() const
+{
+  return m_axis_state[static_cast<size_t>(Axis::LeftY)] << 24 | m_axis_state[static_cast<size_t>(Axis::LeftX)] << 16 |
+         m_axis_state[static_cast<size_t>(Axis::RightY)] << 8 | m_axis_state[static_cast<size_t>(Axis::RightX)];
+}
+
 void AnalogJoystick::ResetTransferState()
 {
   m_transfer_state = TransferState::Idle;

--- a/src/core/analog_joystick.h
+++ b/src/core/analog_joystick.h
@@ -60,6 +60,7 @@ public:
   void SetAxisState(s32 axis_code, float value) override;
   void SetButtonState(s32 button_code, bool pressed) override;
   u32 GetButtonStateBits() const override;
+  std::optional<u32> GetAnalogInputBytes() const override;
 
   void ResetTransferState() override;
   bool Transfer(const u8 data_in, u8* data_out) override;

--- a/src/core/controller.cpp
+++ b/src/core/controller.cpp
@@ -35,6 +35,11 @@ u32 Controller::GetButtonStateBits() const
   return 0;
 }
 
+std::optional<u32> Controller::GetAnalogInputBytes() const
+{
+  return std::nullopt;
+}
+
 u32 Controller::GetVibrationMotorCount() const
 {
   return 0;

--- a/src/core/controller.h
+++ b/src/core/controller.h
@@ -54,6 +54,9 @@ public:
   /// Returns a bitmask of the current button states, 1 = on.
   virtual u32 GetButtonStateBits() const;
 
+  /// Returns analog input bytes packed as a u32. Values are specific to controller type.
+  virtual std::optional<u32> GetAnalogInputBytes() const;
+
   /// Returns the number of vibration motors.
   virtual u32 GetVibrationMotorCount() const;
 

--- a/src/core/negcon.cpp
+++ b/src/core/negcon.cpp
@@ -97,6 +97,17 @@ void NeGcon::SetButtonState(Button button, bool pressed)
     m_button_state |= u16(1) << indices[static_cast<u8>(button)];
 }
 
+u32 NeGcon::GetButtonStateBits() const
+{
+  return m_button_state ^ 0xFFFF;
+}
+
+std::optional<u32> NeGcon::GetAnalogInputBytes() const
+{
+  return m_axis_state[static_cast<size_t>(Axis::L)] << 24 | m_axis_state[static_cast<size_t>(Axis::II)] << 16 |
+         m_axis_state[static_cast<size_t>(Axis::I)] << 8 | m_axis_state[static_cast<size_t>(Axis::Steering)];
+}
+
 void NeGcon::ResetTransferState()
 {
   m_transfer_state = TransferState::Idle;

--- a/src/core/negcon.h
+++ b/src/core/negcon.h
@@ -57,6 +57,9 @@ public:
   void SetAxisState(Axis axis, u8 value);
   void SetButtonState(Button button, bool pressed);
 
+  u32 GetButtonStateBits() const override;
+  std::optional<u32> GetAnalogInputBytes() const override;
+
   void LoadSettings(const char* section) override;
 
 private:


### PR DESCRIPTION
Requested by @PugsyMAME. 

This will return the analog stick inputs even when the Analog Controller type is in digital mode. Byte order, starting at least significant byte, is RightX, RightY, LeftX, LeftY.