### PR TITLE
Misc Qt stuff

### DIFF
--- a/src/duckstation-qt/CMakeLists.txt
+++ b/src/duckstation-qt/CMakeLists.txt
@@ -116,6 +116,7 @@ endif()
 
 set(TS_FILES
   translations/duckstation-qt_de.ts
+  translations/duckstation-qt_en.ts
   translations/duckstation-qt_es.ts
   translations/duckstation-qt_fr.ts
   translations/duckstation-qt_he.ts

--- a/src/duckstation-qt/audiosettingswidget.cpp
+++ b/src/duckstation-qt/audiosettingswidget.cpp
@@ -83,8 +83,7 @@ void AudioSettingsWidget::updateBufferingLabel()
   }
 
   const float max_latency = AudioStream::GetMaxLatency(HostInterface::AUDIO_SAMPLE_RATE, actual_buffer_size);
-  m_ui.bufferingLabel->setText(tr("Maximum Latency: %1 frames (%2ms)")
-                                 .arg(actual_buffer_size)
+  m_ui.bufferingLabel->setText(tr("Maximum Latency: %n frames (%1ms)", "", actual_buffer_size)
                                  .arg(static_cast<double>(max_latency) * 1000.0, 0, 'f', 2));
 }
 

--- a/src/duckstation-qt/autoupdaterdialog.cpp
+++ b/src/duckstation-qt/autoupdaterdialog.cpp
@@ -544,7 +544,7 @@ bool AutoUpdaterDialog::doUpdate(const QString& zip_path, const QString& updater
   }
 
   QStringList arguments;
-  arguments << QStringLiteral("%1").arg(QCoreApplication::applicationPid());
+  arguments << QString::number(QCoreApplication::applicationPid());
   arguments << destination_path;
   arguments << zip_path;
   arguments << program_path;

--- a/src/duckstation-qt/cheatmanagerdialog.cpp
+++ b/src/duckstation-qt/cheatmanagerdialog.cpp
@@ -48,9 +48,9 @@ static QString formatHexAndDecValue(u32 value, u8 size, bool is_signed)
 static QString formatValue(u32 value, bool is_signed)
 {
   if (is_signed)
-    return QStringLiteral("%1").arg(static_cast<int>(value));
+    return QString::number(static_cast<int>(value));
   else
-    return QStringLiteral("%1").arg(static_cast<uint>(value));
+    return QString::number(static_cast<uint>(value));
 }
 
 CheatManagerDialog::CheatManagerDialog(QWidget* parent) : QDialog(parent)

