### PR TITLE
Add touch gliding

### DIFF
--- a/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerButtonView.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerButtonView.java
@@ -28,6 +28,7 @@ public final class TouchscreenControllerButtonView extends View {
     private Hotkey mHotkey = Hotkey.NONE;
     private String mConfigName;
     private boolean mDefaultVisibility = true;
+    private boolean mIsGlidable = true;
 
     public TouchscreenControllerButtonView(Context context) {
         super(context);
@@ -114,6 +115,9 @@ public final class TouchscreenControllerButtonView extends View {
     public void setConfigName(String name) {
         mConfigName = name;
     }
+
+    public boolean getIsGlidable() { return mIsGlidable; }
+    public void setIsGlidable(boolean isGlidable) { mIsGlidable = isGlidable; }
 
     public boolean getDefaultVisibility() { return mDefaultVisibility; }
     public void setDefaultVisibility(boolean visibility) { mDefaultVisibility = visibility; }

--- a/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerView.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerView.java
@@ -44,7 +44,7 @@ public class TouchscreenControllerView extends FrameLayout {
     private float mMovingLastY = 0.0f;
     private ConstraintLayout mEditLayout = null;
     private int mOpacity = 100;
-    private Map<Integer, View> mFirstHolds = new HashMap<>();
+    private Map<Integer, View> mGlidePairs = new HashMap<>();
 
     public TouchscreenControllerView(Context context) {
         super(context);
@@ -446,7 +446,7 @@ public class TouchscreenControllerView extends FrameLayout {
                 if (!AndroidHostInterface.hasInstanceAndEmulationThreadIsRunning())
                     return false;
 
-                mFirstHolds.clear();
+                mGlidePairs.clear();
 
                 for (TouchscreenControllerButtonView buttonView : mButtonViews) {
                     buttonView.setPressed(false);
@@ -463,8 +463,8 @@ public class TouchscreenControllerView extends FrameLayout {
             case MotionEvent.ACTION_POINTER_DOWN:
             case MotionEvent.ACTION_POINTER_UP: {
                 int pointerID = event.getPointerId(event.getActionIndex());
-                if (mFirstHolds.containsKey(pointerID))
-                    mFirstHolds.remove(pointerID);
+                if (mGlidePairs.containsKey(pointerID))
+                    mGlidePairs.remove(pointerID);
 
                 return true;
             }
@@ -490,16 +490,16 @@ public class TouchscreenControllerView extends FrameLayout {
                         if (rect.contains(x, y)) {
                             buttonView.setPressed(true);
                             int pointerID = event.getPointerId(i);
-                            if (!mFirstHolds.containsKey(pointerID) && !mFirstHolds.containsValue(buttonView)) {
+                            if (!mGlidePairs.containsKey(pointerID) && !mGlidePairs.containsValue(buttonView)) {
                                 if (buttonView.getIsGlidable())
-                                    mFirstHolds.put(pointerID, buttonView);
+                                    mGlidePairs.put(pointerID, buttonView);
                             }
                             pressed = true;
                             break;
                         }
                     }
 
-                    if (!pressed  && !mFirstHolds.containsValue(buttonView))
+                    if (!pressed  && !mGlidePairs.containsValue(buttonView))
                         buttonView.setPressed(pressed);
                 }
 

--- a/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerView.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerView.java
@@ -20,7 +20,6 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.preference.PreferenceManager;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -46,7 +45,6 @@ public class TouchscreenControllerView extends FrameLayout {
     private ConstraintLayout mEditLayout = null;
     private int mOpacity = 100;
     private Map<Integer, View> mFirstHolds = new HashMap<>();
-    private ArrayList<String> mDpadButtons = new ArrayList<String>(Arrays.asList("UpButton", "DownButton", "LeftButton", "RightButton"));
 
     public TouchscreenControllerView(Context context) {
         super(context);
@@ -234,20 +232,20 @@ public class TouchscreenControllerView extends FrameLayout {
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
 
-        linkButton(mMainView, R.id.controller_button_up, "UpButton", "Up", true);
-        linkButton(mMainView, R.id.controller_button_right, "RightButton", "Right", true);
-        linkButton(mMainView, R.id.controller_button_down, "DownButton", "Down", true);
-        linkButton(mMainView, R.id.controller_button_left, "LeftButton", "Left", true);
-        linkButton(mMainView, R.id.controller_button_l1, "L1Button", "L1", true);
-        linkButton(mMainView, R.id.controller_button_l2, "L2Button", "L2", true);
-        linkButton(mMainView, R.id.controller_button_select, "SelectButton", "Select", true);
-        linkButton(mMainView, R.id.controller_button_start, "StartButton", "Start", true);
-        linkButton(mMainView, R.id.controller_button_triangle, "TriangleButton", "Triangle", true);
-        linkButton(mMainView, R.id.controller_button_circle, "CircleButton", "Circle", true);
-        linkButton(mMainView, R.id.controller_button_cross, "CrossButton", "Cross", true);
-        linkButton(mMainView, R.id.controller_button_square, "SquareButton", "Square", true);
-        linkButton(mMainView, R.id.controller_button_r1, "R1Button", "R1", true);
-        linkButton(mMainView, R.id.controller_button_r2, "R2Button", "R2", true);
+        linkButton(mMainView, R.id.controller_button_up, "UpButton", "Up", true, false);
+        linkButton(mMainView, R.id.controller_button_right, "RightButton", "Right", true, false);
+        linkButton(mMainView, R.id.controller_button_down, "DownButton", "Down", true, false);
+        linkButton(mMainView, R.id.controller_button_left, "LeftButton", "Left", true, false);
+        linkButton(mMainView, R.id.controller_button_l1, "L1Button", "L1", true, true);
+        linkButton(mMainView, R.id.controller_button_l2, "L2Button", "L2", true, true);
+        linkButton(mMainView, R.id.controller_button_select, "SelectButton", "Select", true, true);
+        linkButton(mMainView, R.id.controller_button_start, "StartButton", "Start", true, true);
+        linkButton(mMainView, R.id.controller_button_triangle, "TriangleButton", "Triangle", true, true);
+        linkButton(mMainView, R.id.controller_button_circle, "CircleButton", "Circle", true, true);
+        linkButton(mMainView, R.id.controller_button_cross, "CrossButton", "Cross", true, true);
+        linkButton(mMainView, R.id.controller_button_square, "SquareButton", "Square", true, true);
+        linkButton(mMainView, R.id.controller_button_r1, "R1Button", "R1", true, true);
+        linkButton(mMainView, R.id.controller_button_r2, "R2Button", "R2", true, true);
 
         if (!linkAxis(mMainView, R.id.controller_axis_left, "LeftAxis", "Left", true))
             linkAxisToButtons(mMainView, R.id.controller_axis_left, "LeftAxis", "");
@@ -264,13 +262,14 @@ public class TouchscreenControllerView extends FrameLayout {
         requestLayout();
     }
 
-    private void linkButton(View view, int id, String configName, String buttonName, boolean defaultVisibility) {
+    private void linkButton(View view, int id, String configName, String buttonName, boolean defaultVisibility, boolean isGlidable) {
         TouchscreenControllerButtonView buttonView = (TouchscreenControllerButtonView) view.findViewById(id);
         if (buttonView == null)
             return;
 
         buttonView.setConfigName(configName);
         buttonView.setDefaultVisibility(defaultVisibility);
+        buttonView.setIsGlidable(isGlidable);
         mButtonViews.add(buttonView);
 
         int code = AndroidHostInterface.getControllerButtonCode(mControllerType, buttonName);
@@ -492,7 +491,7 @@ public class TouchscreenControllerView extends FrameLayout {
                             buttonView.setPressed(true);
                             int pointerID = event.getPointerId(i);
                             if (!mFirstHolds.containsKey(pointerID) && !mFirstHolds.containsValue(buttonView)) {
-                                if (!mDpadButtons.contains(buttonView.getConfigName()))
+                                if (buttonView.getIsGlidable())
                                     mFirstHolds.put(pointerID, buttonView);
                             }
                             pressed = true;


### PR DESCRIPTION
This PR adds the functionality I requested in #1065, that is, touch gliding (for lack of a better name) for Android. The commit has been tested extensively for the better part of a day on a real phone.

This basically keeps the first button held as long as your finger keeps touching the screen. This lets you hold square and then glide/slide over to X to charge and jump as Spyro with minimal effort, using your touchscreen. It also supports multiple touch traces, perfect for games like, I don't know, Crash Team Racing (X to Circle for using items without losing speed, R1<>L1 for drifting and boosting, both can happen concurrently).

How does this work:
A map (mFirstHolds) is available for linking touch pointer IDs to button views. When you touch the screen, a pointer is made. Now, when your pointer starts on, or goes to the first button, the map saves the pointerID>buttonview combo. Any future buttons this pointer slides over are not saved in the combo, but will be activated, and when you slide away it will disable, but the first button remains on. You can do this for as many fingers as you can possibly get on the screen, and they'll be treated separately.

The moment one of your pointers let go of the screen, the combo that was mapped is deleted. When all pointers are released, the map is wholly cleared.