### PR TITLE
Logging fixes

### DIFF
--- a/src/common/cd_image_cue.cpp
+++ b/src/common/cd_image_cue.cpp
@@ -141,7 +141,7 @@ bool CDImageCueSheet::OpenAndParse(const char* filename)
       file_size /= track_sector_size;
       if (track_start >= file_size)
       {
-        Log_ErrorPrintf("Failed to open track %u in '%s': track start is out of range (%u vs %u)", track_num, filename,
+        Log_ErrorPrintf("Failed to open track %u in '%s': track start is out of range (%ld vs %ld)", track_num, filename,
                         track_start, file_size);
         return false;
       }

--- a/src/common/cd_image_memory.cpp
+++ b/src/common/cd_image_memory.cpp
@@ -81,7 +81,7 @@ bool CDImageMemory::CopyImage(CDImage* image, ProgressCallback* progress)
     {
       if (!image->ReadSectorFromIndex(memory_ptr, index, lba))
       {
-        Log_ErrorPrintf("Failed to read LBA %u in index %u", lba, index);
+        Log_ErrorPrintf("Failed to read LBA %u in index %u", lba, i);
         return false;
       }
 

--- a/src/common/gl/program.cpp
+++ b/src/common/gl/program.cpp
@@ -159,7 +159,7 @@ bool Program::GetBinary(std::vector<u8>* out_data, u32* out_data_format)
   }
   else if (static_cast<size_t>(binary_size) != out_data->size())
   {
-    Log_WarningPrintf("Size changed from %zu to %d after glGetProgramBinary()", out_data->data(), binary_size);
+    Log_WarningPrintf("Size changed from %zu to %d after glGetProgramBinary()", out_data->size(), binary_size);
     out_data->resize(static_cast<size_t>(binary_size));
   }
 

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -46,7 +46,7 @@ void SetFilterLevel(LOGLEVEL level);
 
 // writes a message to the log
 void Write(const char* channelName, const char* functionName, LOGLEVEL level, const char* message);
-void Writef(const char* channelName, const char* functionName, LOGLEVEL level, const char* format, ...);
+void Writef(const char* channelName, const char* functionName, LOGLEVEL level, const char* format, ...) printflike(4, 5);
 void Writev(const char* channelName, const char* functionName, LOGLEVEL level, const char* format, va_list ap);
 } // namespace Log
 

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -49,6 +49,12 @@ char (&__countof_ArraySizeHelper(T (&array)[N]))[N];
 #define offsetof(st, m) ((size_t)((char*)&((st*)(0))->m - (char*)0))
 #endif
 
+#ifdef __GNUC__
+#define printflike(n,m) __attribute__((format(printf,n,m)))
+#else
+#define printflike(n,m)
+#endif
+
 // disable warnings that show up at warning level 4
 // TODO: Move to build system instead
 #ifdef _MSC_VER

--- a/src/common/wav_writer.cpp
+++ b/src/common/wav_writer.cpp
@@ -85,7 +85,7 @@ void WAVWriter::WriteFrames(const s16* samples, u32 num_frames)
   const u32 num_frames_written =
     static_cast<u32>(std::fwrite(samples, sizeof(s16) * m_num_channels, num_frames, m_file));
   if (num_frames_written != num_frames)
-    Log_ErrorPrintf("Only wrote %u of %u frames to output file", num_frames_written);
+    Log_ErrorPrintf("Only wrote %u of %u frames to output file", num_frames_written, num_frames);
 
   m_num_frames += num_frames_written;
 }