--- a/src/duckstation-qt/displaysettingswidget.cpp
+++ b/src/duckstation-qt/displaysettingswidget.cpp
@@ -102,7 +102,7 @@ DisplaySettingsWidget::DisplaySettingsWidget(QtHostInterface* host_interface, QW
     tr("Adds padding to the display area to ensure that the ratio between pixels on the host to "
        "pixels in the console is an integer number. <br>May result in a sharper image in some 2D games."));
   dialog->registerWidgetHelp(
-    m_ui.displayIntegerScaling, tr("Stretch To Fill"), tr("Unchecked"),
+    m_ui.displayStretch, tr("Stretch To Fill"), tr("Unchecked"),
     tr("Fills the window with the active display area, regardless of the aspect ratio."));
   dialog->registerWidgetHelp(
     m_ui.vsync, tr("VSync"), tr("Checked"),

--- a/src/duckstation-qt/duckstation-qt.vcxproj
+++ b/src/duckstation-qt/duckstation-qt.vcxproj
@@ -287,6 +287,9 @@
     <QtTs Include="translations\duckstation-qt_de.ts">
       <FileType>Document</FileType>
     </QtTs>
+	<QtTs Include="translations\duckstation-qt_en.ts">
+      <FileType>Document</FileType>
+    </QtTs>
     <QtTs Include="translations\duckstation-qt_es.ts">
       <FileType>Document</FileType>
     </QtTs>

--- a/src/duckstation-qt/duckstation-qt.vcxproj.filters
+++ b/src/duckstation-qt/duckstation-qt.vcxproj.filters
@@ -181,6 +181,9 @@
     <QtTs Include="translations\duckstation-qt_de.ts">
       <Filter>translations</Filter>
     </QtTs>
+	<QtTs Include="translations\duckstation-qt_en.ts">
+      <Filter>translations</Filter>
+    </QtTs>
     <QtTs Include="translations\duckstation-qt_es.ts">
       <Filter>translations</Filter>
     </QtTs>

--- a/src/duckstation-qt/emulationsettingswidget.cpp
+++ b/src/duckstation-qt/emulationsettingswidget.cpp
@@ -121,8 +121,7 @@ void EmulationSettingsWidget::updateRewind()
     System::CalculateRewindMemoryUsage(frames, &ram_usage, &vram_usage);
 
     m_ui.rewindSummary->setText(
-      tr("Rewind for %1 frames, lasting %2 seconds will require up to %3MB of RAM and %4MB of VRAM.")
-        .arg(frames)
+      tr("Rewind for %n frame(s), lasting %1 second(s) will require up to %2MB of RAM and %3MB of VRAM.", "", frames)
         .arg(duration)
         .arg(ram_usage / 1048576)
         .arg(vram_usage / 1048576));

--- a/src/duckstation-qt/gamepropertiesdialog.cpp
+++ b/src/duckstation-qt/gamepropertiesdialog.cpp
@@ -236,7 +236,7 @@ void GamePropertiesDialog::populateTracksInfo(const std::string& image_path)
     const CDImage::TrackMode mode = image->GetTrackMode(static_cast<u8>(track));
     const int row = static_cast<int>(track - 1u);
     m_ui.tracks->insertRow(row);
-    m_ui.tracks->setItem(row, 0, new QTableWidgetItem(QStringLiteral("%1").arg(track)));
+    m_ui.tracks->setItem(row, 0, new QTableWidgetItem(QString::number(track)));
     m_ui.tracks->setItem(row, 1, new QTableWidgetItem(track_mode_strings[static_cast<u32>(mode)]));
     m_ui.tracks->setItem(row, 2, new QTableWidgetItem(MSFTotString(position)));
     m_ui.tracks->setItem(row, 3, new QTableWidgetItem(MSFTotString(length)));

--- a/src/duckstation-qt/inputbindingwidgets.cpp
+++ b/src/duckstation-qt/inputbindingwidgets.cpp
@@ -36,7 +36,7 @@ void InputBindingWidget::updateText()
   if (m_bindings.empty())
     setText(QString());
   else if (m_bindings.size() > 1)
-    setText(tr("%1 bindings").arg(m_bindings.size()));
+    setText(tr("%n bindings", "", m_bindings.size()));
   else
     setText(QString::fromStdString(m_bindings[0]));
 }

--- a/src/duckstation-qt/memorycardeditordialog.cpp
+++ b/src/duckstation-qt/memorycardeditordialog.cpp
@@ -215,7 +215,7 @@ void MemoryCardEditorDialog::updateCardBlocksFree(Card* card)
 {
   card->blocks_free = MemoryCardImage::GetFreeBlockCount(card->data);
   card->blocks_free_label->setText(
-    tr("%1 blocks free%2").arg(card->blocks_free).arg(card->dirty ? QStringLiteral(" (*)") : QString()));
+    tr("%n block(s) free%1", "", card->blocks_free).arg(card->dirty ? QStringLiteral(" (*)") : QString()));
 }
 
 void MemoryCardEditorDialog::setCardDirty(Card* card)

--- a/src/duckstation-qt/memorycardeditordialog.cpp
+++ b/src/duckstation-qt/memorycardeditordialog.cpp
@@ -207,7 +207,7 @@ void MemoryCardEditorDialog::updateCardTable(Card* card)
 
     card->table->setItem(row, 1, new QTableWidgetItem(QString::fromStdString(fi.title)));
     card->table->setItem(row, 2, new QTableWidgetItem(QString::fromStdString(fi.filename)));
-    card->table->setItem(row, 3, new QTableWidgetItem(QStringLiteral("%1").arg(fi.num_blocks)));
+    card->table->setItem(row, 3, new QTableWidgetItem(QString::number(fi.num_blocks)));
   }
 }
 

