### PR TITLE
Achievements Login: Lock "Login" button if credentials are not entered

### DIFF
--- a/src/duckstation-qt/achievementlogindialog.cpp
+++ b/src/duckstation-qt/achievementlogindialog.cpp
@@ -16,11 +16,6 @@ void AchievementLoginDialog::loginClicked()
 {
   const std::string username(m_ui.userName->text().toStdString());
   const std::string password(m_ui.password->text().toStdString());
-  if (username.empty() || password.empty())
-  {
-    QMessageBox::critical(this, tr("Login Error"), tr("A user name and password must be provided."));
-    return;
-  }
 
   // TODO: Make cancellable.
   m_ui.status->setText(tr("Logging in..."));
@@ -52,6 +47,10 @@ void AchievementLoginDialog::connectUi()
 {
   connect(m_ui.login, &QPushButton::clicked, this, &AchievementLoginDialog::loginClicked);
   connect(m_ui.cancel, &QPushButton::clicked, this, &AchievementLoginDialog::cancelClicked);
+
+  auto enableLoginButton = [this](const QString&) { m_ui.login->setEnabled(canEnableLoginButton()); };
+  connect(m_ui.userName, &QLineEdit::textChanged, enableLoginButton);
+  connect(m_ui.password, &QLineEdit::textChanged, enableLoginButton);
 }
 
 void AchievementLoginDialog::enableUI(bool enabled)
@@ -59,5 +58,10 @@ void AchievementLoginDialog::enableUI(bool enabled)
   m_ui.userName->setEnabled(enabled);
   m_ui.password->setEnabled(enabled);
   m_ui.cancel->setEnabled(enabled);
-  m_ui.login->setEnabled(enabled);
+  m_ui.login->setEnabled(enabled && canEnableLoginButton());
+}
+
+bool AchievementLoginDialog::canEnableLoginButton() const
+{
+  return !m_ui.userName->text().isEmpty() && !m_ui.password->text().isEmpty();
 }

--- a/src/duckstation-qt/achievementlogindialog.h
+++ b/src/duckstation-qt/achievementlogindialog.h
@@ -17,6 +17,7 @@ private Q_SLOTS:
 private:
   void connectUi();
   void enableUI(bool enabled);
+  bool canEnableLoginButton() const;
 
   Ui::AchievementLoginDialog m_ui;
 };

--- a/src/duckstation-qt/achievementlogindialog.ui
+++ b/src/duckstation-qt/achievementlogindialog.ui
@@ -125,6 +125,9 @@
      </item>
      <item>
       <widget class="QPushButton" name="login">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
         <string>&amp;Login</string>
        </property>

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1789,7 +1789,7 @@ void CommonHostInterface::RegisterGeneralHotkeys()
 {
   RegisterHotkey(StaticString(TRANSLATABLE("Hotkeys", "General")), StaticString("OpenQuickMenu"),
                  TRANSLATABLE("Hotkeys", "Open Quick Menu"), [this](bool pressed) {
-                   if (!pressed && m_fullscreen_ui_enabled)
+                   if (pressed && m_fullscreen_ui_enabled)
                      FullscreenUI::OpenQuickMenu();
                  });
 


### PR DESCRIPTION
Bigduck does this already, Qt did not - `Login` is now locked if credentials are not entered:

![image](https://user-images.githubusercontent.com/7947461/110377666-f884e800-8054-11eb-93c4-63c912501b43.png)
![image](https://user-images.githubusercontent.com/7947461/110377676-fc186f00-8054-11eb-9dcc-e710086f0785.png)
