### PR TITLE
Fix quick menu exit

### DIFF
--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1789,7 +1789,7 @@ void CommonHostInterface::RegisterGeneralHotkeys()
 {
   RegisterHotkey(StaticString(TRANSLATABLE("Hotkeys", "General")), StaticString("OpenQuickMenu"),
                  TRANSLATABLE("Hotkeys", "Open Quick Menu"), [this](bool pressed) {
-                   if (!pressed && m_fullscreen_ui_enabled)
+                   if (pressed && m_fullscreen_ui_enabled)
                      FullscreenUI::OpenQuickMenu();
                  });
 


### PR DESCRIPTION
Now requires the button to be released, **then** pressed. With this change, e0161c3bb2f5e5f4e9d7f9569ba86010899c08c5 can be reverted.

Should this logic be applied to `DrawChoiceDialog` and `DrawFileSelector` in `imgui_fullscreen.cpp`? If so, maybe it is better to move it there instead of `fullscreen_ui.cpp`.