--- a/src/duckstation-qt/postprocessingshaderconfigwidget.cpp
+++ b/src/duckstation-qt/postprocessingshaderconfigwidget.cpp
@@ -47,7 +47,7 @@ void PostProcessingShaderConfigWidget::createUi()
         QString label;
         if (option.vector_size <= 1)
         {
-          label = QStringLiteral("%1").arg(QString::fromStdString(option.ui_name));
+          label = QString::fromStdString(option.ui_name);
         }
         else
         {
@@ -66,7 +66,7 @@ void PostProcessingShaderConfigWidget::createUi()
 
         if (option.type == PostProcessingShader::Option::Type::Int)
         {
-          slider_label->setText(QStringLiteral("%1").arg(option.value[i].int_value));
+          slider_label->setText(QString::number(option.value[i].int_value));
 
           const int range = std::max(option.max_value[i].int_value - option.min_value[i].int_value, 1);
           const int step_value =
@@ -81,20 +81,20 @@ void PostProcessingShaderConfigWidget::createUi()
             const int new_value = std::clamp(option.min_value[i].int_value + (value * option.step_value[i].int_value),
                                              option.min_value[i].int_value, option.max_value[i].int_value);
             option.value[i].int_value = new_value;
-            slider_label->setText(QStringLiteral("%1").arg(new_value));
+            slider_label->setText(QString::number(new_value));
             configChanged();
           });
           connect(this, &PostProcessingShaderConfigWidget::resettingtoDefaults,
                   [&option, i, slider, slider_label, step_value]() {
                     QSignalBlocker sb(slider);
                     slider->setValue((option.default_value[i].int_value - option.min_value[i].int_value) / step_value);
-                    slider_label->setText(QStringLiteral("%1").arg(option.default_value[i].int_value));
+                    slider_label->setText(QString::number(option.default_value[i].int_value));
                     option.value = option.default_value;
                   });
         }
         else
         {
-          slider_label->setText(QStringLiteral("%1").arg(option.value[i].float_value));
+          slider_label->setText(QString::number(option.value[i].float_value));
 
           const float range = std::max(option.max_value[i].float_value - option.min_value[i].float_value, 1.0f);
           const float step_value =
@@ -111,7 +111,7 @@ void PostProcessingShaderConfigWidget::createUi()
                                                  (static_cast<float>(value) * option.step_value[i].float_value),
                                                option.min_value[i].float_value, option.max_value[i].float_value);
             option.value[i].float_value = new_value;
-            slider_label->setText(QStringLiteral("%1").arg(new_value));
+            slider_label->setText(QString::number(new_value));
             configChanged();
           });
           connect(this, &PostProcessingShaderConfigWidget::resettingtoDefaults,
@@ -119,7 +119,7 @@ void PostProcessingShaderConfigWidget::createUi()
                     QSignalBlocker sb(slider);
                     slider->setValue(static_cast<int>(
                       (option.default_value[i].float_value - option.min_value[i].float_value) / step_value));
-                    slider_label->setText(QStringLiteral("%1").arg(option.default_value[i].float_value));
+                    slider_label->setText(QString::number(option.default_value[i].float_value));
                     option.value = option.default_value;
                   });
         }

