### PR TITLE
Save State UI: Add legend showing hotkeys

### DIFF
--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1292,6 +1292,8 @@ void CommonHostInterface::UpdateHotkeyInputMap(SettingsInterface& si)
       AddButtonToInputMap(binding, device, button, hi.handler);
     }
   }
+
+  m_save_state_selector_ui->RefreshHotkeyLegend();
 }
 
 bool CommonHostInterface::AddButtonToInputMap(const std::string& binding, const std::string_view& device,

--- a/src/frontend-common/save_state_selector_ui.cpp
+++ b/src/frontend-common/save_state_selector_ui.cpp
@@ -158,7 +158,7 @@ std::pair<s32, bool> SaveStateSelectorUI::GetSlotTypeFromSelection(u32 selection
 
 void SaveStateSelectorUI::InitializePlaceholderListEntry(ListEntry* li, s32 slot, bool global)
 {
-  li->title = "No Save State";
+  li->title = m_host_interface->TranslateStdString("SaveStateSelectorUI", "No Save State");
   std::string().swap(li->game_code);
   std::string().swap(li->path);
   std::string().swap(li->formatted_timestamp);
@@ -227,8 +227,19 @@ void SaveStateSelectorUI::Draw()
 
         ImGui::Indent(text_indent);
 
-        ImGui::Text("%s Slot %d",
-                    entry.global ? "Global" : (entry.game_code.empty() ? "Game" : entry.game_code.c_str()), entry.slot);
+        if (entry.global)
+        {
+          ImGui::Text(m_host_interface->TranslateString("SaveStateSelectorUI", "Global Slot %d"), entry.slot);
+        }
+        else if (entry.game_code.empty())
+        {
+          ImGui::Text(m_host_interface->TranslateString("SaveStateSelectorUI", "Gane Slot %d"), entry.slot);
+        }
+        else
+        {
+          ImGui::Text(m_host_interface->TranslateString("SaveStateSelectorUI", "%s Slot %d"), entry.game_code.c_str(),
+                      entry.slot);
+        }
         ImGui::TextUnformatted(entry.title.c_str());
         ImGui::TextUnformatted(entry.formatted_timestamp.c_str());
         ImGui::TextUnformatted(entry.path.c_str());
@@ -270,13 +281,17 @@ void SaveStateSelectorUI::Draw()
         strip_device_name(m_host_interface->GetStringSettingValue("Hotkeys", "SelectPreviousSaveStateSlot"));
 
       ImGui::TableNextColumn();
-      ImGui::Text("%s - %s", load_savestate_hotkey.c_str(), "Load");
+      ImGui::Text("%s - %s", load_savestate_hotkey.c_str(),
+                  m_host_interface->TranslateString("SaveStateSelectorUI", "Load").GetCharArray());
       ImGui::TableNextColumn();
-      ImGui::Text("%s - %s", prev_savestate_hotkey.c_str(), "Select Previous");
+      ImGui::Text("%s - %s", prev_savestate_hotkey.c_str(),
+                  m_host_interface->TranslateString("SaveStateSelectorUI", "Select Previous").GetCharArray());
       ImGui::TableNextColumn();
-      ImGui::Text("%s - %s", save_savestate_hotkey.c_str(), "Save");
+      ImGui::Text("%s - %s", save_savestate_hotkey.c_str(),
+                  m_host_interface->TranslateString("SaveStateSelectorUI", "Save").GetCharArray());
       ImGui::TableNextColumn();
-      ImGui::Text("%s - %s", next_savestate_hotkey.c_str(), "Select Next");
+      ImGui::Text("%s - %s", next_savestate_hotkey.c_str(),
+                  m_host_interface->TranslateString("SaveStateSelectorUI", "Select Next").GetCharArray());
 
       ImGui::EndTable();
     }

--- a/src/frontend-common/save_state_selector_ui.h
+++ b/src/frontend-common/save_state_selector_ui.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "common_host_interface.h"
 #include "common/timer.h"
+#include "common_host_interface.h"
 #include <memory>
 
 class HostDisplayTexture;
@@ -23,6 +23,8 @@ public:
 
   void ClearList();
   void RefreshList();
+
+  void RefreshHotkeyLegend();
 
   const char* GetSelectedStatePath() const;
   s32 GetSelectedStateSlot() const;
@@ -50,6 +52,11 @@ private:
   void InitializePlaceholderListEntry(ListEntry* li, s32 slot, bool global);
   void InitializeListEntry(ListEntry* li, CommonHostInterface::ExtendedSaveStateInfo* ssi);
   std::pair<s32, bool> GetSlotTypeFromSelection(u32 selection) const;
+
+  std::string m_load_legend;
+  std::string m_save_legend;
+  std::string m_prev_legend;
+  std::string m_next_legend;
 
   CommonHostInterface* m_host_interface;
   std::vector<ListEntry> m_slots;


### PR DESCRIPTION
This PR adds a legend to the Save State Selector UI. In my experience, I kept misremembering Save/Load buttons and using the wrong one when on this screen, so a legend should help.

To do:
* ~~Style the legend better? Most notably, some margins may be needed.~~
* ~~Strip the device name maybe - `F1` or `Button14` might be good enough in this case.~~
* ~~Make the legend translatable~~

Current look:
![image](https://user-images.githubusercontent.com/7947461/108550700-352fb000-72ef-11eb-902b-0219e879232c.png)
![image](https://user-images.githubusercontent.com/7947461/108550783-4ed0f780-72ef-11eb-919b-b1414839cd63.png)
