### PR TITLE
Bus: Increase the number of ticks for RAM reads

### DIFF
--- a/src/core/bus.h
+++ b/src/core/bus.h
@@ -72,7 +72,7 @@ enum : u32
 
 enum : TickCount
 {
-  RAM_READ_TICKS = 4
+  RAM_READ_TICKS = 6
 };
 
 enum : size_t


### PR DESCRIPTION
Fixes timings issues in:
- Rollcage Stage II PAL
- Tungsta Legend of Faith PAL
- Tom and Jerry in House Trap PAL
- Crash Bash PAL
- Destrega PAL
- The Note PAL
- Silent Hill cutscene (when icache is enabled)
- Legend of Legaia

No known regressions... yet.