### PR TITLE
Multitap: Add option to enable only on port 2

### DIFF
--- a/src/core/multitap.h
+++ b/src/core/multitap.h
@@ -8,25 +8,22 @@
 class Multitap final
 {
 public:
-  Multitap(u32 index);
+  Multitap();
 
   void Reset();
 
-  ALWAYS_INLINE void SetEnable(bool enable) { m_enabled = enable; };
+  void SetEnable(bool enable, u32 base_index);
   ALWAYS_INLINE bool IsEnabled() const { return m_enabled; };
 
   bool DoState(StateWrapper& sw);
 
   void ResetTransferState();
   bool Transfer(const u8 data_in, u8* data_out);
-  ALWAYS_INLINE bool IsReadingMemoryCard() { return m_enabled && m_transfer_state == TransferState::MemoryCard; };
+  ALWAYS_INLINE bool IsReadingMemoryCard() { return IsEnabled() && m_transfer_state == TransferState::MemoryCard; };
 
 private:
   ALWAYS_INLINE static constexpr u8 GetMultitapIDByte() { return 0x80; };
   ALWAYS_INLINE static constexpr u8 GetStatusByte() { return 0x5A; };
-
-  Controller* GetControllerForSlot(u32 slot) const;
-  MemoryCard* GetMemoryCardForSlot(u32 slot) const;
 
   bool TransferController(u32 slot, const u8 data_in, u8* data_out) const;
   bool TransferMemoryCard(u32 slot, const u8 data_in, u8* data_out) const;
@@ -51,6 +48,6 @@ private:
 
   std::array<u8, 32> m_transfer_buffer{};
 
-  u32 m_index;
+  u32 m_base_index;
   bool m_enabled = false;
 };

--- a/src/core/pad.cpp
+++ b/src/core/pad.cpp
@@ -247,15 +247,6 @@ void Pad::SetMemoryCard(u32 slot, std::unique_ptr<MemoryCard> dev)
   m_memory_cards[slot] = std::move(dev);
 }
 
-void Pad::SetMultitapEnable(u32 port, bool enable)
-{
-  if (m_multitaps[port].IsEnabled() != enable)
-  {
-    m_multitaps[port].SetEnable(enable);
-    m_multitaps[port].Reset();
-  }
-}
-
 u32 Pad::ReadRegister(u32 offset)
 {
   switch (offset)

--- a/src/core/pad.h
+++ b/src/core/pad.h
@@ -30,7 +30,6 @@ public:
   void SetMemoryCard(u32 slot, std::unique_ptr<MemoryCard> dev);
 
   Multitap* GetMultitap(u32 slot) { return &m_multitaps[slot]; };
-  void SetMultitapEnable(u32 port, bool enable);
 
   u32 ReadRegister(u32 offset);
   void WriteRegister(u32 offset, u32 value);
@@ -116,7 +115,7 @@ private:
   std::array<std::unique_ptr<Controller>, NUM_CONTROLLER_AND_CARD_PORTS> m_controllers;
   std::array<std::unique_ptr<MemoryCard>, NUM_CONTROLLER_AND_CARD_PORTS> m_memory_cards;
 
-  std::array<Multitap, NUM_MULTITAPS> m_multitaps = {Multitap(0), Multitap(1)};
+  std::array<Multitap, NUM_MULTITAPS> m_multitaps;
 
   std::unique_ptr<TimingEvent> m_transfer_event;
   State m_state = State::Idle;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "common/log.h"
+#include "common/string.h"
 #include "types.h"
 #include <array>
 #include <optional>
@@ -219,6 +220,8 @@ struct Settings
 
   MultitapMode multitap_mode = MultitapMode::Disabled;
 
+  std::array<TinyString, NUM_CONTROLLER_AND_CARD_PORTS> GeneratePortLabels() const;
+
   LOGLEVEL log_level = LOGLEVEL_INFO;
   std::string log_filter;
   bool log_to_console = false;
@@ -253,8 +256,6 @@ struct Settings
   }
 
   bool HasAnyPerGameMemoryCards() const;
-
-  bool IsMultitapEnabledOnPort(u32 port) const;
 
   static void CPUOverclockPercentToFraction(u32 percent, u32* numerator, u32* denominator);
   static u32 CPUOverclockFractionToPercent(u32 numerator, u32 denominator);

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -1861,22 +1861,29 @@ void UpdateMultitaps()
   {
     case MultitapMode::Disabled:
     {
-      g_pad.SetMultitapEnable(0, false);
-      g_pad.SetMultitapEnable(1, false);
+      g_pad.GetMultitap(0)->SetEnable(false, 0);
+      g_pad.GetMultitap(1)->SetEnable(false, 0);
     }
     break;
 
     case MultitapMode::Port1Only:
     {
-      g_pad.SetMultitapEnable(0, true);
-      g_pad.SetMultitapEnable(1, false);
+      g_pad.GetMultitap(0)->SetEnable(true, 0);
+      g_pad.GetMultitap(1)->SetEnable(false, 0);
+    }
+    break;
+
+    case MultitapMode::Port2Only:
+    {
+      g_pad.GetMultitap(0)->SetEnable(false, 0);
+      g_pad.GetMultitap(1)->SetEnable(true, 1);
     }
     break;
 
     case MultitapMode::BothPorts:
     {
-      g_pad.SetMultitapEnable(0, true);
-      g_pad.SetMultitapEnable(1, true);
+      g_pad.GetMultitap(0)->SetEnable(true, 0);
+      g_pad.GetMultitap(1)->SetEnable(true, 4);
     }
     break;
   }

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -147,6 +147,7 @@ enum class MultitapMode
 {
   Disabled,
   Port1Only,
+  Port2Only,
   BothPorts,
   Count
 };

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -1573,17 +1573,14 @@ void DrawSettingsWindow()
         TinyString section;
         TinyString key;
 
+        std::array<TinyString, NUM_CONTROLLER_AND_CARD_PORTS> port_labels = s_settings_copy.GeneratePortLabels();
+
         for (u32 port = 0; port < NUM_CONTROLLER_AND_CARD_PORTS; port++)
         {
-          u32 console_port = port / 4u;
-          if (s_settings_copy.IsMultitapEnabledOnPort(console_port))
-            MenuHeading(TinyString::FromFormat("Port %u%c", console_port + 1u, 'A' + (port % 4u)));
-          else if (port < 2u)
-            MenuHeading(TinyString::FromFormat("Port %u", port + 1u));
-          else if (port % 4u == 0u && s_settings_copy.IsMultitapEnabledOnPort(0))
-            MenuHeading(TinyString::FromFormat("Port %u", console_port + 1u));
-          else
+          if (port_labels[port].IsEmpty())
             continue;
+          else
+            MenuHeading(port_labels[port]);
 
           settings_changed |= EnumChoiceButton(
             TinyString::FromFormat(ICON_FA_GAMEPAD "  Controller Type##type%u", port),


### PR DESCRIPTION
Turns out there are a small handful of games that use a tapped port 2 and untapped port 1.