--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -919,7 +919,7 @@ ALWAYS_INLINE static TickCount DoEXP3Access(u32 offset, u32& value)
 {
   if constexpr (type == MemoryAccessType::Read)
   {
-    Log_WarningPrintf("EXP3 read: 0x%08X -> 0x%08X", EXP3_BASE | offset);
+    Log_WarningPrintf("EXP3 read: 0x%08X -> 0x%08X", offset, EXP3_BASE | offset);
     value = UINT32_C(0xFFFFFFFF);
 
     return 0;

--- a/src/core/cheats.cpp
+++ b/src/core/cheats.cpp
@@ -1488,7 +1488,7 @@ void CheatCode::Apply() const
         }
         else
         {
-          Log_ErrorPrintf("Invalid command in second slide parameter 0x%02X", write_type);
+          Log_ErrorPrintf("Invalid command in second slide parameter 0x%02hhX", write_type);
         }
 
         index += 2;

--- a/src/core/gpu_hw_opengl.cpp
+++ b/src/core/gpu_hw_opengl.cpp
@@ -341,7 +341,7 @@ void GPU_HW_OpenGL::SetCapabilities(HostDisplay* host_display)
     if (GLAD_GL_VERSION_4_3 || GLAD_GL_ES_VERSION_3_1 || GLAD_GL_ARB_shader_storage_buffer_object)
       glGetInteger64v(GL_MAX_SHADER_STORAGE_BLOCK_SIZE, &max_ssbo_size);
 
-    Log_InfoPrintf("Max shader storage buffer size: %u", max_ssbo_size);
+    Log_InfoPrintf("Max shader storage buffer size: %lld", max_ssbo_size);
     m_use_ssbo_for_vram_writes = (max_ssbo_size >= (VRAM_WIDTH * VRAM_HEIGHT * sizeof(u16)));
     if (m_use_ssbo_for_vram_writes)
     {

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -187,7 +187,7 @@ void HostInterface::ReportDebuggerMessage(const char* message)
 
 bool HostInterface::ConfirmMessage(const char* message)
 {
-  Log_WarningPrintf("ConfirmMessage(\"%s\") -> Yes");
+  Log_WarningPrintf("ConfirmMessage(\"%s\") -> Yes", message);
   return true;
 }
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -2086,7 +2086,7 @@ bool SaveRewindState()
 
   s_rewind_states.push_back(std::move(mss));
 
-  Log_DevPrintf("Saved rewind state (%u bytes, took %.4f ms)", s_rewind_states.back().state_stream->GetSize(),
+  Log_DevPrintf("Saved rewind state (%llu bytes, took %.4f ms)", s_rewind_states.back().state_stream->GetSize(),
                 save_timer.GetTimeMilliseconds());
 
   return true;

--- a/src/core/timers.cpp
+++ b/src/core/timers.cpp
@@ -239,7 +239,7 @@ u32 Timers::ReadRegister(u32 offset)
       return cs.target;
 
     default:
-      Log_ErrorPrintf("Read unknown register in timer %u (offset 0x%02X)", offset);
+      Log_ErrorPrintf("Read unknown register in timer %u (offset 0x%02X)", timer_index, offset);
       return UINT32_C(0xFFFFFFFF);
   }
 }
@@ -302,7 +302,7 @@ void Timers::WriteRegister(u32 offset, u32 value)
     break;
 
     default:
-      Log_ErrorPrintf("Write unknown register in timer %u (offset 0x%02X, value 0x%X)", offset, value);
+      Log_ErrorPrintf("Write unknown register in timer %u (offset 0x%02X, value 0x%X)", timer_index, offset, value);
       break;
   }
 }

--- a/src/frontend-common/opengl_host_display.cpp
+++ b/src/frontend-common/opengl_host_display.cpp
@@ -328,13 +328,13 @@ static void APIENTRY GLDebugCallback(GLenum source, GLenum type, GLuint id, GLen
   switch (severity)
   {
     case GL_DEBUG_SEVERITY_HIGH_KHR:
-      Log_ErrorPrintf(message);
+      Log_ErrorPrint(message);
       break;
     case GL_DEBUG_SEVERITY_MEDIUM_KHR:
       Log_WarningPrint(message);
       break;
     case GL_DEBUG_SEVERITY_LOW_KHR:
-      Log_InfoPrintf(message);
+      Log_InfoPrint(message);
       break;
     case GL_DEBUG_SEVERITY_NOTIFICATION:
       // Log_DebugPrint(message);


### PR DESCRIPTION
Based off of #1581.
Fixes some of the issues with adding a `printflike` macro on `Log::Writef`.