### PR TITLE
UI: Add missing register widget help

### DIFF
--- a/src/duckstation-qt/consolesettingswidget.cpp
+++ b/src/duckstation-qt/consolesettingswidget.cpp
@@ -36,13 +36,31 @@ ConsoleSettingsWidget::ConsoleSettingsWidget(QtHostInterface* host_interface, QW
                                                false);
 
   dialog->registerWidgetHelp(
-    m_ui.cdromLoadImageToRAM, tr("Preload Image to RAM"), tr("Unchecked"),
-    tr("Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some "
-       "cases also eliminates stutter when games initiate audio track playback."));
+    m_ui.region, tr("Region"), tr("Auto-Detect"),
+    tr("Determines the emulated hardware type."));
+  dialog->registerWidgetHelp(
+    m_ui.cpuExecutionMode, tr("Execution Mode"), tr("Recompiler (Fastest)"),
+    tr("Determines how the emulated CPU executes instructions."));
+  dialog->registerWidgetHelp(
+    m_ui.enableCPUClockSpeedControl, tr("Enable Clock Speed Control (Overclocking/Underclocking)"), tr("Unchecked"),
+    tr("When this option is chosen, the clock speed set below will be used."));
+  dialog->registerWidgetHelp(
+    m_ui.cpuClockSpeed, tr("Overclocking Percentage"), tr("100%"),
+    tr("Selects the percentage of the normal clock speed the emulated hardware will run at."));
   dialog->registerWidgetHelp(
     m_ui.cdromReadSpeedup, tr("CDROM Read Speedup"), tr("None (Double Speed)"),
     tr("Speeds up CD-ROM reads by the specified factor. Only applies to double-speed reads, and is ignored when audio "
        "is playing. May improve loading speeds in some games, at the cost of breaking others."));
+  dialog->registerWidgetHelp(
+    m_ui.cdromReadThread, tr("Use Read Thread (Asynchronous)"), tr("Checked"),
+    tr("Reduces hitches in emulation by reading/decompressing CD data asynchronously on a worker thread."));
+  dialog->registerWidgetHelp(
+    m_ui.cdromRegionCheck, tr("Enable Region Check"), tr("Checked"),
+    tr("Simulates the region check present in original, unmodified consoles."));
+  dialog->registerWidgetHelp(
+    m_ui.cdromLoadImageToRAM, tr("Preload Image to RAM"), tr("Unchecked"),
+    tr("Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some "
+       "cases also eliminates stutter when games initiate audio track playback."));
 
   m_ui.cpuClockSpeed->setEnabled(m_ui.enableCPUClockSpeedControl->checkState() == Qt::Checked);
   m_ui.cdromReadSpeedup->setCurrentIndex(m_host_interface->GetIntSettingValue("CDROM", "ReadSpeedup", 1) - 1);

--- a/src/duckstation-qt/displaysettingswidget.cpp
+++ b/src/duckstation-qt/displaysettingswidget.cpp
@@ -113,6 +113,8 @@ DisplaySettingsWidget::DisplaySettingsWidget(QtHostInterface* host_interface, QW
   dialog->registerWidgetHelp(
     m_ui.showSpeed, tr("Show Speed"), tr("Unchecked"),
     tr("Shows the current emulation speed of the system in the top-right corner of the display as a percentage."));
+  dialog->registerWidgetHelp(m_ui.showResolution, tr("Show Resolution"), tr("Unchecked"),
+                             tr("Shows the resolution of the game in the top-right corner of the display."));
 
 #ifdef _WIN32
   {

--- a/src/duckstation-qt/generalsettingswidget.cpp
+++ b/src/duckstation-qt/generalsettingswidget.cpp
@@ -67,6 +67,8 @@ GeneralSettingsWidget::GeneralSettingsWidget(QtHostInterface* host_interface, QW
     m_ui.applyGameSettings, tr("Apply Per-Game Settings"), tr("Checked"),
     tr("When enabled, per-game settings will be applied, and incompatible enhancements will be disabled. You should "
        "leave this option enabled except when testing enhancements with incompatible games."));
+  dialog->registerWidgetHelp(m_ui.autoLoadCheats, tr("Automatically Load Cheats"), tr("Unchecked"),
+                             tr("Automatically loads and applies cheats on game start."));
   dialog->registerWidgetHelp(m_ui.controllerBackend, tr("Controller Backend"),
                              qApp->translate("ControllerInterface", ControllerInterface::GetBackendName(
                                                                       ControllerInterface::GetDefaultBackend())),


### PR DESCRIPTION
I think "Enable TTY Output" is the last missing widget help text. Unfortunately, I have no idea what it does. ^^;

Thanks for your awesome emulator, stenzek! :)