### PR TITLE
optimize locking mechanism for OSD messages (deadlock-proofing)

### DIFF
--- a/src/frontend-common/common_host_interface.h
+++ b/src/frontend-common/common_host_interface.h
@@ -184,6 +184,9 @@ public:
   bool EnumerateOSDMessages(std::function<bool(const std::string&, float)> callback);
   void ClearOSDMessages();
 
+  /// async message queue bookeeping for. Should be called on UI thread.
+  void AcquirePendingOSDMessages();
+
   /// Displays a loading screen with the logo, rendered with ImGui. Use when executing possibly-time-consuming tasks
   /// such as compiling shaders when starting up.
   void DisplayLoadingScreen(const char* message, int progress_min = -1, int progress_max = -1,
@@ -394,7 +397,8 @@ protected:
 
   std::unique_ptr<HostDisplayTexture> m_logo_texture;
 
-  std::deque<OSDMessage> m_osd_messages;
+  std::deque<OSDMessage> m_osd_active_messages;   // accessed only by GUI/OSD thread (no lock reqs)
+  std::deque<OSDMessage> m_osd_posted_messages;          // written to by multiple threads.
   std::mutex m_osd_messages_lock;
 
   bool m_fullscreen_ui_enabled = false;

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -2712,12 +2712,7 @@ void DrawStatsOverlay()
 
 void DrawOSDMessages()
 {
-  if (!g_settings.display_show_osd_messages)
-  {
-    // we still need to remove them from the queue
-    s_host_interface->EnumerateOSDMessages([](const std::string& message, float time_remaining) { return true; });
-    return;
-  }
+  s_host_interface->AcquirePendingOSDMessages();
 
   ImGui::PushFont(g_large_font);
 


### PR DESCRIPTION
Added benefits:
 - uses newly-added EnumerateOSDMessages for the Common UI OSD, same as is used for Fullscreen UI.

It's always a good idea to implement message queues in the fashion I've done here, to avoid the edge case where a callback GUI function might do something that itself blocks against some other mutex and then poses a risk for deadlock. Since the emulator doesn't really make use of threads much at this point, there's not a lot of immediate tangible benefit to this change. It's really more of an academic change, with potentially some future-proofing qualities.

I also removed some dead code from FullscreenUI. The enumerator handles the `display_show_osd_messages` setting internally now so FullscreenUI didn't need a special case handler anymore.