### PR TITLE
Remove duplicate line in gamesettings.ini

### DIFF
--- a/data/database/gamesettings.ini
+++ b/data/database/gamesettings.ini
@@ -732,7 +732,6 @@ ForceRecompilerICache = true
 [SCES-00867]
 DisplayActiveStartOffset = -44
 DisableAnalogModeForcing = true
-DisableAnalogModeForcing = true
 
 
 # SCES-10867 (Final Fantasy VII (Europe) (Disc 2))


### PR DESCRIPTION
Removes a duplicate "DisableAnalogModeForcing = true" for SCES-00867 (Final Fantasy VII (Europe) (Disc 1).