--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -64,7 +64,7 @@ const char* QtHostInterface::GetFrontendName() const
 
 std::vector<std::pair<QString, QString>> QtHostInterface::getAvailableLanguageList()
 {
-  return {{QStringLiteral("English"), QStringLiteral("")},
+  return {{QStringLiteral("English"), QStringLiteral("en")},
           {QStringLiteral("Deutsch"), QStringLiteral("de")},
           {QStringLiteral("Español"), QStringLiteral("es")},
           {QStringLiteral("Français"), QStringLiteral("fr")},
@@ -129,7 +129,7 @@ void QtHostInterface::installTranslator()
 
   std::string language = GetStringSettingValue("Main", "Language", "");
   if (language.empty())
-    return;
+    language = "en";
 
   const QString path =
     QStringLiteral("%1/translations/duckstation-qt_%3.qm").arg(qApp->applicationDirPath()).arg(language.c_str());

--- a/src/duckstation-qt/settingwidgetbinder.h
+++ b/src/duckstation-qt/settingwidgetbinder.h
@@ -44,10 +44,10 @@ struct SettingAccessor<QLineEdit>
   }
 
   static int getIntValue(const QLineEdit* widget) { return widget->text().toInt(); }
-  static void setIntValue(QLineEdit* widget, int value) { widget->setText(QStringLiteral("%1").arg(value)); }
+  static void setIntValue(QLineEdit* widget, int value) { widget->setText(QString::number(value)); }
 
   static float getFloatValue(const QLineEdit* widget) { return widget->text().toFloat(); }
-  static void setFloatValue(QLineEdit* widget, float value) { widget->setText(QStringLiteral("%1").arg(value)); }
+  static void setFloatValue(QLineEdit* widget, float value) { widget->setText(QString::number(value)); }
 
   static QString getStringValue(const QLineEdit* widget) { return widget->text(); }
   static void setStringValue(QLineEdit* widget, const QString& value) { widget->setText(value); }
@@ -118,7 +118,7 @@ struct SettingAccessor<QSlider>
   static float getFloatValue(const QSlider* widget) { return static_cast<float>(widget->value()); }
   static void setFloatValue(QSlider* widget, float value) { widget->setValue(static_cast<int>(value)); }
 
-  static QString getStringValue(const QSlider* widget) { return QStringLiteral("%1").arg(widget->value()); }
+  static QString getStringValue(const QSlider* widget) { return QString::number(widget->value()); }
   static void setStringValue(QSlider* widget, const QString& value) { widget->setValue(value.toInt()); }
 
   template<typename F>
@@ -140,7 +140,7 @@ struct SettingAccessor<QSpinBox>
   static float getFloatValue(const QSpinBox* widget) { return static_cast<float>(widget->value()); }
   static void setFloatValue(QSpinBox* widget, float value) { widget->setValue(static_cast<int>(value)); }
 
-  static QString getStringValue(const QSpinBox* widget) { return QStringLiteral("%1").arg(widget->value()); }
+  static QString getStringValue(const QSpinBox* widget) { return QString::number(widget->value()); }
   static void setStringValue(QSpinBox* widget, const QString& value) { widget->setValue(value.toInt()); }
 
   template<typename F>
@@ -162,7 +162,7 @@ struct SettingAccessor<QDoubleSpinBox>
   static float getFloatValue(const QDoubleSpinBox* widget) { return static_cast<float>(widget->value()); }
   static void setFloatValue(QDoubleSpinBox* widget, float value) { widget->setValue(static_cast<double>(value)); }
 
-  static QString getStringValue(const QDoubleSpinBox* widget) { return QStringLiteral("%1").arg(widget->value()); }
+  static QString getStringValue(const QDoubleSpinBox* widget) { return QString::number(widget->value()); }
   static void setStringValue(QDoubleSpinBox* widget, const QString& value) { widget->setValue(value.toDouble()); }
 
   template<typename F>

--- a/src/duckstation-qt/translations/duckstation-qt_en.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_en.ts
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name>AudioSettingsWidget</name>
+    <message numerus="yes">
+        <source>Maximum Latency: %n frames (%1ms)</source>
+        <translation>
+            <numerusform>Maximum Latency: %n frame (%1ms)</numerusform>
+            <numerusform>Maximum Latency: %n frames (%1ms)</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>EmulationSettingsWidget</name>
+    <message numerus="yes">
+        <source>Rewind for %n frame(s), lasting %1 second(s) will require up to %2MB of RAM and %3MB of VRAM.</source>
+        <translation>
+            <numerusform>Rewind for %n frame, lasting %1 second(s) will require up to %2MB of RAM and %3MB of VRAM.</numerusform>
+            <numerusform>Rewind for %n frames, lasting %1 second(s) will require up to %2MB of RAM and %3MB of VRAM.</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>InputBindingWidget</name>
+    <message numerus="yes">
+        <source>%n bindings</source>
+        <translation>
+            <numerusform>%n binding</numerusform>
+            <numerusform>%n bindings</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>MemoryCardEditorDialog</name>
+    <message numerus="yes">
+        <source>%n block(s) free%1</source>
+        <translation>
+            <numerusform>%n block free%1</numerusform>
+            <numerusform>%n blocks free%1</numerusform>
+        </translation>
+    </message>
+</context>
+</TS>

--- a/src/duckstation-qt/translations/update-and-edit-english.bat
+++ b/src/duckstation-qt/translations/update-and-edit-english.bat
@@ -1,0 +1,10 @@
+@echo off
+
+set "linguist=..\..\..\dep\msvc\qt\5.15.0\msvc2017_64\bin"
+set context=../ ../../core/ ../../frontend-common/ -tr-function-alias translate+=TranslateString -tr-function-alias translate+=TranslateStdString -tr-function-alias QT_TRANSLATE_NOOP+=TRANSLATABLE -pluralonly
+
+"%linguist%\lupdate.exe" %context% -ts duckstation-qt_en.ts
+pause
+
+cd "%linguist%"
+start /B linguist.exe "%~dp0\duckstation-qt_en.ts"


### PR DESCRIPTION
**IMPORTANT NOTE:** If it's not done automatically, `duckstation-qt_en.qm` must be added to the artifacts!

1. Hooks up plurality for English. So far very few strings utilize it, because we can't yet use plurality outside of Qt strings. It'll be much more useful once it's in there though, for strings like `X cheats loaded` etc.
2. "Stretch to fill" had a broken widget help assignment.
3. As far as I can tell, `QStringLiteral("%1").arg(num)` can be simplified to `QString::number(num)`, so I did a full sweep through the codebase.