### PR TITLE
Updated chtdb.txt and added new types F5, 52 & 53. Cleaned up type 51

### DIFF
--- a/data/database/chtdb.txt
+++ b/data/database/chtdb.txt
@@ -56,7 +56,7 @@
 ;
 ; NOTE: Codes will only ever contain hexadecimal characters (0-F) any other
 ;       characters (like WXYZ) in the following descriptions are for
-;       demonstration purposes only.
+;       documentation purposes only.
 ;
 ;  8 Char by 8 Char Code Types (includes 32 bit codes)
 ;  ***************************************************
@@ -71,9 +71,6 @@
 ;* 61XXXXXX YYYYYYYY - 32-Bit Decrement Once, Poke $80XXXXXX with ($80XXXXXX)-0xYYYYYYYY
 ;* A5000XXX YYYYYYYY - 32-Bit Scratchpad Constant Write, Poke $1F800XXX with
 ;                      YYYYYYYY, where XXX is between 000 & 3FF.
-;* A4XXXXXX YYYYYYYY - 32-Bit Master Code, if ($XXXXXX) contains 0xYYYYYYYY poke
-;  00000000 FFFF       all following codes for rest of cheat or until it reaches
-;                      the 00000000 FFFF line.
 ;* A5000XXX YYYYYYYY - 32-Bit Scratchpad Constant Write, Poke $1F800XXX with
 ;                      YYYYYYYY, where XXX is between 000 & 3FF.
 ;* A6XXXXXX YYYYZZZZ - 16-Bit If Equal To Write, if (80XXXXXX)==0xYYYY, Poke
@@ -81,20 +78,20 @@
 ;                      code which use the same address.
 ;* A7XXXXXX YYYYZZZZ - 16-Bit If Equal To Write with Restore, if
 ;                      (80XXXXXX)==0xYYYY, Poke $80XXXXXX with 0xZZZZ. On
-;                      disabling the cheat if (80XXXXXX)==0xZZZZ, Poke $80YYYYYY
+;                      disabling the cheat if (80XXXXXX)==0xZZZZ, Poke $80XXXXXX
 ;                      with 0xYYYY. This can be used for a ASM cheat that has
 ;                      poked dynamic memory with less danger of crashing the
 ;                      game or for 16:9 cheats to go back to 4:3 when disabled
-;* F0XXXXXX HHSSULLL - 8-Bit Force Range, if (80XXXXXX)<0xLL, Poke $80YYYYYY with
-;                      0xSS. If (80XXXXXX)>0xUL, Poke $80YYYYYY with 0xHH.
+;* F0XXXXXX HHSSULLL - 8-Bit Force Range, if (80XXXXXX)<0xLL, Poke $80XXXXXX with
+;                      0xSS. If (80XXXXXX)>0xUL, Poke $80XXXXXX with 0xHH.
 ;* F1XXXXXX ULULLLLL - 16-Bit Force Range to Limit, if (80XXXXXX)<0xLLLL, Poke
-;                      $80YYYYYY with 0xLLLL. If (80XXXXXX)>0xULUL, Poke
-;                      $80YYYYYY with 0xULUL.
+;                      $80XXXXXX with 0xLLLL. If (80XXXXXX)>0xULUL, Poke
+;                      $80XXXXXX with 0xULUL.
 ;* F2XXXXXX ULULLLLL - 16-Bit Force Range to Opposite Limit, if
-;                      (80XXXXXX)<0xLLLL, Poke $80YYYYYY with 0xULUL. If
-;                      (80XXXXXX)>0xULUL, Poke $80YYYYYY with 0xLLLL.
-;* F3XXXXXX ULULLLLL - 16-Bit Force Range, if (80XXXXXX)<0xLLLL, Poke $80YYYYYY
-;  F3000000 HHHHSSSS   with 0xSSSS. If (80XXXXXX)>0xULUL, Poke $80YYYYYY with
+;                      (80XXXXXX)<0xLLLL, Poke $80XXXXXX with 0xULUL. If
+;                      (80XXXXXX)>0xULUL, Poke $80XXXXXX with 0xLLLL.
+;* F3XXXXXX ULULLLLL - 16-Bit Force Range, if (80XXXXXX)<0xLLLL, Poke $80XXXXXX
+;  F3000000 HHHHSSSS   with 0xSSSS. If (80XXXXXX)>0xULUL, Poke $80XXXXXX with
 ;                      0xHHHH.
 ;* F4XXXXXY 00WWSIZE - 8-Bit Find and Replace, Find and Replace for 16 bytes.
 ;  aabbccdd eeffgghh   WW = Wildcard Byte, SIZE = Size of Area to Search/4 so FFFF=256K,
@@ -102,7 +99,13 @@
 ;  AABBCCDD EEFFGGHH   Find aa,bb,cc,dd,ee,ff,gg,hh,ii,jj,kk,ll,mm,nn,oo,pp and
 ;  IIJJKKLL MMNNOOPP   replace with AA,BB,CC,DD,EE,FF,GG,HH,II,JJ,KK,LL,MM,NN,OO,PP.
 ;                      Any byte matching the WW character in the find bytes will
-;                      be ignored.
+;                      be ignored. Any byte matching the WW character in the
+;                      replace bytes will be ignored, ideally all bytes in the
+;                      replace line should be WW with the exception of where
+;                      an actual replacement is required.
+;* F5XXXXXX YYYYZZZZ - 16-Bit Toggle, if (80XXXXXX)=0xYYYY, Poke $80XXXXXX
+;                      with 0xZZZZ. if (80XXXXXX)=0xZZZZ, Poke $80XXXXXX with
+;                      0xYYYY.
 ;  16 Bit Code Types
 ;  *****************
 ;* 80XXXXXX YYYY - 16-Bit Constant Write, Poke $80XXXXXX with 0xYYYY  **COMMON**
@@ -135,10 +138,7 @@
 ;* 11XXXXXX YYYY - 16-Bit Decrement Once, Poke $80XXXXXX with ($80XXXXXX)-0xYYYY
 ;* 1F000XXX YYYY - 16-Bit Scratchpad Constant Write, Poke $1F800XXX with YYYY,
 ;                      where XXX is between 000 & 3FF.
-;* C0XXXXXX YYYY - 16-Bit Master Code, if ($XXXXXX) contains 0xYYYY poke all
-;  00000000 FFFF       following codes for rest of cheat or until it reaches the
-;                      00000000 FFFF line.
-;
+
 ;  8 Bit Code Types
 ;  ****************
 ;* 30XXXXXX 00YY - 8-Bit Constant Write, Poke $80XXXXXX with 0xYY     **COMMON**
@@ -163,6 +163,113 @@
 ;                    number_of_addresses = PP (needs to be >02 to be worthwhile)
 ;                    address_step = QQ (commonly 01 for type 30, 02 for type 80)
 ;                    value_step = TTTT (most commonly 0000)
+;* 53WVPPPP QQQQTTTT - Improved Serial Repeater/Slide, pokes multiple serially changing
+;  X0YYYYYY ZZZZZZZZ   addresses with a possible changing value.
+;                    address_change = W ( 0 = increasing, 1 = decreasing)
+;                    value_change = V ( 0 = increasing, 1 = decreasing) 
+;                    poke_size = X0 (30 for byte, 80 for word or 90 for longword)
+;                    start_address = YYYYYY
+;                    start_value = ZZZZZZZZ
+;                    number_of_addresses = PPPP (needs to be >02 to be worthwhile)
+;                    address_step = QQQQ (commonly 01 for type 30, 02 for 
+;                                         type 80, 04 for type 90)
+;                    value_step = TTTT (most commonly 0000)
+;
+;  Block Conditionals
+;  ******************
+;  If the condition is met these will execute all the following codes to either
+;  a 000000000 FFFF line is reached or it reaches the end of that cheat. You
+;  should always use a 00000000 FFFF line though (dont be lazy!).
+;
+;* A4XXXXXX YYYYYYYY - 32-Bit Master Code, if ($XXXXXX) contains 0xYYYYYYYY poke
+;  00000000 FFFF       all following codes for rest of the cheat or until it reaches
+;                      the 00000000 FFFF line.
+;* C0XXXXXX YYYY - 16-Bit Master Code, if ($XXXXXX) contains 0xYYYY poke all
+;  00000000 FFFF       following codes for rest of the cheat or until it reaches the
+;                      00000000 FFFF line.
+;* C3XXXXXX 00YY - 8-Bit Master Code, if ($XXXXXX) is less than 0xYY poke all
+;  00000000 FFFF       following codes for rest of the cheat or until it reaches the
+;                      00000000 FFFF line.
+;* C4XXXXXX 00YY - 8-Bit Master Code, if ($XXXXXX) is greater than 0xYY poke all
+;  00000000 FFFF       following codes for rest of the cheat or until it reaches the
+;                      00000000 FFFF line.
+;* C5XXXXXX YYYY - 16-Bit Master Code, if ($XXXXXX) is less than 0xYYYY poke all
+;  00000000 FFFF       following codes for rest of the cheat or until it reaches the
+;                      00000000 FFFF line.
+;* C6XXXXXX YYYY - 16-Bit Master Code, if ($XXXXXX) is greater than 0xYYYY poke all
+;  00000000 FFFF       following codes for rest of the cheat or until it reaches the
+;                      00000000 FFFF line.
+;* D5000000 YYYY - 16-Bit All Codes On
+;* D6000000 YYYY - 16-Bit All Codes Off
+;* D7PQRRRR TTYYYYYY - 24-Bit Universal BIT Joker, OR the hex values to
+;                     combine into a multi-button joker. Because it is BIT
+;                     based it is better than D4, D5, D6 or using a D0 joker as
+;                     you do not need to worry about any other buttons being
+;                     pressed at the same time and you get both analog
+;                     sticks for extra functionality. Note if you want to use it
+;                     just as a enhanced joker just use D7000000 00YYYYYY when
+;                     the buttons/directions are pressed or D7100000 00YYYYYY
+;                     when you want to ensure they are not all pressed.
+;                        YYYYYY = 000001 L2 Button
+;                        YYYYYY = 000002 R2 Button
+;                        YYYYYY = 000004 L1 Button
+;                        YYYYYY = 000008 R1 Button
+;                        YYYYYY = 000010 Triangle Button
+;                        YYYYYY = 000020 Circle Button
+;                        YYYYYY = 000040 X Button
+;                        YYYYYY = 000080 Square Button
+;                        YYYYYY = 000100 Select Button
+;                        YYYYYY = 000200 L3 Button
+;                        YYYYYY = 000400 R3 Button
+;                        YYYYYY = 000800 Start Button
+;                        YYYYYY = 001000 Up (Digital)
+;                        YYYYYY = 002000 Right (Digital)
+;                        YYYYYY = 004000 Down (Digital)
+;                        YYYYYY = 008000 Left (Digital)
+;                        YYYYYY = 010000 Up (Right Thumb)
+;                        YYYYYY = 020000 Right (Right Thumb)
+;                        YYYYYY = 040000 Down (Right Thumb)
+;                        YYYYYY = 080000 Left (Right Thumb)
+;                        YYYYYY = 100000 Up (Left Thumb)
+;                        YYYYYY = 200000 Right (Left Thumb)
+;                        YYYYYY = 400000 Down (Left Thumb)
+;                        YYYYYY = 800000 Left (Left Thumb)
+;                      P = 0 or 1. 0 = Check ALL YYYYYY Bits are ON
+;                                  1 = Check ALL YYYYYY Bits are OFF
+;
+;                     QRRRR TT provides the capability of only activating the
+;                     following codes after the keys have been held in for a set
+;                     amount of frames. 003C = 60 Frames = 1 Second at 100% Speed.
+;                       Q = Frame Comparison 0 = Dont do any comparison
+;                                            1 = Check that the button combination
+;                                                has been held down for exactly
+;                                                RRRR frames.
+;                                            2 = Check that the button combination
+;                                                has been held down for at least
+;                                                RRRR frames.
+;                                            3 = Check that the button combination
+;                                                has been held down for less than
+;                                                RRRR frames.
+;                                            4 = Check that the button combination
+;                                                has been held down for anything
+;                                                but RRRR frames.
+;                       TT=Temp Register 00-FF, 00 will mean it wont be used, if
+;                            it's not 00 do not use the same value for jokers
+;                            using different keypress combinations for the same
+;                            game.
+;                       RRRR = 0000 to FFFF, Frame Comparison Value
+;                       NOTE: If you have multiple D7 lines using frame counting
+;                             and the same register, the temp register will be
+;                             out by that factor. Eg. If you have 2 D7 lines
+;                             accessing register 05, then after 60 frames -
+;                             register 05 will contain 120 (0x78)
+;
+;                      It will then poke all following codes for rest of cheat
+;  00000000 FFFF       or until it reaches the 00000000 FFFF line.
+;
+;* 52XXXXXX YYYYYYYY - Register Master Code, if ($XXXXXX) contains 0xYYYYYYYY poke
+;  00000000 FFFF       all following codes for rest of the cheat or until it reaches
+;                      the 00000000 FFFF line.
 ;
 ;  Other Code Types
 ;  ****************
@@ -170,9 +277,512 @@
 ;  the game has started without the use of delays or global jokers. They are
 ;  supported by Duckstation but ideally dont use them if you can help it.
 ;* C1XXXXXX YYYY - Activate Codes On Delay
-;* D5000000 YYYY - 16-Bit All Codes On
-;* D6000000 YYYY - 16-Bit All Codes Off
 ;
+;  Register Code Types
+;  *******************
+;  These codes utilise the internal global 256 32-bit cheat registers. As they
+;  are global they will work across all cheats for a game so be careful not
+;  to re-use registers unintendingly. Type 51 codes can be used to copy and
+;  manipulate register contents between registers and memory. Type 52 codes are
+;  block conditionals that you can test the registers with and branch accordingly.
+;
+;  These code types will only need to be used with very advanced cheats, only
+;  use them if you need them as they may blow your mind....
+; 
+;  General Notes:
+;  ==============
+;  RegXX or RegYY means the immediate value of the register
+;  (RegXX) or (RegYY) means the indirect value of the register = contents of the 
+;                     address held in RegXX or RegYY*
+;  TTTTTTTT = Write to Address TTTTTTTT
+;  (TTTTTTTT) = Read from Address TTTTTTTT
+;  ZZ,ZZZZ,ZZZZZZZ = Value
+;  Note RegXX, RegYY, RegWW can be the same register
+;
+;  8 BIT operations:
+;  =================
+;* 510000XX TTTTTTTT - 8-Bit Address Write from Register, Poke address TTTTTTTT
+;                      with the 8-bit contents of Register XX. 
+;                      u8Poke TTTTTTTT, RegXX
+;* 510100XX TTTTTTTT - 8-Bit Address Read to Register, Peek the 8bit contents of
+;                      address TTTTTTTT and store it in Register XX.
+;                      u8Poke RegXX, (TTTTTTTT) 
+;* 510200XX 000000ZZ - 8-Bit Indirect Register Write, poke ZZ to the 32-Bit 
+;                      address stored in Register XX.
+;                      u8Poke (RegXX), ZZ 
+;* 5103YYXX 000000ZZ - 8-Bit Register Addition, add ZZ and the 8 bit contents 
+;                      of Register YY together and write it to Register XX.
+;                      u8Poke RegXX, RegYY + ZZ                  
+;* 5104YYXX 000000ZZ - 8-Bit Indirect Register Write with addition, add ZZ and  
+;                      the 8 bit contents of Register YY together and write it  
+;                      to the 32-Bit address stored in Register XX.
+;                      u8Poke (RegXX), RegYY + ZZ  
+;* 510500XX 000000ZZ - 8-Bit Direct Register Write, poke ZZ to Register XX.
+;                      u8Poke RegXX, ZZ  
+;
+; 16 BIT operations:
+; ==================
+;* 514000XX TTTTTTTT - 16-Bit Address Write from Register, Poke address TTTTTTTT
+;                      with the 16-bit contents of Register XX.
+;                      u16Poke TTTTTTTT, RegXX
+;* 514100XX TTTTTTTT - 16-Bit Address Read to Register, Peek the 16-bit contents 
+;                      of address TTTTTTTT and store it in Register XX.
+;                      u16Poke RegXX, (TTTTTTTT) 
+;* 514200XX 0000ZZZZ - 16-Bit Indirect Register Write, poke ZZZZ to the 32-Bit 
+;                      address stored in Register XX.
+;                      u16Poke (RegXX), ZZZZ
+;* 5143YYXX 0000ZZZZ - 16-Bit Register Addition, add ZZZZ and the 16 bit contents 
+;                      of Register YY together and write it to Register XX.
+;                      u16Poke RegXX, RegYY + ZZZZ     
+;* 5144YYXX 0000ZZZZ - 16-Bit Indirect Register Write with addition, add ZZZZ  
+;                      and the 16 bit contents of Register YY together and write 
+;                      it to the 32-Bit address stored in Register XX.               
+;                      u16Poke (RegXX), RegYY + ZZZZ 
+;* 514500XX 0000ZZZZ - 16-Bit Direct Register Write, poke ZZZZ to Register XX.
+;                      u16Poke RegXX, ZZZZ  
+;
+; 32 BIT operations:
+; ==================
+;* 518000XX TTTTTTTT - 32-Bit Address Write from Register, Poke address TTTTTTTT
+;                      with the 32-bit contents of Register XX.
+;                      u32Poke TTTTTTTT, RegXX
+;* 518100XX TTTTTTTT - 32-Bit Address Read to Register, Peek the 32-bit contents 
+;                      of address TTTTTTTT and store it in Register XX.
+;                      u32Poke RegXX, (TTTTTTTT) 
+;* 518200XX ZZZZZZZZ - 32-Bit Indirect Register Write, poke ZZZZZZZZ to the  
+;                      32-Bit address stored in Register XX.
+;                      u32Poke (RegXX), ZZZZZZZZ
+;* 5183YYXX ZZZZZZZZ - 32-Bit Register Addition, add ZZZZZZZZ and the 32 bit 
+;                      contents of Register YY together and write it to  
+;                      Register XX.
+;                      u32Poke RegXX, RegYY + ZZZZZZZZ   
+;* 5184YYXX 0000ZZZZ - 32-Bit Indirect Register Write with addition, add 
+;                      ZZZZZZZZ and the 32 bit contents of Register YY together 
+;                      and write it to the 32-Bit address stored in Register XX. 
+;                      u32Poke (RegXX), RegYY + ZZZZZZZZ  
+;* 518500XX ZZZZZZZZ - 32-Bit Direct Register Write, poke ZZZZZZZZ to Register XX.
+;                      u32Poke RegXX, ZZZZZZZZ. Note: This is useful to write
+;                      the actual address to a register.  
+;
+; Generic Register Operations:
+; ============================
+; All these generic register only codes are 32 Bit, but you can read any register
+; register as a u8, u16 or a u32. 
+;
+;* 51C0YYXX 000000RR - Add Register YY to Register XX and store result in
+;                      Register RR. 
+;                      u32Poke RegRR, RegYY + RegXX  
+;* 51C1YYXX 000000RR - Subtract Register XX from Register YY and store result in
+;                      Register RR. 
+;                      u32Poke RegRR, RegYY - RegXX  
+;* 51C2YYXX 000000RR - Multiply Register YY by Register XX and store result in
+;                      Register RR. 
+;                      u32Poke RegRR, RegYY * RegXX  
+;* 51C3YYXX 000000RR - Divide Register YY by Register XX and store result in
+;                      Register RR. Note: If Register XX contains 0, RR will be 
+;                      set to 0.
+;                      u32Poke RegRR, RegYY / RegXX
+;* 51C4YYXX 000000RR - Divide Register YY by Register XX and store remainder in
+;                      Register RR. Note: If Register XX contains 0, RR will be 
+;                      set to RegYY.
+;                      u32Poke RegRR, RegYY % RegXX
+;* 51C5YYXX 000000RR - Bitwise AND Register YY and Register XX and store result
+;                      in Register RR. 
+;                      u32Poke RegRR, RegYY & RegXX  
+;* 51C6YYXX 000000RR - Bitwise OR Register YY and Register XX and store result
+;                      in Register RR. 
+;                      u32Poke RegRR, RegYY | RegXX 
+;* 51C7YYXX 000000RR - Bitwise XOR Register YY and Register XX and store result
+;                      in Register RR. 
+;                      u32Poke RegRR, RegYY ^ RegXX 
+;* 51C800XX 000000RR - Bitwise NOT Register XX and store result in Register RR.  
+;                      aka One's Complement
+;                      u32Poke RegRR, ~RegXX
+;* 51C9TTXX 000000RR - Bitwise LSHIFT Register XX by TT and store result in
+;                      Register RR. 
+;                      u32Poke RegRR, RegXX << TT
+;* 51CATTXX 000000RR - Bitwise RSHIFT Register XX by TT and store result in
+;                      Register RR. 
+;                      u32Poke RegRR, RegXX >> TT
+;
+; Register Block Conditionals:
+; ============================
+;
+;* 5200YYXX 00000000 - If u8RegYY == u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5201YYXX 00000000 - If u8RegYY != u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5202YYXX 00000000 - If u8RegYY > u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5203YYXX 00000000 - If u8RegYY => u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5204YYXX 00000000 - If u8RegYY < u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5205YYXX 00000000 - If u8RegYY =< u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5206YYXX 00000000 - If u8RegYY & u8RegXX = u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5207YYXX 00000000 - If u8RegYY & u8RegXX != u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 520AYYXX 00000000 - If u8RegYY & u8RegXX = u8RegYY poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 520BYYXX 00000000 - If u8RegYY & u8RegXX != u8RegYY poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521000XX 000000ZZ - If u8RegXX == ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521100XX 000000ZZ - If u8RegXX != ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521200XX 000000ZZ - If u8RegXX > ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521300XX 000000ZZ - If u8RegXX => ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521400XX 000000ZZ - If u8RegXX < ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521500XX 000000ZZ - If u8RegXX =< ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521600XX 000000ZZ - If u8RegXX & ZZ = ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521700XX 000000ZZ - If u8RegXX & ZZ != ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521800XX 00TT00ZZ - If u8RegXX > ZZ && u8RegXX < TT poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521900XX 00TT00ZZ - If u8RegXX => ZZ && u8RegXX <= TT poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521A00XX 000000ZZ - If u8RegXX & ZZ = u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 521B00XX 000000ZZ - If u8RegXX & ZZ != u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5220YYXX 00000000 - If u8(RegYY) == u8(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5221YYXX 00000000 - If u8(RegYY) != u8(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5222YYXX 00000000 - If u8(RegYY) > u8(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5223YYXX 00000000 - If u8(RegYY) => u8(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5224YYXX 00000000 - If u8(RegYY) < u8(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5225YYXX 00000000 - If u8(RegYY) =< u8(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line
+;
+;* 522600XX 000000ZZ - If u8(RegXX) & ZZ = ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 522700XX 000000ZZ - If u8(RegXX) & ZZ != ZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 522800XX 00TT00ZZ - If u8(RegXX) > ZZ && u8(RegXX) < TT poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 522900XX 00TT00ZZ - If u8(RegXX) => ZZ && u8(RegXX) <= TT poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 522A00XX 000000ZZ - If u8(RegXX) & ZZ = u8(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 522B00XX 000000ZZ - If u8(RegXX) & ZZ != u8(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 523000XX TTTTTTTT - If u8RegXX == (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 523100XX TTTTTTTT - If u8RegXX != (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 523200XX TTTTTTTT - If u8RegXX > (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 523300XX TTTTTTTT - If u8RegXX => (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 523400XX TTTTTTTT - If u8RegXX < (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 523600XX TTTTTTTT - If u8RegXX & (TTTTTTTT) = (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 523700XX TTTTTTTT - If u8RegXX & (TTTTTTTT) != (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 523A00XX TTTTTTTT - If u8RegXX & (TTTTTTTT) = u8RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;                      
+;* 523B00XX TTTTTTTT - If u8RegXX & (TTTTTTTT) != u8RegXX poke all following codes for rest
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5240YYXX 00000000 - If u16RegYY == u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5241YYXX 00000000 - If u16RegYY != u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5242YYXX 00000000 - If u16RegYY > u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5243YYXX 00000000 - If u16RegYY => u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5244YYXX 00000000 - If u16RegYY < u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5245YYXX 00000000 - If u16RegYY =< u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5246YYXX 00000000 - If u16RegYY & u16RegXX = u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5247YYXX 00000000 - If u16RegYY & u16RegXX != u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 524AYYXX 00000000 - If u16RegYY & u16RegXX = u16RegYY poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 524BYYXX 00000000 - If u16RegYY & u16RegXX != u16RegYY poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525000XX 0000ZZZZ - If u16RegXX == ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525100XX 0000ZZZZ - If u16RegXX != ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525200XX 0000ZZZZ - If u16RegXX > ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525300XX 0000ZZZZ - If u16RegXX => ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525400XX 0000ZZZZ - If u16RegXX < ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525500XX 0000ZZZZ - If u16RegXX =< ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525600XX 0000ZZZZ - If u16RegXX & ZZZZ = ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525700XX 0000ZZZZ - If u16RegXX & ZZZZ != ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525800XX TTTTZZZZ - If u16RegXX > ZZZZ && u16RegXX < TTTT poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525900XX TTTTZZZZ - If u16RegXX => ZZZZ && u16RegXX <= TTTT poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525A00XX 0000ZZZZ - If u16RegXX & ZZZZ = u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 525B00XX 0000ZZZZ - If u16RegXX & ZZZZ != u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5260YYXX 00000000 - If u16(RegYY) == u16(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5261YYXX 00000000 - If u16(RegYY) != u16(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5262YYXX 00000000 - If u16(RegYY) > u16(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5263YYXX 00000000 - If u16(RegYY) => u16(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5264YYXX 00000000 - If u16(RegYY) < u16(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5265YYXX 00000000 - If u16(RegYY) =< u16(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line
+;
+;* 526600XX 0000ZZZZ - If u16(RegXX) & ZZZZ = ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 526700XX 0000ZZZZ - If u16(RegXX) & ZZZZ != ZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 526800XX TTTTZZZZ - If u16(RegXX) > ZZZZ && u16(RegXX) < TTTT poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 526900XX TTTTZZZZ - If u16(RegXX) => ZZZZ && u16(RegXX) <= TTTT poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 526A00XX 0000ZZZZ - If u16(RegXX) & ZZZZ = u16(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 526B00XX 0000ZZZZ - If u16(RegXX) & ZZZZ != u16(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 527000XX TTTTTTTT - If u16RegXX == (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 527100XX TTTTTTTT - If u16RegXX != (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 527200XX TTTTTTTT - If u16RegXX > (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 527300XX TTTTTTTT - If u16RegXX => (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 527400XX TTTTTTTT - If u16RegXX < (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 527600XX TTTTTTTT - If u16RegXX & (TTTTTTTT) = (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 527700XX TTTTTTTT - If u16RegXX & (TTTTTTTT) != (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 527A00XX TTTTTTTT - If u16RegXX & (TTTTTTTT) = u16RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;                      
+;* 527B00XX TTTTTTTT - If u16RegXX & (TTTTTTTT) != u16RegXX poke all following codes for rest
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5280YYXX 00000000 - If u32RegYY == u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5281YYXX 00000000 - If u32RegYY != u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5282YYXX 00000000 - If u32RegYY > u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5283YYXX 00000000 - If u32RegYY => u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5284YYXX 00000000 - If u32RegYY < u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5285YYXX 00000000 - If u32RegYY =< u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5286YYXX 00000000 - If u32RegYY & u32RegXX = u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 5287YYXX 00000000 - If u32RegYY & u32RegXX != u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 528AYYXX 00000000 - If u32RegYY & u32RegXX = u32RegYY poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 528BYYXX 00000000 - If u32RegYY & u32RegXX != u32RegYY poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529000XX ZZZZZZZZ - If u32RegXX == ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529100XX ZZZZZZZZ - If u32RegXX != ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529200XX ZZZZZZZZ - If u32RegXX > ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529300XX ZZZZZZZZ - If u32RegXX => ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529400XX ZZZZZZZZ - If u32RegXX < ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529500XX ZZZZZZZZ - If u32RegXX =< ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529600XX ZZZZZZZZ - If u32RegXX & ZZZZZZZZ = ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529700XX ZZZZZZZZ - If u32RegXX & ZZZZZZZZ != ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529A00XX ZZZZZZZZ - If u32RegXX & ZZZZZZZZ = u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 529B00XX ZZZZZZZZ - If u32RegXX & ZZZZZZZZ != u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52A0YYXX 00000000 - If u32(RegYY) == u32(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52A1YYXX 00000000 - If u32(RegYY) != u32(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52A2YYXX 00000000 - If u32(RegYY) > u32(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52A3YYXX 00000000 - If u32(RegYY) => u32(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52A4YYXX 00000000 - If u32(RegYY) < u32(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52A5YYXX 00000000 - If u32(RegYY) =< u32(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line
+;
+;* 52A600XX ZZZZZZZZ - If u32(RegXX) & ZZZZZZZZ = ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52A700XX ZZZZZZZZ - If u32(RegXX) & ZZZZZZZZ != ZZZZZZZZ poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52AA00XX ZZZZZZZZ - If u32(RegXX) & ZZZZZZZZ = u32(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52AB00XX ZZZZZZZZ - If u32(RegXX) & ZZZZZZZZ != u32(RegXX) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52B000XX TTTTTTTT - If u32RegXX == (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52B100XX TTTTTTTT - If u32RegXX != (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52B200XX TTTTTTTT - If u32RegXX > (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52B300XX TTTTTTTT - If u32RegXX => (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52B400XX TTTTTTTT - If u32RegXX < (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52B600XX TTTTTTTT - If u32RegXX & (TTTTTTTT) = (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52B700XX TTTTTTTT - If u32RegXX & (TTTTTTTT) != (TTTTTTTT) poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;
+;* 52BA00XX TTTTTTTT - If u32RegXX & (TTTTTTTT) = u32RegXX poke all following codes for rest 
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+;                      
+;* 52BB00XX TTTTTTTT - If u32RegXX & (TTTTTTTT) != u32RegXX poke all following codes for rest
+;  00000000 FFFF       of the cheat or until it reaches the 00000000 FFFF line.
+
 ;*******************************************************************************
 
 ; [ 007 Racing (USA) (2000) (Electronic Arts) {SLUS-01300, SLUS-01300CE} <007rcng> ]
@@ -272,6 +882,19 @@ A7025882 A0202400
 3001F2D2 0001
 #Unlock Secret Win Game Movie
 8001F28E 0002
+#Walk through Walls/Courier
+A7075CAA 10401000
+;Need to look at the other levels
+;King's Ransom
+;Cold Reception
+;Russian Roulette
+;Night Watch
+;Masquerade
+;Flashpoint
+;City of Walkways
+;Turncoat
+;Fallen Angel
+;Meltdown
 
 ; [ Thousand Arms (USA) (1999) (Atlus U.S.A.) {SLUS-00845 / SLUS-00858} <1000arms> ]
 :SLUS-00845
@@ -886,7 +1509,7 @@ D008F96C FDFF
 900001A4 03E00008
 900001A8 A307001D
 
-; [ Adidas Power Soccer (USA) (1996) (Psygnosis) {SCUS-94502} <adidas98> ]
+; [ Adidas Power Soccer (USA) (1996) (Psygnosis) {SCUS-94502} <adidas> ]
 :SCUS-94502
 #Select Home Team Score\9 Goals
 800DAC4E 0009
@@ -3052,11 +3675,152 @@ D0041578 0001
 300343DF 0001
 
 ; [ Armored Core (USA, v1.1) (1997) (Sony Computer Entertainment America) {SLUS-01323} <armcore> ]
-;:SLUS-01323
-;This game currently has no cheats
+:SLUS-01323
+#Infinite Time
+8019F52C FFFF
+#Infinite Energy
+80040FBE 6D60
+#Infinite Money
+8003A2D4 FFFF
+#Infinite Money (ALT)
+80039CA6 00FF
+#Infinite Weapon 1
+8004128A 00C8
+#Infinite Weapon 2
+800412C6 00C8
+#Infinite Armor
+801A2818 7000
+#Change View to Far View
+801987EC F3E7
+#Change View to Left View
+801987F4 F3E7
+#Have All Head Parts
+80031A94 0101
+80031A96 0101
+80031A98 0101
+80031A9A 0101
+80031A9C 0101
+#Have All Core Parts
+80031A9E 0101
+80031AA0 0101
+#Have All Arm Parts
+80031AA2 0101
+80031AA4 0101
+80031AA6 0101
+80031AA8 0101
+80031AAA 0101
+80031AAC 0101
+80031AAE 0101
+80031AB0 0101
+#Have All Leg Parts
+80031AB2 0101
+80031AB4 0101
+80031AB6 0101
+80031AB8 0101
+80031ABA 0101
+80031ABC 0101
+80031ABE 0101
+80031AC0 0101
+80031AC2 0101
+80031AC4 0101
+80031AC6 0101
+80031AC8 0101
+80031ACA 0101
+80031ACC 0101
+80031ACE 0101
+80031AD0 0101
+#Have All Generator Parts
+80031AD2 0101
+80031AD4 0101
+80031AD6 0101
+#Have All FCS Parts
+80031AD8 0101
+80031ADA 0101
+80031ADC 0101
+80031ADE 0101
+#Have All Optional Parts
+80031AE0 0101
+80031AE2 0101
+80031AE4 0101
+80031AE6 0101
+80031AE8 0101
+80031AEA 0101
+#Have All Booster Parts
+80031AEC 0101
+80031AEE 0101
+80031AF0 0101
+#Have All Left & Right Back Weapons
+80031AF2 0101
+80031AF4 0101
+80031AF6 0101
+80031AF8 0101
+80031AFA 0101
+80031AFC 0101
+80031AFE 0101
+80031B00 0101
+80031B02 0101
+80031B04 0101
+80031B06 0101
+80031B08 0101
+80031B0A 0101
+80031B0C 0101
+80031B0E 0101
+80031B10 0101
+80031B12 0101
+#Have All Right Arm Weapons
+80031B14 0101
+80031B16 0101
+80031B18 0101
+80031B1A 0101
+80031B1C 0101
+80031B1E 0101
+80031B20 0101
+80031B22 0101
+#Have All Left Arm Weapons
+80031B24 0101
+80031B26 0101
+#Human Plus Mode
+80039D20 0001
+#Rapid Fire
+80045492 0000
+#Tin Enemies
+801A2988 0000
+801A2AF8 0000
+801A2C68 0000
+801A2DD8 0000
+801A2F48 0000
+801A30B8 0000
+#Infinite Ammo All Weapons
+800412C6 0028
+8004128A 01F4
+80041302 0028
+#Hand Weapon Range Max
+8004128E 7D00
+80041290 7D00
+#Max Capacity Hand Weapon Ammo
+80041288 03E8
+#Fastest Lock On
+80041292 00FF
+#FCS-Hand Weapon (Widest Lock On)
+80041296 00FF
+80041298 00FF
+#FCS-Missile Locks Max (All Weapons Autofire)
+8004129C 0006
+#Back Weapon Maximum Range
+800412CA 7D00
+800412CC 7D00
+80041306 7D00
+80041308 7D00
+#FCS-Back Weapons (Widest Lock On)
+800412D2 00FF
+800412D4 00FF
+8004130E 00FF
+80041310 00FF
 
 ; [ Armored Core (USA, v1.0) (1997) (Sony Computer Entertainment America) {SCUS-94182} <armcorea> ]
 :SCUS-94182
+#Infinite Time
+8019F52C FFFF
 #Infinite Energy
 80040FBE 6D60
 #Infinite Weapon 1
@@ -3065,8 +3829,6 @@ D0041578 0001
 800412C6 00C8
 #Infinite Armor
 801A2818 7000
-#Infinite Time
-8019F52C FFFF
 
 ; [ Armorines - Project S.W.A.R.M. (USA) (2000) (Acclaim Entertainment) {SLUS-01022} <armorine> ]
 :SLUS-01022
@@ -3368,8 +4130,43 @@ C01C41AA FBFF
 800834E0 03E7
 
 ; [ Backyard Soccer (USA) (2001) (Infogrames) {SLUS-01094} <backyard> ]
-;:SLUS-01094
-;This game currently has no cheats
+:SLUS-01094
+#Select Goals Score\0
+800540F4 0000
+#Select Goals Score\9
+800540F4 0009
+#Select Home Team Score\25
+300BD428 0019
+#Select Home Team Score\0
+300BD428 0000
+#Select Home Team Special\Twister
+300BD442 00FF
+300BD43E 0001
+#Select Home Team Special\Underground
+300BD442 00FF
+300BD43E 0002
+#Select Home Team Special\Bowling Ball
+300BD442 00FF
+300BD43E 0003
+#Select Home Team Special\Cannonball
+300BD442 00FF
+300BD43E 0004
+#Select Away Team Score\9
+300BDA84 0019
+#Select Away Team Score\0
+300BDA84 0000
+#Select Away Team Special\Twister
+300BDA9E 00FF
+300BDA9A 0001
+#Select Away Team Special\Underground
+300BDA9E 00FF
+300BDA9A 0002
+#Select Away Team Special\Bowling Ball
+300BDA9E 00FF
+300BDA9A 0003
+#Select Away Team Special\Cannonball
+300BDA9E 00FF
+300BDA9A 0004
 
 ; [ Bust A Groove (USA) (1998) (989 Studios) {SCUS-94263} <bag> ]
 :SCUS-94263
@@ -4525,13 +5322,95 @@ A60F23DC 00000005
 300B7014 00FF
 
 ; [ NHL Blades of Steel 2000 (USA) (2000) (Konami of America) {SLUS-00825} <blades2k> ]
-;:SLUS-00825
-;This game currently has no cheats
+:SLUS-00825
+#Select Home Team Score\0
+30133D44 0000
+#Select Home Team Score\99
+30133D44 0063
+#Select Away Team Score\0
+30133D6C 0000
+#Select Away Team Score\99
+30133D6C 0063
+#Stats\Max Speed
+3015AC4C 0064
+#Stats\Max Accel/Back
+3015AC4D 0064
+#Stats\Max Agility
+3015AC4E 0064
+#Stats\Max Lying/Power
+3015AC4F 0064
+#Stats\Max Passing/Control
+3015AC50 0064
+#Stats\Max Quickness
+3015AC51 0064
+#Stats\Max Glove/Keeping
+3015AC52 0064
+#Stats\Max Stick/Face-Off
+3015AC53 0064
+#Stats\Max Aggressive
+3015AC54 0064
+#Stats\Max Checking
+3015AC55 0064
+#Stats\Max Reliable/Intensity
+3015AC56 0064
+#Stats\Max Stamina
+3015AC57 0064
 
 ; [ Blast Chamber (USA) (1996) (Activision) {SLUS-00219} <blastchm> ]
 :SLUS-00219
+#Infinite Chamber Time
+800B504E 00B4
 #Infinite Lives
 800B438C 0009
+#Green Arrows Always Function
+8008D050 0001
+#Walk on the Floor (L1 & R1)
+D00B4336 000C
+8008D018 0000
+#Walk on the Ceiling (L2 & R2)
+D00B4336 0003
+8008D018 0002
+#Walk on the Left Wall (L1 & L2)
+D00B4336 0005
+8008D018 0003
+#Walk on the Right Wall (R1 & R2)
+D00B4336 000A
+8008D018 0001
+#P1 Infinite Time
+800B438A 0037
+#P1 Can Jump Much Higher
+800B436A 0001
+#P1 Runs Faster
+800B436E 000F
+#P1 Has No Deaths
+800B4388 0000
+#P2 Infinite Time
+800B44F6 0037
+#P2 Can Jump Much Higher
+800B44D6 0001
+#P2 Runs Faster
+800B44DA 000F
+#P2 Has 999 Deaths
+800B44F4 03E7
+#P3 Infinite Time
+800B4662 0037
+#P3 Can Jump Much Higher
+800B4642 0001
+#P3 Runs Faster
+800B4646 000F
+#P3 Has 999 Deaths
+800B4660 03E7
+#P4 Infinite Time
+800B47CE 0037
+#P4 Can Jump Much Higher
+800B47AE 0001
+#P4 Runs Faster
+800B47B2 000F
+#P4 Has 999 Deaths
+800B47CC 03E7
+#Access Multi-Tap Mode
+D008E55C 0003
+3008E618 0006
 
 ; [ Blasto (USA) (1998) (Sony Computer Entertainment America) {SCUS-94412} <blasto> ]
 :SCUS-94412
@@ -9282,8 +10161,25 @@ A6084B4C 00000001
 A6084B9A 00000100
 
 ; [ Jim Henson's Bear in the Big Blue House (USA) (2002) (Ubi Soft Entertainment Software) {SLUS-01524} <bluehous> ]
-;:SLUS-01524
-;This game currently has no cheats
+:SLUS-01524
+#Select Points Worth\2
+80024994 0002
+#Select Points Worth\3
+80024994 0003
+#Select Points Worth\4
+80024994 0004
+#Select Points Worth\5
+80024994 0005
+#Select Points Worth\6
+80024994 0006
+#Select Points Worth\7
+80024994 0007
+#Select Points Worth\8
+80024994 0008
+#Select Points Worth\9
+80024994 0009
+#Select Points Worth\10
+80024994 000A
 
 ; [ Black Bass with Blue Marlin (USA) (1999) (HOT-B USA) {SLUS-00648} <bluemarl> ]
 :SLUS-00648
@@ -9783,16 +10679,68 @@ A609F7A2 04000001
 801330B8 0000
 #Select Home Team Score\99
 801330B8 6300
-#Select For 0 Balls + 2 Strikes
+#0 Balls + 2 Strikes (Press Select)
 D007684A 0100
 801330BE 0120
-#Select For 3 Balls + 0 Strikes
+#3 Balls + 0 Strikes (Press Select)
 D007684A 0008
 801330BE 0103
 
 ; [ Bottom of the 9th (USA) (1996) (Konami of America) {SLUS-00049} <bottom9> ]
-;:SLUS-00049
-;This game currently has no cheats
+:SLUS-00049
+#Select Away Team Score\0
+8005777C  0000
+#Select Away Team Score\99
+8005777C  0099
+#Select Home Team Score\0
+3005777D 0000
+#Select Home Team Score\99
+3005777D 0099
+#Always Out on Hitting Ball
+A70F64B6 10621000
+#Infinite Strikes
+82100F8C 0030
+#Infinite Balls
+82100F8C 0003
+#Infinite Outs
+82100F8C 00C0
+;#Select Balls\Infinite
+;30100F8C 0000
+;#Select Balls\Only One Needed for Walk
+;30100F8C 0003
+;#Select Balls\0
+;82100F8C 0003
+;81100F8C 0000
+;#Select Balls\1
+;82100F8C 0003
+;81100F8C 0001
+;#Select Balls\2
+;82100F8C 0003
+;81100F8C 0002
+;#Select Balls\3
+;82100F8C 0003
+;81100F8C 0003
+;#Select Strikes\0
+;82100F8C 0030
+;81100F8C 0000
+;#Select Strikes\1
+;82100F8C 0030
+;81100F8C 0010
+;#Select Strikes\2
+;82100F8C 0030
+;81100F8C 0020
+;#Select Outs\0
+;82100F8C 0180
+;81100F8C 0000
+;#Select Outs\1
+;82100F8C 0180
+;81100F8C 0040
+;#Select Outs\2
+;82100F8C 0180
+;81100F8C 0080
+;#Select Outs\3
+;82100F8C 0180
+;81100F8C 0100
 
 ; [ Bowling (USA) (2000) (Agetec / A1 Games) {SLUS-01288} <bowling> ]
 :SLUS-01288
@@ -10485,9 +11433,52 @@ A71CBF20 10000C00
 30010047 00FF
 #Maximum Clocks
 30010045 00FF
-#Moon Jump
-D001000C 0040
-800BCC18 0009
+#Faster and more fluid Bugs Bunny (L3/R3 On/Off):The code makes for a smoother experience but makes things faster, you can jump farther as well but when pushing boxes for example it is best to turn the code of temporarily, other characters might become faster too.
+E001000D 0002
+8001C958 7257
+E001000D 0002
+8001C95A 0800
+E001000D 0002
+8001C940 7251
+E001000D 0002
+8001C942 0800
+E001000D 0004
+8001C958 00EC
+E001000D 0004
+8001C95A AE22
+E001000D 0004
+8001C940 00E4
+E001000D 0004
+8001C942 AE22
+#Invincibility
+30069690 001E
+#Low gravity jumps (L2+R2+X)
+E0010010 0043
+8002021C 0001
+E1010010 0043
+8002021C 0400
+#Moonjump (Hold X to Moonjump)
+E0010010 0040
+8002479C FFF0
+E0010010 0040
+8002479E 21AD
+E1010010 0040
+8002479C 6820
+E1010010 0040
+8002479E 01AA
+#Multi-Jumps & Float/Walk in air (L2+R2+X jump/L2+R2 float&walk)
+E0010010 0043
+800247C6 2400
+E1010010 0043
+800247C6 1040
+E0010010 0003
+8002479E 2400
+E1010010 0003
+8002479E 01AA
+#Walk through Stage Boundaries:But it'll lead to death if there is nothing there.
+A701ADD2 14621000
+A701C346 14621000
+A702347A 10821000
 #Widescreen 16-9
 A7076150 10000C00
 
@@ -10653,6 +11644,13 @@ E00D9B3D 0000
 800F3900 0004
 #Infinite Shield
 800F38E4 03E8
+#Walk Through Obstacles/Walls
+A702D16E 10431000
+A702D13E 10431000
+#Pick Up Weapons on Sight
+A70994BA 14801400
+#One Hit Kills
+A7032AA6 18801000
 #Select Level\Test Level
 300F1520 0000
 #Select Level\CC (doesn't load)
@@ -10982,6 +11980,8 @@ A6114FE8 0000FFFF
 80095DCC 0003
 #Arcade Mode\P2 Infinite Lives
 80095DD0 0002
+#Adventure Mode\Invincibility (No Hit)
+A704F1FA 18401000
 
 ; [ Championship Bass (USA) (2000) (Electronic Arts) {SLUS-01084} <champbas> ]
 :SLUS-01084
@@ -11884,6 +12884,9 @@ D0069922 FDFF
 ; [ Crash Bandicoot - Warped (USA) (1998) (Sony Computer Entertainment America) {SCUS-94244, SCUS-94244CE} <crash3> ]
 :SCUS-94244
 :SCUS-94244CE
+#Infinite Time
+D303AE8D 0030
+8003AE8D 0000
 #99 Lives
 C005BEEC F64C
 800B5D4C 6300
@@ -11912,15 +12915,23 @@ D0065BCE FFEE
 8001DDAA 2400
 D0065BCE FFBE
 8001DDAA 0C00
-#Infinite Time
-D303AE8D 0030
-8003AE8D 0000
+#Walk/Drive Through Walls (Hold L2+R2)
+A718F866 10061000
+80044D46 00001000
+8002EDDE 00001000
+D7100000 00000003
+8002EDDE 00001060
+80044D46 000011C0
 #Widescreen 16-9
 80018A90 0C00
 80018A92 2402
 80018A94 1000
 80018A96 2413
 80018AB2 A633
+#Enable 60 FPS (Play with Overclock to get preferred speed)
+A704B40E 10401000
+#Enable 60 FPS Alternative (Play with Overclock to get preferred speed)
+A704B2E2 04812400
 
 ; [ Crash Bash (USA) (2000) (Sony Computer Entertainment America) {SCUS-94570} <crashbsh> ]
 :SCUS-94570
@@ -12025,102 +13036,102 @@ D00926A6 FEFF
 :SLUS-00576
 #Level Modifier Code (16 Levels 0-F)
 80120630 000?
-#Hitting The Streets More Time
+#Hitting The Streets\More Time
 80159D62 0000
 80159D64 0000
-#Hitting The Streets Infinite Ammo
+#Hitting The Streets\Infinite Ammo
 8015AB0C 00FF
-#Hitting The Streets Infinite Shields
+#Hitting The Streets\Infinite Shields
 8015AB10 00FF
-#Suburbia More Time
+#Suburbia\More Time
 8017B4D2 0000
 8017B4D4 0000
-#Suburbia Infinite Ammo
+#Suburbia\Infinite Ammo
 8017C284 00FF
-#Suburbia Infinite Shields
+#Suburbia\Infinite Shields
 8017C288 00FF
-#The Break In More Time
+#The Break In\More Time
 801A991A 0000
 801A991C 0000
-#The Break In Infinite Ammo
+#The Break In\Infinite Ammo
 801AA784 00FF
-#The Break In Infinite Shields
+#The Break In\Infinite Shields
 801AA788 00FF
-#Rapid Responce More Time
+#Rapid Response\More Time
 8019C06A 0000
 8019C06C 0000
-#Rapid Responce Infinite Ammo
+#Rapid Response\Infinite Ammo
 8019CE4C 00FF
-#Rapid Responce Infinite Shields
+#Rapid Response\Infinite Shields
 8019CE50 00FF
-#Cult Moves More Time
+#Cult Moves\More Time
 8019F702 0000
 8019F704 0000
-#Cult Moves Infinite Ammo
+#Cult Moves\Infinite Ammo
 801A053C 00FF
-#Cult Moves Infinite Shields
+#Cult Moves\Infinite Shields
 801A0540 00FF
-#The Kidnap More Time
+#The Kidnap\More Time
 801AB0AA 0000
 801AB0AC 0000
-#The Kidnap Infinite Ammo
+#The Kidnap\Infinite Ammo
 801ABED4 00FF
-#The Kidnap Infinite Shields
+#The Kidnap\Infinite Shields
 801ABED8 00FF
-#Family More Time
+#Family\More Time
 801A80DC 0000
 801A80E0 0000
-#Family Infinite Ammo
+#Family\Infinite Ammo
 801A8EFC 00FF
-#Family Infinite Shields
+#Family\Infinite Shields
 801A8F00 00FF
-#Police Hijack More Time
+#Police Hijack\More Time
 8019CCFE 0000
 8019CD00 0000
-#Police Hijack Infinite Ammo
+#Police Hijack\Infinite Ammo
 8019DAEC 00FF
-#Police Hijack Infinite Shields
+#Police Hijack\Infinite Shields
 8019DAF0 00FF
-#The Rescue More Time
+#The Rescue\More Time
 801994EE 0000
 801994F0 0000
-#The Rescue Infinite Ammo
+#The Rescue\Infinite Ammo
 8019A33C 00FF
-#The Rescue Infinite Shields
+#The Rescue\Infinite Shields
 8019A340 00FF
-#Static More Time
+#Static\More Time
 801A6B8A 0000
 801A6B8C 0000
-#Static Infinite Ammo
+#Static\Infinite Ammo
 801A7A3C 00FF
-#Static Infinite Shields
+#Static\Infinite Shields
 801A7A40 00FF
-#Use Of Force More Time
+#Use Of Force\More Time
 801A06E6 0000
 801A06E8 0000
-#Use Of Force Infinite Ammo
+#Use Of Force\Infinite Ammo
 801A14BC 00FF
-#Use Of Force Infinite Health
+#Use Of Force\Infinite Health
 801A14C0 00FF
-#The Deadline More Time
+#The Deadline\More Time
 801A2062 0000
 801A2064 0000
-#The Deadline Infinite Health
+#The Deadline\Infinite Health
 801A2E08 00FF
-#M.E. More Time
+#M.E.\More Time
 801AB1F6 0000
 801AB1F8 0000
-#M.E. Infinite Health
+#M.E.\Infinite Health
 801AC068 00FF
-#Freeway Racers More Time
+#Freeway Racers\More Time
 8015486E 0000
 80154870 0000
-#Freeway Racers Infinite Health
+#Freeway Racers\Infinite Health
 801555F0 00FF
-#Revelation More Time
+#Revelation\More Time
 801A3FC6 0000
 801A3FC8 0000
-#Revelation Infinite Health
+#Revelation\Infinite Health
 801A4E30 00FF
 
 ; [ Criticom (USA) (1995) (Vic Tokai) {SLUS-00046} <criticom> ]
@@ -12230,6 +13241,16 @@ C200C006 0002
 80076B54 0001
 #Enable Cheat Menu (Press L2 + R2)
 8006FF88 0001
+#Invincibility Against Enemies L3/R3 On/Off (Turn off to pick up diamonds)
+D7000000 00000200
+80041B5E 00001000
+00000000 0000FFFF
+D7000000 00000400
+80041B5E 00001040
+#No Game Over
+A701252E 14621000
+#Slowmotion '20 FPS'
+A70126CA 14622400
 #Widescreen 16-9
 80014C64 C410
 80014C66 0801
@@ -12368,6 +13389,9 @@ A71CF364 10000C00
 800FC1B4 FFFF
 #P2 Max No. Of Hits
 800FC210 FFFF
+#No Gun Flash
+A705945A 0C021400
+A705E446 0C021400
 
 ; [ CTR - Crash Team Racing (USA) (1999) (Sony Computer Entertainment America) {SCUS-94426} <ctr> ]
 :SCUS-94426
@@ -18750,6 +19774,9 @@ D0133014 0070
 80011586 0E13
 #Debug Menu press Select while in control of your character to access the menu
 800F2518 0100
+#Widescreen 16-9
+A7026544 10000C00
+A7026554 10000C00
 
 ; [ Dynasty Warriors (USA) (1997) (Koei) {SLUS-00438} <dynwarr> ]
 :SLUS-00438
@@ -18853,8 +19880,15 @@ A70BBB94 10000C00
 80111E34 0003
 
 ; [ EA Sports Superbike 2000 (USA) (2000) (Electronic Arts) {SLUS-01052} <easbk2k> ]
-;:SLUS-01052
-;This game currently has no cheats
+:SLUS-01052
+#Drive Full Speed Off Road
+A7040FB2 10401000
+A703AFA2 10601000
+A703A8E2 10401000
+A703913A 10401000
+A703B00A 10E01000
+A703E53A 10401000
+A703916E 10401000
 
 ; [ Easter Bunny's Big Day (USA) (2003) (Mastiff) {SLUS-01551} <easterbn> ]
 :SLUS-01551
@@ -21805,7 +22839,7 @@ D0057A9A AC64
 90008210 03E00008
 90008214 8C450004
 
-; [ EinhÃ¤nder (USA) (1998) (Sony Computer Entertainment America) {SCUS-94243} <einhandr> ]
+; [ Einhänder (USA) (1998) (Sony Computer Entertainment America) {SCUS-94243} <einhandr> ]
 :SCUS-94243
 #Infinite Lives
 800813C4 0003
@@ -21887,6 +22921,8 @@ A713EFF8 10000C00
 8000E2E0 0003
 #Infinite Credits
 800529C0 0003
+#No Hit Flash
+A702498A 0C001400
 
 ; [ Eliminator (USA) (1999) (Psygnosis) {SLUS-00699} <eliminat> ]
 :SLUS-00699
@@ -22319,8 +23355,10 @@ E009F0AC 0000
 8001421C 0016
 
 ; [ F1 Championship Season 2000 (USA) (2000) (Electronic Arts) {SLUS-01290} <f1cs2k> ]
-;:SLUS-01290
-;This game currently has no cheats
+:SLUS-01290
+#Always First
+D10518B4 0000
+800518B4 0001
 
 ; [ F1 Racing Championship (USA) (2000) (Ubi Soft Entertainment Software) {SLUS-01088} <f1rc> ]
 ;:SLUS-01088
@@ -24250,13 +25288,13 @@ D00B8A24 005A
 
 ; [ FIFA Soccer 2002 (USA) (2001) (Electronic Arts) {SLUS-01408} <fifa2k2> ]
 :SLUS-01408
-"Away Team Score 9
+#Away Team Score 9
 8003A59C 0009
-"Away Team Score 0
+#Away Team Score 0
 8003A59C 0000
-"Home Team Score 9
+#Home Team Score 9
 8003A598 0009
-"Home Team Score 0
+#Home Team Score 0
 8003A598 0000
 
 ; [ 2002 FIFA World Cup (USA) (2002) (Electronic Arts) {SLUS-01449} <fifa2k2w> ]
@@ -24506,8 +25544,158 @@ A607AB68 0001001D
 80019E2E 00A0
 
 ; [ Formula One 99 (USA) (1999) (Psygnosis) {SLUS-00870} <fone99> ]
-;:SLUS-00870
-;This game currently has no cheats
+:SLUS-00870
+#Select Mode\Quick Race
+800A0B8A 0000
+#Select Mode\Single Race
+800A0B8A 0001
+#Select Mode\Championship
+800A0B8A 0002
+#Select Mode\Test Drive
+800A0B8A 0003
+#Select Mode\High Speed
+800A0B8A 0004
+#Select Mode\Medium Speed
+800A0B8A 0005
+#Select Mode\Low Speed
+800A0B8A 0006
+#Select Mode\Quick Race+
+800A0B8A 0007
+#Select Position View\1st
+800CC9F0 0000
+#Select Position View\2nd
+800CC9F0 0001
+#Select Position View\3rd
+800CC9F0 0002
+#Select Position View\4th
+800CC9F0 0003
+#Select Position View\5th
+800CC9F0 0004
+#Select Position View\6th
+800CC9F0 0005
+#Select Position View\7th
+800CC9F0 0006
+#Select Position View\8th
+800CC9F0 0007
+#Select Position View\9th
+800CC9F0 0008
+#Select Position View\10th
+800CC9F0 0009
+#Select Position View\11th
+800CC9F0 000A
+#Select Position View\12th
+800CC9F0 000B
+#Select Position View\13th
+800CC9F0 000C
+#Select Position View\14th
+800CC9F0 000D
+#Select Position View\15th
+800CC9F0 000E
+#Select Position View\16th
+800CC9F0 000F
+#Select Position View\17th
+800CC9F0 0010
+#Select Position View\18th
+800CC9F0 0011
+#Select Position View\19th
+800CC9F0 0012
+#Select Position View\20th
+800CC9F0 0013
+#Select Position View\21st
+800CC9F0 0014
+#Select Position View\22nd
+800CC9F0 0015
+#Stop Race Timer:1 Player Mode
+8005027A 2400
+800502E2 2400
+#Select Driver (Press Select)\Team McLaren - Mika Hakkinen
+D00A69DC 0001
+800A0B74 0001
+#Select Driver (Press Select)\Team McLaren - David Coulthard
+D00A69DC 0001
+800A0B74 0002
+#Select Driver (Press Select)\Team Ferrari - Mike Schumacher
+D00A69DC 0001
+800A0B74 0003
+#Select Driver (Press Select)\Team Ferrari - Eddie Irvine
+D00A69DC 0001
+800A0B74 0004
+#Select Driver (Press Select)\Team Williams - Alessandro Zanardi
+D00A69DC 0001
+800A0B74 0005
+#Select Driver (Press Select)\Team Williams - Ralf Schumacher
+D00A69DC 0001
+800A0B74 0006
+#Select Driver (Press Select)\Team Jordan - Damon Hill
+D00A69DC 0001
+800A0B74 0007
+#Select Driver (Press Select)\Team Jordan - Heinz-Harald Frentzen
+D00A69DC 0001
+800A0B74 0008
+#Select Driver (Press Select)\Team Benetton - Giancarlo Fisichella
+D00A69DC 0001
+800A0B74 0009
+#Select Driver (Press Select)\Team Benetton - Alexander Wurz
+D00A69DC 0001
+800A0B74 000A
+#Select Driver (Press Select)\Team Sauber - Jean Alesi
+D00A69DC 0001
+800A0B74 000B
+#Select Driver (Press Select)\Team Sauber - Pedro Diniz
+D00A69DC 0001
+800A0B74 000C
+#Select Driver (Press Select)\Team Arrows - Pedro de la Rosa
+D00A69DC 0001
+800A0B74 000D
+#Select Driver (Press Select)\Team Arrows - Toranosuke Takagi
+D00A69DC 0001
+800A0B74 000E
+#Select Driver (Press Select)\Team Stewart - Rubens Barrichello
+D00A69DC 0001
+800A0B74 000F
+#Select Driver (Press Select)\Team Stewart - Johnny Herbert
+D00A69DC 0001
+800A0B74 0010
+#Select Driver (Press Select)\Team Prost - Olivier Panis
+D00A69DC 0001
+800A0B74 0011
+#Select Driver (Press Select)\Team Prost - Jarno Trulli
+D00A69DC 0001
+800A0B74 0012
+#Select Driver (Press Select)\Team Minardi - Luca Badoer
+D00A69DC 0001
+800A0B74 0013
+#Select Driver (Press Select)\Team Minardi - Marc Gene
+D00A69DC 0001
+800A0B74 0014
+#Select Driver (Press Select)\Team British American Racing - Jacques Villeneuve
+D00A69DC 0001
+800A0B74 0015
+#Select Driver (Press Select)\Team British American Racing - Ricardo Zonta
+D00A69DC 0001
+800A0B74 0016
+#Select Driver (Press Select)\Team Safety Car - Mika Salo (Glitchy Fast Car)
+D00A69DC 0001
+800A0B74 0017
+#Select Driver (Press Select)\Team Safety Car - Stephane Sarrazin (Glitchy Fast Car)
+D00A69DC 0001
+800A0B74 0018
+#Top Speed Increase
+D00CD288 0070
+800CD288 03E7
+#Instant Win/Place 1st
+D00CCA4C 0003
+800CCA4C 0005
+D00D4830 0000
+800D4830 0005
+D00D4830 0005
+800E0D9C 0000
+D00D4830 0005
+800E0F3C 0000
+D00D4830 0005
+800E100C 0000
+D00D4830 0005
+800E1EAC 0004
 
 ; [ Ford Racing (USA) (2000) (Take-Two Interactive Software) {SLUS-01301} <fordrac> ]
 :SLUS-01301
@@ -24618,8 +25806,14 @@ D00E4A1E BFEF
 300CCA3E 0012
 
 ; [ FOX Sports Golf '99 (USA) (1998) (Fox Interactive) {SLUS-00636} <foxglf99> ]
-;:SLUS-00636
-;This game currently has no cheats
+:SLUS-00636
+#Skip FMV
+D001784C 7ED2
+8001784E 2400
+#Only One Shot Recorded
+8018CF18 0000
+#Shot Score = 0
+801C9038 0000
 
 ; [ Fox Hunt (USA) (1996) (Capcom Entertainment) {SLUS-00101 / SLUS-00175 / SLUS-00176} <foxhunt> ]
 :SLUS-00101
@@ -25703,6 +26897,12 @@ A70B5AE2 ACC42400
 
 ; [ Disney's Donald Duck - Goin' Quackers (USA) (2000) (Ubi Soft Entertainment Software) {SLUS-01242} <goinquak> ]
 :SLUS-01242
+#Invincibility against enemies
+F4074000 00AA5000
+25004116 00000000
+7B41000C 21202002
+AAAA0010 AAAAAAAA
+AAAAAAAA AAAAAAAA
 #Forest Edge Infinite Lives
 800A7F18 0009
 #Dangerous Cliffs Infinite Lives
@@ -26300,7 +27500,7 @@ D004E2AC 0042
 #Simulation Mode 1 Billion Dollars
 9009B8F4 3B9ACA00
 #Drive through Background
-800243A2 1000
+A70243A2 04411000
 
 ; [ Gran Turismo (USA, v1.0) (1998) (Sony Computer Entertainment America) {SCUS-94194} <gt1a> ]
 :SCUS-94194
@@ -26653,16 +27853,16 @@ A61FFA82 02000300
 #More Misc.\Replay Screen Clear (Arcade Disc)
 A61FFA8A 02000300
 #Widescreen 16-9
-$D0010000 FFE8
-$8007B2FC 0156
-$D0010000 FFD0
-$8007B2FC 03DE
-$D0010000 FFE0
-$8007B2FC 01AC
-$8007B2FE 3402
+D0010000 FFE8
+8007B2FC 0156
+D0010000 FFD0
+8007B2FC 03DE
+D0010000 FFE0
+8007B2FC 01AC
+8007B2FE 3402
 #Widescreen 16-9 option Better Graphics
-$8006744C 0060
-$8006744E 3404
+8006744C 0060
+8006744E 3404
 
 ; [ Gran Turismo 2 (USA, v1.0) (1999) (Sony Computer Entertainment America) {SCUS-94455} <gt2b> ]
 :SCUS-94455
@@ -26764,9 +27964,9 @@ A61FFA82 02000300
 A61FFA8A 02000300
 #Widescreen 16-9
 D0010000 FFE8
-8007B2AC 0156
+8007B2AC 0155
 D0010000 FFD0
-8007B2AC 03DE
+8007B2AC 0370
 D0010000 FFE0
 8007B2AC 01AC
 8007B2AE 3402
@@ -27215,6 +28415,10 @@ D0066CCC 0414
 #Infinite Ammo
 801291B0 0063
 80111AE4 0063
+#Widescreen 16-9
+8007663C 1333
+#Dither Off
+A705B048 02000000
 
 ; [ Herc's Adventures (USA) (1997) (LucasArts Entertainment Company) {SLUS-00298} <hercsadv> ]
 :SLUS-00298
@@ -28067,7 +29271,7 @@ A711A7DC 10000C00
 90084724 FFFFFFFF
 80084500 0300
 80084862 0063
-Unlock All Report Card - Quidditch Training
+#Unlock All Report Card - Quidditch Training
 800844F0 FFFF
 #Widescreen 16-9
 80075C6E 2000
@@ -28109,6 +29313,18 @@ Unlock All Report Card - Quidditch Training
 90082970 00000000
 #Invincibility
 3007C9F9 00FF
+#Walk Through Walls & Climb Any Wall (L1+R1 & L2+R2)
+800432C6 00001000
+8004323A 00001000
+800442AA 00001000
+D7100000 0000000C
+800442AA 00001220
+800432C6 00001462
+8004323A 00001040
+00000000 0000FFFF
+800442AA 00001000
+D7100000 00000003
+800442AA 00001220
 #Widescreen 16-9
 800710F2 2000
 
@@ -28545,6 +29761,34 @@ A70719D0 10000C00
 800A4AA0 0001
 #Unlock Turin In Free Ride
 8009D9C0 0001
+#Collisions with Buildings cause no damage
+F4060A8E 00AA1000
+43140000 00001300
+AAAAAAAA AAAAAAAA
+0010AAAA AAAAAAAA
+AAAAAAAA AAAAAAAA
+#Drive through mafia/police (police can still nick you)
+F406244A 00AA1000
+43142110 00000A80
+AAAAAAAA AAAAAAAA
+0010AAAA AAAAAAAA
+AAAAAAAA AAAAAAAA
+#Don't get Nicked
+F407C24E 00AA1000
+02160000 00003800
+AAAAAAAA AAAAAAAA
+0010AAAA AAAAAAAA
+AAAAAAAA AAAAAAAA
+#Drive through other vehicles (non-mafia/non-police):Other vehicles on the The Getaway Mission count as background
+F407B8A2 00AA1000
+43142110 00001800
+AAAAAAAA AAAAAAAA
+0010AAAA AAAAAAAA
+AAAAAAAA AAAAAAAA
+#Red, White & Blue - Simple Car Loading
+A7057A36 10401400
+;#Drive through vehicles (Last Level):Ensure it's not enabled when you try and hit the mafia car or you cant finish the game
+;A707AF42 14431000
 
 ; [ International Track & Field (USA) (1996) (Konami of America) {SLUS-00238} <itf> ]
 :SLUS-00238
@@ -30455,6 +31699,39 @@ D00EDCB8 0F00
 800E8578 0003
 #Select Weapon\Crossbow
 800E8578 0004
+#Invincibility to Cannon Balls
+A70462C6 10401000
+#Invincibility to normal stuff like crabs/spiders/knights
+A70AA5F2 14621000
+#Invincibility to Swinging Anchor
+A7046566 18401000
+#Invincibility to Barrels - Walk through Barrels, Boulders and Gates
+A708E3FA 10401000
+#Invincibility to Boss Slashing
+A70990A6 10401000
+#Invincibility to Bosses Dropping on You
+A708E30A 10C81000
+#Float (Hold R3 Down to rise upwards)
+D7000000 00000200
+300E8510 00000010
+#Fall safely from Heights:Use with Float
+A7049A6E 18801000
+#Walk through Water
+A7048A26 10401000
+#One Hit Kill Bosses
+A70980FA 1C401400
+#Automatically Open Chests
+A70A757E 10401400
+#Automatically Collect Chest Treasure
+A7052AE6 10401400
+A7052AD2 10401400
+A7052ADE 10401400
+A7052B12 10401400
+A7052B26 10401400
+A7052B3A 10401400
+A7052B4E 14401400
+A7052B66 14401400
+A7052B76 14401400
 #Widescreen 16-9
 800E6F6C 0F00
 
@@ -30468,6 +31745,11 @@ D00EDCB8 0F00
 801B2500 270F
 #50000 OF GOLD
 801B2534 C350
+#Uncap game at 30 FPS (200 Overclock for stable 30 FPS)
+A7019656 14402400
+#Uncap Game at 60 FPS (160 Overclock for stable 60 FPS)
+A7019656 14402400
+A7079272 10401000
 
 ; [ King's Field (USA) (1995) (ASCII Entertainment Software) {SLUS-00158} <kingsfld> ]
 :SLUS-00158
@@ -31173,6 +32455,8 @@ D00687B0 4003
 8006C21C 0014
 #Last Stage Lethal Enforcers II
 8006C21C 0017
+#No Gun Flash
+A703741E 0C011400
 
 ; [ Disney's Lilo & Stitch (USA) (2002) (Sony Computer Entertainment America) {SCUS-94646} <lilostch> ]
 :SCUS-94646
@@ -31295,193 +32579,193 @@ D00FC970 0100
 80050CAA 0701
 #Infinite Lives (Bpc)
 90015FE4 00000000
-#Compy Level Beat Levels At Touch Of A Button
+#Compy Level\Beat Levels At Touch Of A Button
 D000857C 0001
 80050CD4 0004
-#Compy Level Infinite Breath (Beneath The Surface)
+#Compy Level\Infinite Breath (Beneath The Surface)
 8008A684 03E8
-#Compy Level Infinite Energy (Aisle of Giants)
+#Compy Level\Infinite Energy (Aisle of Giants)
 800D0C7E 0064
-#Compy Level Infinite Energy (Beneath The Surface)
+#Compy Level\Infinite Energy (Beneath The Surface)
 80088ACE 0064
-#Compy Level Infinite Energy (Beneath The Surface)
+#Compy Level\Infinite Energy (Beneath The Surface)
 8008A664 0063
-#Compy Level Infinite Energy (Creek Bed)
+#Compy Level\Infinite Energy (Creek Bed)
 800AB90E 0064
-#Compy Level Infinite Energy (High Ridge)
+#Compy Level\Infinite Energy (High Ridge)
 800B3A7E 0064
-#Compy Level Infinite Energy (Plains)
+#Compy Level\Infinite Energy (Plains)
 8009886E 0064
-#Compy Level Infinite Energy (Plains)
+#Compy Level\Infinite Energy (Plains)
 8009A404 0063
-#Compy Level Infinite Energy (Rain Forest)
+#Compy Level\Infinite Energy (Rain Forest)
 800AA1FE 0064
-#Compy Level Infinite Energy (River's Edge)
+#Compy Level\Infinite Energy (River's Edge)
 800A4F6E 0064
-#Compy Level Infinite Energy (River's Edge)
+#Compy Level\Infinite Energy (River's Edge)
 800A6B04 0063
-#Compy Level Infinite Energy (Sleeping Titan)
+#Compy Level\Infinite Energy (Sleeping Titan)
 800A441E 0064
-#Compy Level Infinite Energy (Sleeping Titan)
+#Compy Level\Infinite Energy (Sleeping Titan)
 800A5FB4 0063
-#Compy Level Infinite Energy (Tidal Cavern)
+#Compy Level\Infinite Energy (Tidal Cavern)
 800DF66E 0064
-#Compy Level Infinite Energy (Tidal Cavern)
+#Compy Level\Infinite Energy (Tidal Cavern)
 800E1204 0063
-#Compy Level Infinite Lives (Aisle of Giants)
+#Compy Level\Infinite Lives (Aisle of Giants)
 800D2814 0063
-#Compy Level Infinite Lives (Creek Bed)
+#Compy Level\Infinite Lives (Creek Bed)
 800AD4A4 0063
-#Compy Level Infinite Lives (High Ridge)
+#Compy Level\Infinite Lives (High Ridge)
 800B5614 0063
-#Compy Level Infinite Lives (Rain Forest)
+#Compy Level\Infinite Lives (Rain Forest)
 800ABD94 0063
-#Compy Level Level Modifier High Ridge
+#Compy Level\Level Modifier High Ridge
 80050CD0 0001
-#Compy Level Level Modifier Rain Forest
+#Compy Level\Level Modifier Rain Forest
 80050CD0 0002
-#Compy Level Level Modifier Creek Bed
+#Compy Level\Level Modifier Creek Bed
 80050CD0 0003
-#Compy Level Level Modifier Aisle of Giants
+#Compy Level\Level Modifier Aisle of Giants
 80050CD0 0004
-#Compy Level Level Modifier Sleeping Titan
+#Compy Level\Level Modifier Sleeping Titan
 80050CD0 000F
-#Compy Level Level Modifier Plains
+#Compy Level\Level Modifier Plains
 80050CD0 0005
-#Compy Level Level River's Edge
+#Compy Level\Level River's Edge
 80050CD0 0006
-#Compy Level Level Modifier Beneath The Surface
+#Compy Level\Level Modifier Beneath The Surface
 80050CD0 0007
-#Compy Level Level Modifier Tidal Cavern
+#Compy Level\Level Modifier Tidal Cavern
 80050CD0 0010
-#Hunter Level Beat Levels At Touch Of A Button
+#Hunter Level\Beat Levels At Touch Of A Button
 D000857C 0001
 800582D4 0004
-#Hunter Level Infinite Cannon Gun
+#Hunter Level\Infinite Cannon Gun
 30064BD1 0063
-#Hunter Level Infinite Energy (Arid Canyon)
+#Hunter Level\Infinite Energy (Arid Canyon)
 800B032E 0064
-#Hunter Level Infinite Energy (Enter Carefully)
+#Hunter Level\Infinite Energy (Enter Carefully)
 800C0D5E 0064
-#Hunter Level Infinite Energy (Geothermal Center)
+#Hunter Level\Infinite Energy (Geothermal Center)
 800B635E 0064
-#Hunter Level Infinite Energy (Heart of The Island)
+#Hunter Level\Infinite Energy (Heart of The Island)
 800B6B2E 0064
-#Hunter Level Infinite Energy (Ingen Complex)
+#Hunter Level\Infinite Energy (Ingen Complex)
 800C73BE 0064
-#Hunter Level Infinite Energy (Underground)
+#Hunter Level\Infinite Energy (Underground)
 800BBB5E 0064
-#Hunter Level Infinite Flame Gun
+#Hunter Level\Infinite Flame Gun
 30064BD0 0063
-#Hunter Level Infinite Lighting Gun
+#Hunter Level\Infinite Lighting Gun
 30064BD6 0063
-#Hunter Level Infinite Lives (Arid Canyon)
+#Hunter Level\Infinite Lives (Arid Canyon)
 800B1EC4 0063
-#Hunter Level Infinite Lives (Enter Carefully)
+#Hunter Level\Infinite Lives (Enter Carefully)
 800C28F4 0063
-#Hunter Level Infinite Lives (Geothermal Center)
+#Hunter Level\Infinite Lives (Geothermal Center)
 800B7EF4 0063
-#Hunter Level Infinite Lives (Heart of The Island)
+#Hunter Level\Infinite Lives (Heart of The Island)
 800B86C4 0063
-#Hunter Level Infinite Lives (Ingen Complex)
+#Hunter Level\Infinite Lives (Ingen Complex)
 800C8F54 0063
-#Hunter Level Infinite Lives (Underground)
+#Hunter Level\Infinite Lives (Underground)
 800BD6F4 0063
-#Hunter Level Infinite Machine Gun
+#Hunter Level\Infinite Machine Gun
 30064BD4 0063
-#Hunter Level Infinite Smoke Gun
+#Hunter Level\Infinite Smoke Gun
 30064BD2 0063
-#Hunter Level Infinite Timer Bomb
+#Hunter Level\Infinite Timer Bomb
 30064BD3 0063
-#Hunter Level Level Modifier Enter Carefully
+#Hunter Level\Level Modifier Enter Carefully
 800582D0 0001
-#Hunter Level Level Modifier Arid Canyon
+#Hunter Level\Level Modifier Arid Canyon
 800582D0 0003
-#Hunter Level Level Modifier Heart of The Island
+#Hunter Level\Level Modifier Heart of The Island
 800582D0 0004
-#Hunter Level Level Modifier Underground
+#Hunter Level\Level Modifier Underground
 800582D0 0005
-#Hunter Level Level Modifier Geothermal Center
+#Hunter Level\Level Modifier Geothermal Center
 800582D0 0006
-#Hunter Level Level Modifier Ingen Complex
+#Hunter Level\Level Modifier Ingen Complex
 800582D0 0007
-#Raptor Level Beat Levels At Touch Of A Button
+#Raptor Level\Beat Levels At Touch Of A Button
 D000857C 0001
 8005733C 0004
-#Raptor Level Infinite Energy (Eve of Chaos)
+#Raptor Level\Infinite Energy (Eve of Chaos)
 801279EE 0064
-#Raptor Level Infinite Energy (Into The Fire)
+#Raptor Level\Infinite Energy (Into The Fire)
 800C365E 0064
-#Raptor Level Infinite Energy (Raptor Ravine)
+#Raptor Level\Infinite Energy (Raptor Ravine)
 800B2D7E 0064
-#Raptor Level Infinite Energy (The Burn Zone)
+#Raptor Level\Infinite Energy (The Burn Zone)
 800D8ECE 0064
-#Raptor Level Infinite Energy (The Way Out)
+#Raptor Level\Infinite Energy (The Way Out)
 800CDC1E 0064
-#Raptor Level Infinite Lives (Eve of Chaos)
+#Raptor Level\Infinite Lives (Eve of Chaos)
 80129584 0063
-#Raptor Level Infinite Lives (Into The Fire)
+#Raptor Level\Infinite Lives (Into The Fire)
 800C51F4 0063
-#Raptor Level Infinite Lives (Raptor Ravine)
+#Raptor Level\Infinite Lives (Raptor Ravine)
 800B4914 0063
-#Raptor Level Infinite Lives (The Burn Zone)
+#Raptor Level\Infinite Lives (The Burn Zone)
 800DAA64 0063
-#Raptor Level Infinite Lives (The Way Out)
+#Raptor Level\Infinite Lives (The Way Out)
 800CF7B4 0063
-#Raptor Level Level The Way Out
+#Raptor Level\Level The Way Out
 80057338 0001
-#Raptor Level Level Raptor Ravine
+#Raptor Level\Level Raptor Ravine
 80057338 0003
-#Raptor Level Level The Burn Zone
+#Raptor Level\Level The Burn Zone
 80057338 0005
-#Raptor Level Level Into The Fire
+#Raptor Level\Level Into The Fire
 80057338 0007
-#Raptor Level Level Eve of Chaos
+#Raptor Level\Level Eve of Chaos
 80057338 0008
-#T-Rex Level Beat Levels At Touch Of A Button
+#T-Rex Level\Beat Levels At Touch Of A Button
 D000857C 0001
 80059C74 0004
-#T-Rex Level Infinite Energy (Aftermath)
+#T-Rex Level\Infinite Energy (Aftermath)
 800B49CE 0064
-#T-Rex Level Infinite Energy (Dinosaur Lairs)
+#T-Rex Level\Infinite Energy (Dinosaur Lairs)
 8009792E 0064
-#T-Rex Level Infinite Energy (Force of Nature)
+#T-Rex Level\Infinite Energy (Force of Nature)
 8009785E 0064
-#T-Rex Level Infinite Energy (Hunter Camp)
+#T-Rex Level\Infinite Energy (Hunter Camp)
 800AEE6E 0064
-#T-Rex Level Infinite Energy (Predator's Ball)
+#T-Rex Level\Infinite Energy (Predator's Ball)
 80091F6E 0064
-#T-Rex Level Infinite Energy (Sulphure Fields)
+#T-Rex Level\Infinite Energy (Sulphure Fields)
 800B035E 0064
-#T-Rex Level Infinite Energy (The Hunters Regroup)
+#T-Rex Level\Infinite Energy (The Hunters Regroup)
 800AD63E 0064
-#T-Rex Level Infinite Lives (Aftermath)
+#T-Rex Level\Infinite Lives (Aftermath)
 800B6564 0063
-#T-Rex Level Infinite Lives (Dinosaur Lairs)
+#T-Rex Level\Infinite Lives (Dinosaur Lairs)
 800994C4 0063
-#T-Rex Level Infinite Lives (Force of Nature)
+#T-Rex Level\Infinite Lives (Force of Nature)
 800993F4 0063
-#T-Rex Level Infinite Lives (Hunter Camp)
+#T-Rex Level\Infinite Lives (Hunter Camp)
 800B0A04 0063
-#T-Rex Level Infinite Lives (Predator's Ball)
+#T-Rex Level\Infinite Lives (Predator's Ball)
 80093B04 0063
-#T-Rex Level Infinite Lives (Sulphure Fields)
+#T-Rex Level\Infinite Lives (Sulphure Fields)
 800B1EF4 0063
-#T-Rex Level Infinite Lives (The Hunters Regroup)
+#T-Rex Level\Infinite Lives (The Hunters Regroup)
 800AF1D4 0063
-#T-Rex Level Level Modifier Aftermath
+#T-Rex Level\Level Modifier Aftermath
 80059C70 000A
-#T-Rex Level Level Modifier Force of Nature
+#T-Rex Level\Level Modifier Force of Nature
 80059C70 0014
-#T-Rex Level Level Modifier Sulphure Fields
+#T-Rex Level\Level Modifier Sulphure Fields
 80059C70 001E
-#T-Rex Level Level Modifier Dinosaur Lairs
+#T-Rex Level\Level Modifier Dinosaur Lairs
 80059C70 0032
-#T-Rex Level Level Modifier Predator's Ball
+#T-Rex Level\Level Modifier Predator's Ball
 80059C70 003C
-#T-Rex Level Level Modifier Hunter Camp
+#T-Rex Level\Level Modifier Hunter Camp
 80059C70 0046
-#T-Rex Level Level Modifier The Hunters Regroup
+#T-Rex Level\Level Modifier The Hunters Regroup
 80059C70 0050
 #Enter Level Select Password Only Once With this code, goto the password screen and enter, Square, X, Circle, Triangle, Triangle, X, Square, Circle, Triable, Circle, X Square!
 8002EEF8 0002
@@ -31503,193 +32787,193 @@ D0009E10 0007
 80050CAA 0701
 #Infinite Lives (Bpc)
 90015FE4 00000000
-#Compy Level Beat Levels At Touch Of A Button
+#Compy Level\Beat Levels At Touch Of A Button
 D000857C 0001
 80050CD4 0004
-#Compy Level Infinite Breath (Beneath The Surface)
+#Compy Level\Infinite Breath (Beneath The Surface)
 8008A684 03E8
-#Compy Level Infinite Energy (Aisle of Giants)
+#Compy Level\Infinite Energy (Aisle of Giants)
 800D0C7E 0064
-#Compy Level Infinite Energy (Beneath The Surface)
+#Compy Level\Infinite Energy (Beneath The Surface)
 80088ACE 0064
-#Compy Level Infinite Energy (Beneath The Surface)
+#Compy Level\Infinite Energy (Beneath The Surface)
 8008A664 0063
-#Compy Level Infinite Energy (Creek Bed)
+#Compy Level\Infinite Energy (Creek Bed)
 800AB90E 0064
-#Compy Level Infinite Energy (High Ridge)
+#Compy Level\Infinite Energy (High Ridge)
 800B3A7E 0064
-#Compy Level Infinite Energy (Plains)
+#Compy Level\Infinite Energy (Plains)
 8009886E 0064
-#Compy Level Infinite Energy (Plains)
+#Compy Level\Infinite Energy (Plains)
 8009A404 0063
-#Compy Level Infinite Energy (Rain Forest)
+#Compy Level\Infinite Energy (Rain Forest)
 800AA1FE 0064
-#Compy Level Infinite Energy (River's Edge)
+#Compy Level\Infinite Energy (River's Edge)
 800A4F6E 0064
-#Compy Level Infinite Energy (River's Edge)
+#Compy Level\Infinite Energy (River's Edge)
 800A6B04 0063
-#Compy Level Infinite Energy (Sleeping Titan)
+#Compy Level\Infinite Energy (Sleeping Titan)
 800A441E 0064
-#Compy Level Infinite Energy (Sleeping Titan)
+#Compy Level\Infinite Energy (Sleeping Titan)
 800A5FB4 0063
-#Compy Level Infinite Energy (Tidal Cavern)
+#Compy Level\Infinite Energy (Tidal Cavern)
 800DF66E 0064
-#Compy Level Infinite Energy (Tidal Cavern)
+#Compy Level\Infinite Energy (Tidal Cavern)
 800E1204 0063
-#Compy Level Infinite Lives (Aisle of Giants)
+#Compy Level\Infinite Lives (Aisle of Giants)
 800D2814 0063
-#Compy Level Infinite Lives (Creek Bed)
+#Compy Level\Infinite Lives (Creek Bed)
 800AD4A4 0063
-#Compy Level Infinite Lives (High Ridge)
+#Compy Level\Infinite Lives (High Ridge)
 800B5614 0063
-#Compy Level Infinite Lives (Rain Forest)
+#Compy Level\Infinite Lives (Rain Forest)
 800ABD94 0063
-#Compy Level Level Modifier High Ridge
+#Compy Level\Level Modifier High Ridge
 80050CD0 0001
-#Compy Level Level Modifier Rain Forest
+#Compy Level\Level Modifier Rain Forest
 80050CD0 0002
-#Compy Level Level Modifier Creek Bed
+#Compy Level\Level Modifier Creek Bed
 80050CD0 0003
-#Compy Level Level Modifier Aisle of Giants
+#Compy Level\Level Modifier Aisle of Giants
 80050CD0 0004
-#Compy Level Level Modifier Sleeping Titan
+#Compy Level\Level Modifier Sleeping Titan
 80050CD0 000F
-#Compy Level Level Modifier Plains
+#Compy Level\Level Modifier Plains
 80050CD0 0005
-#Compy Level Level River's Edge
+#Compy Level\Level River's Edge
 80050CD0 0006
-#Compy Level Level Modifier Beneath The Surface
+#Compy Level\Level Modifier Beneath The Surface
 80050CD0 0007
-#Compy Level Level Modifier Tidal Cavern
+#Compy Level\Level Modifier Tidal Cavern
 80050CD0 0010
-#Hunter Level Beat Levels At Touch Of A Button
+#Hunter Level\Beat Levels At Touch Of A Button
 D000857C 0001
 800582D4 0004
-#Hunter Level Infinite Cannon Gun
+#Hunter Level\Infinite Cannon Gun
 30064BD1 0063
-#Hunter Level Infinite Energy (Arid Canyon)
+#Hunter Level\Infinite Energy (Arid Canyon)
 800B032E 0064
-#Hunter Level Infinite Energy (Enter Carefully)
+#Hunter Level\Infinite Energy (Enter Carefully)
 800C0D5E 0064
-#Hunter Level Infinite Energy (Geothermal Center)
+#Hunter Level\Infinite Energy (Geothermal Center)
 800B635E 0064
-#Hunter Level Infinite Energy (Heart of The Island)
+#Hunter Level\Infinite Energy (Heart of The Island)
 800B6B2E 0064
-#Hunter Level Infinite Energy (Ingen Complex)
+#Hunter Level\Infinite Energy (Ingen Complex)
 800C73BE 0064
-#Hunter Level Infinite Energy (Underground)
+#Hunter Level\Infinite Energy (Underground)
 800BBB5E 0064
-#Hunter Level Infinite Flame Gun
+#Hunter Level\Infinite Flame Gun
 30064BD0 0063
-#Hunter Level Infinite Lighting Gun
+#Hunter Level\Infinite Lighting Gun
 30064BD6 0063
-#Hunter Level Infinite Lives (Arid Canyon)
+#Hunter Level\Infinite Lives (Arid Canyon)
 800B1EC4 0063
-#Hunter Level Infinite Lives (Enter Carefully)
+#Hunter Level\Infinite Lives (Enter Carefully)
 800C28F4 0063
-#Hunter Level Infinite Lives (Geothermal Center)
+#Hunter Level\Infinite Lives (Geothermal Center)
 800B7EF4 0063
-#Hunter Level Infinite Lives (Heart of The Island)
+#Hunter Level\Infinite Lives (Heart of The Island)
 800B86C4 0063
-#Hunter Level Infinite Lives (Ingen Complex)
+#Hunter Level\Infinite Lives (Ingen Complex)
 800C8F54 0063
-#Hunter Level Infinite Lives (Underground)
+#Hunter Level\Infinite Lives (Underground)
 800BD6F4 0063
-#Hunter Level Infinite Machine Gun
+#Hunter Level\Infinite Machine Gun
 30064BD4 0063
-#Hunter Level Infinite Smoke Gun
+#Hunter Level\Infinite Smoke Gun
 30064BD2 0063
-#Hunter Level Infinite Timer Bomb
+#Hunter Level\Infinite Timer Bomb
 30064BD3 0063
-#Hunter Level Level Modifier Enter Carefully
+#Hunter Level\Level Modifier Enter Carefully
 800582D0 0001
-#Hunter Level Level Modifier Arid Canyon
+#Hunter Level\Level Modifier Arid Canyon
 800582D0 0003
-#Hunter Level Level Modifier Heart of The Island
+#Hunter Level\Level Modifier Heart of The Island
 800582D0 0004
-#Hunter Level Level Modifier Underground
+#Hunter Level\Level Modifier Underground
 800582D0 0005
-#Hunter Level Level Modifier Geothermal Center
+#Hunter Level\Level Modifier Geothermal Center
 800582D0 0006
-#Hunter Level Level Modifier Ingen Complex
+#Hunter Level\Level Modifier Ingen Complex
 800582D0 0007
-#Raptor Level Beat Levels At Touch Of A Button
+#Raptor Level\Beat Levels At Touch Of A Button
 D000857C 0001
 8005733C 0004
-#Raptor Level Infinite Energy (Eve of Chaos)
+#Raptor Level\Infinite Energy (Eve of Chaos)
 801279EE 0064
-#Raptor Level Infinite Energy (Into The Fire)
+#Raptor Level\Infinite Energy (Into The Fire)
 800C365E 0064
-#Raptor Level Infinite Energy (Raptor Ravine)
+#Raptor Level\Infinite Energy (Raptor Ravine)
 800B2D7E 0064
-#Raptor Level Infinite Energy (The Burn Zone)
+#Raptor Level\Infinite Energy (The Burn Zone)
 800D8ECE 0064
-#Raptor Level Infinite Energy (The Way Out)
+#Raptor Level\Infinite Energy (The Way Out)
 800CDC1E 0064
-#Raptor Level Infinite Lives (Eve of Chaos)
+#Raptor Level\Infinite Lives (Eve of Chaos)
 80129584 0063
-#Raptor Level Infinite Lives (Into The Fire)
+#Raptor Level\Infinite Lives (Into The Fire)
 800C51F4 0063
-#Raptor Level Infinite Lives (Raptor Ravine)
+#Raptor Level\Infinite Lives (Raptor Ravine)
 800B4914 0063
-#Raptor Level Infinite Lives (The Burn Zone)
+#Raptor Level\Infinite Lives (The Burn Zone)
 800DAA64 0063
-#Raptor Level Infinite Lives (The Way Out)
+#Raptor Level\Infinite Lives (The Way Out)
 800CF7B4 0063
-#Raptor Level Level The Way Out
+#Raptor Level\Level The Way Out
 80057338 0001
-#Raptor Level Level Raptor Ravine
+#Raptor Level\Level Raptor Ravine
 80057338 0003
-#Raptor Level Level The Burn Zone
+#Raptor Level\Level The Burn Zone
 80057338 0005
-#Raptor Level Level Into The Fire
+#Raptor Level\Level Into The Fire
 80057338 0007
-#Raptor Level Level Eve of Chaos
+#Raptor Level\Level Eve of Chaos
 80057338 0008
-#T-Rex Level Beat Levels At Touch Of A Button
+#T-Rex Level\Beat Levels At Touch Of A Button
 D000857C 0001
 80059C74 0004
-#T-Rex Level Infinite Energy (Aftermath)
+#T-Rex Level\Infinite Energy (Aftermath)
 800B49CE 0064
-#T-Rex Level Infinite Energy (Dinosaur Lairs)
+#T-Rex Level\Infinite Energy (Dinosaur Lairs)
 8009792E 0064
-#T-Rex Level Infinite Energy (Force of Nature)
+#T-Rex Level\Infinite Energy (Force of Nature)
 8009785E 0064
-#T-Rex Level Infinite Energy (Hunter Camp)
+#T-Rex Level\Infinite Energy (Hunter Camp)
 800AEE6E 0064
-#T-Rex Level Infinite Energy (Predator's Ball)
+#T-Rex Level\Infinite Energy (Predator's Ball)
 80091F6E 0064
-#T-Rex Level Infinite Energy (Sulphure Fields)
+#T-Rex Level\Infinite Energy (Sulphure Fields)
 800B035E 0064
-#T-Rex Level Infinite Energy (The Hunters Regroup)
+#T-Rex Level\Infinite Energy (The Hunters Regroup)
 800AD63E 0064
-#T-Rex Level Infinite Lives (Aftermath)
+#T-Rex Level\Infinite Lives (Aftermath)
 800B6564 0063
-#T-Rex Level Infinite Lives (Dinosaur Lairs)
+#T-Rex Level\Infinite Lives (Dinosaur Lairs)
 800994C4 0063
-#T-Rex Level Infinite Lives (Force of Nature)
+#T-Rex Level\Infinite Lives (Force of Nature)
 800993F4 0063
-#T-Rex Level Infinite Lives (Hunter Camp)
+#T-Rex Level\Infinite Lives (Hunter Camp)
 800B0A04 0063
-#T-Rex Level Infinite Lives (Predator's Ball)
+#T-Rex Level\Infinite Lives (Predator's Ball)
 80093B04 0063
-#T-Rex Level Infinite Lives (Sulphure Fields)
+#T-Rex Level\Infinite Lives (Sulphure Fields)
 800B1EF4 0063
-#T-Rex Level Infinite Lives (The Hunters Regroup)
+#T-Rex Level\Infinite Lives (The Hunters Regroup)
 800AF1D4 0063
-#T-Rex Level Level Modifier Aftermath
+#T-Rex Level\Level Modifier Aftermath
 80059C70 000A
-#T-Rex Level Level Modifier Force of Nature
+#T-Rex Level\Level Modifier Force of Nature
 80059C70 0014
-#T-Rex Level Level Modifier Sulphure Fields
+#T-Rex Level\Level Modifier Sulphure Fields
 80059C70 001E
-#T-Rex Level Level Modifier Dinosaur Lairs
+#T-Rex Level\Level Modifier Dinosaur Lairs
 80059C70 0032
-#T-Rex Level Level Modifier Predator's Ball
+#T-Rex Level\Level Modifier Predator's Ball
 80059C70 003C
-#T-Rex Level Level Modifier Hunter Camp
+#T-Rex Level\Level Modifier Hunter Camp
 80059C70 0046
-#T-Rex Level Level Modifier The Hunters Regroup
+#T-Rex Level\Level Modifier The Hunters Regroup
 80059C70 0050
 #Enter Level Select Password Only Once With this code, goto the password screen and enter, Square, X, Circle, Triangle, Triangle, X, Square, Circle, Triable, Circle, X Square!
 8002EEF8 0002
@@ -32021,13 +33305,13 @@ C00616C6 801D
 
 ; [ Madden NFL 2005 (USA) (2004) (Electronic Arts) {SLUS-01584} <maddn2k5> ]
 :SLUS-01584
-Select Home Team Score\0
+#Select Home Team Score\0
 8006F3C0 0000
-Select Home Team Score\10
+#Select Home Team Score\10
 8006F3C0 000A
-Select Away Team Score\0
+#Select Away Team Score\0
 800714A0 0000
-Select Away Team Score\10
+#Select Away Team Score\10
 800714A0 000A
 
 ; [ Madden NFL 97 (USA) (1996) (Electronic Arts) {SLUS-00018} <madden97> ]
@@ -32765,6 +34049,16 @@ D00F192C 0A00
 300F81C7 0001
 50001401 0000
 300F81DE 0001
+#Walk Through Walls (Hold L1+R1)
+8003EDE6 00001000
+8003799A 00001000
+800379CA 00001000
+8003858E 00001000
+D7100000 0000000C
+8003EDE6 00001443
+8003799A 00001040
+800379CA 00001440
+8003858E 00001440
 #Widescreen 16-9
 A7AF88FC 19991333
 
@@ -33376,6 +34670,15 @@ D00D1C0C 0016
 800E1258 FFFF
 #Liquid-No Health Final Fight
 8017997C 0000
+#Snake Has Rainbow Breath
+A706162E 10401400
+A70610FE 14401400
+#Walk Through Walls (L3 On/Off)
+D7010001 00000200
+F502A3E2 10C01000
+#Walk On Water (R3 On/Off)
+D7010001 01000400
+F502ABD6 14401000
 #Press R1 For An Easy Fight Against Ninja
 D00B2D58 0008
 8015B59C 0000
@@ -34511,84 +35814,84 @@ D00C6016 FFFE
 :SLUS-01016
 #Infinite Time
 8008FD7C 00FF
-#Select Starting Level\Icy Cold - Lundkwist-Base
-D008F894 0000
-3008F894 0000
-#Select Starting Level\Icy Cold - Submarine Harbor
-D008F894 0000
-3008F894 0001
-#Select Starting Level\The NOC-List - The Embassy
-D008F894 0000
-3008F894 0002
-#Select Starting Level\The NOC-List - The Camp
-D008F894 0000
-3008F894 0003
-#Select Starting Level\The NOC-List - KGB-HQ
-D008F894 0000
-3008F894 0004
-#Select Starting Level\The NOC-List - Security corridor
-D008F894 0000
-3008F894 0005
-#Select Starting Level\The NOC-List - Sewer
-D008F894 0000
-3008F894 0006
-#Select Starting Level\The NOC-List - On the Run
-D008F894 0000
-3008F894 0007
-#Select Starting Level\The NOC-List - On the Run II
-D008F894 0000
-3008F894 0008
-#Select Starting Level\The NOC-List - Fire Alarm
-D008F894 0000
-3008F894 0009
-#Select Starting Level\Escape the CIA - The Interrogation
-D008F894 0000
-3008F894 000A
-#Select Starting Level\Escape the CIA - Serum
-D008F894 0000
-3008F894 000B
-#Select Starting Level\Escape the CIA - Medical Room
-D008F894 0000
-3008F894 000C
-#Select Starting Level\Escape the CIA - Rooftops
-D008F894 0000
-3008F894 000D
-#Select Starting Level\Escape the CIA - Terminal Room
-D008F894 0000
-3008F894 000E
-#Select Starting Level\Escape the CIA - Escape the Roof
-D008F894 0000
-3008F894 000F
-#Select Starting Level\The Mole - Waterloo Station
-D008F894 0000
-3008F894 0010
-#Select Starting Level\The Mole - TGV
-D008F894 0000
-3008F894 0011
-#Select Starting Level\The Mole - TGV II
-D008F894 0000
-3008F894 0012
-#Select Starting Level\The Mole - On the Roof
-D008F894 0000
-3008F894 0013
-#Select Starting Level\Ice Storm - Submarine Harbor
-D008F894 0000
-3008F894 0014
-#Select Starting Level\Ice Storm - Tunnel
-D008F894 0000
-3008F894 0015
-#Select Starting Level\Ice Storm - The Base
-D008F894 0000
-3008F894 0016
-#Select Starting Level\Ice Storm - Gunboat
-D008F894 0000
-3008F894 0017
+;#Select Starting Level\Icy Cold - Lundkwist-Base
+;D008F894 0000
+;3008F894 0000
+;#Select Starting Level\Icy Cold - Submarine Harbor
+;D008F894 0000
+;3008F894 0001
+;#Select Starting Level\The NOC-List - The Embassy
+;D008F894 0000
+;3008F894 0002
+;#Select Starting Level\The NOC-List - The Camp
+;D008F894 0000
+;3008F894 0003
+;#Select Starting Level\The NOC-List - KGB-HQ
+;D008F894 0000
+;3008F894 0004
+;#Select Starting Level\The NOC-List - Security corridor
+;D008F894 0000
+;3008F894 0005
+;#Select Starting Level\The NOC-List - Sewer
+;D008F894 0000
+;3008F894 0006
+;#Select Starting Level\The NOC-List - On the Run
+;D008F894 0000
+;3008F894 0007
+;#Select Starting Level\The NOC-List - On the Run II
+;D008F894 0000
+;3008F894 0008
+;#Select Starting Level\The NOC-List - Fire Alarm
+;D008F894 0000
+;3008F894 0009
+;#Select Starting Level\Escape the CIA - The Interrogation
+;D008F894 0000
+;3008F894 000A
+;#Select Starting Level\Escape the CIA - Serum
+;D008F894 0000
+;3008F894 000B
+;#Select Starting Level\Escape the CIA - Medical Room
+;D008F894 0000
+;3008F894 000C
+;#Select Starting Level\Escape the CIA - Rooftops
+;D008F894 0000
+;3008F894 000D
+;#Select Starting Level\Escape the CIA - Terminal Room
+;D008F894 0000
+;3008F894 000E
+;#Select Starting Level\Escape the CIA - Escape the Roof
+;D008F894 0000
+;3008F894 000F
+;#Select Starting Level\The Mole - Waterloo Station
+;D008F894 0000
+;3008F894 0010
+;#Select Starting Level\The Mole - TGV
+;D008F894 0000
+;3008F894 0011
+;#Select Starting Level\The Mole - TGV II
+;D008F894 0000
+;3008F894 0012
+;#Select Starting Level\The Mole - On the Roof
+;D008F894 0000
+;3008F894 0013
+;#Select Starting Level\Ice Storm - Submarine Harbor
+;D008F894 0000
+;3008F894 0014
+;#Select Starting Level\Ice Storm - Tunnel
+;D008F894 0000
+;3008F894 0015
+;#Select Starting Level\Ice Storm - The Base
+;D008F894 0000
+;3008F894 0016
+;#Select Starting Level\Ice Storm - Gunboat
+;D008F894 0000
+;3008F894 0017
 #Infinite Ammo (All Weapons) {ASM]
 800454AA 2400
-#Infinite Ammo after pickup (ASM ALT)
-80045446 3C00
-#Infinite Ammo (RAM)
-301F5812 0063
+;#Infinite Ammo after pickup (ASM ALT)
+;80045446 3C00
+;#Infinite Ammo (RAM)
+;301F5812 0063
 #Infinite Fire extinguisher
 301F5820 00FF
 #Infinite Masks
@@ -34615,11 +35918,11 @@ D01FADBC FBFE
 3008F8EC 0001
 D01FADBC FEFE
 3008F8EC 0000
-#Walk Through Walls - ON (Press Select & Left), OFF (Press Select & Right)
-D01FAD9A FF7E
-80048E4A 1000
-D01FAD9A FFDE
-80048E4A 1040
+;#Walk Through Walls - ON (Press Select & Left), OFF (Press Select & Right)
+;D01FAD9A FF7E
+;80048E4A 1000
+;D01FAD9A FFDE
+;80048E4A 1040
 #Paralysed Enemies - ON (Press Select & Up), OFF (Press Select & Down)
 D01FAD9A FFEE
 3006CB38 0000
@@ -34785,6 +36088,12 @@ D008F888 0100
 :SLUS-00605
 #P1 Infinite Health
 900AABA8 00010000
+#Hit Anywhere
+A7061F6E 14402400
+#Hit Anywhere Alternative
+A7061806 10402400
+#Walk Through Enemies
+A705E1AE 14401000
 
 ; [ Mortal Kombat - Special Forces (USA) (2000) (Midway Home Entertainment) {SLUS-00824} <mksf> ]
 :SLUS-00824
@@ -35658,6 +36967,10 @@ D008E6FA BDFF
 8004F14C 0032
 #Have All Coins On Pick-Up
 800B53E6 0064
+#Debug Mode\ON
+310B814C 0001
+#Debug Mode\OFF
+310B814C 0000
 
 ; [ Moto Racer (USA) (1997) (Electronic Arts) {SLUS-00498} <motorcr> ]
 :SLUS-00498
@@ -36983,102 +38296,102 @@ D0052E88 0024
 
 ; [ Namco Museum Vol. 2 (USA) (1996) (Namco Hometek) {SLUS-00216} <namcoms2> ]
 :SLUS-00216
-#Dragon Buster Infinite Credits
+#Dragon Buster\Infinite Credits
 800C97D8 0005
-#Dragon Buster P1 Infinite Fireballs
+#Dragon Buster\P1 Infinite Fireballs
 800C9918 0002
 80143738 0101
-#Dragon Buster P1 Infinite Vitality
+#Dragon Buster\P1 Infinite Vitality
 800C9978 0080
-#Gaplus Infinite Credits
+#Gaplus\Infinite Credits
 80102B84 0005
-#Galus P1 Infinite Lives
+#Gaplus\P1 Infinite Lives
 30151104 0004
-#Grabda Infinite Credits
+#Grabda\Infinite Credits
 800E9EAC 0005
-#Grabda Infinite Shield (Both Players)
+#Grabda\Infinite Shield (Both Players)
 80100764 2800
-#Grabda P1 Infinite Lives
+#Grabda\P1 Infinite Lives
 800CAD64 0002
-#Mappy Infinite Credits
+#Mappy\Infinite Credits
 80179CE8 0005
-#Mappy Infinite Lives (Both Players)
+#Mappy\Infinite Lives (Both Players)
 801DE864 0400
-#Super Pacman Infinite Lives (Both Players)
+#Super Pacman\Infinite Lives (Both Players)
 801E1006 0300
-#Super Pacman Always #SUPER# Pacman (Both Players)
+#Super Pacman\Always #SUPER# Pacman (Both Players)
 801E1626 0001
 801E1630 6700
-#Super Pacman Infinite Time In Bonus Levels
+#Super Pacman\Infinite Time In Bonus Levels
 801E108E 6019
 801E10FE 0507
-#Xevious Infinite Lives (Both Players)
+#Xevious\Infinite Lives (Both Players)
 80196E48 0003
 801DE8BC FF63
-#Xevious Infinite Credits
+#Xevious\Infinite Credits
 80178580 0005
 
 ; [ Namco Museum Vol. 3 (USA) (1996) (Namco Hometek) {SLUS-00398} <namcoms3> ]
 :SLUS-00398
-#Dig Dug P1 Infinite Lives
-80125418 0004
-#Galaxian Infinite Lives (Both Players)
+#Dig Dug\P1 Infinite Lives
+80125418 0009
+#Galaxian\Infinite Lives (Both Players)
 8010EC04 0005
-#Ms. Pacman P1 Infinite Lives
+#Ms. Pacman\P1 Infinite Lives
 80135960 0004
-#Ms. Pacman P2 Infinite Lives
+#Ms. Pacman\P2 Infinite Lives
 80135964 0004
-#Pozon P1 Infinite Lives
+#Pozon\P1 Infinite Lives
 30168D4C 0005
-#Pozon P2 Infinite Lives
+#Pozon\P2 Infinite Lives
 30168D4D 0005
-#Pole Position 2Infinite Time
+#Pole Position 2\Infinite Time
 8013551E 7000
-#Pole Position 2 Lap Time Always Below 0.01
+#Pole Position 2\Lap Time Always Below 0.01
 90135530 00000000
 9013552C 00000000
-#Tower of Druaga P1 Infinite Lives
+#Tower of Druaga\P1 Infinite Lives
 8016664A 0004
-#Tower of Druaga P2 Infinite Lives
+#Tower of Druaga\P2 Infinite Lives
 80166696 0004
-#Tower of Druaga Infinite Time (Both Players)
+#Tower of Druaga\Infinite Time (Both Players)
 8015F464 4E20
-#Tower of Druaga Infinite Keys (Both Players)
+#Tower of Druaga\Infinite Keys (Both Players)
 8015F530 0001
-#Tower of Druaga Enable Level Select
+#Tower of Druaga\Enable Level Select
 3016664B 003B
-#Tower of Druaga Enable Secret Message In Druaga Room
+#Tower of Druaga\Enable Secret Message In Druaga Room
 800FFA14 0003
 
 ; [ Namco Museum Vol. 4 (USA) (1997) (Namco Hometek) {SLUS-00416} <namcoms4> ]
 :SLUS-00416
-#Assault Infinite Lives (Both Players)
+#Assault\Infinite Lives (Both Players)
 801DCA3A 0005
-#Assault Infinite Time (Both Players)
+#Assault\Infinite Time (Both Players)
 801DCA5A 0063
-#Ordyne Infinite Infinite Credits
+#Ordyne\Infinite Infinite Credits
 800C5664 0009
-#Ordyne P1 Infinite Lives
+#Ordyne\P1 Infinite Lives
 800C55C8 0005
-#Ordyne P2 Infinite Lives
+#Ordyne\P2 Infinite Lives
 800C55CA 0005
-#The Return of Ishtar Infinite Credits
+#The Return of Ishtar\Infinite Credits
 8015A7B8 0009
-#The Return of Ishtar Infinite Guys
+#The Return of Ishtar\Infinite Guys
 8015A3C0 000F
-#Pacland Infinite Credits
+#Pacland\Infinite Credits
 80057F46 0009
-#Pacland Infinite Lives (Both Players)
+#Pacland\Infinite Lives (Both Players)
 30058055 0005
-#Pacland Infinite Time (Both Players)
+#Pacland\Infinite Time (Both Players)
 800580BC 0909
 #Infinite Credits
 800A05EC 0009
-#The Genji and the Heike Clans Infinite Energy (Both Players)
+#The Genji and the Heike Clans\Infinite Energy (Both Players)
 300A01B0 0032
-#The Genji and the Heike Clans Infinite Money (Both Players)
+#The Genji and the Heike Clans\Infinite Money (Both Players)
 300A01C1 0063
-#The Genji and the Heike Clans Infinite Sword (Both Players)
+#The Genji and the Heike Clans\Infinite Sword (Both Players)
 300A01C9 0063
 
 ; [ Namco Museum Vol. 5 (USA) (1997) (Namco Hometek) {SLUS-00417} <namcoms5> ]
@@ -37663,13 +38976,13 @@ A60209DC 0000FFFF
 #Unlock All Legends
 50000402 0000
 8008267C FFFF
-#Home Team Infinite Timeouts
+#Select Home Team Timeouts\Infinite Timeouts
 800AE120 0007
-#Home Team No Timeouts
+#Select Home Team Timeouts\No Timeouts
 800AE120 0000
-#Away Team Infinite Timeouts
+#Select Away Team Timeouts\Infinite Timeouts
 800AE770 0007
-#Away Team No Timeouts
+#Away Team Timeouts\No Timeouts
 800AE770 0000
 #Max Stats
 D008235A 0BB8
@@ -37743,13 +39056,13 @@ D008235A 0BB8
 800A8E64 0064
 #Select Away Team Score\0
 800A8E64 0000
-#Home Team Infinite Time-Outs
+#Select Home Team Timeouts\Infinite Timeouts
 300A8818 0006
-#Away Team Infinite Time-Outs
-300A8E6C 0006
-#Home Team No Time-Outs
+#Select Home Team Timeouts\No Timeouts
 300A8818 0000
-#Away Team No Time-Outs
+#Select Away Team Timeouts\Infinite Timeouts
+300A8E6C 0006
+#Away Team Timeouts\No Timeouts
 300A8E6C 0000
 
 ; [ NBA Live 2002 (USA) (2001) (Electronic Arts) {SLUS-01416} <nbalv2k2> ]
@@ -38241,21 +39554,21 @@ D009CAB0 8010
 80016828 0000
 #Infinite Creation Points
 8014B904 0258
-#Home Team Infinite Time-Outs
+#Select Home Team Timeouts\Infinite Timeouts
 300153F0 0007
-#Home Team No Time-Outs
+#Select Home Team Timeouts\No Timeouts
 300153F0 0000
-#Home Team Infinite 20 Sec Time-Outs
+#Select Home Team Timeouts\Infinite 20 Sec Timeouts
 300153F1 0007
-#Home Team No 20 Sec Time-Outs
+#Select Home Team Timeouts\No 20 Sec Timeouts
 300153F1 0000
-#Away Team Infinite Time-Outs
+#Select Away Team Timeouts\Infinite Timeouts
 3001682C 0007
-#Away Team No Time-Outs
+#Select Away Team Timeouts\No Timeouts
 3001682C 0000
-#Away Team Infinite 20 Sec Time-Outs
+#Select Away Team Timeouts\Infinite 20 Sec Timeouts
 3001682D 0007
-#Away Team No 20 Sec Time-Outs
+#Select Away Team Timeouts\No 20 Sec Timeouts
 3001682D 0000
 #Infinite Shot Clock
 801613A8 0609
@@ -38276,21 +39589,21 @@ D009CAB0 8010
 80122B90 0063
 #Full Momentum Away Team
 80122B90 0000
-#Home Team Infinite Full Time Outs
+#Select Home Team Timeouts\Infinite Timeouts
 30016704 0004
-#Home Team No Full Time Outs
+#Select Home Team Timeouts\No Timeouts
 30016704 0000
-#Home Team Infinite 20 Sec Time Outs
+#Select Home Team Timeouts\Infinite 20 Sec Timeouts
 30016705 0002
-#Home Team No 20 Sec Time Outs
+#Select Home Team Timeouts\No 20 Sec Timeouts
 30016705 0000
-#Away Team Infinite Full Time Outs
+#Select Away Team Timeouts\Infinite Timeouts
 300152C8 0004
-#Away Team No Full Time Outs
+#Select Away Team Timeouts\No Timeouts
 300152C8 0000
-#Away Team Infinite 20 Sec Time Outs
+#Select Away Team Timeouts\Infinite 20 Sec Timeouts
 300152C9 0002
-#Away Team No 20 Sec Time Outs
+#Select Away Team Timeouts\No 20 Sec Timeouts
 300152C9 0000
 #No Shot Clock
 800E8A54 0000
@@ -39255,37 +40568,37 @@ C00A879E FFFE
 8006CFE4 0009
 #Infinite Health (ALT)
 800D5A54 86A0
-Select Weapon\Nothing
+#Select Weapon\Nothing
 8006AD2A 0000
-Select Weapon\Katana
+#Select Weapon\Katana
 8006AD2A 0004
-Select Weapon\Skeleton
+#Select Weapon\Skeleton
 8006AD2A 0008
-Select Weapon\Skeleton w/Katana
+#Select Weapon\Skeleton w/Katana
 8006AD2A 000C
-Select Weapon\Mace
+#Select Weapon\Mace
 8006AD2A 0010
-Select Weapon\Skeleton w/Mace
+#Select Weapon\Skeleton w/Mace
 8006AD2A 0018
-Select Weapon\Axe
+#Select Weapon\Axe
 8006AD2A 0020
-Select Weapon\Skeleton w/Axe
+#Select Weapon\Skeleton w/Axe
 8006AD2A 0028
-Select Weapon\Mace?
+#Select Weapon\Mace?
 8006AD2A 0030
-Select Weapon\Skeleton w/Mace?
+#Select Weapon\Skeleton w/Mace?
 8006AD2A 0038
-Select Weapon\Sai
+#Select Weapon\Sai
 8006AD2A 0080
-Select Weapon\Skeleton w/Sai
+#Select Weapon\Skeleton w/Sai
 8006AD2A 0088
-Select Weapon\Staff
+#Select Weapon\Staff
 8006AD2A 0100
-Select Weapon\Skeleton w/Staff
+#Select Weapon\Skeleton w/Staff
 8006AD2A 0108
-Select Weapon\Ultimate Sword
+#Select Weapon\Ultimate Sword
 8006AD2A 0200
-Select Weapon\Skeleton w/Ultimate Sword
+#Select Weapon\Skeleton w/Ultimate Sword
 8006AD2A 0208
 
 ; [ No Fear Downhill Mountain Bike Racing (USA) (1999) (The Codemasters Software Company) {SLUS-01000} <nofear> ]
@@ -39673,169 +40986,173 @@ D010B85C 0500
 800EF55C 0001
 #Widescreen 16-9
 A70EBB90 10000C00
+#Widescreen 16-9 [ALT]
+A7076370 10000C00
+#Dither Off
+A704517C 02000000
 
 ; [ Pac-Man World (USA) (1999) (Namco Hometek) {SLUS-00439, SLUS-00439GH} <pacmnwld> ]
 :SLUS-00439
 :SLUS-00439GH
-#Quest Infinite Lives
+#Quest\Infinite Lives
 80153C64 0063
-#Quest Infinite Health
+#Quest\Infinite Health
 80153C58 0004
-#Quest Invincibility
+#Quest\Invincibility
 80153C58 0004
-#Quest Max Pac Dots
+#Quest\Max Pac Dots
 80153C68 00FF
-#Quest Max Score
+#Quest\Max Score
 90153C60 0FFFFFFF
-#Quest 100 Cherries On Pick-Up
+#Quest\100 Cherries On Pick-Up
 80153E16 0063
-#Quest 100 Strawberries On Pick-Up
+#Quest\100 Strawberries On Pick-Up
 80153E18 0063
-#Quest 100 Oranges On Pick-Up
+#Quest\100 Oranges On Pick-Up
 80153E1A 0063
-#Quest 100 Apples On Pick-Up
+#Quest\100 Apples On Pick-Up
 80153E1E 0063
-#Quest 100 Bananas On Pick-Up
+#Quest\100 Bananas On Pick-Up
 80153E20 0063
-#Quest Have Pacman (Press Select)
+#Quest\Have Pacman (Press Select)
 D014790A 0001
 50000602 0000
 80153E58 0001
-#Classic Infinite Lives
+#Classic\Infinite Lives
 801A9468 0063
-#Classic Max Points
+#Classic\Max Points
 801BD678 FFFF
-#Maze Unlock Outtakes
+#Maze\Unlock Outtakes
 80111BAC 0001
-#Maze Max Score
+#Maze\Max Score
 A6153C60 0000FFFF
-#Maze 100 Melons On Pick-Up
+#Maze\100 Melons On Pick-Up
 80153E22 0063
-#Maze 100 Lemons On Pick-Up
+#Maze\100 Lemons On Pick-Up
 80153E24 0063
-#Maze 100 Peaches On Pick-Up
+#Maze\100 Peaches On Pick-Up
 80153E1C 0063
-#Maze 100 Bells On Pick-Up
+#Maze\100 Bells On Pick-Up
 80153E28 0063
-#Maze 100 Galaxians On Pick-Up
+#Maze\100 Galaxians On Pick-Up
 80153E26 0063
-#Maze 100 Keys On Pick-Up
+#Maze\100 Keys On Pick-Up
 80153E2E 0063
-#Unlock Pirate Level 1
+#Pirate\Unlock Pirate Level 1
 80153E84 00FF
-#Pirate Level 1 Completed
+#Pirate\Pirate Level 1 Completed
 80153DA2 00FF
-#Unlock Pirate Level 2
+#Pirate\Unlock Pirate Level 2
 80153E78 00FF
-#Pirate Level 2 Completed
+#Pirate\Pirate Level 2 Completed
 80153DA4 00FF
-#Unlock Pirate Level 3
+#Pirate\Unlock Pirate Level 3
 80153E7C 00FF
-#Pirate Level 3 Completed
+#Pirate\Pirate Level 3 Completed
 80153DA6 00FF
-#Unlock Pirate Level 4
+#Pirate\Unlock Pirate Level 4
 80153E80 00FF
-#Pirate Level 4 Completed
+#Pirate\Pirate Level 4 Completed
 80153DA8 00FF
-#Pirate Level 5 Completed
+#Pirate\Pirate Level 5 Completed
 80153DAA 00FF
-#Pirate Level 6 Completed
+#Pirate\Pirate Level 6 Completed
 80153DAC 00FF
-#Unlock Ruins Level 1
+#Ruins\Unlock Ruins Level 1
 80153E68 00FF
-#Ruins Level 1 Completed
+#Ruins\Ruins Level 1 Completed
 80153DAE 00FF
-#Unlock Ruins Level 2
+#Ruins\Unlock Ruins Level 2
 80153E6C 00FF
-#Ruins Level 2 Completed
+#Ruins\Ruins Level 2 Completed
 80153DB0 00FF
-#Unlock Ruins Level 3
+#Ruins\Unlock Ruins Level 3
 80153E74 00FF
-#Ruins Level 3 Completed
+#Ruins\Ruins Level 3 Completed
 80153DB2 00FF
-#Ruins Level 4 Completed
+#Ruins\Ruins Level 4 Completed
 80153DB4 00FF
 #Ruins Level 5 Completed
 80153DB6 00FF
 #Ruins Level 6 Completed
 80153DB8 00FF
-#Unlock Space Level 1
+#Space\Unlock Space Level 1
 80153CE8 00FF
-#Space Level 1 Completed
+#Space\Space Level 1 Completed
 80153DBA 00FF
-#Unlock Space Level 2
+#Space\Unlock Space Level 2
 80153CEC 00FF
-#Space Level 2 Completed
+#Space\Space Level 2 Completed
 80153DBC 00FF
-#Unlock Space Level 3
+#Space\Unlock Space Level 3
 80153CF0 00FF
-#Space Level 3 Completed
+#Space\Space Level 3 Completed
 80153DBE 00FF
-#Unlock Space Level 4
+#Space\Unlock Space Level 4
 80153CF4 00FF
-#Space Level 4 Completed
+#Space\Space Level 4 Completed
 80153DC0 00FF
-#Space Level 5 Completed
+#Space\Space Level 5 Completed
 80153DC2 00FF
-#Space Level 6 Completed
+#Space\Space Level 6 Completed
 80153DC4 00FF
-#Unlock Funhouse Level 1
+#Funhouse\Unlock Funhouse Level 1
 80153CF8 00FF
-#Funhouse Level 1 Completed
+#Funhouse\Funhouse Level 1 Completed
 80153DC6 00FF
-#Unlock Funhouse Level 2
+#Funhouse\Unlock Funhouse Level 2
 80153CFC 00FF
-#Funhouse Level 2 Completed
+#Funhouse\Funhouse Level 2 Completed
 80153DC8 00FF
-#Unlock Funhouse Level 3
+#Funhouse\Unlock Funhouse Level 3
 80153D00 00FF
-#Funhouse Level 3 Completed
+#Funhouse\Funhouse Level 3 Completed
 80153DCA 00FF
-#Unlock Funhouse Level 4
+#Funhouse\Unlock Funhouse Level 4
 80153D04 00FF
-#Funhouse Level 4 Completed
+#Funhouse\Funhouse Level 4 Completed
 80153DCC 00FF
-#Funhouse Level 5 Completed
+#Funhouse\Funhouse Level 5 Completed
 80153DCE 00FF
-#Funhouse Level 6 Completed
+#Funhouse\Funhouse Level 6 Completed
 80153DD0 00FF
-#Unlock Factory Level 1
+#Factory\Unlock Factory Level 1
 80153D14 00FF
-#Factory Level 1 Completed
+#Factory\Factory Level 1 Completed
 80153DD2 00FF
-#Unlock Factory Level 2
+#Factory\Unlock Factory Level 2
 80153D18 00FF
-#Factory Level 2 Completed
+#Factory\Factory Level 2 Completed
 80153DD4 00FF
-#Unlock Factory Level 3
+#Factory\Unlock Factory Level 3
 80153D1C 00FF
-#Factory Level 3 Completed
+#Factory\Factory Level 3 Completed
 80153DD6 00FF
-#Unlock Factory Level 4
+#Factory\Unlock Factory Level 4
 80153D20 00FF
-#Factory Level 4 Completed
+#Factory\Factory Level 4 Completed
 80153DD8 00FF
-#Factory Level 5 Completed
+#Factory\Factory Level 5 Completed
 80153D26 00FF
-#Factory Level 6 Completed
+#Factory\Factory Level 6 Completed
 80153D28 00FF
-#Unlock Mansion Level 1
+#Mansion\Unlock Mansion Level 1
 80153D08 00FF
-#Mansion Level 1 Completed
+#Mansion\Mansion Level 1 Completed
 80153D2A 00FF
-#Unlock Mansion Level 2
+#Mansion\Unlock Mansion Level 2
 80153D0C 00FF
-#Mansion Level 2 Completed
+#Mansion\Mansion Level 2 Completed
 80153D2C 00FF
-#Unlock Mansion Level 3
+#Mansion\Unlock Mansion Level 3
 80153D10 00FF
-#Mansion Level 3 Completed
+#Mansion\Mansion Level 3 Completed
 80153D2E 00FF
-#Mansion Level 4 Completed
+#Mansion\Mansion Level 4 Completed
 80153D30 00FF
-#Mansion Level 5 Completed
+#Mansion\Mansion Level 5 Completed
 80153D32 00FF
-#Mansion Level 6 Completed
+#Mansion\Mansion Level 6 Completed
 80153D34 00FF
 #Unlock Gallery + All Mazes Completed
 50000802 0000
@@ -39971,20 +41288,6 @@ D00B6E1A 9205
 #Infinite Ammo For All Secondary Attachment Weapons
 D00B6E7A 9205
 800B6E7C 2400
-#Go through Locked Doors
-A70ADF06 10401400
-A70AE0E2 14401000
-#Easier Battles
-A71053C6 1C401400
-A71153C6 1C401400
-A71253C6 1C401400
-A71353C6 1C401400
-A71453C6 1C401400
-A71553C6 1C401400
-A71653C6 1C401400
-A71753C6 1C401400
-A71853C6 1C401400
-A71953C6 1C401400
 #Upgrade PE energy once to have lvl 3
 800D35DC 0003
 800D35DE 3402
@@ -40197,61 +41500,61 @@ A609CA10 00000001
 :SLUS-01339
 #Infinite Money
 800833A8 FFFF
-#Baofu Infinite HP
+#Baofu\Infinite HP
 800846A0 03E7
-#Baofu Max HP
+#Baofu\Max HP
 800846A2 03E7
-#Baofu Infinite SP
+#Baofu\Infinite SP
 800846A4 03E7
-#Baofu Max SP
+#Baofu\Max SP
 800846A6 03E7
-#Ellen Infinite HP
+#Ellen\Infinite HP
 80084748 03E7
-#Ellen Max HP
+#Ellen\Max HP
 8008474A 03E7
-#Ellen Infinite SP
+#Ellen\Infinite SP
 8008474C 03E7
-#Ellen Max SP
+#Ellen\Max SP
 8008474E 03E7
-#Katsuya Infinite HP
+#Katsuya\Infinite HP
 8008464C 03E7
-#Katsuya Max HP
+#Katsuya\Max HP
 8008464E 03E7
-#Katsuya Infinite SP
+#Katsuya\Infinite SP
 80084650 03E7
-#Katsuya Max SP
+#Katsuya\Max SP
 80084652 03E7
-#Maya Infinite HP
+#Maya\Infinite HP
 800845A4 03E7
-#Maya Max HP
+#Maya\Max HP
 800845A6 03E7
-#Maya Infinite SP
+#Maya\Infinite SP
 800845A8 03E7
-#Maya Max SP
+#Maya\Max SP
 800845AA 03E7
-#Nanjo Infinite HP
+#Nanjo\Infinite HP
 800846F4 03E7
-#Nanjo Max HP
+#Nanjo\Max HP
 800846F6 03E7
-#Nanjo Infinite SP
+#Nanjo\Infinite SP
 800846F8 03E7
-#Nanjo Max SP
+#Nanjo\Max SP
 800846FA 03E7
-#Tatsuya Infinite HP
+#Tatsuya\Infinite HP
 8008479C 03E7
-#Tatsuya Max HP
+#Tatsuya\Max HP
 8008479E 03E7
-#Tatsuya Infinite SP
+#Tatsuya\Infinite SP
 800847A0 03E7
-#Tatsuya Max SP
+#Tatsuya\Max SP
 800847A2 03E7
-#Urara Infinite HP
+#Urara\Infinite HP
 800845F8 03E7
-#Urara Max HP
+#Urara\Max HP
 800845FA 03E7
-#Urara Infinite SP
+#Urara\Infinite SP
 800845FC 03E7
-#Urara Max SP
+#Urara\Max SP
 800845FE 03E7
 #Have All Persona Arcanums
 9008392C FFFFFFFF
@@ -40445,9 +41748,9 @@ C00D2DCE FBFF
 8007C348 0005
 #Arcade Mode\Infinite Health
 8007C388 00FF
-#Level 1 Infinite Lives
+#Level 1\Infinite Lives
 8007C348 0005
-#Level 1 Infinite Health
+#Level 1\Infinite Health
 8007C388 00FF
 #Level 2\Have 10 Gold Bars
 8007D308 000A
@@ -40496,61 +41799,61 @@ D0081384 0040
 800E2890 0009
 #Level 5\Have 10 Gold Bars
 8008BDD8 000A
-#Level 6 Infinite Lives
+#Level 6\Infinite Lives
 80081520 0005
-#Level 6 Infinite Health
+#Level 6\Infinite Health
 80081560 00FF
-#Level 7 Infinite Health
+#Level 7\Infinite Health
 80083960 00FF
-#Level 7 Infinite Lives
+#Level 7\Infinite Lives
 80083920 0005
-#Level 7 Have 10 Gold Bars
+#Level 7\Have 10 Gold Bars
 80083A1C 000A
-#Boss 2 Infinite Lives
+#Boss 2\Infinite Lives
 80067B98 0008
-#Boss 2 Infinite Health
+#Boss 2\Infinite Health
 80067B94 0040
-#Level 8 Infinite Lives
+#Level 8\Infinite Lives
 8007DC48 0005
-#Level 8 Infinite Health
+#Level 8\Infinite Health
 8007DC88 00FF
-#Level 8 Infinite Time Bombs
+#Level 8\Infinite Time Bombs
 800D4250 0009
-#Level 8 Infinite Boomerangs
+#Level 8\Infinite Boomerangs
 800D4254 0009
-#Level 8 Have 10 Gold Bars
+#Level 8\Have 10 Gold Bars
 8007DD4C 000A
-#Level 9 Infinite Lives
+#Level 9\Infinite Lives
 8007DD58 0005
-#Level 9 Infinite Health
+#Level 9\Infinite Health
 8007DD94 00FF
-#Level 9 Infinite Boomerangs
+#Level 9\Infinite Boomerangs
 800D7884 0009
-#Level 9 Infinite Power Boosts
+#Level 9\Infinite Power Boosts
 800D7888 0009
-#Level 9 Have 10 Gold Bars
+#Level 9\Have 10 Gold Bars
 8007DE50 000A
-#Level 10 Infinite Lives
+#Level 10\Infinite Lives
 8007986C 0005
-#Level 10 Infinite Health
+#Level 10\Infinite Health
 800798AC 00FF
-#Level 10 Have 10 Gold Bars
+#Level 10\Have 10 Gold Bars
 80079968 000A
-#Level 11 Infinite Lives
+#Level 11\Infinite Lives
 80077A50 0005
-#Level 11 Infinite Health
+#Level 11\Infinite Health
 80077A90 00FF
-#Level 11 Have 10 Gold Bars
+#Level 11\Have 10 Gold Bars
 80077B50 000A
-#Level 11 Infinite Lightning
+#Level 11\Infinite Lightning
 800D0040 0009
-#Scourge Boss Infinite Lives
+#Scourge Boss\Infinite Lives
 8005C9D0 0005
-#Scourge Boss Infinite Health
+#Scourge Boss\Infinite Health
 8005C9CC 0040
-#Original 2600 game Infinite Lives
+#Original 2600 game\Infinite Lives
 A6030FA8 00010002
-#Original 2600 game Infinite Time
+#Original 2600 game\Infinite Time
 A6030FB0 00130014
 
 ; [ Project - Horned Owl (USA) (1996) (Sony Computer Entertainment America) {SCUS-94408} <pjhorned> ]
@@ -41033,43 +42336,43 @@ C0038A74 0001
 800465C6 2400
 #Infinite Ammo
 8006B454 2400
-#Mission 2 - Police Academy Basic Pursuit Infinite Health
+#Mission 2 - Police Academy Basic Pursuit\Infinite Health
 8016C9F2 0000
-#Mission 3 - Police Academy Advanced Pursuit Infinite Health
+#Mission 3 - Police Academy Advanced Pursuit\Infinite Health
 8016D1D6 0000
-#Mission 4 - Police Academy Expert Pursuit
+#Mission 4 - Police Academy Expert Pursuit\Infinite Health
 8017533A 0000
-#Mission 5 - Dui Dummy Infinite Health
+#Mission 5 - Dui Dummy\Infinite Health
 801704FE 0000
-#Mission 6 - The Crazed Car Thief
+#Mission 6 - The Crazed Car Thief\Infinite Health
 801721F2 0000
-#Mission 7 - Gangbanger Deathmatch
+#Mission 7 - Gangbanger Deathmatch\Infinite Health
 801718CE 0000
-#Mission 8 - Bus Driver Gone Bad
+#Mission 8 - Bus Driver Gone Bad\Infinite Health
 80172D52 0000
-#Mission 9 - Drug Smuggling Scum
+#Mission 9 - Drug Smuggling Scum\Infinite Health
 8017408E 0000
-#Mission 10 - Race Against Death
+#Mission 10 - Race Against Death\Infinite Health
 80172B2E 0000
-#Mission 11 - Sentence Of Fire
+#Mission 11 - Sentence Of Fire\Infinite Health
 80173DD2 0000
-#Mission 12 - Nosey News Van
+#Mission 12 - Nosey News Van\Infinite Health
 801736BE 0000
-#Mission 13 - The Stool Pigeon
+#Mission 13 - The Stool Pigeon\Infinite Health
 80171906 0000
-#Mission 14 - Tank Rush
+#Mission 14 - Tank Rush\Infinite Health
 801720E6 0000
-#Mission 15 - Nothing Is Ever Routine
+#Mission 15 - Nothing Is Ever Routine\Infinite Health
 8017330A 0000
-#Mission 16 - Jacked Up Jailbird
+#Mission 16 - Jacked Up Jailbird\Infinite Health
 801722EA 0000
-#Mission 17 - Lou Ferris Returns
+#Mission 17 - Lou Ferris Returns\Infinite Health
 8017492A 0000
-#Mission 18 - Brazen Bank Bandits
+#Mission 18 - Brazen Bank Bandits\Infinite Health
 80175446 0000
-#Mission 19 - 30 Minutes Or Less
+#Mission 19 - 30 Minutes Or Less\Infinite Health
 80172402 0000
-#Mission 20 - Final Showdown
+#Mission 20 - Final Showdown\Infinite Health
 80172BCA 0000
 
 ; [ Pong - The Next Level (USA) (1999) (Hasbro Interactive) {SLUS-00889} <pongnext> ]
@@ -42189,61 +43492,61 @@ A60659BA 00010005
 
 ; [ Rampage 2 - Universal Tour (USA) (1999) (Midway Home Entertainment) {SLUS-00742} <rampage2> ]
 :SLUS-00742
-#Curtis Infinite Health
+#Curtis\Infinite Health
 801E0DA2 0044
-#Curtis Infinite Lives
+#Curtis\Infinite Lives
 801E0D9C 0005
-#Curtis Always Have Super Move
+#Curtis\Always Have Super Move
 801E0DAA 0044
-#Curtis Invincibility
+#Curtis\Invincibility
 801E0ED8 0001
-#Boris Infinite Health
+#Boris\Infinite Health
 801E0FC2 0044
-#Boris Infinite Lives
+#Boris\Infinite Lives
 801E0FBC 0005
-#Boris Always Have Super Move
+#Boris\Always Have Super Move
 801E0FCA 0044
-#Boris Invincibility
+#Boris\Invincibility
 801E10F8 0001
-#Ruby Infinite Health
+#Ruby\Infinite Health
 801E11E2 0044
-#Ruby Infinite Lives
+#Ruby\Infinite Lives
 801E11DC 0005
-#Ruby Always Have Super Move
+#Ruby\Always Have Super Move
 801E11EA 0044
-#Ruby Invincibility
+#Ruby\Invincibility
 801E1318 0001
-#George Infinite Health
+#George\Infinite Health
 801E1402 0044
-#George Infinite Lives
+#George\Infinite Lives
 801E13FC 0005
-#George Always Have Super Move
+#George\Always Have Super Move
 801E140A 0044
-#George Invincibility
+#George\Invincibility
 801E1538 0001
-#Lizzie Infinite Health
+#Lizzie\Infinite Health
 801E1622 0044
-#Lizzie Infinite Lives
+#Lizzie\Infinite Lives
 801E161C 0005
-#Lizzie Always Have Super Move
+#Lizzie\Always Have Super Move
 801E162A 0044
-#Lizzie Invincibility
+#Lizzie\Invincibility
 801E1758 0001
-#Ralph Infinite Health
+#Ralph\Infinite Health
 801E1842 0044
-#Ralph Infinite Lives
+#Ralph\Infinite Lives
 801E183C 0005
-#Ralph Always Have Super Move
+#Ralph\Always Have Super Move
 801E184A 0044
-#Ralph Invincibility
+#Ralph\Invincibility
 801E1978 0001
-#Myukus Infinite Health
+#Myukus\Infinite Health
 801E1A62 0044
-#Myukus Infinite Lives
+#Myukus\Infinite Lives
 801E1A5C 0005
-#Myukus Always Have Super Move
+#Myukus\Always Have Super Move
 801E1A6A 0044
-#Myukus Invincibility
+#Myukus\Invincibility
 801E1B98 0001
 #Enable George
 801F9A4A 0000
@@ -42258,37 +43561,37 @@ A60659BA 00010005
 
 ; [ Rampage - Through Time (USA) (2000) (Midway Home Entertainment) {SLUS-01065} <rampagtt> ]
 :SLUS-01065
-#Curtis - Infinite Health
+#Curtis\Infinite Health
 801F6A56 0044
-#Curtis - Infinite Special
+#Curtis\Infinite Special
 801F6A5A 0044
-#Boris - Infinite Health
+#Boris\Infinite Health
 801F6BDA 0044
-#Boris - Infinite Special
+#Boris\Infinite Special
 801F6BDE 0044
-#Ruby - Infinite Health
+#Ruby\Infinite Health
 801F6D5E 0044
-#Ruby - Infinite Special
+#Ruby\Infinite Special
 801F6D62 0044
-#George - Infinite Health
+#George\Infinite Health
 801F6EE2 0044
-#George - Infinite Special
+#George\Infinite Special
 801F6EE6 0044
-#Lizzie - Infinite Health
+#Lizzie\Infinite Health
 801F7066 0044
-#Lizzie - Infinite Special
+#Lizzie\Infinite Special
 801F706A 0044
-#Ralph - Infinite Health
+#Ralph\Infinite Health
 801F71EA 0044
-#Ralph - Infinite Special
+#Ralph\Infinite Special
 801F71EE 0044
-#Myukus - Infinite Health
+#Myukus\Infinite Health
 801F736E 0044
-#Myukus - Infinite Special
+#Myukus\Infinite Special
 801F7372 0044
-#Harley - Infinite Health
+#Harley\Infinite Health
 801F74F2 0044
-#Harley - Infinite Special
+#Harley\Infinite Special
 801F74F6 0044
 #P1 Have All 9 Stars
 801F8268 0009
@@ -42458,6 +43761,12 @@ D01F7EDA FFDE
 800BCFFC 00A0
 #Infinite Air
 A60669E2 A604A600
+#Moon Jump
+F406A000 00AA5000
+4400048E 00000000
+0D008128 0E002014
+AAAA0024 AAAAAAAA
+AAAAAAAA AAAAAAAA
 #Have level complete The Clearing
 D00100D4 4465
 300A6BB0 000A
@@ -43106,6 +44415,21 @@ C00CF844 0021
 800C8752 0F2C
 50001302 0001
 800C8758 0F30
+#Select Character\Chris
+A7044822 90A43404
+A7044832 90A33403
+#Select Character\Jill
+A7044820 00000001
+A7044830 00000001
+A7044822 90A43404
+A7044832 90A33403
+#Select Character\Rebecca
+A7044820 00000003
+A7044830 00000003
+A7044822 90A43404
+A7044832 90A33403
+#Character Alternative Costume:You will need to restart the game after turning this cheat off
+A704483A 30622400
 
 ; [ Resident Evil 2 (USA) (1998) (Capcom Entertainment) {SLUS-00421 / SLUS-00592} <revil2> ]
 :SLUS-00421
@@ -43147,6 +44471,14 @@ D00CFB76 0000
 300CFB77 0001
 #All Characters + Levels (Extreme Battle Mode)
 800CFB98 0200
+#Quick Turn Claire (Down + Square)
+E00CE2B5 0040
+E00CE2B8 0080
+100CFC26 0401
+#Quick Turn Leon (Down + Square)
+E00CE2FD 0040
+E00CE300 0080
+100CFC6E 0401
 
 ; [ Resident Evil 3 - Nemesis (USA) (1999) (Capcom Entertainment) {SLUS-00923D, SLUS-00923GH} <revil3> ]
 :SLUS-00923
@@ -43234,6 +44566,33 @@ A6044E18 00060001
 3009E4C1 000D
 3009E4C8 0001
 3009E4C9 000F
+#Matrix Mode (Press L3 On/Off, Hold L1 for slo-mo)
+D7010001 00000200
+F501BBA6 10401000
+F5023E3A 10401000
+00000000 0000FFFF
+900292E8 92A3018C
+D7200000 01000004
+900292E8 24030004
+#Alt Matrix Mode (Press L3 On/Off, Press L1 On/Off for slo-mo)
+D7010001 00000200
+F501BBA6 10401000
+F5023E3A 10401000
+00000000 0000FFFF
+D7010001 01000004
+F50292E8 018C0006
+F50292EA 92A32403
+#Dodge On Command With R2
+8003925C 0701
+8003925E 3402
+8003A53C 0701
+8003A53E 3402
+80039778 0701
+8003977A 3402
+80039EC0 0701
+80039EC2 3402
+80039B24 0701
+80039B26 3402
 #Auto Dodge Zombies (Hold L3)
 D5000000 00000200
 F4104BD0 00AA7000
@@ -43248,6 +44607,62 @@ F4104BD0 00AA7000
 AAAAAAAA AAAAAAAA
 0500AAAA AAAAAAAA
 AAAAAAAA AAAAAAAA
+#Ready Your Weapon Faster - Disables Auto-Aim
+A703EE1A 10402400
+#Mines Have Red Electricity
+A701B906 14461000
+#Select initial 'Mine Thrower' damage type\Knife
+A70455DE 000C0001
+#Select initial 'Mine Thrower' damage type\Mercs Handgun
+A70455DE 000C0002
+#Select initial 'Mine Thrower' damage type\Handgun
+A70455DE 000C0003
+#Select initial 'Mine Thrower' damage type\Shotgun
+A70455DE 000C0004
+#Select initial 'Mine Thrower' damage type\Magnum
+A70455DE 000C0005
+#Select initial 'Mine Thrower' damage type\Grenade EXG
+A70455DE 000C0006
+#Select initial 'Mine Thrower' damage type\Grenade FLG
+A70455DE 000C0007
+#Select initial 'Mine Thrower' damage type\Grenade ACG
+A70455DE 000C0008
+#Select initial 'Mine Thrower' damage type\Grenade FRZ
+A70455DE 000C0009
+#Select initial 'Mine Thrower' damage type\R Launcher
+A70455DE 000C000A
+#Select initial 'Mine Thrower' damage type\Gatling Gun
+A70455DE 000C001B
+#Select initial 'Mine Thrower' damage type\Mine Thrower
+A70455DE 000C001C
+#Select initial 'Mine Thrower' damage type\Mine Thrower E
+A70455DE 000C0014
+#Select initial 'Mine Thrower' damage type\Eagle 6.0
+A70455DE 000C000D
+#Select initial 'Mine Thrower' damage type\AS Rifle
+A70455DE 000C000E
+#Select initial 'Mine Thrower' damage type\As Rifle 2
+A70455DE 000C000F
+#Select initial 'Mine Thrower' damage type\Western Custom
+A70455DE 000C0010
+#Select initial 'Mine Thrower' damage type\Sigpro E
+A70455DE 000C0011
+#Select initial 'Mine Thrower' damage type\M92F E
+A70455DE 000C0012
+#Select initial 'Mine Thrower' damage type\Benelli M3S E
+A70455DE 000C0013
+#Remote Detonate Mines (Hold L1)
+800464B2 00001000
+D7200000 01000004
+800464B2 00002400
+#Increased Reverb 
+A707E99A 112B1000
+#Remove Cutscene Black Bars
+A7029D62 10601000
+#Disable Choice Events
+A7023BA6 10401000
+#No choice menu
+A702FEBA 10401000
 #60 FPS Beta
 800101BC 0000FFFF
 10027F44 00000001
@@ -43268,8 +44683,11 @@ E00CCBC9 0000000F
 A70CCCE0 40A4407C
 
 ; [ Resident Evil - Director's Cut (USA) (1997) (Capcom Entertainment) {SLUS-00551} <revildc> ]
-;:SLUS-00551
-;This game currently has no cheats
+:SLUS-00551
+#Quick Turn (Down + Square)
+E00CF845 0040
+E00CF848 0080
+100C5198 03E8
 
 ; [ Resident Evil - Director's Cut - Dual Shock Ver. (USA) (1998) (Capcom Entertainment) {SLUS-00747} <revildcds> ]
 :SLUS-00747
@@ -43520,33 +44938,33 @@ A60BE36C 00000005
 800DFE46 03E7
 #Max Inotium
 9004BBE8 05F5E0FF
-#Character 1 Infinite HP
+#Character 1\Infinite HP
 8004BFFC 03E7
-#Character 1 Infinite MP
+#Character 1\Infinite MP
 8004BFFE 03E7
-#Character 1 Max HP
+#Character 1\Max HP
 8004C000 03E7
-#Character 1 Max MP
+#Character 1\Max MP
 8004C002 03E7
-#Character 2 Infinite HP
+#Character 2\Infinite HP
 8004C020 03E7
-#Character 2 Infinite MP
+#Character 2\Infinite MP
 8004C022 03E7
-#Character 3 Infinite HP
+#Character 3\Infinite HP
 8004C044 03E7
-#Character 3 Infinite MP
+#Character 3\Infinite MP
 8004C046 03E7
-#Character 4 Infinite HP
+#Character 4\Infinite HP
 8004C068 03E7
-#Character 4 Infinite MP
+#Character 4\Infinite MP
 8004C06A 03E7
-#Character 5 Infinite HP
+#Character 5\Infinite HP
 8004C08C 03E7
-#Character 5 Infinite MP
+#Character 5\Infinite MP
 8004C08E 03E7
-#Character 6 Infinite HP
+#Character 6\Infinite HP
 8004C0B0 03E7
-#Character 6 Infinite MP
+#Character 6\Infinite MP
 8004C0B2 03E7
 #Have All/Infinite Items
 50001601 0000
@@ -47155,53 +48573,53 @@ A71DD2E0 10000C00
 ; [ Shadow Madness (USA) (1999) (Crave Entertainment) {SLUS-00468 / SLUS-00718} <shadwmad> ]
 :SLUS-00468
 :SLUS-00718
-#Clementt Infinite HP
+#Clementt\Infinite HP
 8010B602 03E7
-#Clementt Max HP
+#Clementt\Max HP
 8010B604 03E7
-#Clementt Infinite MP
+#Clementt\Infinite MP
 8010B606 03E7
-#Clementt Max MP
+#Clementt\Max MP
 8010B608 03E7
-#Harv-5Infinite HP
+#Harv-5\Infinite HP
 8010B5C4 03E7
-#Harv-5 Max HP
+#Harv-5\Max HP
 8010B5C6 03E7
-#Harv-5 Infinite MP
+#Harv-5\Infinite MP
 8010B5C8 03E7
-#Harv-5 Max MP
+#Harv-5\Max MP
 8010B5CA 03E7
-#Jirina Infinite HP
+#Jirina\Infinite HP
 8010B50A 03E7
-#Jirina Max HP
+#Jirina\Max HP
 8010B50C 03E7
-#Jirina Infinite MP
+#Jirina\Infinite MP
 8010B50E 03E7
-#Jirina Max MP
+#Jirina\Max MP
 8010B510 03E7
-#Stinger Infinite HP
+#Stinger\Infinite HP
 8010B586 03E7
-#Stinger Max HP
+#Stinger\Max HP
 8010B588 03E7
-#Stinger Infinite MP
+#Stinger\Infinite MP
 8010B58A 03E7
-#Stinger Max MP
+#Stinger\Max MP
 8010B58C 03E7
-#Windleaf Infinite HP
+#Windleaf\Infinite HP
 8010B4CC 03E7
-#Windleaf Max HP
+#Windleaf\Max HP
 8010B4CE 03E7
-#Windleaf Infinite MP
+#Windleaf\Infinite MP
 8010B4D0 03E7
-#Windleaf Max MP
+#Windleaf\Max MP
 8010B4D2 03E7
-#Xero Infinite HP
+#Xero\Infinite HP
 8010B548 03E7
-#Xero Max HP
+#Xero\Max HP
 8010B54A 03E7
-#Xero Infinite MP
+#Xero\Infinite MP
 8010B54C 03E7
-#Xero Max MP
+#Xero\Max MP
 8010B54E 03E7
 
 ; [ Shadow Master (USA) (1998) (Psygnosis) {SLUS-00545} <shadwmst> ]
@@ -47439,6 +48857,28 @@ D00BC76C 2400
 300C48B5 0064
 #How Many Games Cleared Max
 300BCC7E 00FF
+#Kill Mostly All Enemies Near You (Press L3)
+D7010001 01000200
+800BA222 00000FFF
+800BA34A 00000FFF
+800BA472 00000FFF
+800BA59A 00000FFF
+800BA6C2 00000FFF
+800BA7EA 00000FFF
+#Quick Turn (Down + Square)
+E00BC76E 0004
+E00BC771 0080
+100BA032 03E8
+#FPS Unlock
+A70132A2 10401000
+#Solid Snow
+A70CED8E 10401400
+#Thicker Snow
+A70CEE1E 10401400
+#Freeze Snow Mid-Air
+A70CE902 14401400
+#Remove Snow
+A70CEDF2 10401000
 #Widescreen 16-9
 A70C6FE0 10000C00
 A70C6FF0 10000C00
@@ -49832,6 +51272,18 @@ C2067446 0002
 300698BF 0001
 #World 3\More Misc.\All Abilities
 300698B0 0001
+#Floating Water
+A7023E32 10601000
+#Halve Animation Speed Spyro
+A70423A2 11A01000
+#Spyro Alternative Wing Tips
+A7042E2E 1A402400
+#See Items Through Walls
+A70474F2 04212400
+#See Organisms Through walls
+A7043FBA 05412400
+#Make Spirit Collection Icon Color Lilac
+A70520FA 14402400
 #Widescreen 16-9
 8001C354 2081
 8001C356 0800
@@ -50467,7 +51919,7 @@ A711E878 10000C00
 #Infinite Ammo
 8004C1F2 3C00
 
-; [ Starblade Î± (USA) (1996) (Namco Hometek) {SLUS-00057} <starblad> ]
+; [ Starblade α (USA) (1996) (Namco Hometek) {SLUS-00057} <starblad> ]
 :SLUS-00057
 #Infinite Credits
 80075898 000F
@@ -51290,6 +52742,16 @@ E00775F4 0040
 300B82E8 0003
 #All Characters Use Obi-Wan's Weapon Codes
 800B86F4 0000
+#Walk Through Walls L3/R3 On/Off
+E00775F5 0002
+8005A732 1400
+E00775F5 0004
+8005A732 0500
+#Look Through Walls (Hold L1+R1)
+800538A2 00001000
+D7100000 0000000C
+800538A2 0000106C
+00000000 0000FFFF
 #Select Action\Swing Sword (Fast)
 80086674 0001
 #Select Action\Double Jump
@@ -52657,6 +54119,16 @@ A706F2C8 10000C00
 800ACBB8 0000
 #Tournament Race Class 4 Tour 2 Finished 1st
 800ACC08 0000
+#Drive Through Walls
+D7000000 00000200
+8003321A 00001000
+80033636 00001000
+800333BA 00001000
+00000000 0000FFFF
+D7000000 00000400
+8003321A 00000621
+80033636 00000601
+800333BA 00000621
 #Widescreen 16-9
 A70A56C0 10000C00
 
@@ -58837,6 +60309,8 @@ A709EE4C 10000C00
 #Cheat Menu (Press Select)
 D010C426 FFFE
 800C37C8 0004
+#No Gun Flash
+A70137F6 10401000
 
 ; [ Time Crisis - Project Titan (USA) (2001) (Namco Hometek) {SLUS-01336} <timecrpt> ]
 :SLUS-01336
@@ -59301,6 +60775,24 @@ C200C00C 0002
 800E7EB4 0000
 C200C00E 0002
 800E7EB6 0000
+#Hit Pigs From Anywhere
+80021A1E 00002400
+D7100000 00000020
+80021A1E 00001080
+#Grapple Almost Anything
+A706997E 15022400
+#Infinite Weapons Range (All Weapons)
+D7000000 00000020
+8006A26E 00001400
+8006B22A 00001400
+00000000 0000FFFF
+D7100000 00000020
+8006A26E 00001067
+8006B22A 00001067
+#Uncap FPS Full
+A7050CF2 14402400
+#Uncap FPS At 60 FPS (Needs Slight Overclock to remain stable)
+A7050CDA 00432400
 
 ; [ Tom and Jerry in House Trap (USA) (2000) (NewKidCo) {SLUS-01191} <tomjerry> ]
 :SLUS-01191
@@ -64819,6 +66311,10 @@ D0079EB4 0002
 #Infinite Ammo All Weapons
 50003E04 0000
 8014B4EE 0001
+#Disable Movement
+A7072A86 10401000
+#Walk Up Steep Walls
+A7063ECA 14401000
 #P1 Indestructable Worm 1
 8014AAA8 0064
 #P1 Indestructable Worm 2
@@ -65954,7 +67450,7 @@ D00417CA AE02
 80131EA4 0002
 #Xevious 3D\P2 Infinite Lives
 8012DD5C 0009
-##Xevious 3D\P2 Invincibility
+#Xevious 3D\P2 Invincibility
 801468D4 0002
 
 ; [ The X-Files (USA) (1999) (Fox Interactive) {SLUS-00915 / SLUS-00949 / SLUS-00950 / SLUS-00951} <xfiles> ]
@@ -66113,7 +67609,14 @@ A70A26FC 19991333
 #Press Select To Open Ex Menu At Main Menu
 D00420D0 0100
 80042180 0107
-#Hit Your Opponent Anywhere
+#Do Insane Hit Anywhere Combo (Hold Select):You need to have hit the player at least once because it repeats your last attack
+800327CA 00001040
+D7000000 00000100
+800327CA 00001400
+#Hit Anywhere
+A7032D2A 10401400
+A703346E 10401400
+#Hit Your Opponent Anywhere (ALT)
 8003346E 2400
 800334EE 2400
 #P1 Infinite Energy
@@ -66131,6 +67634,8 @@ C0097D56 000A
 00000000 FFFF
 #P1 Play As Apocalypse
 80042A64 0010
+#P1 Faster Character
+A7033F12 10402400
 #P2 Infinite Energy
 80042F7C 0090
 80042F84 0090
@@ -66142,6 +67647,10 @@ C0097D56 000A
 80042F7C 0001
 80042F84 0001
 00000000 FFFF
+#P2 Faster Character
+A7033E36 10402400
+#Uncap Gamespeed to 120 FPS
+A701199A 04812400
 
 ; [ X Games Pro Boarder (USA) (1998) (Electronic Arts) {SLUS-00704} <xpboard> ]
 :SLUS-00704
@@ -66334,7 +67843,7 @@ A61B40B6 00000098
 ;:DUS0005-I
 ;This game currently has no cheats
 
-; [ Cheats 'N Volume 1 (USA) (2000) (<unlicensed>) {G-22811} <cheatsv1> ]
+; [ Cheats 'N Codes Volume 1 (USA) (2000) (<unlicensed>) {G-22811} <cheatsv1> ]
 ;:G-22811
 ;This game currently has no cheats
 
@@ -67643,6 +69152,15 @@ AAAAAAAA AAAAAAAA
 ;:SCUS-94475
 ;This game currently has no cheats
 
+; [ Creature Shock (Jpn) (1996) (Data East) {SLPS-00120~SLPS-00121} <crshock> ]
+;:SLPS-00120
+;:SLPS-00121
+;This game currently has no cheats
+
+; [ Depth (Jpn) (1996) (Sony Computer Entertainment) {SCPS 18003} <depth> ]
+;:SCPS18003
+;This game currently has no cheats
+
 ; [ Front Mission 1st (Jpn) (2003) (Square Enix) {SLPM-87317} <frontmis> ]
 :SLPM-87317
 #Main unit Infinite Body HP
@@ -67668,6 +69186,10 @@ D014B930 327E
 
 ; [ Leading Jockey Highbred (Jpn) (1996) (Harvest One) {SLPS-00348} <leadingj> ]
 ;:SLPS-00348
+;This game currently has no cheats
+
+; [ Pi to Mail (Jpn) (1999) (Hudson) {SLPS-01866} <pitomail> ]
+;:SLPS-01866
 ;This game currently has no cheats
 
 ; [ Raiden DX (Jpn, Major Wave Series) (2000) (Hamster) {SLPM-86656} <raidendx> ]
@@ -67722,6 +69244,11 @@ C00460EC 0005
 900460EC 08011853
 00000000 FFFF
 
+; [ Sentou Kokka: Air Land Battle (Jpn, Rev. 1) (1995) (Sony Computer Entertainment) {SCPS 10015, SCPS 91008} <sentokka> ]
+;:SCPS10015
+;:SCPS91008
+;This game currently has no cheats
+
 ; [ Side by Side Special 2000 (Jpn) (1999) (Taito) {SLPM-86344 (TCPS10011)} <sidebs2k> ]
 :SLPM-86344
 #Infinite Checkpoint Time
@@ -67730,6 +69257,11 @@ C00460EC 0005
 8008B3C0 0000
 #Total Time 00:00:00/1st
 8008B418 0000
+
+; [ Wares 1092: Souheiden (Jpn) (1997) (Yutaka) {SLPS 00596 (104017-0052421-9800), SLPS 00740 (104017-0051785-5800)} <wares> ]
+;:SLPS00596
+;:SLPS00740
+;This game currently has no cheats
 
 ; [ World Neverland - Olerud Oukoku Monogatari (Jpn) (1997) (Riverhill Soft) {SLPS-01037, SLPS-91086 (Playstation the Best)} <worldnev> ]
 :SLPS-01037
@@ -67838,6 +69370,15 @@ C01C50A4 0603
 80169372 1000
 #Infinite Time
 80170B9C 0DEA
+#Widescreen 16-9
+A7161F60 10000C00
+#Widescreen 16-9 (Secondary)
+A7161F60 10000C00
+#Widescreen 16-9 (Cut Scenes)
+A7066F70 10000C00
+A7071F40 10000C00
+A707B4F0 10000C00
+A7116A68 10000C00
 
 ; [ Ad Lib Ouji ...to Fuyukai na Nakamatachi!? (Jpn) (2002) (Nihon Telenet) {SLPS-03510} <adlibouj> ]
 :SLPS-03510
@@ -67914,6 +69455,12 @@ A6095732 00460000
 :SLPS-00559
 #Invincibility
 800B4F9C 0006
+#Shield Has A Comeback
+8002F692 8C23
+#Infinite Credit
+80027BC2 8022
+#Infinite Overdrive
+800B52E4 0100
 
 ; [ The Airs (Jpn) (1999) (Victor Interactive Software) {SLPS-01916} <airs> ]
 :SLPS-01916
@@ -68676,7 +70223,7 @@ A6020E3E 00440040
 #P1 Select Character\K-2
 801AD948 000B
 
-; [ Advanced V.G. 2 (Jpn, SuperLite 1500 Series) (2003) (TGL) {SLPM-87226 (SuperLite 1500 Series)} <avg2> ]
+; [ Advanced V.G. 2 (Jpn, SuperLite 1500 Series) (2003) (TGL) {SLPM-87226} <avg2> ]
 ;:SLPM-87226
 ;This game currently has no cheats
 
@@ -70162,7 +71709,7 @@ D01E4EEA 7FFF
 #Infinite Special Attack Captain Harlock
 801BDF77 0063
 
-; [ MÃ¤rchen Adventure Cotton 100% (Jpn, SuperLite 1500 Series) (2003) (Success) {SLPM-87211} <cotton> ]
+; [ Märchen Adventure Cotton 100% (Jpn, SuperLite 1500 Series) (2003) (Success) {SLPM-87211} <cotton> ]
 :SLPM-87211
 #Infinite Lives
 800CA284 0008
@@ -70609,7 +72156,7 @@ D0053408 000C
 #P2 Infinite HP
 8005100E 1FE9
 
-; [ Dragon Ball Z - Ultimate Battle 22 (Jpn) (1995) (Bandai) {SLPS-00073} <dbzub22j> ]
+; [ Dragon Ball Z - Idainaru Dragon Ball Densetsu (Jpn) (1995) (Bandai) {SLPS-00073} <dbzub22j> ]
 :SLPS-00073
 #P1 Infinite Health
 800BE388 0190
@@ -70744,7 +72291,7 @@ D001004C 0100
 D01ACE00 FFFC
 800D6F50 0000
 
-; [ Densha Daisuki - Play Rail ga Ippai (Jpn) (1998) (Tomy) {SLPS-01753} <dendaisu> ]
+; [ Densha Daisuki - Plarail ga Ippai (Jpn) (1998) (Tomy) {SLPS-01753} <dendaisu> ]
 :SLPS-01753
 #Always 100 points
 80035548 0064
@@ -71118,7 +72665,7 @@ D002FE2A 2442
 
 ; [ Doki Doki Shutter Chance - Koi no Puzzle o Kumitatete (Jpn) (1997) (Nippon Ichi Software) {SLPS-01038} <dokishut> ]
 :SLPS-01038
-"Have All Pieces Of The Puzzle
+#Have All Pieces Of The Puzzle
 800E018A 0024
 800F7944 0024
 
@@ -71441,7 +72988,7 @@ A6089BF4 FFFF0000
 ;:SLPS-00090
 ;This game currently has no cheats
 
-; [ Ã©lan (Jpn) (1999) (Visco) {SLPS-01925} <elan> ]
+; [ élan (Jpn) (1999) (Visco) {SLPS-01925} <elan> ]
 :SLPS-01925
 #No Stress
 8004C9D4 0000
@@ -71500,7 +73047,7 @@ A6089BF4 FFFF0000
 #Sub character ending flag Sarai
 8004C8E0 0400
 
-; [ Ã©lan plus (Jpn) (2000) (Visco) {SLPS-02759} <elanplus> ]
+; [ élan plus (Jpn) (2000) (Visco) {SLPS-02759} <elanplus> ]
 :SLPS-02759
 #No stress
 80051164 0000
@@ -71596,7 +73143,7 @@ A6089BF4 FFFF0000
 #Max Money (Press L2+Up)
 D0050C50 1001
 800FDF3C FFFF
-"VICTORY PRESS Triangle + L1
+#VICTORY PRESS Triangle + L1
 D0050DD8 0014
 8012EBC4 0000
 
@@ -72174,7 +73721,7 @@ D011CA7A FFFE
 
 ; [ Forget me not - Palette (Jpn) (2001) (Enterbrain) {SLPS-03191} <fgtmenot> ]
 :SLPS-03191
-"Infinite Moves in memories world (Can Freeze the game)
+#Infinite Moves in memories world (Can Freeze the game)
 800F8738 0009
 
 ; [ Final Doom (Jpn) (1997) (Soft Bank) {SLPS-00727} <findoomj> ]
@@ -72467,7 +74014,7 @@ D007095A 1440
 #Infinite Time
 8018D430 99D4
 
-; [ Î“Î‘Î›Î•ÎŸÎ– (Jpn) (1996) (Atlus) {SLPS-00621} <galeoz> ]
+; [ GALEOZ (Jpn) (1996) (Atlus) {SLPS-00621} <galeoz> ]
 :SLPS-00621
 #Infinite Bullets
 801B5B36 000A
@@ -73150,7 +74697,7 @@ D013F5FA FFFE
 #Widescreen 16-9
 8013BA70 0C00
 
-; [ Golgo 13 (1) - Karairu no Yabou (Jpn) (1998) (Daiki) {SLPS-01712} <golgo13k> ]
+; [ Golgo 13 - 1 - Karairu no Yabou (Jpn) (1998) (Daiki) {SLPS-01712} <golgo13k> ]
 ;:SLPS-01712
 ;This game currently has no cheats
 
@@ -73336,7 +74883,7 @@ B0030004 0000
 #En-S3 Max 9999
 80117B62 270F
 
-; [ Hai-Shin-2 (Jpn) (1998) (Aques) {SLPM-86066} <haishin2> ]
+; [ Hai-Shin-2 (Jpn) (1998) (Squaresoft) {SLPM-86066} <haishin2> ]
 :SLPM-86066
 #Player has 99999 points
 901C71B0 0001869F
@@ -73360,7 +74907,7 @@ B0030004 0000
 80010010 3F3F
 3001023B 0014
 
-; [ Happy Salvage (Jpn, Disc 1 Only) (2000) (MediaWorks) {SLPS-02821} <happyslv> ]
+; [ Happy Salvage (Jpn) (2000) (MediaWorks) {SLPS-02821} <happyslv> ]
 :SLPS-02821
 #Infinity Air
 800F2D12 03E7
@@ -74801,7 +76348,7 @@ D00CB82C 0102
 ;:SLPS-01338
 ;This game currently has no cheats
 
-; [ KoukÎ»oÎ¸ÎµÎ±tÏo - Yuukyuu no Hitomi (Jpn) (1999) (Sunsoft) {SLPS-02385} <koukrose> ]
+; [ Kouklotheatro - Yuukyuu no Hitomi (Jpn) (1999) (Sunsoft) {SLPS-02385} <koukrose> ]
 :SLPS-02385
 #Infinite Health Luke Maximum HP
 8008F50A 03E7
@@ -75825,13 +77372,13 @@ A7021BB6 10401000
 
 ; [ Masumon Kids - The Another World of The Master of Monsters (Jpn) (1998) (Toshiba EMI) {SLPS-01426} <masumkid> ]
 :SLPS-01426
-"Infinite Energy Character 1
+#Infinite Energy Character 1
 90020B94 03E703E7
-"Infinite Energy Character 2
+#Infinite Energy Character 2
 90020C60 03E703E7
-"Infinite Energy Character 3
+#Infinite Energy Character 3
 90020D2C 03E703E7
-"Infinite Money (999999)
+#Infinite Money (999999)
 901E05BC 000F423F
 
 ; [ MaxRacer (Jpn) (1997) (PD) {SLPS-00795} <maxracer> ]
@@ -76093,7 +77640,7 @@ A603A7B8 FFE90001
 #Mortal blow
 A603566E 00430000
 
-; [ Meta-Ph-List Î¼.Ï‡.2297 (Jpn) (1997) (A.D.M) {SLPS-00680~SLPS-00681} <metaphls> ]
+; [ Meta-Ph-List μ.χ.2297 (Jpn) (1997) (A.D.M) {SLPS-00680~SLPS-00681} <metaphls> ]
 :SLPS-00680
 :SLPS-00681
 #Infinite Shield
@@ -76289,7 +77836,8 @@ D0025112 A385
 300A373C 0007
 #Widescreen 16-9
 800FE2B0 0C00
-
+#Dither Off
+A7054300 02000000
 
 ; [ Pro Mahjong Kiwame Plus (Jpn) (1996) (Athena) {SLPS-00402} <mjkiwamp> ]
 :SLPS-00402
@@ -76722,7 +78270,7 @@ E21AE8CC 008C
 D00CE928 0003
 800E5ED2 1E00
 
-; [ Nage Libre - Rasen No Soukoku (1997) (Varie) {SLPS-00692} <nagelibr> ]
+; [ Nage Libre - Rasen No Soukoku (Jpn) (1997) (Varie) {SLPS-00692} <nagelibr> ]
 :SLPS-00692
 #Infinite HP Makoto
 900B3820 03E703E7
@@ -76944,7 +78492,7 @@ A7047D5A 14401000
 #Have 9999 Food
 8012ACCA 270F
 
-; [ NOÃ«L 3 - Mission on the Line (Jpn) (1999) (Pioneer LDC) {SLPS-01895~SLPS-01897} <noel3> ]
+; [ NOëL 3 - Mission on the Line (Jpn) (1999) (Pioneer LDC) {SLPS-01895~SLPS-01897} <noel3> ]
 ;:SLPS-01895
 ;:SLPS-01896
 ;:SLPS-01897
@@ -77224,7 +78772,7 @@ E0089E24 0001
 
 ; [ Oshigotoshiki Jinsei Game - Mezase Shokugyou-oh (Jpn) (2000) (Takara) {SLPS-03056} <oshijins> ]
 :SLPS-03056
-"Player has 999999 money
+#Player has 999999 money
 900C2214 000F423F
 
 ; [ One Two Smash - Tanoshii Tennis (Jpn, Honkakuha de 1300Yen Series) (2000) (Hect) {SLPS-02585} <otsmash> ]
@@ -77763,15 +79311,15 @@ D00A5584 0100
 ;:SLPS-03442
 ;This game currently has no cheats
 
-; [ Power Stakes (Jpn) (1997) (Aques) {SLPM-86032} <pstakes> ]
+; [ Power Stakes (Jpn) (1997) (Squaresoft) {SLPM-86032} <pstakes> ]
 ;:SLPM-86032
 ;This game currently has no cheats
 
-; [ Power Stakes Grade 1 (Jpn) (1997) (Aques) {SLPM-86050} <pstakg1> ]
+; [ Power Stakes Grade 1 (Jpn) (1997) (Squaresoft) {SLPM-86050} <pstakg1> ]
 ;:SLPM-86050
 ;This game currently has no cheats
 
-; [ Pro Logic Mahjong Hai-Shin (Jpn) (1997) (Aques) {SLPM-86018} <prologmj> ]
+; [ Pro Logic Mahjong Hai-Shin (Jpn) (1997) (Squaresoft) {SLPM-86018} <prologmj> ]
 :SLPM-86018
 #Player has 99900 points
 800FB168 03E7
@@ -78125,7 +79673,7 @@ D00CF3A6 2462
 #Walk Through Enemies
 8018874E FFFF
 
-; [ Ranma Â½ - Battle Renaissance (Jpn) (1996) (Shogakukan) {SLPS-00522} <ranma> ]
+; [ Ranma ½ - Battle Renaissance (Jpn) (1996) (Shogakukan) {SLPS-00522} <ranma> ]
 :SLPS-00522
 #P1 Infinite Energy
 800C7A5C 00C0
@@ -78641,7 +80189,7 @@ D00E50A0 0100
 #Enemy does not come out
 30079C8C 0000
 
-; [ SchrÃ¶dinger no Neko - Die Katze von SchrÃ¶dinger (Jpn) (1997) (Takara) {SLPS-00780} <schrodin> ]
+; [ Schrödinger no Neko - Die Katze von Schrödinger (Jpn) (1997) (Takara) {SLPS-00780} <schrodin> ]
 :SLPS-00780
 #Infinite Energy
 80154A04 0063
@@ -78664,11 +80212,11 @@ D00E50A0 0100
 50002004 0000
 80156C9E 0001
 
-; [ Simple Characters 2000 Series Vol.02 - Afro Ken - The Puzzle (Jpn) (2001) (Bandai) {SLPS-03307} <scs01afr> ]
+; [ Simple Characters 2000 Series Vol.02 - Afro Ken - The Puzzle (Jpn) (2001) (Bandai) {SLPS-03307} <scs02afr> ]
 ;:SLPS-03307
 ;This game currently has no cheats
 
-; [ Simple Characters 2000 Series Vol.03 - Kamen Rider - The Bike Race (Jpn) (2001) (Bandai) {SLPS-03308} <scs02kmn> ]
+; [ Simple Characters 2000 Series Vol.03 - Kamen Rider - The Bike Race (Jpn) (2001) (Bandai) {SLPS-03308} <scs03kmn> ]
 :SLPS-03308
 #Quick Win - Press L1 Wait till you're in first position only then press L1 to finish the race.
 D0197D4A FBFF
@@ -79076,7 +80624,7 @@ D005A90C 000C
 ;:SCPS-45510
 ;This game currently has no cheats
 
-; [ Shibas 1-2-3 - Destiny! Unmei O Kaerusha! (Jpn) (2000) (Jaleco) {SLPS-01893} <shiba123> ]
+; [ Shiibas 1-2-3 - Destiny! Unmei O Kaerusha! (Jpn) (2000) (Jaleco) {SLPS-01893} <shiba123> ]
 :SLPS-01893
 #Infinite Energy In Battle
 800CD49C 00C8
@@ -79241,7 +80789,7 @@ C004D900 3659
 #Invincibility
 801B9968 FFFF
 
-; [ Silent MÃ¶bius - Genei no Datenshi (Jpn, Disc 1 Only) (1998) (Bandai) {SLPS-01803} <silentmb> ]
+; [ Silent Möbius - Genei no Datenshi (Jpn, Disc 1 Only) (1998) (Bandai) {SLPS-01803} <silentmb> ]
 :SLPS-01803
 #Katsumi Infinite HP In Battle
 801EBA9C 00B4
@@ -79441,7 +80989,7 @@ C0136C2A 0004
 ;:SLPM-87051
 ;This game currently has no cheats
 
-; [ Simple 1500 Jitsuyou Series Vol.16 - Neko no Kaikata - Sekai no Neko Catalo (Jpn) (2002) (D3 Publisher) {SLPM-87052} <sjs16nek> ]
+; [ Simple 1500 Jitsuyou Series Vol.16 - Neko no Kaikata - Sekai no Neko Catalog (Jpn) (2002) (D3 Publisher) {SLPM-87052} <sjs16nek> ]
 ;:SLPM-87052
 ;This game currently has no cheats
 
@@ -79481,7 +81029,7 @@ D0088D72 FFFE
 #Widescreen 16-9
 80200464 0C00
 
-; [ Super Live Stadium (Jpn) (1998) (Aques) {SLPM-86019} <slivstad> ]
+; [ Super Live Stadium (Jpn) (1998) (Squaresoft) {SLPM-86019} <slivstad> ]
 :SLPM-86019
 #Strike 2, 0 ball, 2 out in the select + left button
 C009DC68 7EFF
@@ -79760,7 +81308,7 @@ D00535CC 1023
 ;:SLPM-86864
 ;This game currently has no cheats
 
-; [ Simple 1500 Series vol.71 - The Renai Simulation 2 (Jpn) (2001) (D3 Publisher) {SLPM-86870} <ss071rn2> ]
+; [ Simple 1500 Series vol.71 - The Ren'ai Simulation 2 (Jpn) (2001) (D3 Publisher) {SLPM-86870} <ss071rn2> ]
 :SLPM-86870
 #Friendship point Max
 8007F182 00FF
@@ -81961,7 +83509,7 @@ D01CCAD4 0100
 ;:SLPM-80063
 ;This game currently has no cheats
 
-; [ Granstream Denki (Jpn, Demo) (1997) (<unknown>) {PCPX-96087} <granstrmjd> ]
+; [ Granstream Denki (Jpn, Demo) (1997) (SCEI) {PCPX-96087} <granstrmjd> ]
 ;:PCPX-96087
 ;This game currently has no cheats
 
@@ -81984,6 +83532,2177 @@ D01CCAD4 0100
 ; [ Tamamayu Monogatari - Dennou Bijutsukan (Jpn, Demo) (199?) (Genki) {SLPM-80325} <tamamayd> ]
 ;:SLPM-80325
 ;This game currently has no cheats
+
+; [ Ape Escape (Euro) (1999) (Sony Computer Entertainment Europe) {SCES-01564} <apescapee> ]
+:SCES-01564
+#Infinite Health
+800EC388 0005
+#Infinite Oxygen
+800F4E88 0255
+#All Weapons
+800F5284 00FF
+#Infinite Missiles
+800F5282 010A
+#Infinite Bombs
+300F5281 0009
+#Infinite Lives
+800F442C 0005
+#Infinite Health
+800EC268 0005
+#Lots Of Gold Triangles
+800F4456 FFFF
+#Infinite Oxygen
+800F4D68 0258
+#Get One Monkey To Finish Level
+800F4454 00FF
+#Widescreen 16-9
+800AF050 0C00
+
+; [ Autumn/Christmas Releases '96 (Euro) (1996) (Sony Computer Entertainment Europe) {SCED-00273 (9636229)} <acrels96> ]
+;:SCED-00273
+;This game currently has no cheats
+
+; [ Beatmania (Euro) (2000) (Konami of Europe) {SLES-02096} <bm> ]
+:SLES-02096
+#P1 Max Gauge
+800A5178 0039
+800A5248 0039
+#P2 Max Gauge
+800A517A 0039
+800A524A 0039
+#P1 Max Stage Score
+900A5360 000F423F
+#P2 Max Stage Score
+900A5364 000F423F
+#P1 Perfect Results
+800A525C 03E7
+800A5368 03E7
+50000302 0000
+800A536A 0000
+#P2 Perfect Results
+800A525E 03E7
+800A5370 03E7
+50000302 0000
+800A5372 0000
+#Unlock Extras
+9009A764 00000000
+#P1-Codes\Start With High Total Score
+A60A51D0 000086A0
+D00A51D0 0000
+300A51D2 0001
+#P1-Codes\Always Get 'A'-Ranking
+A60A5360 000086A0
+D00A5360 0000
+300A5362 0001
+#P1-Codes\The Public is Always Pleased
+800A51E8 0640
+#P1-Codes\The Public is Never Pleased
+800A51E8 0000
+#P1-Codes\Max Combo
+800A525C 03E7
+#P1-Codes\No Combos
+800A525C 0000
+#P1-Codes\Great = 300
+800A5368 012C
+#P1-Codes\Great = 0
+300A5368 0000
+#P1-Codes\Good, Bad & Poor = 0
+50000302 0000
+800A536A 0000
+#P2-Codes\Start With High Total Score
+A60A51D4 000086A0
+D00A51D4 0000
+300A51D6 0001
+#P2-Codes\Always Get 'A'-Ranking
+A60A5364 000086A0
+D00A5364 0000
+300A5366 0001
+#P2-Codes\The Public is Always Pleased
+800A51EA 0640
+#P2-Codes\The Public is Never Pleased
+800A51EA 0000
+#P2-Codes\Max Combo
+800A525E 03E7
+#P2-Codes\No Combos
+800A525E 0000
+#P2-Codes\Great = 300
+800A5370 012C
+#P2-Codes\Great = 0
+300A5370 0000
+#P2-Codes\Good, Bad & Poor = 0
+50000302 0000
+800A5372 0000
+
+; [ Chase the Express (Euro) (2000) (Sony Computer Entertainment Europe) {SCES-02812 (9184829)} <cte> ]
+:SCES-02812
+:SCES-12812
+#Timer Stopped
+8001CE8E 0000
+#Infinite Health
+80010402 1000
+#Infinite Ammo & Items
+8007D6DE 0000
+#All Maps Complete
+50000704 0000
+80010A80 0080
+50000804 0000
+80010AA0 0080
+50000404 0000
+80010AD0 0080
+50000204 0000
+80010AE4 0080
+50000704 0000
+80010B14 0080
+#Have All Data
+50002702 0202
+8001088C 0201
+#Have All Weapons In Crate (Press Up & L1)
+D00D8E8E FBEF
+50000202 0100
+80010470 0200
+D00D8E8E FBEF
+50000202 0200
+80010474 3000
+D00D8E8E FBEF
+50000202 0100
+80010478 3800
+D00D8E8E FBEF
+50000202 0100
+8001047C 3D00
+#Have All Keys In Crate (Press Up & L2)
+D00D8E8E FEEF
+50000E02 0100
+80010470 0A00
+#Have All Items In Crate (Press Up & R1)
+D00D8E8E F7EF
+50000502 0100
+80010470 0500
+D00D8E8E F7EF
+50001202 0100
+8001047A 1800
+#Max Item\Slot 1
+3001045C 00FF
+#Max Item\Slot 2
+3001045E 00FF
+#Max Item\Slot 3
+30010460 00FF
+#Max Item\Slot 4
+30010462 00FF
+#Max Item\Slot 5
+30010464 00FF
+#Max Item\Slot 6
+30010466 00FF
+#Max Item\Slot 7
+30010468 00FF
+#Max Item\Slot 8
+3001046A 00FF
+#Max Item In Crate\Slot 1
+30010470 00FF
+#Max Item In Crate\Slot 2
+30010472 00FF
+#Max Item In Crate\Slot 3
+30010474 00FF
+#Max Item In Crate\Slot 4
+30010476 00FF
+#Max Item In Crate\Slot 5
+30010478 00FF
+#Max Item In Crate\Slot 6
+3001047A 00FF
+#Max Item In Crate\Slot 7
+3001047C 00FF
+#Max Item In Crate\Slot 8
+3001047E 00FF
+#Max Item In Crate\Slot 9
+30010480 00FF
+#Max Item In Crate\Slot 10
+30010482 00FF
+#Max Item In Crate\Slot 11
+30010484 00FF
+#Max Item In Crate\Slot 12
+30010486 00FF
+#Max Item In Crate\Slot 13
+30010488 00FF
+#Max Item In Crate\Slot 14
+3001048A 00FF
+#Max Item In Crate\Slot 15
+3001048C 00FF
+#Max Item In Crate\Slot 16
+3001048E 00FF
+#Max Item In Crate\Slot 17
+30010490 00FF
+#Max Item In Crate\Slot 18
+30010492 00FF
+#Max Item In Crate\Slot 19
+30010494 00FF
+#Max Item In Crate\Slot 20
+30010496 00FF
+#Max Item In Crate\Slot 21
+30010498 00FF
+#Max Item In Crate\Slot 22
+3001049A 00FF
+#Max Item In Crate\Slot 23
+3001049C 00FF
+#Max Item In Crate\Slot 24
+3001049E 00FF
+#Max Item In Crate\Slot 25
+300104A0 00FF
+#Max Item In Crate\Slot 26
+300104A2 00FF
+#Max Item In Crate\Slot 27
+300104A4 00FF
+#Max Item In Crate\Slot 28
+300104A6 00FF
+#Max Item In Crate\Slot 29
+300104A8 00FF
+#Max Item In Crate\Slot 30
+300104AA 00FF
+#Max Item In Crate\Slot 31
+300104AC 00FF
+#Max Item In Crate\Slot 32
+300104AE 00FF
+
+; [ Crash Bash (Euro) (2000) (Sony Computer Entertainment Europe) {SCES-02834, SCES-02834-P} <crashbshe> ]
+:SCES-02834
+#999 Points pogo painter
+800A20EC 03E7
+#Infinite Health Jungle bash event y papu event
+800A20D2 0014
+#Infinite Health crash ball
+800A20EC 000F
+#InfInite health
+D009BAAA 0014
+3009BA9E 0014
+#Infinite Points (Press R1)
+D0070B7A F7FF
+8009BAB8 000F
+#Infinite Points
+8009BAB8 000F
+#Unlock Warp room 2
+3005C564 0001
+#Unlock Warp room 3
+3005C576 0001
+#Unlock Warp room 4
+3005C569 0001
+#Unlock Warp room 5
+3005C57F 0001
+#P1 only needs 1 trophy to win
+D005C4BC 0000
+3005C4BC 0002
+#Widescreen 16-9
+80052AF0 0004
+80052AF4 0003
+
+; [ Demo One (Version 1) (Euro) (1995?) (Sony Computer Entertainment Europe) {SCES-00048} <demo1_1> ]
+;:SCES-00048
+;This game currently has no cheats
+
+; [ Demo One (Version 2) (Euro) (1995?) (Sony Computer Entertainment Europe) {SCES-00120} <demo1_2> ]
+;:SCES-00120
+;This game currently has no cheats
+
+; [ Demo One (Version 4) (Ger) (1996?) (Sony Computer Entertainment Europe) {SCED-00457 (9644224)} <demo1_4g> ]
+;:SCED-00457
+;This game currently has no cheats
+
+; [ Disney/Pixar Monsters, Inc.: Skrämmarön (Swe) (2002) (Sony Computer Entertainment Europe) {SCES-03768 (9315629)} <monstincsw> ]
+:SCES-03768
+#Infinite Lives
+800100A3 0063
+#Movie theater Fully Open
+90010118 FFFFFFFF
+#All Medals
+900100C8 63636363
+900100CC 63636363
+800100D0 6363
+300100D2 0063
+300100C7 0063
+900100D4 FFFFFFFF
+900100D8 FFFFFFFF
+900100DC FFFFFFFF
+#All stages
+800100EE FFFF
+800100F0 FFFF
+900100F8 FFFFFFFF
+800100FC FFFF
+900100F4 FFFFFFFF
+300100F3 00FF
+
+; [ Dracula: The Resurrection (Euro) (2000) (Microïds) {SLES-02757} <draculae> ]
+;:SLES-02757
+;:SLES-12757
+;This game currently has no cheats
+
+; [ Driver 2: Back on the Streets (Euro, Rev. 1) (2000) (Infogrames Europe) {SLES-02993#, SLES-02993-P} <driver2e> ]
+;:SLES-02993
+;This game currently has no cheats
+
+; [ Euro Demo 21 (Euro) (1996?) (Sony Computer Entertainment Europe) {SCED-00817 (9668626)} <edemo21> ]
+;:SCED-00817
+;This game currently has no cheats
+
+; [ Euro Demo 22 (Euro) (1996?) (Sony Computer Entertainment Europe) {SCED-00818 (9678823)} <edemo22> ]
+;:SCED-00818
+;This game currently has no cheats
+
+; [ Euro Demo 28 (Euro) (1997?) (Sony Computer Entertainment Europe) {SCED-00824 (9680420)} <edemo28> ]
+;:SCED-00824
+;This game currently has no cheats
+
+; [ Euro Demo 58 (Euro) (2000?) (Sony Computer Entertainment Europe) {SCED-02632 (9151425)} <edemo58> ]
+;:SCED-02632
+;This game currently has no cheats
+
+; [ Euro Demo 60 (Euro) (2000?) (Sony Computer Entertainment Europe) {SCED-02634} <edemo60> ]
+;:SCED-02634
+;This game currently has no cheats
+
+; [ Euro Demo 62 (Euro) (2000?) (Sony Computer Entertainment Europe) {SCED-02636 (9151821)} <edemo62> ]
+;:SCED-02636
+;This game currently has no cheats
+
+; [ Euro Demo 63 (Euro) (2000?) (Sony Computer Entertainment Europe) {SCED-02637 (9151920)} <edemo63> ]
+;:SCED-02637
+;This game currently has no cheats
+
+; [ Euro Demo 64 (Euro) (2000?) (Sony Computer Entertainment Europe) {SCED-02638 (9152026)} <edemo64> ]
+;:SCED-02638
+;This game currently has no cheats
+
+; [ Euro Demo 65 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-02639} <edemo65> ]
+;:SCED-02639
+;This game currently has no cheats
+
+; [ Euro Demo 66 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-02640} <edemo66> ]
+;:SCED-02640
+;This game currently has no cheats
+
+; [ Euro Demo 67 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-02641} <edemo67> ]
+;:SCED-02641
+;This game currently has no cheats
+
+; [ Euro Demo 68 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-02642} <edemo68> ]
+;:SCED-02642
+;This game currently has no cheats
+
+; [ Euro Demo 69 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-02643} <edemo69> ]
+;:SCED-02643
+;This game currently has no cheats
+
+; [ Euro Demo 70 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-02644} <edemo70> ]
+;:SCED-02644
+;This game currently has no cheats
+
+; [ Euro Demo 71 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-02645} <edemo71> ]
+;:SCED-02645
+;This game currently has no cheats
+
+; [ Euro Demo 72 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-02646} <edemo72> ]
+;:SCED-02646
+;This game currently has no cheats
+
+; [ Euro Demo 73 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-03450} <edemo73> ]
+;:SCED-03450
+;This game currently has no cheats
+
+; [ Euro Demo 74 (Euro) (2001?) (Sony Computer Entertainment Europe) {SCED-03451} <edemo74> ]
+;:SCED-03451
+;This game currently has no cheats
+
+; [ Everybody's Golf 2 (Euro) (2000) (Sony Computer Entertainment Europe) {SCES-02146} <evryglf2> ]
+:SCES-02146
+#Enable All Characters
+A6046EB0 00071FFF
+#Enable All Stages
+80047894 00FF
+#P1 Always Win
+50001202 0000
+80046D7E 0002
+#P1 Max Status
+90046EB8 00FDFFFF
+30046E8C 0063
+80046EC2 0005
+#Hole In One Every Shot
+800FA75C 0001
+#20 Under Par
+80046E76 FFEC
+#Hole In One All Courses (Press L2)
+D004B020 0001
+50001202 0000
+80046D7E 0001
+
+; [ F1 Championship Season 2000 (Euro) (2000) (Electronic Arts) {SLES-03119, SLES-03119-P} <f1cs2ke> ]
+;:SLES-03119
+;This game currently has no cheats
+
+; [ Final Fantasy VIII (Euro, Aus) (1999) (Sony Computer Entertainment Europe) {SCES-02080 ANZ-P, SLES-02080} <ffant8e> ]
+;:SCES-02080
+;This game currently has no cheats
+
+; [ Ghoul Panic (Euro) (2000) (Sony Computer Entertainment Europe) {SCES-02543} <ghlpanic> ]
+;:SCES-02543
+;This game currently has no cheats
+
+; [ Gran Turismo (Euro) (1998) (Sony Computer Entertainment Europe) {SCES-00984, SCES-00984#} <gt1e> ]
+:SCES-00984
+#Quick Arcade-Mode Codes\Highspeed Ring A
+30081B48 0004
+#Quick Arcade-Mode Codes\Highspeed Ring B
+30081B49 0004
+#Quick Arcade-Mode Codes\Highspeed Ring c
+30081B4A 0004
+#Quick Arcade-Mode Codes\Trial Mountain A
+30081B4C 0004
+#Quick Arcade-Mode Codes\Trial Mountain B
+30081B4D 0004
+#Quick Arcade-Mode Codes\Trial Mountain c
+30081B4E 0004
+#Quick Arcade-Mode Codes\Grand Valley East A
+30081B50 0004
+#Quick Arcade-Mode Codes\Grand Valley East B
+30081B51 0004
+#Quick Arcade-Mode Codes\Grand Valley East c
+30081B52 0004
+#Quick Arcade-Mode Codes\Clubman Stage 5 A
+30081B54 0004
+#Quick Arcade-Mode Codes\Clubman Stage 5 B
+30081B55 0004
+#Quick Arcade-Mode Codes\Clubman Stage 5 c
+30081B56 0004
+#Quick Arcade-Mode Codes\Autumn Ring A
+30081B58 0004
+#Quick Arcade-Mode Codes\Autumn Ring B
+30081B59 0004
+#Quick Arcade-Mode Codes\Autumn Ring c
+30081B5A 0004
+#Quick Arcade-Mode Codes\Deep Forest A
+30081B5C 0004
+#Quick Arcade-Mode Codes\Deep Forest B
+30081B5D 0004
+#Quick Arcade-Mode Codes\Deep Forest c
+30081B5E 0004
+#Quick Arcade-Mode Codes\Ss R5 A
+30081B60 0004
+#Quick Arcade-Mode Codes\Ss R5 B
+30081B61 0004
+#Quick Arcade-Mode Codes\Ss R5 c
+30081B62 0004
+#Quick Arcade-Mode Codes\Grand Valley Speedway A
+30081B64 0004
+#Quick Arcade-Mode Codes\Grand Valley Speedway B
+30081B65 0004
+#Quick Arcade-Mode Codes\Grand Valley Speedway c
+30081B66 0004
+#Gran Turismo Codes\100 Million Credits
+9009B874 05F5E100
+#Gran Turismo Codes\100 Million Credits (Press Select in the Start-Area to get the money)
+D009AADE 0001
+8009B874 E100
+D009AADE 0001
+8009B876 05F5
+#Gran Turismo Codes\B-License
+9009E3C4 03030303
+9009E3C8 03030303
+#Gran Turismo Codes\A-License
+9009E3CC 03030303
+9009E3D0 03030303
+#Gran Turismo Codes\A-International License
+9009E3D4 03030303
+9009E3D8 03030303
+#Gt League\Have All Gold Cups And Open Gt Hifi-Mode
+9009F8DC 01010101
+#Special Event\Have Gold Cups
+9009F8E0 01010101
+8009F8E4 0101
+8009F8EA 0101
+9009F8EC 01010101
+8009F8F0 0101
+#Special Event\Always Be First
+D01B3A7E 001B
+80093BC8 0000
+#Special Event\Only One Lap To Race (This code will finish the race as you pass the startline on all two lap races. If you try to race a three lap race you will have only one lap to finish)
+A60B6700 00000002
+#Special Event\Speed Boost-Code. Press R3
+D00BC016 0002
+800B6DBE 0005
+D00BC016 0002
+800B6D92 0005
+
+; [ Gran Turismo 2 (Euro) (2000) (Sony Computer Entertainment Europe) {SCES-02380} <gt2e> ]
+:SCES-02380
+:SCES-12380
+#Gran Turismo Disc - Auto Pilot P1 (Press R1 & R2 & Triangle Pad 2 before race starts)
+D01F0CEC E5FF
+801D5976 0001
+#Gran Turismo Disc - Auto Pilot P1 alternate (Press R1 & R2 & Triangle Pad 2 before race starts)
+801D5976 0001
+#Infinite Money
+901D1598 05F5E0FF
+#Have Gold B Licence
+50000AA4 0000
+301CCD31 0004
+#Have Gold A Licence
+50000AA4 0000
+301CC6C9 0004
+#Have Gold International c Licence
+50000AA4 0000
+301CC061 0004
+#Have Gold International B Licence
+50000AA4 0000
+301CB9F9 0004
+#Have Gold International A Licence
+50000AA4 0000
+301CB391 0004
+#Have Special Licence
+50000AA4 0000
+301CAD29 0004
+#Unlock Extra Tracks And Cars In Arcade Mode
+50000A02 0000
+801C99C8 0505
+301C99DC 0005
+#Hold L2 To Drive Through Scenery
+E00A95E4 0080
+800A96CC 0006
+E00A95E4 0080
+800A9CE4 0006
+#Stop Race Timer
+8002F894 0000
+80046F44 0000
+#Start On Lap 4
+E00A9CEC 0000
+300A9CEC 0004
+#Begin The Game With A Lot Of Money
+900107A0 3C0205F5
+#Unlock All Tracks 1P/2P Any Road, Time Trial Etc, More Than 130...
+800F3992 0083
+800F3996 0017
+800F399A 0027
+900F399C 00060015
+#Turbo Arcade Disc Press R3
+D00A956C 4000
+800A9D1E 0020
+D00A956C 4000
+800A9D22 0020
+#Ending Unlocked (Push Select in the Play Movie Screen)
+D01C97DA FFFE
+80052714 0001
+#Unlock One Half Of The Reverse Track (use the Quick won race-codes for the other half)
+50000A20 0000
+80050B8C 0001
+#Unlock All Licences In 1 Code
+8005DE8A A270
+#Unlock All Tracks (112% Complete)
+50004402 0000
+801C9A28 1111
+#Play Any Race With Any Car In Simulation Mode
+D0014908 000C
+8001490A 1000
+#Widescreen 16-9
+D0010000 FFE8
+8007B3E0 0156
+D0010000 FFD0
+8007B3E0 03DE
+D0010000 FFE0
+8007B3E0 01AC
+8007B3E2 3402
+#Widescreen 16-9 Better Graphics (Optional)
+8006752C 0060
+8006752E 3404
+
+; [ Grand Theft Auto 2 (Euro, Rev. 1) (1999) (Rockstar Games) {SLES-01404#} <gta2e> ]
+:SLES-01404
+#Stop Kill Frenzy Time
+801683F0 0C97
+#Infinite Lives
+80120004 0009
+#Infinite Health
+80145A96 0064
+#Have Pistol + Infinite Ammo
+80164D68 0122
+#Have Machine Gun + Infinite Ammo
+80164D90 0122
+#Have Rocket Launcher + Infinite Ammo
+80164DB8 0122
+#Have Electric Gun + Infinite Ammo
+80164DE0 0122
+#Have Petrol Bombs + Infinite Ammo
+80164E08 0122
+#Have Grenades + Infinite Ammo
+80164E30 0122
+#Have Shotgun + Infinite Ammo
+80164E58 0122
+#Have Stun Rod + Infinite Ammo
+80164E80 0122
+#Have Flame Thrower + Infinite Ammo
+80164EA8 0122
+#Have Silenced Machine Gun + Infinite Ammo
+80164ED0 0122
+#Have 2 Way Firing Pistol + Infinite Ammo
+80164EF8 0122
+#Other Weapons And Infinite Ammo
+80164FC0 0122
+80164FE8 0122
+80165038 0122
+80165150 0122
+80165178 0122
+801651C8 0122
+801651F0 0122
+80165268 0122
+801652B8 0122
+801652E0 0122
+#Lots Of Cash!
+8011FD0A 0098
+#Number Of Kills 0
+8012A86C 0000
+#No Cops
+80145A8A 0000
+#All Cops
+80145A8A 2EE0
+#Have Police And Swat After You .Use only 1 code at a time.
+80145A8A 8813
+#21 Have Police, Swat And Spy's After You
+80145A8A 401F
+#Have Police, Swat, Spy's And The Army After You
+80145A8A E02E
+#Infinite Ammo After Pickup
+800FD452 3C00
+#All Weapons
+50000B28 0000
+80164D68 FFFF
+#Infinite Bonus & Kill Frenzy Time
+800A40C8 3C00
+#Max Points
+8011FD08 FFFF
+
+; [ Le Mans 24 Hours (Euro) (1999) (Infogrames Europe) {SLES-01362 (0006672), SLES-01362#} <lemans24> ]
+:SLES-01362
+#No Fuel Consution And Overheating
+8008B4C2 3C00
+8007FA36 3C00
+8008B4C6 3C00
+#Unlock all
+50000B02 0000
+80026FA0 0101
+
+; [ Medal of Honor: Underground (Euro) (2000) (Electronic Arts) {SLES-03124, SLES-03124/P} <mhonrunde> ]
+:SLES-03124
+#Infinite Health all levels
+A704E166 AE022400
+A705B14A 8C822400
+#Invincibility all levels
+A704E15C 10232400
+A705B14A 8C822400
+#Open all cheats
+80039D24 FFFF
+
+; [ Metal Gear Solid (Euro) (1999) (Konami) {SLES-01370} <mgse> ]
+:SLES-01370
+:SLES-11370
+#Infinite Health
+800B5E06 0600
+#Infinite Oxygen
+800ACA8C 0400
+#Infinite Medicine
+800B5E56 0002
+#Infinite Rations
+800B5E54 0002
+#Infinite Diazepam
+800B5E58 0001
+#Socom Pistol + Infinite Ammo
+800B5E12 00FF
+#Famas Rifle + Infinite Ammo
+800B5E14 00FF
+#Psg1 Rifle + Infinite Ammo
+800B5E24 00FF
+#Nikita + Infinite Ammo
+800B5E18 00FF
+#Stinger + Infinite Ammo
+800B5E1A 00FF
+#Infinite Stun Grenades
+800B5E20 00FF
+#Infinite Chaff Grenades
+800B5E22 00FF
+#Infinite Grenades
+800B5E16 00FF
+#Infinite Claymores
+800B5E1C 00FF
+#Infinite C4 Explosive
+800B5E1E 00FF
+#Cardboard Box A - Heliport
+800B5E3E 0001
+#Cardboard Box B - Nuke Store
+800B5E40 0001
+#Cardboard Box c - Snow Field
+800B5E42 0001
+#Night-Vision Goggles
+800B5E44 0001
+#Thermal Goggles
+800B5E46 0001
+#Gasmask
+800B5E48 0001
+#Body Armour
+800B5E4A 0001
+#Ketchup
+800B5E4C 0001
+#Stealth
+800B5E4E 0001
+#Bandanna
+800B5E50 0001
+#Camera
+800B5E52 0001
+#Pal Keys
+800B5E5A 0001
+#Mine Detector
+800B5E60 0001
+#Mo Disk
+800B5E62 0001
+#Rope
+800B5E64 0001
+#Handkerchief
+800B5E66 0001
+#Have Level 100 Key Card
+800B5E5C 0064
+#All Modes In Vr-Training
+300B500B 0020
+#Max Ammo Socom
+800B5E26 0063
+#Max Ammo Fa-Mas
+800B5E28 0063
+#Max Ammo Grenades
+800B5E2A 0063
+#Max Ammo Nikita
+800B5E2C 0063
+#Max Ammo Stinger
+800B5E2E 0063
+#Max Ammo Claymore
+800B5E30 0063
+#Max Ammo C4
+800B5E32 0063
+#Max Ammo Stun Grenade
+800B5E34 0063
+#Max Ammo Chaff Grenades
+800B5E36 0063
+#Max Ammo Psg1 Sniper Rifle
+800B5E38 0063
+#Have Cigs
+800B5E3A 0001
+#Have Scope
+800B5E3C 0001
+#Have Time Bomb
+800B5E5E 0001
+#Never Have Time Bomb
+800B5E5E 0000
+#Have Supressor
+800B5E68 0001
+#Have Supressor Active
+800B5E68 0000
+#Have All Weapons
+50000A02 0000
+800B5E12 0063
+#Have All Items
+50001902 0000
+800B5E3A 0001
+#Start With Extended Life Bar
+800B5E08 0600
+#Max Life
+800B76FE 05EA
+#Radar Not Jammed When Spotted
+800ACA58 0000
+#Quick Vr Training This code gives you the end triangular thing that you need to touch to pass the level
+800E2188 0000
+#Ocelot Has 0 Bullets
+80167CD8 0000
+80167B98 0000
+#Invincibility (Must Get Hit First)
+800ACAAA 0010
+#Automatic Socom
+800B161C FFFF
+#Easy Fight With Liquid
+8017997C 0001
+#Play In 1st Person Perspective just press Triangle
+800AC4AC 0020
+#Ghost Mode
+900ACA68 00000000
+
+; [ Metal Gear Solid: Special Missions (Euro) (1999) (Konami of Europe) {SLES-02136} <mgssm> ]
+:SLES-02136
+#Infinite Health
+800B757E 0600
+800B7580 0600
+#Never Get A Cold
+800B7582 0000
+#Infinite Air
+800ACAAC 03E7
+#Radar Not Jammed When Spotted
+800ACA78 0000
+#Never Reload
+800ACA64 0019
+#Never Have Time Bomb In Pocket
+800B5E7E 0000
+#Ghost Mode
+900ACA88 00000000
+#Have Cigs
+800B5E5A 0001
+#Have Scope
+800B5E5C 0001
+#Have C. Box A
+800B5E5E 0001
+#Have C. Box B
+800B5E60 0001
+#Have C. Box c
+800B5E62 0001
+#Have Night Vision Goggles
+800B5E64 0001
+#Have Thermal Goggles
+800B5E66 0001
+#Have Gas Mask
+800B5E68 0001
+#Have Body Armor
+800B5E6A 0001
+#Have Ketchup
+800B5E6C 0001
+#Have Stealth
+800B5E6E 0001
+#Have Bandana
+800B5E70 0001
+#Have Camera
+800B5E72 0001
+#Have 255 Rations
+800B5E74 03E7
+800B5E8A 03E7
+#Have 255 Medicine
+800B5E76 03E7
+800B5E8C 03E7
+#Have 255 Diazepam
+800B5E78 03E7
+800B5E8E 03E7
+#Have Pal-Key
+800B5E7A 0001
+#Have Level 100 Key Card
+800B5E7C 0064
+#Have Mine Detector
+800B5E80 0001
+#Have Mo-Disc
+800B5E82 0001
+#Have Rope
+800B5E84 0001
+#Have Handker
+800B5E86 0001
+#Have Suppressor Active
+800B5E88 0000
+#Have All Items (Replaces Above Item-Codes)Press L2
+D00AC9CC 0001
+50001202 0000
+800B5E5A 0001
+D00AC9CC 0001
+50000502 0000
+800B5E80 0001
+#Have Socom Pistol
+800B5E32 03E7
+800B5E46 03E7
+#Have Famas
+800B5E34 03E7
+800B5E48 03E7
+#Have Grenades
+800B5E36 03E7
+800B5E4A 03E7
+#Have Nikita
+800B5E38 03E7
+800B5E4C 03E7
+#Have Stinger
+800B5E3A 03E7
+800B5E4E 03E7
+#Have Claymore Mines
+800B5E3C 03E7
+800B5E50 03E7
+#Have C4
+800B5E3E 03E7
+800B5E52 03E7
+#Have Stun-Grenades
+800B5E40 03E7
+800B5E54 03E7
+#Have Chaff Grenades
+800B5E42 03E7
+800B5E56 03E7
+#Have Sniper Rifle
+800B5E44 03E7
+800B5E58 03E7
+#Have Alle Weapons & Ammo Press R2 Use this code or the specified weapon/ammo codes.
+D00AC9CC 0002
+50001402 0000
+800B5E32 03E7
+#Special Mode Codes\All Missions Open
+800E58FC FFFF
+#Special Mode Codes\Vs. 12 Battle All Levels Open & Complete
+800E58FE FFFF
+800E5900 FFFF
+#Special Mode Codes\Ninja All Levels Open & Complete
+900E589C FFFFFFFF
+#Special Mode Codes\Ng Selection All Levels Open & Complete
+800E587E FFFF
+800E5880 FFFF
+#Special Mode Codes\Variety All Levels Open & Complete
+800E591A FFFF
+800E591C FFFF
+#Special Mode Codes\Puzzle All Levels Open & Complete
+800E593A FFFF
+800E593C FFFF
+#Special Mode Codes\Mystery All Levels Open & Complete
+800E594E FFFF
+800E5950 FFFF
+#Special Mode Codes\Vr Mission Complete
+800E5930 1000
+#1 Min. Battle Codes\Vs. Target All Levels Open & Complete
+900E5884 FFFFFFFF
+#1 Min. Battle Codes\Vs. Enemy All Levels Open & Complete
+900E586C FFFFFFFF
+#Sneak Mode - No Weapons\Practice All Levels Opened
+800E5830 FFFE
+#Sneak Mode - No Weapons\Time Attack All Levels Opened
+800E5848 FFFE
+#Sneak Mode - Socom\Practice All Levels Opened
+800E5800 FFFE
+#Sneak Mode - Socom\Time Attack All Levels Opened
+800E5818 FFFE
+#Weapon Mode - Time Attack\All Weapons, All Levels Opened
+800E581A 8FE0
+900E581C F0F83E0F
+900E5820 F83E0F8F
+#Weapon Mode - Practice\All Weapons, All Levels Opened
+800E5802 8FE0
+900E5804 F0F83E0F
+900E5808 F83E0F8F
+#Advanced Mode - Time Attack\All Weapons, All Levels Opened
+800E584A 8FE0
+900E584C F0F83E0F
+900E5850 F83E0F8F
+#Advanced Mode - Practice\All Weapons, All Levels Opened
+800E5832 8FE0
+900E5834 F0F83E0F
+900E5838 F83E0F8F
+
+; [ Micro Machines V3 (Euro, EDC) (1997) (The Codemasters Software Company) {SLES-00016#} <micromc3e> ]
+:SLES-00016
+#P1 Infinite Lives
+800129DA 0003
+#Only one lap to race
+8013AB3E 0003
+#Lap time 0:00:00
+800BB5CC 0000
+
+; [ Moto Racer (Euro) (1997) (Electronic Arts) {SLES-00469} <motorcre> ]
+:SLES-00469
+#1-PLAYER-MODE Infinite checkpoint time On (Press Select & Up)
+D00BCE92 FFEE
+8003B09C 0023
+#Infinite Time
+8008F4D0 D852
+#Extra speed
+800A538E 42A0
+#Select course Fun Fair
+30110440 0006
+#Select course Sea of Sands
+30110440 0007
+#Select course Red City
+30110440 0008
+#Select course Snow Ride
+30110440 0009
+
+; [ Moto Racer World Tour (Euro) (2000) (Infogrames) {SCES-03037} <motorcwte> ]
+:SCES-03037
+#Unlock Everything Enter a menu in world tour first, then go back and everything will be open. Save on MC and deactivate the code
+50002204 0000
+80159040 0001
+50002204 0000
+80159042 0000
+#Opponents Frozen Press select while the race is loading
+D00DE2FA FFFE
+80057C1A 2A00
+#Infinite Boost
+D00281FE 00E5
+80028200 0000
+D00281FE 00E5
+80028202 0000
+D002826A 0002
+8002826C 0000
+D002826A 0002
+8002826E 0000
+#Speed Championship\250Ccm\Sachsenring\Start At Last Lap/Always First
+D010E7F4 FF00
+3010E7F4 0002
+#Speed Championship\250Ccm\Sachsenring\Always Good Grip
+A617D456 01000000
+A617D456 02000000
+#Speed Championship\250Ccm\Sachsenring\300 Points
+D010E7F4 FF00
+8010E7C0 012C
+#Speed Championship\250Ccm\Suzuka\Start At Last Lap/Always First
+D0111D48 FF00
+30111D48 0002
+#Speed Championship\250Ccm\Suzuka\Always Good Grip
+A61949BE 01000000
+A61949BE 02000000
+#Speed Championship\250Ccm\Suzuka\600 Points
+D0111D48 FF00
+80111D14 0258
+#Speed Championship\250Ccm\Isle Of Man Road\Start At Last Lap/Always First
+D010DDB8 FF00
+3010DDB8 0003
+#Speed Championship\250Ccm\Isle Of Man Road\900 Points
+D010DDB8 FF00
+8010DD84 0384
+#Speed Championship\250Ccm\Eastern Creek\Start At Last Lap/Always First
+D010EED0 FF00
+3010EED0 0002
+#Speed Championship\250Ccm\Eastern Creek\Always Good Grip
+A618471E 01000000
+A618471E 02000000
+#Speed Championship\250Ccm\Eastern Creek\1200 Points
+D010EED0 FF00
+8010EE9C 04B0
+#Speed Championship\500Ccm\Sachsenring\Start At Last Lap/Always First
+D010E7C0 FF00
+3010E7C0 0002
+#Speed Championship\500Ccm\Sachsenring\Always Good Grip
+A617D43E 01000000
+A617D43E 02000000
+#Speed Championship\500Ccm\Sachsenring\300 Points
+D010E7C0 FF00
+8010E78C 012C
+#Speed Championship\500Ccm\Suzuka\Start At Last Lap/Always First
+D0111D14 FF00
+30111D14 0002
+#Speed Championship\500Ccm\Suzuka\Always Good Grip
+A61949A6 01000000
+A61949A6 02000000
+#Speed Championship\500Ccm\Suzuka\600 Points
+D0111D14 FF00
+80111CE0 0258
+#Speed Championship\500Ccm\Isle Of Man Road\Start At Last Lap/Always First
+D010DD70 FF00
+3010DD70 0003
+#Speed Championship\500Ccm\Isle Of Man Road\900 Points
+D010DD70 FF00
+8010DD3C 0384
+#Speed Championship\500Ccm\Eastern Creek\Start At Last Lap/Always First
+D010EE98 FF00
+3010EE98 0002
+#Speed Championship\500Ccm\Eastern Creek\Always Good Grip
+A6184706 01000000
+A6184706 02000000
+#Speed Championship\500Ccm\Eastern Creek\1200 Points
+D010EE98 FF00
+8010EE64 04B0
+#Speed Championship\500Ccm\Isle Of Man Hills\Start At Last Lap/Always First
+D010C098 FF00
+3010C098 0002
+#Speed Championship\500Ccm\Isle Of Man Hills\1500 Points
+D010C098 FF00
+8010C064 05DC
+#Cross Championship\125Ccm\Barcelona\Start At Last Lap/Always First
+D0107C58 FF00
+30107C58 0005
+#Cross Championship\125Ccm\Barcelona\300 Points
+D0107C58 FF00
+80107C24 012C
+#Cross Championship\125Ccm\Usa Park\Start At Last Lap/Always First
+D0114068 FF00
+30114068 0002
+#Cross Championship\125Ccm\Usa Park\600 Points
+D0114068 FF00
+80104034 0258
+#Cross Championship\125Ccm\Stade De France\Start At Last Lap/Always First
+D01089E0 FF00
+301089E0 0003
+#Cross Championship\125Ccm\Stade De France\900 Points
+D01089E0 FF00
+801089AC 0384
+#Cross Championship\125Ccm\Reygades\Start At Last Lap/Always First
+D01115B8 FF00
+301115B8 0001
+#Cross Championship\125Ccm\Reygades\1200 Points
+D01115B8 FF00
+80111584 04B0
+#Cross Championship\250Ccm\Barcelona\Start At Last Lap/Always First
+D0107A30 FF00
+30107A30 0005
+#Cross Championship\250Ccm\Barcelona\300 Points
+D0107A30 FF00
+801079FC 012C
+#Cross Championship\250Ccm\Usa Park\Start At Last Lap/Always First
+D0114008 FF00
+30114008 0002
+#Cross Championship\250Ccm\Usa Park\600 Points
+D0114008 FF00
+80103FD4 0258
+#Cross Championship\250Ccm\Stade De France\Start At Last Lap/Always First
+D01087CC FF00
+301087CC 0003
+#Cross Championship\250Ccm\Stade De France\900 Points
+D01087CC FF00
+80108798 0384
+#Cross Championship\250Ccm\Reygades\Start At Last Lap/Always First
+D0111570 FF00
+30111570 0001
+#Cross Championship\250Ccm\Reygades\1200 Points
+D0111570 FF00
+8011153C 04B0
+#Cross Championship\250Ccm\Belo Horizonte\Start At Last Lap/Always First
+D0107058 FF00
+30107058 0004
+#Cross Championship\250Ccm\Belo Horizonte\1500 Points
+D0107058 FF00
+80107024 05DC
+#World Tour Championship\Isle Of Man Town\Start At Last Lap/Always First %NOTE
+D010D414 FF00
+3010D414 0003
+#World Tour Championship\Isle Of Man Town\1200 Points %NOTE
+D010D414 FF00
+8010D3E0 04B0
+#Dragster Race\1st Track\Start At Last Lap/Always First
+D010AA04 FF00
+3010AA04 0006
+#Dragster Race\1st Track\Always Good Grip
+A6160076 02000000
+#Dragster Race\2nd Track\Start At Last Lap/Always First
+D0110F7C FF00
+30110F7C 0001
+#Dragster Race\2nd Track\Always Good Grip
+A617C02E 02000000
+#Freestyle/ Trial\Timer Stopped
+D005697A 0050
+8005697C 0000
+#Freestyle/ Trial\Hide Stopwatch
+A60526BA 0C013400
+#Traffic\Start At Last Lap/Always First
+A610E864 FF000001
+#Hide Map
+A60525E8 00A8FFFF
+#Good Grip On Sand
+A60304BA A222A220
+#Good Grip On Grass
+A60304EA A222A220
+
+; [ Music: Music Creation for the PlayStation (Euro) (1998) (Codemasters) {SLES-01356} <music> ]
+;:SLES-01356
+;This game currently has no cheats
+
+; [ Need for Speed II (Euro) (1997) (Electronic Arts) {SLES-00658} <nfs2e> ]
+:SLES-00658
+#All cars upgraded
+300360A0 0001
+#Bonuslap Hollywood
+800E2C90 0006
+
+; [ Need for Speed III: Hot Pursuit (Euro) (1998) (Electronic Arts) {SLES-01154} <nfs3e> ]
+:SLES-01154
+#Enable Clk-Gtr And Xjr-15
+80043F0A 0101
+#Enable Ferrari 550 And Diablo Sv
+80043F08 0101
+#Enable Nazca C2
+80043F06 0101
+#Afterburner
+D311DFEA 001F
+8011DFEA 005D
+#All Tracks & Cars
+80125FC0 03F8
+#Select Starting Lap\2
+D011DDE0 0000
+3011DDE0 0001
+#Select Starting Lap\3
+D011DDE0 0000
+3011DDE0 0002
+#Select Starting Lap\4
+D011DDE0 0000
+3011DDE0 0003
+#Fourth Lap Press X & L2 & R2
+D012E3A2 BCFF
+3011DDE0 0003
+#Stopwatch 00:00:00 Press X & L1 & R1
+D012E3A2 B3FF
+80108468 0000
+D012E3A2 B3FF
+8010846A 0000
+#Camera Modifier\Micromachines-Style Press Select & X
+D012E3A2 BFFE
+800F7B40 0010
+D012E3A2 BFFE
+800F7B42 0010
+
+; [ No Fear Downhill Mountain Biking (Euro) (1999) (The Codemasters Software Company) {SLES-00849, SLES-00849#} <nofeare> ]
+:SLES-00849
+#Infinite Energy
+D00D3C3A BFFF
+800D772C EBBF
+#Time 000 1ST
+800CC644 0000
+#Energy Bar Always Full
+800D772C EBBF
+#Have All Extra Bike Parts
+50000402 0000
+800D15AA 0303
+#Trick Mode 9999 Points
+800CC648 270F
+#Trick Trail Mode Freeze Time
+800CC644 6000
+
+; [ Oddworld: Abe's Oddysee (Euro) (1997) (GT Interactive Software Europe / Infogrames) {SLES-00664, SLES-00664#} <abeodysse> ]
+:SLES-00664
+#Zero Casualties
+800B3D50 0000
+#Invincibility
+30082286 0001
+
+; [ Point Blank (Euro, Demo) (1998) (Sony Computer Entertainment Europe) {SCED-00287 (9721925)} <ptblanked> ]
+;:SCED-00287
+;This game currently has no cheats
+
+; [ Point Blank (Euro, Rev. 1) (1997) (Sony Computer Entertainment Europe) {SCES-00886#} <ptblanke> ]
+:SCES-00886
+#Infinite Bullets
+800B7418 0010
+800B7434 0010
+#Infinite Hits
+800B4318 00FF
+#Arcade Mode Codes\P1 Infinite Lives
+800C159C 0005
+#Arcade Mode Codes\P2 Infinite Lives
+800C159E 0005
+#Arcade Mode Codes\P1 Infinite Bullets
+800B7418 0063
+#Arcade Mode Codes\P2 Infinite Bullets
+800B741A 0063
+#Arcade Mode Codes\Always Max Hits
+800BE588 00FF
+#Arcade Mode Codes\Infinite Time Press L1 & R1 & Select (On) Press L2 & R2 & Select (Off)
+800B7434 0016
+800AD856 FFFF
+#Quest Mode Codes\Infinite Money
+800AE0D4 FFFF
+#Quest Mode Codes\P1 Quick Level Gain
+800C1918 FFFF
+
+; [ Point Blank 2 (Euro, Aus) (1999?) (Namco) {SCES-02180} <ptblank2e> ]
+:SCES-02180
+#Point Blank Castle Mode-Codes\P1 Infinite Lives
+800BF328 0009
+#Point Blank Castle Mode-Codes\P2 Infinite Lives
+800BF32A 0009
+#Theme Park Mode Codes\Infinite Lives
+800AAB88 0009
+#Theme Park Mode Codes\Haunted House - Infinite Time
+800B447C 012C
+#Theme Park Mode Codes\Abyss Tours - Max Targets Hits
+A60AAD52 00000063
+#Theme Park Mode Codes\Cosmic Drive - Max Targets Hit
+A60B5088 00000063
+#Theme Park Mode Codes\Superbullet Train - Max Targets Hit
+A60B4EFC 00000FFF
+
+; [ Porsche Challenge (Euro) (1997) (Sony Computer Entertainment Europe) {SCES-00409, SCES-00409#} <porschece> ]
+:SCES-00409
+#Infinite Time
+800DA334 0608
+#Always First
+800DA31E 0001
+#Widescreen 16-9
+800C9DA4 1222
+
+; [ Power Source (Euro) (1997?) (Sony Computer Entertainment Europe) {SCES-00667} <powrsrc> ]
+;:SCES-00667
+;This game currently has no cheats
+
+; [ Pro Pinball: Big Race USA (Euro) (1998) (Empire Interactive Entertainment) {SLES-01211} <ppinbrue> ]
+:SLES-01211
+#P1 Infinite Balls
+A60AABE0 00020001
+#Ballsaver always active
+800AC004 0800
+#Airbag always active
+800AC010 0800
+
+; [ Rescue Shot (Euro) (2000) (Namco) {SCES-02569 (9169024)} <rshot> ]
+:SCES-02569
+#Acorn-Bullets Increase
+A6045B3C FFFF0001
+#Infinite Life-Bar
+D00421C6 0062
+800421C8 0000
+D00421C6 0062
+800421CA 0000
+D0043586 0801
+80043584 0000
+A6043586 08010000
+#Max Life-Bar
+A6034D30 06061414
+#P1 Infinite $
+80034DC8 0063
+#P2 Infinite $
+80034DD8 0063
+#P1 Infinite Ammo
+30052AB5 0063
+#P2 Infinite Ammo
+30052AC5 0063
+
+; [ Resident Evil (Euro, EDC) (1996) (Virgin Interactive Entertainment (Europe)) {SLES-00200} <revile> ]
+:SLES-00200
+#Infinite Health
+800C51AC 00C8
+#L1 + X Button For Save Anywhere (May need 1 ink ribbon to save)
+D00Cf844 0044
+800C8456 0002
+800343F2 2400
+8003446E 2400
+#Infinite Ammo Gun
+800C8786 0F02
+#Have All Maps and Files
+300C8714 003F
+900C871C FFFF0FFF
+300C8721 00CF
+800C8722 FFFF
+#Infinite Ink ribbons when you get one
+800345FA 2402
+
+; [ Resident Evil 3: Nemesis (Euro) (1999) (Eidos Interactive) {SLES-02529} <revil3e> ]
+:SLES-02529
+#Infinite Health
+800CEA48 00C8
+#Always 1 First Aid Pack
+300D3EFD 0001
+#Machinegun 100% This code can crash the game while loading
+300D3EED 0064
+#Condition Fine
+300CEA4F 0004
+#Save Anywhere Press L1+Triangle
+D0082AD2 0014
+800D3AD0 169C
+D0082AD2 0014
+800D3AD2 8005
+#Infinite Rocket Launcher
+900D3F58 0001990A
+#Infinite Gatling Gun
+900D3F58 0001990B
+#Infinite Western Custom
+900D3F58 00019910
+#Infinite Benelli M3S
+900D3F58 00019913
+#Infinite M97F Eagle
+900D3F58 00019912
+#Infinite Mine Thrower
+900D3F58 00019914
+#Infinite Eagle 6.0
+900D3F58 0001990D
+#Infinite Magnum
+900D3F58 00019914
+#Infinite Merc's Handgun
+900D3F58 00019902
+#Infinite Hanggun
+900D3F58 00019903
+#Infinite Grenade Launcher (Explocive Rounds)
+900D3F58 00019906
+#Infinite Grenade Launcher (Acid Rounds)
+900D3F58 00019909
+#Infinite Grenade Launcher (Flame Rounds)
+900D3F58 00019907
+#Hyper Mode
+800D6304 0002
+#Quick Ending Press L1+L2+R1+R2
+D00CE5E8 000F
+800CEA10 C000
+D00CE5E8 000F
+800CEA12 0001
+#Rapid Fire Press R1+R2+X
+D00CE5E8 004A
+300CEA45 001E
+#Total Time 0:00 .Get Grade S
+900D3CE0 00000000
+#Secret Mode With this code, it starts a new game with new weapons in chest and all weapons and infinite ink ribbons and a key to Boutique with all costumes!
+800D3CEA FFE0
+#Enhanced/Extra Ammo
+900D4018 01F401F4
+800D401E 01F4
+900D4020 01F401F4
+800D4024 01F4
+#Makes Game Think You Never Saved
+800D3CF8 0000
+#Select Character\Carlos
+800D3D3E 0008
+#Select Character\Mikhall
+800D3D3E 0009
+#Select Character\Nichotai
+800D3D3E 000A
+#Select Character\Tofu
+800D3D3E 000F
+#Sudden Death Enemies
+A604502C 00060001
+#Almost All Doors Open
+D0082AD2 0014
+800D3AD0 169C
+D0082AD2 0014
+800D3AD2 8005
+50000502 0000
+800D3E84 FFFF
+#Walk Thru Walls Activate with L1+R2, deactivate with L2+R2
+D0082AD2 0003
+80033CD6 1040
+D0082AD2 0003
+8004B576 12A0
+D0082AD2 0005
+80033CD6 1000
+D0082AD2 0005
+8004B576 1000
+#Mercenaries Always get Reward
+800CE60A FFFF
+#Mercenaries Infinite Money
+900D43A4 0098967F
+#Mercenaries Infinite Time
+D00D3D50 0077
+300D3D50 0078
+#Auto Dodge Zombies (Hold L3)
+D5000000 00000200
+F4104BD0 00AA7000
+05004234 040062AE
+AAAAAAAA AAAAAAAA
+010DAAAA AAAAAAAA
+AAAAAAAA AAAAAAAA
+00000000 0000FFFF
+D6000000 00000200
+F4104BD0 00AA7000
+010D4234 040062AE
+AAAAAAAA AAAAAAAA
+0500AAAA AAAAAAAA
+AAAAAAAA AAAAAAAA
+
+; [ Resident Evil: Survivor (Euro) (2000) (Eidos Interactive) {SLES-02732} <revilsrve> ]
+:SLES-02732
+#Infinite Health
+800A8734 00C8
+#Ammo Won't Decrease
+D006FD9C 0002
+8006FD98 0000
+#OK Status
+800A8736 0000
+#Widescreen 16-9
+80065B80 0C00
+
+; [ Silent Hill (Euro) (1999) (Konami Digital Entertainment) {SLES-01514, SLES-01514 - P} <silenthe> ]
+:SLES-01514
+#Infinite Health
+800B96AE 0006
+#Infinite Ammo & No Reloads
+800B95F8 0063
+#Have All Weapons
+800BC098 0180
+800BC09C 0181
+800BC0A4 0184
+800BC0A8 0185
+800BC0B0 0187
+800BC0B4 FFA0
+800BC0B8 FFA1
+800BC0C0 FFA3
+800BC0BC FFA2
+#Slide & Glide Mode
+800B9722 3800
+#Have Map
+300BC188 0002
+#Map Complete
+50000402 FFFF
+800BC1F8 0000
+#Flassh light Always on
+300BB94D 0001
+#Invincibility
+8008BEA2 1000
+#Infinite Health (ASM)
+8007CB5E 2400
+#Infinite Ammo (ASM)
+80074A6E 2400
+#Total Time = 00:00
+900BC274 00000000
+#Saves = 0
+800BC0CA 0000
+#Have All Maps
+800BC188 FFFE
+300BC18A 00FF
+50006201 0000
+300BC1F8 00FF
+#Perfect Game Results
+800BC260 00CC
+50000702 0000
+800BC288 0000
+300BC29F 0000
+#Start New Game at Cafe (skip chasing Cheryl down the alley intro part)
+900BC18C FFFFFFFF
+#Language Option Always Available
+801E7698 0001
+#Widescreen 16-9
+A70C65D0 10000C00
+A70C65E0 10000C00
+
+; [ Sphere 360° (Euro) (1999?) (ASCII Entertainment Europe) {SLED-01711 (2083014)} <sphere360> ]
+;:SLED-01711
+;This game currently has no cheats
+
+; [ Spider-Man (Euro) (2000) (Activision Publishing) {SLES-02886, SLES-02886/P} <spidermne> ]
+:SLES-02886
+#Invulnerable
+300EA335 0056
+#Infinite Web Carts
+801B7599 2400
+#Countdown Time Frozen
+800EA486 C100
+#Unlock All
+5004FFDA F5F4
+800F9AA0 FFFF
+#Level Select
+300EA319 0001
+#Enable What If Contest
+800EA325 0001
+
+; [ Spyro the Dragon (Euro) (1998) (Sony Computer Entertainment Europe) {SCES-01438 (9750925)} <spyroe> ]
+:SCES-01438
+#Infinite Lives
+8007C100 000F
+#Infinite Health
+8007F54C 0003
+#Infinite Time
+8007C110 0A00
+#Moon Jump
+E007DD10 0040
+8007F468 0000
+#Have All found
+50000404 0000
+8007EFC0 0008
+
+; [ Spyro: Year of the Dragon (Euro, Rev. 1) (2001) (Sony Computer Entertainment Europe) {SCES-02835} <spyro3e> ]
+:SCES-02835
+#Have 999 jewels
+8006F9F8 03E7
+#Have 15000 jewels
+8006F9F8 3A98
+#Have 20000 jewels
+8006F9F8 4e20
+#Have all eggs
+8006F93C 0096
+#Infinite Health
+A60738A4 00020003
+#Infinite Lives
+A606FA60 00030004
+#Moon Jump (Press Up & X)
+D0074736 BFEF
+3007362D 00A0
+#Boarding More Time(Press L1 & L2)
+D0074736 FAFF
+8018BCD0 2312
+#Start With Lots Of Points
+A618A160 00002710
+#Sunrise Spring Worlds Unlocked
+3007546C 0001
+#Sunny Villa Unlocked
+3007546D 0001
+#Cloud Spires Unlocked
+3007546E 0001
+#Molten Crater Unlocked
+3007546F 0001
+#Seashell Shore Unlocked
+30075470 0001
+#Mushroom Speedway Unlocked
+30075471 0001
+#Sheila's Alp Unlocked
+30075472 0001
+#Buzz's Dungeon Unlocked
+30075473 0001
+#Midday Garden Worlds Unlocked
+30075475 0001
+#Icy Peak Unlocked
+30075476 0001
+#Enchanted Towers Unlocked
+30075477 0001
+#Spooky Swamp Unlocked
+30075478 0001
+#Bamboo Terrace Unlocked
+30075479 0001
+#Country Speedway Unlocked
+3007547A 0001
+#Sgt. Byrd's Base Unlocked
+3007547B 0001
+#Spike's Arena Unlocked
+3007547C 0001
+#Evening Lake Worlds Unlocked
+3007547E 0001
+#Frozen Altars Unlocked
+3007547F 0001
+#Last Fleet Unlocked
+30075480 0001
+#Firewords Factory Unlocked
+30075481 0001
+#Charmed Ridge Unlocked
+30075482 0001
+#Honey Speedway Unlocked
+30075483 0001
+#Bentley's Outpost Unlocked
+30075484 0001
+#Scorch's Pit Unlocked
+30075485 0001
+#Midnight Mountain Worlds Unlocked
+30075487 0001
+#Crystal Islands Unlocked
+30075488 0001
+#Desert Ruins Unlocked
+30075489 0001
+#Haunted Tomb Unlocked
+3007548A 0001
+#Dino Mines Unlocked
+3007548B 0001
+#Harbor Speedway Unlocked
+3007548C 0001
+#Agent 9's Lab Unlocked
+3007548D 0001
+#Sorceress's Lair Unlocked
+3007548E 0001
+#Sparx Worlds Unlocked
+30075474 0001
+#Spider Town Unlocked
+3007547D 0001
+#Starfish Reef Unlocked
+30075486 0001
+#Bugbot Factory Unlocked
+3007548F 0001
+#Super Bonus World Unlocked
+30075490 0001
+#Have All Eggs Codes\Sunrise Spring Home
+300735FC 001F
+#Have All Eggs Codes\Sunny Villa
+300735FD 003F
+#Have All Eggs Codes\Cloud Spires
+300735FE 003F
+#Have All Eggs Codes\Molten Crater
+300735FF 003F
+#Have All Eggs Codes\Seashell Shore
+30073600 003F
+#Have All Eggs Codes\Mushroom Speedway
+30073601 0007
+#Have All Eggs Codes\Sheila's Alp
+30073602 0007
+#Have All Eggs Codes\Buzz's Dungeon
+30073603 0001
+#Have All Eggs Codes\Crawdad Farm
+30073604 0001
+#Have All Eggs Codes\Midday Garden Home
+30073605 001F
+#Have All Eggs Codes\Icy Peak
+30073606 003F
+#Have All Eggs Codes\Enchanted Towers
+30073607 003F
+#Have All Eggs Codes\Spooky Swamp
+30073608 003F
+#Have All Eggs Codes\Bamboo Terrace
+30073609 003F
+#Have All Eggs Codes\Country Speedway
+3007360A 0007
+#Have All Eggs Codes\Sgt. Byrd's Base
+3007360B 0007
+#Have All Eggs Codes\Spike's Arena
+3007360C 0001
+#Have All Eggs Codes\Spider Town
+3007360D 0001
+#Have All Eggs Codes\Evening Lake Home
+3007360E 001F
+#Have All Eggs Codes\Frozen Altars
+3007360F 003F
+#Have All Eggs Codes\Last Fleet
+30073610 003F
+#Have All Eggs Codes\Firewords Factory
+30073611 003F
+#Have All Eggs Codes\Charmed Ridge
+30073612 003F
+#Have All Eggs Codes\Honey Speedway
+30073613 0007
+#Have All Eggs Codes\Bentley's Outpost
+30073614 0007
+#Have All Eggs Codes\Scorch's Pit
+30073615 0001
+#Have All Eggs Codes\Starfish Reef
+30073616 0001
+#Have All Eggs Codes\Midnight Mountain Home
+30073617 003F
+#Have All Eggs Codes\Crystal Islands
+30073618 003F
+#Have All Eggs Codes\Desert Ruins
+30073619 003F
+#Have All Eggs Codes\Haunted Tomb
+3007361A 003F
+#Have All Eggs Codes\Dino Mines
+3007361B 003F
+#Have All Eggs Codes\Harbor Speedway
+3007361C 0007
+#Have All Eggs Codes\Agent 9's Lab
+3007361D 0007
+#Have All Eggs Codes\Sorceress' Lair
+3007361E 0001
+#Have All Eggs Codes\Bugbot Factory
+3007361F 0001
+#Have All Eggs Codes\Super Bonus World
+30073620 0001
+#Max Gems Codes\Sunrise Spring Home
+80074ECC 0190
+#Max Gems Codes\Sunny Villa
+80074ED0 0190
+#Max Gems Codes\Cloud Spires
+80074ED4 0190
+#Max Gems Codes\Molten Crater
+80074ED8 0190
+#Max Gems Codes\Seashell Shore
+80074EDC 0190
+#Max Gems Codes\Mushroom Speedway
+80074EE0 0190
+#Max Gems Codes\Sheila's Alp
+80074EE4 0190
+#Max Gems Codes\Buzz's Dungeon
+80074EE8 0000
+#Max Gems Codes\Crawdad Farm
+80074EEC 00C8
+#Max Gems Codes\Midday Garden Home
+80074EF0 0190
+#Max Gems Codes\Icy Peak
+80074EF4 01F4
+#Max Gems Codes\Enchanted Towers
+80074EF8 01F4
+#Max Gems Codes\Spooky Swamp
+80074EFC 01F4
+#Max Gems Codes\Bamboo Terrace
+80074F00 01F4
+#Max Gems Codes\Country Speedway
+80074F04 0190
+#Max Gems Codes\Sgt. Byrd's Base
+80074F08 01F4
+#Max Gems Codes\Spike's Arena
+80074F0C 0000
+#Max Gems Codes\Spider Town
+80074F10 00C8
+#Max Gems Codes\Evening Lake Home
+80074F14 0190
+#Max Gems Codes\Frozen Altars
+80074F18 0258
+#Max Gems Codes\Last Fleet
+80074F1C 0258
+#Max Gems Codes\Firewords Factory
+80074F20 0258
+#Max Gems Codes\Charmed Ridge
+80074F24 0258
+#Max Gems Codes\Honey Speedway
+80074F28 0190
+#Max Gems Codes\Bentley's Outpost
+80074F2C 0258
+#Max Gems Codes\Scorch's Pit
+80074F30 0000
+#Max Gems Codes\Starfish Reef
+80074F34 00C8
+#Max Gems Codes\Midnight Mountain Home
+80074F38 0190
+#Max Gems Codes\Crystal Islands
+80074F3C 02BC
+#Max Gems Codes\Desert Ruins
+80074F40 02BC
+#Max Gems Codes\Haunted Tomb
+80074F44 02BC
+#Max Gems Codes\Dino Mines
+80074F48 02BC
+#Max Gems Codes\Harbor Speedway
+80074F4C 0190
+#Max Gems Codes\Agent 9's Lab
+80074F50 02BC
+#Max Gems Codes\Sorceress' Lair
+80074F54 0000
+#Max Gems Codes\Bugbot Factory
+80074F58 00C8
+#Max Gems Codes\Extra bonus world
+80074F5C 1388
+
+; [ Street Skater 2 (Euro) (2000) (Electronic Arts) {SLES-02703 (EAE06103049)} <strskat2> ]
+:SLES-02703
+#Each Trick is Worth Max Points
+90085548 2402FFFF
+#Mega Boost With Up
+E00388C1 0010
+8003883C 1400
+#Great Trick Score
+8003872E 0098
+#Infinite Time L1 for 15 points/L2 for 0 points
+80038724 1200
+#Bonus Points
+D00988C0 0004
+801FAC00 000F
+D00988C0 0001
+801FAC00 0000
+#Max Character-Codes
+50000501 0000
+301FA9F0 000F
+#Unlock All Levels
+8008D3F8 FFFF
+#Unlock All Characters
+8008D400 FFFF
+#Unlock All Boards
+9008D404 FFFFFFFF
+#Unlock Movieplayer
+8008D3F4 0002
+
+; [ Tenchu: Stealth Assassins (Euro, Demo) (1998) (Activision) {SLED-01467 (7005053)} <tenchude> ]
+;:SLED-01467
+;This game currently has no cheats
+
+; [ Test Drive 6 (Euro) (2000) (Cryo Interactive Entertainment) {SLES-02752} <td6e> ]
+:SLES-02752
+#Infinite Money & All Cars And Stages Unlocked
+D009EFF8 9C40
+8009EFFA 0DC8
+A609EFF8 9C4021B8
+#Infinite Checkpoint Time
+800471F4 0000
+#Total Time 00:00:00/Always 1st
+90046FFC 00000000
+#Always First (Display)
+30018982 0020
+#Enable Pitbull Cup
+300A6A70 0001
+#Enable Masters Cup
+300A6A71 0001
+#Enable Ultimate Cup
+30096A72 0001
+#Enable Cop Chase Mode
+300A6A73 0001
+#Enable Challenge Cup
+800A6A6E 0100
+#Global Car Reflection Intensity
+80039FB8 ????
+80039FBA 3406
+#Red Reflection Intensity
+8003A0B0 ????
+8003A0B2 3402
+#Green Reflection Intensity
+8003A0DC ????
+8003A0DE 3402
+#Blue Reflection Intensity
+8003A100 ????
+8003A102 3402
+#Bomb Detonation Time Modifier
+8002313C ????
+#Remote Detonate Bombs (Press L3)
+80022EC8 0000
+E1098080 0002
+80022ECA 2400
+E0098080 0002
+80022ECA 3402
+#Controllable AI Bomber Cars:Auto Bombs Above 40kmph
+8009AA14 00000006
+D3098729 00000102
+1000C000 00000001
+D3098729 00000102
+E000C000 00000020
+80030D5E 00001400
+D3098729 00000102
+E000C000 00000021
+80030D5E 00001462
+E300C000 00000022
+3000C000 00000000
+D2098729 00000102
+3000C000 00000000
+#Become Invisible
+A7038A2A 14401000
+#Going above 40kmph gives controller vibration
+D3098729 0102
+3009840D 0002
+#Widescreen 16-9
+8009806C 0C00
+
+; [ Theme Hospital (Euro) (1998) (Electronic Arts) {SLES-00627} <themehose> ]
+;:SLES-00627
+;This game currently has no cheats
+
+; [ Theme Park World (Euro) (2000) (Electronic Arts) {SLES-02688, SLES-02688/GER} <themepw> ]
+:SLES-02688
+#Infinite Money
+801D56B8 A120
+#Number Of Visitors Max
+801D69C4 0FFF
+#Have 5 Golden Tickets
+80103984 0005
+
+; [ TOCA World Touring Cars (Euro) (2000) (The Codemasters Software Company) {SLES-02572, SLES-02572/P} <tocawtc> ]
+:SLES-02572
+#Activate Bonuses Menu Always Open
+300A1778 0001
+#only one lap to race / always first
+D00F936E 0003
+300F936C 0003
+D00F936E 0004
+300F936C 0004
+D00F936E 0005
+300F936C 0005
+D00F936E 0006
+300F936C 0006
+D00F936E 0008
+300F936C 0008
+#Always 6 races won
+30059279 0006
+#Always get 100 points per season
+D10592C0 0000
+800592C0 0064
+#Other drivers can't score
+50000B04 0000
+800592C4 0000
+#Max career-points
+D105938C 0000
+8005938C 02C6
+#All boni available (Press L1 & L2 & R1 & R2)
+D0054056 F0FF
+800581C8 FFFF
+#Time trial stop timer
+80057A0C 00CF
+#Auto Pilot - Press x & Select
+D0053E58 4001
+800F938A 0100
+#Auto Pilot Deactivate - Press Select
+D0053E58 0001
+800F938A 1030
+#Nitro Boost - Press x & Up
+D0053E58 4010
+800FD1D2 0001
+
+; [ Tomb Raider: The Last Revelation (Euro, Aus) (1999) (Eidos Interactive) {SLES-02238, SLES-02238/ANZ} <traid4e> ]
+:SLES-02238
+#Infinite Oxygen
+300AB2CE 0708
+#Infinite Health
+90051F9C 340203E8
+90051FA0 A6020022
+#Stage Select Press Select at the title screen to have access to all levels and after loading one level end it and then you can select the level you wanted.
+D00AA120 0F00
+800A6AEE 0200
+#Infinite Large Medi-Packs
+300AB2CE 00FC
+#Infinite Flares
+800AB400 00FF
+#Have all weapons
+50000402 FFFF
+800AB3D4 0000
+#Infinite Ammo UZI
+800AB404 00FF
+#Infinite Ammo Normal gun
+800AB408 00FF
+#8 golden skulls (Training-level)
+300AB3E3 0008
+
+; [ Urban Chaos (Euro) (2000) (Eidos Interactive) {SLES-02071, SLES-02071#} <urbchaose> ]
+:SLES-02071
+#Enable All Levels
+8010C2EC 0001
+#Stop Timer
+D002C660 0004
+8002C662 3C00
+#Infinite Ammo
+D005AF08 000A
+8005AF0A 3C00
+D005AE30 000C
+8005AE32 3C00
+#Gatecrasher Level\Infinite Health
+80191A24 00C8
+#Arms Breaker Level\Infinite Health
+80195194 00C8
+#Arms Breaker Level\Infinite Pistol Ammo
+80195192 010C
+#Arms Breaker Level\Infinite Shotgun Ammo
+80199300 0005
+#Media Trouble Level\Infinite Health
+801955A4 00C8
+#Media Trouble Level\Infinite Pistol Ammo
+801955A2 010F
+#Media Trouble Level\Infinite Shotgun Ammo
+8019907C 0005
+#Urban Shakedown Level\Infinite Health
+80195908 00C8
+#Urban Shakedown Level\Infinite Pistol Ammo
+80195906 010F
+#Urban Shakedown Level\Infinite Shotgun Ammo
+801985A0 0005
+#Auto-Destruct Level\Infinite Health
+80196F0C 00C8
+#Auto-Destruct Level\Infinite Pistol Ammo
+8010A03C 010F
+#Auto-Destruct Level\Infinite Shotgun Ammo
+8019A044 0005
+#Grim Gardens\Infinite Health
+80195A40 00C8
+#Grim Gardens\Infinite Pistol Ammo
+80195A3E 010F
+#Semtex\Infinite Health
+80194DCC 00C8
+#Semtex\Infinite Pistol Ammo
+80194DCA 010F
+#Semtex\Infinite Shotgun Ammo
+801992FC 0005
+#Cop Killers\Infinite Health
+8019121C 00C8
+#Cop Killers\Infinite Shotgun Ammo
+8019582C 0005
+#Cop Killers\Infinite Shotgun Ammo For Roper
+80194E54 0005
+#Southside Offensive\Infinite Health
+80194954 00C8
+#Southside Offensive\Infinite Shotgun Ammo
+80199234 0005
+#Southside Offensive\Infinite Shotgun Ammo
+80199234 0005
+#Psycho Park\Infinite Health
+801947BC 00C8
+#Psycho Park\Infinite Shotgun Ammo
+80199640 0005
+#The Fallen\Infinite Health
+80194EF0 00C8
+#The Fallen\Infinite Shotgun Ammo
+801993A4 0005
+#Stern Revenge\Infinite Shotgun Ammo
+80198334 0005
+#Transmission Terminated\Infinite Health
+80192CEC 00C8
+#Transmission Terminated\Infinite Shotgun Ammo
+80197630 0005
+#Estate Of Emergency\Infinite Health
+8019288C 00C8
+#Estate Of Emergency\Infinite Health For Roper
+8019490C 0190
+#Seek, Sneak And Seize\Infinite Health
+801982BC 00C8
+#Target Uc\Infinite Health
+801964D4 00C8
+#Target Uc\Stop Timer
+800F7E34 1400
+80194A60 A380
+80194F00 8C1A
+#Headline Hostage\Infinite Health
+80195A78 00C8
+#Headline Hostage\Stop Timer
+800F7E34 13C0
+801928E8 29A4
+#Insane Assault\Infinite Health
+801918A8 00C8
+#Day Of Reckoning\Infinite Health
+8018B09C 00C8
+#Day Of Reckoning\Infinite Health For Roper
+8018A89C 0190
+#Day Of Reckoning\Stop First Timer
+80189108 AF2D
+#Day Of Reckoning\Stop Second Timer
+801894C8 128E
+800F7E34 1440
+#Gangaland / Rat Catch Infinite Health
+80197704 00C8
+#Gangaland / Rat Catch Suddendeath
+A61960A8 00C80000
+#Gangaland / Nitro Car Infinite Health
+8019798C 00C8
+#Gangaland / Nitro Car No Car Damage
+80196FE6 012C
+#Gangaland / Auto-Destruct Stop Time
+8019350D 0122
+8019B2A9 1E23
+#Gangaland / Auto-Destruct Infinite Energy
+80196F0C 00C8
+#Gangaland / Assassin Infinite Energy
+801966F4 00C8
+#Infinite Ammo
+D005AF08 000A
+8005AF0A 3C00
+D005AE30 000C
+8005AE32 3C00
+
+; [ Vanishing Point (Euro) (2001) (Acclaim Entertainment) {SLES-02534} <vanishpte> ]
+:SLES-02534
+#Always 1st
+80010CC8 0000
+#Always Have 100 Points
+80010CC6 0000
+#Stage Time 00:00:00 / Always First
+3002BDC6 0000
+#Unlock All Cars
+50000202 0000
+8003CE94 FFFF
+#Unock All Stages
+50000402 0000
+8003CEA0 FFFF
+#Unlock Tune Up Shop
+8003CEAC FFFF
+#Unlock Series-Option
+3003CEAA 0001
+#Unlock Aggressive Traffic
+3003CEAA 0002
+#Unlock Both
+3003CEAA 0003
+#Unlock All Intros, Fmvs & Dias
+8003CEAE 3FFF
+#Unlock Cwg-Rally
+3003CDA0 0001
+#Stunt driver All Events Time 0'00'00
+50000F04 0000
+8003FE30 0000
+#Stunt driver All Events Have 100 Points
+50000F04 0000
+8003FE32 6400
+#Stunt driver Always get 100 points (even when failed)
+D0094634 1021
+80094638 0064
+D0094634 1021
+8009463A 3403
+
+; [ Warpath: Jurassic Park (Euro) (1999) (Electronic Arts) {SLES-02253} <warpathe> ]
+:SLES-02253
+#P1 Quick win
+9006144C 14800003
+8006145A 3C00
+#Start on final Stage
+800313B6 0008
+#Unlock all characters
+50000601 0000
+300313CD 0001
+#Unlock all levels
+50000401 0000
+300313F9 0001
+#Unlock all Extra Modes
+3003143F 0001
+#P1 only needs 1 win
+E00313A7 0000
+300313A7 0001
+#Widescreen 16-9
+80041BA8 0C00
+
+; [ WCW Mayhem (Euro) (1999) (Electronic Arts) {SLES-02193 (EAX06102705D), SLES-02193#} <wcwmayhme> ]
+:SLES-02193
+#Player on left has full Momentum meter
+800F9D1A 0000
+800F9D1C 0000
+#Player on right has full Momentum meter
+800F9D1A 00FF
+800F9D1C 00FF
+#Quest-Cheat Enabled (Press R1 in Start-Menu)
+D00AD6A2 F7FF
+3009CFF5 002F
+#Unlock all fighters ( press L1 in the Wrestlers Select menu)
+D00AD6A2 FBFF
+3009CFF5 0001
+#Stamina bar switch (Press Select & L1)
+D00AD6A2 FBFE
+3009CFF5 0020
+#Classic TNT Nitro set unlock ( Press R2 in the Start menu)
+D00AD6A2 FDFF
+3009CFF5 008F
+#P1 max stamina
+D009D700 0002
+800F9B78 07D0
+#P2 max stamina
+D009D700 0002
+800F9D18 07D0
+#P2 no stamina
+D009D700 0002
+800F9D18 0000
 
 ; [ Firebugs (Euro) (2002) (Sony) {SCES-03884} <firebugs> ]
 :SCES-03884
@@ -82012,10 +85731,52 @@ B0050001 0000
 800DDAB0 2710
 #Infinite Money (For Duplications)
 8001001C 03E7
-#T.O.P.S. All
-80010014 01F6
-#Collected LCC's All movies open
+#Collected Launch Code Cartridges (LCCs) Cheats\All movies open
 80010096 FFFF
+#Collected Launch Code Cartridges (LCCs) Cheats\Earth
+80010094 01FF
+#Collected Launch Code Cartridges (LCCs) Cheats\Jupiter
+80010092 01FF
+#Collected Launch Code Cartridges (LCCs) Cheats\Neptune
+80010090 01FF
+#Collected Launch Code Cartridges (LCCs) Cheats\Uranus
+8001008E 01FF
+#Collected Launch Code Cartridges (LCCs) Cheats\Venus
+8001008C 01FF
+#Terracon Outrider Pick-up Systems (TOPS) Cheats\Always have RADAR Sweeper (Blue):Puts RADAR in the top-left of the display
+31010014 0002
+#Terracon Outrider Pick-up Systems (TOPS) Cheats\Always have Life-Force-Regenerator (Green):Absorbs incoming damage from enemies
+31010014 0020
+#Terracon Outrider Pick-up Systems (TOPS) Cheats\Always have Turbo-Fire Aggregate (Dark Purple):Doubles the player's rate of fire
+31010015 0001
+#Terracon Outrider Pick-up Systems (TOPS) Cheats\Always have Auxiliary Ggenergy-Projector (Red):Doubles the number of bolts from the genergy-projector, but maintains the usual rate of fire
+31010014 0004
+#Terracon Outrider Pick-up Systems (TOPS) Cheats\Always have Holoflage-Emitter (Orange):Player is invisible to enemies, upon sustaining damage
+31010014 0040
+#Terracon Outrider Pick-up Systems (TOPS) Cheats\Always have Firepower Supercharger (Light Purple):Player can fire a single shot of charged genergy
+31010014 0080
+#Terracon Outrider Pick-up Systems (TOPS) Cheats\Always have Micro Missile-Launcher (Yellow):Small homing missiles of enemies and objects
+31010014 0010
+#Terracon Outrider Pick-up Systems (TOPS) Cheats\Always have Time-Delay Unit (Grey):In later levels replenishes the player's oxygen for a few seconds
+31010014 0008
+#Walk/Run on Water:Jump to Sink
+A702D1BE 14431000
+#One Hit Kills
+A706073A 14401400
+#Collect Life Energy (Green) from anywhere
+A7082D1E 10401400
+#Collect Geenergy Clusters (Red) on Sight
+A703FCAA 10401400
+;Buggy crashes game on end of level structures
+;#One Hit to Generate Meshes
+;A7026C8E 10401000
+#Collect LCCs from anywhere
+A7083C96 10401400
+#Walk through Beams
+A709D3AA 10401000
+#Invincibility
+A70B27FE 10401000
+A702E0C6 14621000
 
 ; [ Baldur's Gate (USA, Prototype) (19??) (Interplay) {SLUS-01037} <baldgate> ]
 :SLUS-01037
@@ -83783,35 +87544,6 @@ A605F300 000103E8
 #Infinite Fuel
 800EDF0C 8FFF
 
-; [ Air Combat (Europe) {SCES-00007} ]
-:SCES-00007
-#Infinite Guns
-800EEB44 0027
-#Infinite Ammo
-800EEB40 0041
-#Infinite Fuel
-300EEB34 8FFF
-#No Damage
-800EEA60 00C8
-#Infinite Cannon Ammo
-A60EEB44 270E270F
-#Infinite Missiles
-A60EEB40 00400041
-#Infinite Fuel
-D10EEB34 8FFF
-800EEB34 8FFF
-#Infinite Armor
-D10EEA60 00C8
-800EEA60 00C8
-#Start Mini-Game With 1000 Points
-A605F300 000103E8
-#Infinite Missiles
-800EDF18 0040
-#Infinite Ammo
-300EDF1C 0027
-#Infinite Fuel
-800EDF0C 8FFF
-
 ; [ Air Hockey (Europe) (Pocket Price Midas) {SLES-03743} ]
 
 ; [ Air Management '96 (Japan) {SLPS-00269} ]
@@ -84893,41 +88625,6 @@ D00D0DC4 0105
 50000504 0000
 8015C390 0006
 
-; [ Anna Kournikova's Smash Court Tennis (Europe) Rev 1 {SCES-01833} ]
-:SCES-01833
-#P1 40 Gamepoints
-8007A658 0003
-#P2 0 Gamepoints
-8007A65C 0000
-#P1 Set 1 Won
-8015C380 0005
-#P1 Set 1 Won (.Press Select+L1+L2)
-D00D0DC4 0105
-8015C380 0005
-#P1 5 Points Set 2
-8015C384 0005
-#P1 5 Points Set 3
-8015C388 0005
-#P1 5 Points Set 4
-8015C38C 0005
-#P1 5 Points Set 5
-8015C390 0005
-#9999 Point In Tournament Mode
-8015E448 270F
-#All Items
-50001801 0000
-3015E7DF 0001
-#P1 All Sets Max Wins
-50000504 0000
-8015C380 0006
-50000504 0000
-8015C390 0000
-#P2 All Sets Max Wins
-50000504 0000
-8015C380 0000
-50000504 0000
-8015C390 0006
-
 ; [ Ano Ko Doko no Ko (Japan) {SLPS-01522} ]
 :SLPS-01522
 #Have all stats at 999
@@ -84948,31 +88645,6 @@ D0061FD0 0800
 
 ; [ Anstoss: Premier Manager (Germany) {SLES-02563} ]
 ; [ Ape Escape (Europe) Demo {SCED-02133} ]
-
-; [ Ape Escape (Europe) {SCES-01564} ]
-:SCES-01564
-#Infinite Health
-800EC388 0005
-#Infinite Oxygen
-800F4E88 0255
-#All Weapons
-800F5284 00FF
-#Infinite Missiles
-800F5282 010A
-#Infinite Bombs
-300F5281 0009
-#Infinite Lives
-800F442C 0005
-#Infinite Health
-800EC268 0005
-#Lots Of Gold Triangles
-800F4456 FFFF
-#Infinite Oxygen
-800F4D68 0258
-#Get One Monkey To Finish Level
-800F4454 00FF
-#Widescreen 16-9
-800AF050 0C00
 
 ; [ Ape Escape (France) {SCES-02028} ]
 :SCES-02028
@@ -85651,6 +89323,16 @@ A604192E 002000C8
 ; [ Armored Core (Japan) (Tsuushin Taisen Taikenban) {SLP-80119} ]
 ; [ Armored Core (Japan) Rev 1 {SLPS-03581} ]
 ; [ Armored Core (Japan) {SLPS-00900} ]
+:SLPS-00900
+#Infinite Time
+8019F3F4 FFFF
+#Infinite Money
+90039CCC 00FFFFFF
+#Infinite Power
+80041016 6D60
+#Infinite HP
+801A26E0 8000
+
 ; [ Armored Core: Master of Arena (Japan) (PSone Books) {SLPS-91444 | SLPS-91445} ]
 ; [ Armored Core: Master of Arena (Japan) (The Preview Movie) {SLP-80371} ]
 
@@ -85684,6 +89366,19 @@ D0084708 002A
 8003EA94 FFFF
 
 ; [ Armored Core: Project Phantasma (Japan) (PlayStation the Best, PSone Books) {SLPS-91110} ]
+:SLPS-91110
+#Infinite Mission Timer
+801A1694 0F80
+#Infinite Energy
+801A4980 8300
+#Infinite Jet Packs
+80041A26 6D60
+#Infinite Rifle
+80041CF8 00C8
+#Infinite Small Missiles
+80041D36 0028
+#Infinite Money
+9003A634 50F5E0FF
 
 ; [ Armored Core: Project Phantasma (Japan) Rev 1 {SLPS-01130} ]
 :SLPS-01130
@@ -86620,7 +90315,6 @@ A6056020 00010025
 8004D670 0000
 
 ; [ Autorennen Spezial '98 (Germany) {SCED-01306} ]
-; [ Autumn/Christmas Releases '96 (Europe) {SCED-00273} ]
 ; [ Ayrton Senna Kart Duel (Europe) {SLES-00493} ]
 
 ; [ Ayrton Senna Kart Duel (Japan) {SLPS-00380} ]
@@ -87414,75 +91108,6 @@ A604345C FFFF0000
 ; [ Beat-Em-Up Speziale (Germany) {SCED-01643} ]
 
 ; [ Beatmania (Europe) {SLES-02096} ]
-:SLES-02096
-#P1 Max Gauge
-800A5178 0039
-800A5248 0039
-#P2 Max Gauge
-800A517A 0039
-800A524A 0039
-#P1 Max Stage Score
-900A5360 000F423F
-#P2 Max Stage Score
-900A5364 000F423F
-#P1 Perfect Results
-800A525C 03E7
-800A5368 03E7
-50000302 0000
-800A536A 0000
-#P2 Perfect Results
-800A525E 03E7
-800A5370 03E7
-50000302 0000
-800A5372 0000
-#Unlock Extras
-9009A764 00000000
-#P1-Codes\Start With High Total Score
-A60A51D0 000086A0
-D00A51D0 0000
-300A51D2 0001
-#P1-Codes\Always Get 'A'-Ranking
-A60A5360 000086A0
-D00A5360 0000
-300A5362 0001
-#P1-Codes\The Public is Always Pleased
-800A51E8 0640
-#P1-Codes\The Public is Never Pleased
-800A51E8 0000
-#P1-Codes\Max Combo
-800A525C 03E7
-#P1-Codes\No Combos
-800A525C 0000
-#P1-Codes\Great = 300
-800A5368 012C
-#P1-Codes\Great = 0
-300A5368 0000
-#P1-Codes\Good, Bad & Poor = 0
-50000302 0000
-800A536A 0000
-#P2-Codes\Start With High Total Score
-A60A51D4 000086A0
-D00A51D4 0000
-300A51D6 0001
-#P2-Codes\Always Get 'A'-Ranking
-A60A5364 000086A0
-D00A5364 0000
-300A5366 0001
-#P2-Codes\The Public is Always Pleased
-800A51EA 0640
-#P2-Codes\The Public is Never Pleased
-800A51EA 0000
-#P2-Codes\Max Combo
-800A525E 03E7
-#P2-Codes\No Combos
-800A525E 0000
-#P2-Codes\Great = 300
-800A5370 012C
-#P2-Codes\Great = 0
-300A5370 0000
-#P2-Codes\Good, Bad & Poor = 0
-50000302 0000
-800A5372 0000
 
 ; [ Beatmania 6thMix + Core Remix (Japan) {SLP-87012} ]
 ; [ Beatmania Append 4thMix: The Beat Goes On (Japan) {SLP-86266} ]
@@ -90042,11 +93667,6 @@ A60636AE 00442442
 #Widescreen 16-9
 80017E0C 1334
 
-; [ Bust-A-Groove (Europe) (Review) {SCES-01313} ]
-:SCES-01313
-#P1 Max Enthusiasm
-80068790 7530
-
 ; [ Bust-A-Groove (Europe) {SCES-01313} ]
 :SCES-01313
 #P1 Max Enthusiasm
@@ -90234,9 +93854,9 @@ D00329C0 000E
 
 ; [ CT Special Forces (Europe) {SLES-03986} ]
 :SLES-03986
-#Infinite Energy PL 1
+#P1 Infinite Energy 
 8009D8F0 0064
-#Infinite Energy PL 2
+#P2 Infinite Energy 
 8009DA2C 0064
 #Infinite Lives
 8004D318 0000
@@ -90248,6 +93868,28 @@ D00329C0 000E
 8009db48 0005
 #Infinite Time in sniper level
 80078674 1770
+#Invincibility
+A7028FF2 10402400
+#Remove Enemies - Activate at Beginning Of Level
+A70284F6 14201000
+#FPS Unlock
+A7012126 04812400
+#Skip Level (Press L3)
+80023FCA 00001420
+D7010001 00000200
+80023FCA 00002400
+#Multi - Jump
+8004B93A 00001440
+D7010001 01000040
+8004B93A 00001000
+#Walk Through Walls (Hold L2+R2)
+8004D6FA 00001000
+8004D5E6 00001000
+8004B66A 00001000
+D7100000 02000003
+8004D6FA 00001441
+8004D5E6 00001441
+8004B66A 00001040
 
 ; [ CT Special Forces 3: Bioterror (Europe) {SLES-04155} ]
 :SLES-04155
@@ -91598,8 +95240,22 @@ D00E524E 015E
 300E52A4 0063
 50000502 0000
 800E52A6 6363
+#Widescreen 16-9
+A70F2B80 10000C00
+#Widescreen 16-9 (Optional Extra)
+A70F2BA0 10000C00
+#Dither Off
+A70905D4 02000000
 
 ; [ Chaos Break (Japan) {SLP-86363} ]
+:SLP-86363
+:SLPM-86363
+#Widescreen 16-9
+A70F3148 10000C00
+#Widescreen 16-9 (Optional Extra)
+A70F3168 10000C00
+#Dither Off
+A709097C 02000000
 
 ; [ Charumera (Japan) {SLPS-02415} ]
 :SLPS-02415
@@ -91610,133 +95266,6 @@ D00E524E 015E
 50009D01 0000
 301E1A71 0001
 
-; [ Chase the Express (Europe) {SCES-02812 | SCES-12812} ]
-:SCES-02812
-:SCES-12812
-#Timer Stopped
-8001CE8E 0000
-#Infinite Health
-80010402 1000
-#Infinite Ammo & Items
-8007D6DE 0000
-#All Maps Complete
-50000704 0000
-80010A80 0080
-50000804 0000
-80010AA0 0080
-50000404 0000
-80010AD0 0080
-50000204 0000
-80010AE4 0080
-50000704 0000
-80010B14 0080
-#Have All Data
-50002702 0202
-8001088C 0201
-#Have All Weapons In Crate (Press Up & L1)
-D00D8E8E FBEF
-50000202 0100
-80010470 0200
-D00D8E8E FBEF
-50000202 0200
-80010474 3000
-D00D8E8E FBEF
-50000202 0100
-80010478 3800
-D00D8E8E FBEF
-50000202 0100
-8001047C 3D00
-#Have All Keys In Crate (Press Up & L2)
-D00D8E8E FEEF
-50000E02 0100
-80010470 0A00
-#Have All Items In Crate (Press Up & R1)
-D00D8E8E F7EF
-50000502 0100
-80010470 0500
-D00D8E8E F7EF
-50001202 0100
-8001047A 1800
-#Max Item\Slot 1
-3001045C 00FF
-#Max Item\Slot 2
-3001045E 00FF
-#Max Item\Slot 3
-30010460 00FF
-#Max Item\Slot 4
-30010462 00FF
-#Max Item\Slot 5
-30010464 00FF
-#Max Item\Slot 6
-30010466 00FF
-#Max Item\Slot 7
-30010468 00FF
-#Max Item\Slot 8
-3001046A 00FF
-#Max Item In Crate\Slot 1
-30010470 00FF
-#Max Item In Crate\Slot 2
-30010472 00FF
-#Max Item In Crate\Slot 3
-30010474 00FF
-#Max Item In Crate\Slot 4
-30010476 00FF
-#Max Item In Crate\Slot 5
-30010478 00FF
-#Max Item In Crate\Slot 6
-3001047A 00FF
-#Max Item In Crate\Slot 7
-3001047C 00FF
-#Max Item In Crate\Slot 8
-3001047E 00FF
-#Max Item In Crate\Slot 9
-30010480 00FF
-#Max Item In Crate\Slot 10
-30010482 00FF
-#Max Item In Crate\Slot 11
-30010484 00FF
-#Max Item In Crate\Slot 12
-30010486 00FF
-#Max Item In Crate\Slot 13
-30010488 00FF
-#Max Item In Crate\Slot 14
-3001048A 00FF
-#Max Item In Crate\Slot 15
-3001048C 00FF
-#Max Item In Crate\Slot 16
-3001048E 00FF
-#Max Item In Crate\Slot 17
-30010490 00FF
-#Max Item In Crate\Slot 18
-30010492 00FF
-#Max Item In Crate\Slot 19
-30010494 00FF
-#Max Item In Crate\Slot 20
-30010496 00FF
-#Max Item In Crate\Slot 21
-30010498 00FF
-#Max Item In Crate\Slot 22
-3001049A 00FF
-#Max Item In Crate\Slot 23
-3001049C 00FF
-#Max Item In Crate\Slot 24
-3001049E 00FF
-#Max Item In Crate\Slot 25
-300104A0 00FF
-#Max Item In Crate\Slot 26
-300104A2 00FF
-#Max Item In Crate\Slot 27
-300104A4 00FF
-#Max Item In Crate\Slot 28
-300104A6 00FF
-#Max Item In Crate\Slot 29
-300104A8 00FF
-#Max Item In Crate\Slot 30
-300104AA 00FF
-#Max Item In Crate\Slot 31
-300104AC 00FF
-#Max Item In Crate\Slot 32
-300104AE 00FF
 
 ; [ Chase the Express (France) {SCES-02813 | SCES-12813} ]
 
@@ -93903,203 +97432,6 @@ E0184548 0001
 #Have 999999 points
 900783AC 000F423F
 
-; [ Crash Bandicoot (Europe) (EDC Platinum) {SCES-00344} ]
-:SCES-00344
-#All Levels Selectable
-30061628 0040
-#Reset To 2nd Mask At Map
-800615D0 0200
-#Infinite Lives-Codes\N. Sanity Beach
-D00B078C 0000
-8009E218 6300
-#Infinite Lives-Codes\Jungle Rollers
-D00B078C 0001
-8009E27C 6300
-#Infinite Lives-Codes\The Great Gate
-D00B078C 0002
-8009E430 6300
-#Infinite Lives-Codes\Boulders
-D00B078C 0003
-8009E264 6300
-#Infinite Lives-Codes\Upstream
-D00B078C 0004
-8009E2BC 6300
-#Infinite Lives-Codes\Papu Papu
-D00B078C 0005
-8009DDB0 6300
-#Infinite Lives-Codes\Rolling Stones
-D00B078C 0006
-8009E2F0 6300
-#Infinite Lives-Codes\Hog Wild
-D00B078C 0007
-8009E32C 6300
-#Infinite Lives-Codes\Native Fortress
-D00B078C 0008
-8009E480 6300
-#Infinite Lives-Codes\Up The Creek
-D00B078C 0009
-8009E380 6300
-#Infinite Lives-Codes\Ripper Roo
-D00B078C 000A
-8009DDC0 6300
-#Infinite Lives-Codes\The Lost City
-D00B078C 000B
-8009E384 6300
-#Infinite Lives-Codes\Temple Ruins
-D00B078C 000C
-8009E32C 6300
-#Infinite Lives-Codes\Road To Nowhere
-D00B078C 000D
-8009E300 6300
-#Infinite Lives-Codes\Boulder Dash
-D00B078C 000E
-8009E4E8 6300
-#Infinite Lives-Codes\Sunset Vista
-D00B078C 000F
-8009E4F8 6300
-#Infinite Lives-Codes\Koala Kong
-D00B078C 0010
-8009DE78 6300
-#Infinite Lives-Codes\Heavy Machinery
-D00B078C 0011
-8009E508 6300
-#Infinite Lives-Codes\Cortex Power
-D00B078C 0012
-8009E45C 6300
-#Infinite Lives-Codes\Generator Room
-D00B078C 0013
-8009E22C 6300
-#Infinite Lives-Codes\Toxic Waste
-D00B078C 0014
-8009E1AC 6300
-#Infinite Lives-Codes\Pinstripe
-D00B078C 0015
-8009DE70 6300
-#Infinite Lives-Codes\The High Road
-D00B078C 0016
-8009E2A0 6300
-#Infinite Lives-Codes\Slippery Climb
-D00B078C 0017
-8009E2D0 6300
-#Infinite Lives-Codes\Lights Out
-D00B078C 0018
-8009E1E8 6300
-#Infinite Lives-Codes\Fumbling In The Dark
-8009E28C 6300
-#Infinite Lives-Codes\Jaws Of Darkness
-D00B078C 0019
-8009E458 6300
-#Infinite Lives-Codes\Castle Machinery
-D00B078C 001A
-8009E56C 6300
-#Infinite Lives-Codes\Nitrus Brio
-D00B078C 001B
-8009DE80 6300
-#Infinite Lives-Codes\The Lab
-D00B078C 001C
-8009E20C 6300
-#Infinite Lives-Codes\The Great Hall
-D00B078C 001D
-8009E048 6300
-#Infinite Lives-Codes\Dr. Neo Cortex
-D00B078C 001E
-8009DDD8 6300
-#99 Wumpa Fruits For Crash\N. Sanity Beach
-D00B078C 0000
-8009E214 6300
-#99 Wumpa Fruits For Crash\Jungle Rollers
-D00B078C 0001
-8009E278 6300
-#99 Wumpa Fruits For Crash\The Great Gate
-D00B078C 0002
-8009E42C 6300
-#99 Wumpa Fruits For Crash\Boulders
-D00B078C 0003
-8009E260 6300
-#99 Wumpa Fruits For Crash\Upstream
-D00B078C 0004
-8009E2BC 6300
-#99 Wumpa Fruits For Crash\Papu Papu
-D00B078C 0005
-8009DDAC 6300
-#99 Wumpa Fruits For Crash\Rolling Stones
-D00B078C 0006
-8009E2EC 6300
-#99 Wumpa Fruits For Crash\Hog Wild
-D00B078C 0007
-8009E328 6300
-#99 Wumpa Fruits For Crash\Native Fortress
-D00B078C 0008
-8009E4AC 6300
-#99 Wumpa Fruits For Crash\Up The Creek
-D00B078C 0009
-8009E37C 6300
-#99 Wumpa Fruits For Crash\Ripp Roo
-D00B078C 000A
-8009DDBC 6300
-#99 Wumpa Fruits For Crash\The Lost City
-D00B078C 000B
-8009E380 6300
-#99 Wumpa Fruits For Crash\Temple Ruins
-D00B078C 000C
-8009E328 6300
-#99 Wumpa Fruits For Crash\Road To Nowhere
-D00B078C 000D
-8009E2FC 6300
-#99 Wumpa Fruits For Crash\Boulder Dash
-D00B078C 000E
-8009E4E4 6300
-#99 Wumpa Fruits For Crash\Sunset Vista
-D00B078C 000F
-8009E4F4 6300
-#99 Wumpa Fruits For Crash\Koala Kong
-D00B078C 0010
-8009DE74 6300
-#99 Wumpa Fruits For Crash\Heavy Machinery
-D00B078C 0011
-8009E504 6300
-#99 Wumpa Fruits For Crash\Cortex Power
-D00B078C 0012
-8009E458 6300
-#99 Wumpa Fruits For Crash\Generator Room
-D00B078C 0013
-8009E228 6300
-#99 Wumpa Fruits For Crash\Toxic Waste
-D00B078C 0014
-8009E1A8 6300
-#99 Wumpa Fruits For Crash\Pinstripe
-D00B078C 0015
-8009DE6C 6300
-#99 Wumpa Fruits For Crash\The High Road
-D00B078C 0016
-8009E29C 6300
-#99 Wumpa Fruits For Crash\Slippery Climb
-D00B078C 0017
-8009E2CC 6300
-#99 Wumpa Fruits For Crash\Lights Out
-D00B078C 0018
-8009E1E4 6300
-#99 Wumpa Fruits For Crash\Fumbling In The Dark
-8009E288 6300
-#99 Wumpa Fruits For Crash\Jaws Of Darkness
-D00B078C 0019
-8009E454 6300
-#99 Wumpa Fruits For Crash\Castle Machinery
-D00B078C 001A
-8009E568 6300
-#99 Wumpa Fruits For Crash\Nitrus Brio
-D00B078C 001B
-8009DE7C 6300
-#99 Wumpa Fruits For Crash\The Lab
-D00B078C 001C
-8009E208 6300
-#99 Wumpa Fruits For Crash\The Great Hall
-D00B078C 001D
-8009E044 6300
-#99 Wumpa Fruits For Crash\Dr. Neo Cortex
-D00B078C 001E
-8009DDD4 6300
-
 ; [ Crash Bandicoot (Europe) {SCES-00344} ]
 :SCES-00344
 #All Levels Selectable
@@ -94314,37 +97646,6 @@ D005E714 0004
 8001E018 0000
 D005E714 0008
 8001E018 00C8
-
-; [ Crash Bandicoot 2: Cortex Strikes Back (Europe) (EDC Platinum) {SCES-00967} ]
-:SCES-00967
-#100 Lives (To restore your lives to 100 you must enter the Warp Room)
-8006CE68 6400
-#All Crystals
-9006D03C FFFFFFFF
-8006D040 FFFF
-#All Gems
-9006CEC0 FFFFFFFF
-9006CEC4 FFFFFFFF
-#Open All Levels (This code must be used with all crystals and gems turned on)
-80008006 CE74
-800043C8 0000
-#Always have Aku Aku mask
-8006CE6C 0200
-9003A204 08001D80
-90007600 3C088007
-90007604 8D08CE48
-90007608 15100007
-9000760C 34090300
-90007610 85080174
-90007614 11090004
-90007618 3C088007
-9000761C 8D08CE48
-90007620 34090200
-90007624 A5090174
-90007628 03E00008
-#Always have the gray gem
-3006CF01 0000
-3006D059 0000
 
 ; [ Crash Bandicoot 2: Cortex Strikes Back (Europe) (Preview) {Unlicensed} ]
 
@@ -94812,33 +98113,6 @@ D00B45E4 001E
 
 ; [ Crash Bandicoot: Warped (USA) Demo {SCUS-94289} ]
 
-; [ Crash Bash (Europe) {SCES-02834} ]
-:SCES-02834
-#999 Points pogo painter
-800A20EC 03E7
-#Infinite Health Jungle bash event y papu event
-800A20D2 0014
-#Infinite Health crash ball
-800A20EC 000F
-#InfInite health
-D009BAAA 0014
-3009BA9E 0014
-#Infinite Points (Press R1)
-D0070B7A F7FF
-8009BAB8 000F
-#Infinite Points
-8009BAB8 000F
-#Unlock Warp room 2
-3005C564 0001
-#Unlock Warp room 3
-3005C576 0001
-#Unlock Warp room 4
-3005C569 0001
-#Unlock Warp room 5
-3005C57F 0001
-#P1 only needs 1 trophy to win
-D005C4BC 0000
-3005C4BC 0002
 
 ; [ Crash Bash (USA) Demo {SCUS-94616} ]
 ; [ Creatures (Europe) {SLES-03690} ]
@@ -95977,7 +99251,6 @@ A60C2000 00000028
 
 ; [ De Sang Froid (France) {SCES-02150 | SCES-12150} ]
 
-; [ Dead or Alive (Europe) (Review) {SCES-01259} ]
 ; [ Dead or Alive (Europe) {SCES-01259} ]
 :SCES-01259
 #P1 Select Health\Infinite Health
@@ -96312,11 +99585,8 @@ D00A3472 0000
 ; [ Demo Disc (Europe) {SCED-02417} ]
 ; [ Demo One (Germany) {SCES-00064} ]
 ; [ Demo One (Germany) {SCES-00121} ]
-; [ Demo One (Version 1) (Europe) {SCES-00048} ]
-; [ Demo One (Version 2) (Europe, Australia) {SCES-00120} ]
 ; [ Demo One (Version 3) (Europe, Australia) {SCES-00238} ]
 ; [ Demo One (Version 4) (Europe) {SCED-00456} ]
-; [ Demo One (Version 4) (Germany) {SCED-00457} ]
 ; [ Demo One (Version 5) (Europe) {PBPX-95001} ]
 ; [ Demo One (Version 6) (Europe) {PBPX-95007} ]
 ; [ Demo One (Version 7) (Europe) {PBPX-95008} ]
@@ -98934,27 +102204,6 @@ D007AD52 F0FF
 ; [ Disney/Pixar A Bug's Life: Disney's Activity Centre (Europe) {SCES-02014} ]
 ; [ Disney/Pixar A Bug's Life: Disneys Malen und Spielen (Germany) {SCES-02460} ]
 
-; [ Disney/Pixar A Bug's Life: Megaminimondo (Italy) Rev 1 {SCES-01522} ]
-:SCES-01522
-#GodMode
-90048CB4 00000000
-90048CBC 34627FFF
-#All letters always taken
-300A8CA2 000F
-#All levels unlocked
-30082404 000F
-#Always have 50 grains
-300A8CA1 0032
-#Always have killed all insects with the gold berry
-800A8C8E 0000
-#Always have purple berry
-800A8C96 0403
-#Always have super jump power + machine collect beans L1 button activate Circle button to deactivate
-D00891BA FBFF
-300A8C90 00A0
-D00891BA DFFF
-300A8C90 0000
-
 ; [ Disney/Pixar A Bug's Life: Megaminimondo (Italy) {SCES-01522} ]
 :SCES-01522
 #GodMode
@@ -99175,29 +102424,6 @@ D0082974 2000
 800F4EC0 0005
 #Infinite Health (Sulley) Level 1
 800E50AC 0005
-#Movie theater Fully Open
-90010118 FFFFFFFF
-#All Medals
-900100C8 63636363
-900100CC 63636363
-800100D0 6363
-300100D2 0063
-300100C7 0063
-900100D4 FFFFFFFF
-900100D8 FFFFFFFF
-900100DC FFFFFFFF
-#All stages
-800100EE FFFF
-800100F0 FFFF
-900100F8 FFFFFFFF
-800100FC FFFF
-900100F4 FFFFFFFF
-300100F3 00FF
-
-; [ Disney/Pixar Monsters, Inc.: SkrämmarÃ¶n (Sweden) (Promo) {SCES-03768} ]
-:SCES-03768
-#Infinite Lives
-800100A3 0063
 #Movie theater Fully Open
 90010118 FFFFFFFF
 #All Medals
@@ -100499,7 +103725,6 @@ A60A8890 00000001
 300A51A4 0001
 
 ; [ Dracula: Résurrection (France) {SLES-02758 | SLES-12758} ]
-; [ Dracula: The Resurrection (Europe) {SLES-02757 | SLES-12757} ]
 
 ; [ Dragon Ball Z: Idainaru Dragon Ball Densetsu (Japan) {SLPS-00355} ]
 :SLPS-00355
@@ -102383,10 +105608,8 @@ A606DFDA 00332402
 ; [ Euro Demo 20 aka Official UK PlayStation Magazine CD 03 Vol. 2 (Europe) {SCED-00372} ]
 ; [ Euro Demo 21 (France) {SCED-01114} ]
 ; [ Euro Demo 21 aka Euro Demo 09/98 (Germany) {SCED-01126} ]
-; [ Euro Demo 21 aka Official UK PlayStation Magazine CD 04 Vol. 2 (Europe) {SCED-00817} ]
 ; [ Euro Demo 22 (France) {SCED-01115} ]
 ; [ Euro Demo 22 aka Euro Demo 10/98 (Germany) {SCED-01127} ]
-; [ Euro Demo 22 aka Official UK PlayStation Magazine CD 05 Vol. 2 (Europe) {SCED-00818} ]
 ; [ Euro Demo 23 (France) {SCED-01116} ]
 ; [ Euro Demo 23 aka Euro Demo 11/98 (Germany) {SCED-01128} ]
 ; [ Euro Demo 23 aka Official UK PlayStation Magazine CD 06 Vol. 2 (Europe) {SCED-00819} ]
@@ -102403,7 +105626,6 @@ A606DFDA 00332402
 ; [ Euro Demo 27 aka Official UK PlayStation Magazine CD 10 Vol. 2 (Europe) {SCED-00823} ]
 ; [ Euro Demo 28 (France) {SCED-01785} ]
 ; [ Euro Demo 28 aka Euro Demo 02/99 Rennspiele (Germany) {SCED-01786} ]
-; [ Euro Demo 28 aka Official UK PlayStation Magazine CD 11 Vol. 2 (Europe) {SCED-00824} ]
 ; [ Euro Demo 29 (France) {SCED-01849} ]
 ; [ Euro Demo 29 aka Euro Demo 03/99 (Germany) {SCED-01834} ]
 ; [ Euro Demo 29 aka Official UK PlayStation Magazine CD 12 Vol. 2 (Europe) {SCED-00825} ]
@@ -102461,25 +105683,10 @@ A606DFDA 00332402
 ; [ Euro Demo 55 aka Official UK PlayStation Magazine 55 (Europe) {SCED-01829} ]
 ; [ Euro Demo 56 aka Official UK PlayStation Magazine 56 (Europe) {SCED-01830} ]
 ; [ Euro Demo 57 aka Official UK PlayStation Magazine 57 (Europe) {SCED-01831} ]
-; [ Euro Demo 58 aka Official UK PlayStation Magazine 58 (Europe) {SCED-02632} ]
 ; [ Euro Demo 59 aka Official UK PlayStation Magazine 59 (Europe) {SCED-02633} ]
-; [ Euro Demo 60 aka Official UK PlayStation Magazine 60 (Europe) {SCED-02634} ]
 ; [ Euro Demo 61 aka Official UK PlayStation Magazine 61 (Europe) (EDC) {SCED-02635} ]
 ; [ Euro Demo 61 aka Official UK PlayStation Magazine 61 (Europe) {SCED-02635} ]
-; [ Euro Demo 62 aka Official UK PlayStation Magazine 62 (Europe) (EDC) {SCED-02636} ]
-; [ Euro Demo 62 aka Official UK PlayStation Magazine 62 (Europe) {SCED-02636} ]
 ; [ Euro Demo 63 aka Official UK PlayStation Magazine 63 (Europe) {SCED-02637} ]
-; [ Euro Demo 64 aka Official UK PlayStation Magazine 64 (Europe) {SCED-02638} ]
-; [ Euro Demo 65 aka Official UK PlayStation Magazine 65 (Europe) {SCED-02639} ]
-; [ Euro Demo 66 aka Official UK PlayStation Magazine 66 (Europe) {SCED-02640} ]
-; [ Euro Demo 67 aka Official UK PlayStation Magazine 67 (Europe) {SCED-02641} ]
-; [ Euro Demo 68 aka Official UK PlayStation Magazine 68 (Europe) {SCED-02642} ]
-; [ Euro Demo 69 aka Official UK PlayStation Magazine 69 (Europe) {SCED-02643} ]
-; [ Euro Demo 70 aka Official UK PlayStation Magazine 70 (Europe) {SCED-02644} ]
-; [ Euro Demo 71 aka Official UK PlayStation Magazine 71 (Europe) {SCED-02645} ]
-; [ Euro Demo 72 aka Official UK PlayStation Magazine 72 (Europe) {SCED-02646} ]
-; [ Euro Demo 73 aka Official UK PlayStation Magazine 73 (Europe) {SCED-03450} ]
-; [ Euro Demo 74 aka Official UK PlayStation Magazine 74 (Europe) {SCED-03451} ]
 ; [ Euro Demo 75 aka Official UK PlayStation Magazine 75 (Europe, Australia) {SCED-03452} ]
 ; [ Euro Demo 76 aka Official UK PlayStation Magazine 76 (Europe) {SCED-03453} ]
 ; [ Euro Demo 77 aka Official UK PlayStation Magazine 77 (Europe) {SCED-03454} ]
@@ -102569,28 +105776,6 @@ D01FF41A BFEF
 8010468A 0002
 #Have Extra Characters
 A6104784 00000009
-
-; [ Everybody's Golf 2 (Europe) {SCES-02146} ]
-:SCES-02146
-#Enable All Characters
-A6046EB0 00071FFF
-#Enable All Stages
-80047894 00FF
-#P1 Always Win
-50001202 0000
-80046D7E 0002
-#P1 Max Status
-90046EB8 00FDFFFF
-30046E8C 0063
-80046EC2 0005
-#Hole In One Every Shot
-800FA75C 0001
-#20 Under Par
-80046E76 FFEC
-#Hole In One All Courses (Press L2)
-D004B020 0001
-50001202 0000
-80046D7E 0001
 
 ; [ Evil Dead: Hail to the King (Europe) {SLES-03428 | SLES-13428} ]
 :SLES-03428
@@ -103000,7 +106185,6 @@ D0038FA6 FDFE
 ; [ F1 2000 (Italy) {SLES-02724} ]
 ; [ F1 2000 (Japan) {SLPS-02758} ]
 ; [ F1 Championship Season 2000 (Europe) {SLES-03117} ]
-; [ F1 Championship Season 2000 (Europe) {SLES-03119} ]
 ; [ F1 Championship Season 2000 (Italy) {SLES-03118} ]
 ; [ F1 GP Nippon no Chousen: Dome no Yabou (Japan) {SLPS-00519} ]
 
@@ -108637,7 +111821,6 @@ A605D386 24C62406
 #Training Mission Codes\Unendlich Granaten
 80117F78 0001
 
-; [ Ghoul Panic (Europe) {SCES-02543} ]
 ; [ Gioca con i Teletubbies (Italy) {SLES-03170} ]
 ; [ Gionbana (Japan) {SLPS-00132} ]
 
@@ -108859,92 +112042,6 @@ D0091238 0000
 
 ; [ Gradius Gaiden (Japan) Rev 1 {SLP-86103} ]
 ; [ Gradius Gaiden (Japan) {SLP-86042} ]
-
-; [ Gran Turismo (Europe) (EDC Platinum, 2 Games) {SCES-00984} ]
-:SCES-00984
-#Quick Arcade-Mode Codes\Highspeed Ring A
-30081B48 0004
-#Quick Arcade-Mode Codes\Higspeed Ring B
-30081B49 0004
-#Quick Arcade-Mode Codes\Highspeed Ring c
-30081B4A 0004
-#Quick Arcade-Mode Codes\Trial Mountain A
-30081B4C 0004
-#Quick Arcade-Mode Codes\Trial Mountain B
-30081B4D 0004
-#Quick Arcade-Mode Codes\Trial Mountain c
-30081B4E 0004
-#Quick Arcade-Mode Codes\Grand Valley East A
-30081B50 0004
-#Quick Arcade-Mode Codes\Grand Valley East B
-30081B51 0004
-#Quick Arcade-Mode Codes\Grand Valley East c
-30081B52 0004
-#Quick Arcade-Mode Codes\Clubman Stage 5 A
-30081B54 0004
-#Quick Arcade-Mode Codes\Clubman Stage 5 B
-30081B55 0004
-#Quick Arcade-Mode Codes\Clubman Stage 5 c
-30081B56 0004
-#Quick Arcade-Mode Codes\Autumn Ring A
-30081B58 0004
-#Quick Arcade-Mode Codes\Autumn Ring B
-30081B59 0004
-#Quick Arcade-Mode Codes\Autumn Ring c
-30081B5A 0004
-#Quick Arcade-Mode Codes\Deep Forest A
-30081B5C 0004
-#Quick Arcade-Mode Codes\Deep Forest B
-30081B5D 0004
-#Quick Arcade-Mode Codes\Deep Forest c
-30081B5E 0004
-#Quick Arcade-Mode Codes\Ss R5 A
-30081B60 0004
-#Quick Arcade-Mode Codes\Ss R5 B
-30081B61 0004
-#Quick Arcade-Mode Codes\Ss R5 c
-30081B62 0004
-#Quick Arcade-Mode Codes\Grand Valley Speedway A
-30081B64 0004
-#Quick Arcade-Mode Codes\Grand Valley Speedway B
-30081B65 0004
-#Quick Arcade-Mode Codes\Grand Valley Speedway c
-30081B66 0004
-#Gran Turismo Codes\100 Million Credits
-9009B874 05F5E100
-#Gran Turismo Codes\100 Million Credits (Press Select in the Start-Area to get the money)
-D009AADE 0001
-8009B874 E100
-D009AADE 0001
-8009B876 05F5
-#Gran Turismo Codes\B-License
-9009E3C4 03030303
-9009E3C8 03030303
-#Gran Turismo Codes\A-License
-9009E3CC 03030303
-9009E3D0 03030303
-#Gran Turismo Codes\A-International License
-9009E3D4 03030303
-9009E3D8 03030303
-#Gt League\Have All Gold Cups And Open Gt Hifi-Mode
-9009F8DC 01010101
-#Special Event\Have Gold Cups
-9009F8E0 01010101
-8009F8E4 0101
-8009F8EA 0101
-9009F8EC 01010101
-8009F8F0 0101
-#Special Event\Always Be First
-D01B3A7E 001B
-80093BC8 0000
-#Special Event\Only One Lap To Race (This code will finish the race as you pass the startline on all two lap races. If you try to race a three lap race you will have only one lap to finish)
-A60B6700 00000002
-#Special Event\Speed Boost-Code. Press R3
-D00BC016 0002
-800B6DBE 0005
-D00BC016 0002
-800B6D92 0005
-
 ; [ Gran Turismo (France) Demo {SCED-01279} ]
 ; [ Gran Turismo (Japan) (Test Drive Disc) {PCPX-96085} ]
 ; [ Gran Turismo (Japan) Demo {PAPX-90026} ]
@@ -108964,87 +112061,6 @@ D00BC016 0002
 90090868 03030303
 #High Racing Points
 9008DD04 05F5E100
-
-; [ Gran Turismo 2 (Arcade Mode) (Europe) {SCES-02380 | SCES-12380} ]
-:SCES-02380
-:SCES-12380
-#Gran Turismo Disc - Auto Pilot P1 (Press R1 & R2 & Triangle Pad 2 before race starts)
-D01F0CEC E5FF
-801D5976 0001
-#Gran Turismo Disc - Auto Pilot P1 alternate (Press R1 & R2 & Triangle Pad 2 before race starts)
-801D5976 0001
-#Infinite Money
-901D1598 05F5E0FF
-#Have Gold B Licence
-50000AA4 0000
-301CCD31 0004
-#Have Gold A Licence
-50000AA4 0000
-301CC6C9 0004
-#Have Gold International c Licence
-50000AA4 0000
-301CC061 0004
-#Have Gold International B Licence
-50000AA4 0000
-301CB9F9 0004
-#Have Gold International A Licence
-50000AA4 0000
-301CB391 0004
-#Have Special Licence
-50000AA4 0000
-301CAD29 0004
-#Unlock Extra Tracks And Cars In Arcade Mode
-50000A02 0000
-801C99C8 0505
-301C99DC 0005
-#Hold L2 To Drive Through Scenery
-E00A95E4 0080
-800A96CC 0006
-E00A95E4 0080
-800A9CE4 0006
-#Stop Race Timer
-8002F894 0000
-80046F44 0000
-#Start On Lap 4
-E00A9CEC 0000
-300A9CEC 0004
-#Begin The Game With A Lot Of Money
-900107A0 3C0205F5
-#Unlock All Tracks 1P/2P Any Road, Time Trial Etc, More Than 130...
-800F3992 0083
-800F3996 0017
-800F399A 0027
-900F399C 00060015
-#Turbo Arcade Disc Press R3
-D00A956C 4000
-800A9D1E 0020
-D00A956C 4000
-800A9D22 0020
-#Ending Unlocked (Push Select in the Play Movie Screen)
-D01C97DA FFFE
-80052714 0001
-#Unlock One Half Of The Reverse Track (use the Quick won race-codes for the other half)
-50000A20 0000
-80050B8C 0001
-#Unlock All Licences In 1 Code
-8005DE8A A270
-#Unlock All Tracks (112% Complete)
-50004402 0000
-801C9A28 1111
-#Play Any Race With Any Car In Simulation Mode
-D0014908 000C
-8001490A 1000
-#Widescreen 16-9
-D0010000 FFE8
-8007B3E0 0156
-D0010000 FFD0
-8007B3E0 03DE
-D0010000 FFE0
-8007B3E0 01AC
-8007B3E2 3402
-#Widescreen 16-9 Better Graphics (Optional)
-8006752C 0060
-8006752E 3404
 
 ; [ Gran Turismo 2 (Arcade) (Japan, Asia) {SCPS-10116 | SCPS-10117} ]
 :SCPS-10116
@@ -109167,91 +112183,6 @@ D0010000 FFE0
 ; [ Gran Turismo 2 (Japan) (Test Drive Disc) {PAPX-90054} ]
 ; [ Gran Turismo 2 (Un CD Bonus) (France) {SCED-02904} ]
 
-; [ Gran Turismo aka Gran Turismo: The Real Driving Simulator (Europe) {SCES-00984} ]
-:SCES-00984
-#Quick Arcade-Mode Codes\Highspeed Ring A
-30081B48 0004
-#Quick Arcade-Mode Codes\Higspeed Ring B
-30081B49 0004
-#Quick Arcade-Mode Codes\Highspeed Ring c
-30081B4A 0004
-#Quick Arcade-Mode Codes\Trial Mountain A
-30081B4C 0004
-#Quick Arcade-Mode Codes\Trial Mountain B
-30081B4D 0004
-#Quick Arcade-Mode Codes\Trial Mountain c
-30081B4E 0004
-#Quick Arcade-Mode Codes\Grand Valley East A
-30081B50 0004
-#Quick Arcade-Mode Codes\Grand Valley East B
-30081B51 0004
-#Quick Arcade-Mode Codes\Grand Valley East c
-30081B52 0004
-#Quick Arcade-Mode Codes\Clubman Stage 5 A
-30081B54 0004
-#Quick Arcade-Mode Codes\Clubman Stage 5 B
-30081B55 0004
-#Quick Arcade-Mode Codes\Clubman Stage 5 c
-30081B56 0004
-#Quick Arcade-Mode Codes\Autumn Ring A
-30081B58 0004
-#Quick Arcade-Mode Codes\Autumn Ring B
-30081B59 0004
-#Quick Arcade-Mode Codes\Autumn Ring c
-30081B5A 0004
-#Quick Arcade-Mode Codes\Deep Forest A
-30081B5C 0004
-#Quick Arcade-Mode Codes\Deep Forest B
-30081B5D 0004
-#Quick Arcade-Mode Codes\Deep Forest c
-30081B5E 0004
-#Quick Arcade-Mode Codes\Ss R5 A
-30081B60 0004
-#Quick Arcade-Mode Codes\Ss R5 B
-30081B61 0004
-#Quick Arcade-Mode Codes\Ss R5 c
-30081B62 0004
-#Quick Arcade-Mode Codes\Grand Valley Speedway A
-30081B64 0004
-#Quick Arcade-Mode Codes\Grand Valley Speedway B
-30081B65 0004
-#Quick Arcade-Mode Codes\Grand Valley Speedway c
-30081B66 0004
-#Gran Turismo Codes\100 Million Credits
-9009B874 05F5E100
-#Gran Turismo Codes\100 Million Credits (Press Select in the Start-Area to get the money)
-D009AADE 0001
-8009B874 E100
-D009AADE 0001
-8009B876 05F5
-#Gran Turismo Codes\B-License
-9009E3C4 03030303
-9009E3C8 03030303
-#Gran Turismo Codes\A-License
-9009E3CC 03030303
-9009E3D0 03030303
-#Gran Turismo Codes\A-International License
-9009E3D4 03030303
-9009E3D8 03030303
-#Gt League\Have All Gold Cups And Open Gt Hifi-Mode
-9009F8DC 01010101
-#Special Event\Have Gold Cups
-9009F8E0 01010101
-8009F8E4 0101
-8009F8EA 0101
-9009F8EC 01010101
-8009F8F0 0101
-#Special Event\Always Be First
-D01B3A7E 001B
-80093BC8 0000
-#Special Event\Only One Lap To Race (This code will finish the race as you pass the startline on all two lap races. If you try to race a three lap race you will have only one lap to finish)
-A60B6700 00000002
-#Special Event\Speed Boost-Code. Press R3
-D00BC016 0002
-800B6DBE 0005
-D00BC016 0002
-800B6D92 0005
-
 ; [ Grand Theft Auto (Europe) (EDC Platinum, Collector's Edition) {SLES-00032} ]
 :SLES-00032
 #Infinite Weapons, Ammo, 99 Lives & Coordinates
@@ -109330,137 +112261,7 @@ D0047942 FFEE
 D0047942 FFBE
 3011E3E0 0001
 
-; [ Grand Theft Auto 2 (Europe) Rev 1 {SLES-01404} ]
-:SLES-01404
-#Stop Kill Frenzy Time
-801683F0 0C97
-#Infinite Lives
-80120004 0009
-#Infinite Health
-80145A96 0064
-#Have Pistol + Infinite Ammo
-80164D68 0122
-#Have Machine Gun + Infinite Ammo
-80164D90 0122
-#Have Rocket Launcher + Infinite Ammo
-80164DB8 0122
-#Have Electric Gun + Infinite Ammo
-80164DE0 0122
-#Have Petrol Bombs + Infinite Ammo
-80164E08 0122
-#Have Grenades + Infinite Ammo
-80164E30 0122
-#Have Shotgun + Infinite Ammo
-80164E58 0122
-#Have Stun Rod + Infinite Ammo
-80164E80 0122
-#Have Flame Thrower + Infinite Ammo
-80164EA8 0122
-#Have Silenced Machine Gun + Infinite Ammo
-80164ED0 0122
-#Have 2 Way Firing Pistol + Infinite Ammo
-80164EF8 0122
-#Other Weapons And Infinite Ammo
-80164FC0 0122
-80164FE8 0122
-80165038 0122
-80165150 0122
-80165178 0122
-801651C8 0122
-801651F0 0122
-80165268 0122
-801652B8 0122
-801652E0 0122
-#Lots Of Cash!
-8011FD0A 0098
-#Number Of Kills 0
-8012A86C 0000
-#No Cops
-80145A8A 0000
-#All Cops
-80145A8A 2EE0
-#Have Police And Swat After You .Use only 1 code at a time.
-80145A8A 8813
-#21 Have Police, Swat And Spy's After You
-80145A8A 401F
-#Have Police, Swat, Spy's And The Army After You
-80145A8A E02E
-#Infinite Ammo After Pickup
-800FD452 3C00
-#All Weapons
-50000B28 0000
-80164D68 FFFF
-#Infinite Bonus & Kill Frenzy Time
-800A40C8 3C00
-#Max Points
-8011FD08 FFFF
-
 ; [ Grand Theft Auto 2 (France) {SLES-02453} ]
-
-; [ Grand Theft Auto 2 aka GTA2 (Europe) {SLES-01404} ]
-:SLES-01404
-#Stop Kill Frenzy Time
-801683F0 0C97
-#Infinite Lives
-80120004 0009
-#Infinite Health
-80145A96 0064
-#Have Pistol + Infinite Ammo
-80164D68 0122
-#Have Machine Gun + Infinite Ammo
-80164D90 0122
-#Have Rocket Launcher + Infinite Ammo
-80164DB8 0122
-#Have Electric Gun + Infinite Ammo
-80164DE0 0122
-#Have Petrol Bombs + Infinite Ammo
-80164E08 0122
-#Have Grenades + Infinite Ammo
-80164E30 0122
-#Have Shotgun + Infinite Ammo
-80164E58 0122
-#Have Stun Rod + Infinite Ammo
-80164E80 0122
-#Have Flame Thrower + Infinite Ammo
-80164EA8 0122
-#Have Silenced Machine Gun + Infinite Ammo
-80164ED0 0122
-#Have 2 Way Firing Pistol + Infinite Ammo
-80164EF8 0122
-#Other Weapons And Infinite Ammo
-80164FC0 0122
-80164FE8 0122
-80165038 0122
-80165150 0122
-80165178 0122
-801651C8 0122
-801651F0 0122
-80165268 0122
-801652B8 0122
-801652E0 0122
-#Lots Of Cash!
-8011FD0A 0098
-#Number Of Kills 0
-8012A86C 0000
-#No Cops
-80145A8A 0000
-#All Cops
-80145A8A 2EE0
-#Have Police And Swat After You .Use only 1 code at a time.
-80145A8A 8813
-#21 Have Police, Swat And Spy's After You
-80145A8A 401F
-#Have Police, Swat, Spy's And The Army After You
-80145A8A E02E
-#Infinite Ammo After Pickup
-800FD452 3C00
-#All Weapons
-50000B28 0000
-80164D68 FFFF
-#Infinite Bonus & Kill Frenzy Time
-800A40C8 3C00
-#Max Points
-8011FD08 FFFF
 
 ; [ Grand Theft Auto: London 1969 aka Grand Theft Auto: London (Europe) {SLES-03389} ]
 
@@ -110172,6 +112973,10 @@ A6107086 00620000
 800FF620 0C00
 800C7E60 1000
 800C7DD8 1000
+#Widescreen 16-9 (ALT)
+A70FF648 10000C00
+#Dither Off
+A7069D90 02000000
 
 ; [ Gunpey (Japan) {SLPS-02485} ]
 :SLPS-02485
@@ -112325,8 +115130,6 @@ D00585B8 0020
 ; [ Interactive CD Sampler Disk Volume 5 (USA) Rev 1 {SCUS-94222} ]
 ; [ Interactive CD Sampler Disk Volume 5 (USA) {PBPX-95003} ]
 ; [ Interactive CD Sampler Disk Volume 5 (USA) {SCUS-94224} ]
-; [ Interactive CD Sampler Pack Volume 3.5 aka Interactive CD Sampler Pack Volume Three (Version 3.5) (USA) {SCUS-94966} ]
-; [ Interactive CD Sampler Pack Volume 3.5 aka Interactive CD Sampler Pack Volume Three (Version 3.5) (USA) {SCUS-94966} ]
 ; [ Interactive CD Sampler Volume 1 (USA) {SCUS-94955} ]
 ; [ Interactive CD Sampler Volume 1 (USA) {SCUS-94956} ]
 ; [ Interactive Preview Plus: PS2 Launch Guide & Playable GameShark Sampler (USA) {Unlicensed} ]
@@ -112897,27 +115700,6 @@ A60C382C 00010000
 :SLPS-01428
 #Maximum Speed
 800E23CE 000C
-
-; [ Jackie Chan Stuntmaster (Europe) {SCES-01444} ]
-:SCES-01444
-#Infinite Lives
-D0129664 0003
-30129664 000A
-#Infinite Health
-D01293EA 00C8
-301293E8 00C8
-#Have All Red & Gold Dragons
-50000F10 0000
-800E7514 0A03
-#Unlock All Paths
-50000E10 0000
-800E7528 FFFF
-#Enable Level Select Cheat
-800500FE 2400
-#Enable Level + Dragon Unlock Cheat
-80050132 2400
-#Enable Bonus Movie Cheat
-800500DA 2400
 
 ; [ Jackie Chan Stuntmaster (Europe) {SCES-01444} ]
 :SCES-01444
@@ -114167,6 +116949,10 @@ A7105568 10000C00
 A7109950 10000C00
 #Remove Dither (Use with widescreen code)
 A70A95DC 02000000
+#Widescreen Heart Sprites (Level 1 only)
+A70C3CFC 10000C00
+A70C3D34 10000C00
+A70C3D18 10000C00
 
 ; [ Kaze no Notam: Notam of Wind (Japan, Asia) {SCPS-45111} ]
 ; [ Kaze no Oka Kouen Nite (Japan) {SLPS-01565} ]
@@ -116271,17 +119057,6 @@ D0068C8A F0FF
 ; [ Lattice: 200EC7 (Japan) (Major Wave) {SLP-86491} ]
 ; [ Le Concert: ff: Fortissimo (Japan) {SLPS-02344} ]
 ; [ Le Concert: pp: Pianissimo (Japan) {SLPS-02343} ]
-
-; [ Le Mans 24 Hours (Europe) {SLES-01362} ]
-:SLES-01362
-#No Fuel Consution And Overheating
-8008B4C2 3C00
-8007FA36 3C00
-8008B4C6 3C00
-#Unlock all
-50000B02 0000
-80026FA0 0101
-
 ; [ Le Monde Des Bleus 2 (France) Demo {SCED-03202} ]
 ; [ Le Monde des Bleus 2 aka Le Monde des Bleus 2: Le Jeu Officiel de Ã‰quipe de France (France) {SCES-03073} ]
 ; [ Le Monde des Bleus: Le Jeu Officiel de l'Ã‰quipe de France (France) {SCES-01701} ]
@@ -118723,34 +121498,12 @@ D007E86C 0048
 
 ; [ Medal of Honor: Resistance (France) {SLES-03125} ]
 
-; [ Medal of Honor: Underground (Europe) {SLES-03124} ]
-:SLES-03124
-#Infinite Health all levels
-A704E166 AE022400
-A705B14A 8C822400
-#Invincibility all levels
-A704E15C 10232400
-A705B14A 8C822400
-#Open all cheats
-80039D24 FFFF
-
 ; [ Medal of Honor: Underground (Germany) (Platinum) {SLES-03126} ]
 :SLES-03126
 #Alle Cheats
 80039D24 01FF
 #Alle Medaillen
 80039D20 0FFF
-
-; [ MediEvil (Europe) Beta {SCES-00311} ]
-:SCES-00311
-#Infinite Energy
-800F81AC 012C
-#Infinite Money
-800EDA58 0064
-800F82C4 0064
-#Whole map visible
-800F81DC FFFF
-300F81DE 00FF
 
 ; [ MediEvil (Europe) Beta {Unlicensed} ]
 ; [ MediEvil (Europe) Beta {Unlicensed} ]
@@ -119544,135 +122297,6 @@ A601C0CE A0620000
 ; [ Metal Gear Solid (Europe) Demo {SLED-01400} ]
 ; [ Metal Gear Solid (Europe) Demo {SLED-01775} ]
 
-; [ Metal Gear Solid (Europe) {SLES-01370 | SLES-11370} ]
-:SLES-01370
-:SLES-11370
-#Infinite Health
-800B5E06 0600
-#Infinite Oxygen
-800ACA8C 0400
-#Infinite Medicine
-800B5E56 0002
-#Infinite Rations
-800B5E54 0002
-#Infinite Diazepam
-800B5E58 0001
-#Socom Pistol + Infinite Ammo
-800B5E12 00FF
-#Famas Rifle + Infinite Ammo
-800B5E14 00FF
-#Psg1 Rifle + Infinite Ammo
-800B5E24 00FF
-#Nikita + Infinite Ammo
-800B5E18 00FF
-#Stinger + Infinite Ammo
-800B5E1A 00FF
-#Infinite Stun Grenades
-800B5E20 00FF
-#Infinite Chaff Grenades
-800B5E22 00FF
-#Infinite Grenades
-800B5E16 00FF
-#Infinite Claymores
-800B5E1C 00FF
-#Infinite C4 Explosive
-800B5E1E 00FF
-#Cardboard Box A - Heliport
-800B5E3E 0001
-#Cardboard Box B - Nuke Store
-800B5E40 0001
-#Cardboard Box c - Snow Field
-800B5E42 0001
-#Night-Vision Goggles
-800B5E44 0001
-#Thermal Goggles
-800B5E46 0001
-#Gasmask
-800B5E48 0001
-#Body Armour
-800B5E4A 0001
-#Ketchup
-800B5E4C 0001
-#Stealth
-800B5E4E 0001
-#Bandanna
-800B5E50 0001
-#Camera
-800B5E52 0001
-#Pal Keys
-800B5E5A 0001
-#Mine Detector
-800B5E60 0001
-#Mo Disk
-800B5E62 0001
-#Rope
-800B5E64 0001
-#Handkerchief
-800B5E66 0001
-#Have Level 100 Key Card
-800B5E5C 0064
-#All Modes In Vr-Training
-300B500B 0020
-#Max Ammo Socom
-800B5E26 0063
-#Max Ammo Fa-Mas
-800B5E28 0063
-#Max Ammo Grenades
-800B5E2A 0063
-#Max Ammo Nikita
-800B5E2C 0063
-#Max Ammo Stinger
-800B5E2E 0063
-#Max Ammo Claymore
-800B5E30 0063
-#Max Ammo C4
-800B5E32 0063
-#Max Ammo Stun Grenade
-800B5E34 0063
-#Max Ammo Chaff Grenades
-800B5E36 0063
-#Max Ammo Psg1 Sniper Rifle
-800B5E38 0063
-#Have Cigs
-800B5E3A 0001
-#Have Scope
-800B5E3C 0001
-#Have Time Bomb
-800B5E5E 0001
-#Never Have Time Bomb
-800B5E5E 0000
-#Have Supressor
-800B5E68 0001
-#Have Supressor Active
-800B5E68 0000
-#Have All Weapons
-50000A02 0000
-800B5E12 0063
-#Have All Items
-50001902 0000
-800B5E3A 0001
-#Start With Extended Life Bar
-800B5E08 0600
-#Max Life
-800B76FE 05EA
-#Radar Not Jammed When Spotted
-800ACA58 0000
-#Quick Vr Training This code gives you the end triangular thing that you need to touch to pass the level
-800E2188 0000
-#Ocelot Has 0 Bullets
-80167CD8 0000
-80167B98 0000
-#Invincibility (Must Get Hit First)
-800ACAAA 0010
-#Automatic Socom
-800B161C FFFF
-#Easy Fight With Liquid
-8017997C 0001
-#Play In 1st Person Perspective just press Triangle
-800AC4AC 0020
-#Ghost Mode
-900ACA68 00000000
-
 ; [ Metal Gear Solid (France) {SLES-01506 | SLES-11506} ]
 :SLES-01506
 :SLES-11506
@@ -120244,163 +122868,6 @@ D00ACD48 0061
 ; [ Metal Gear Solid aka ãƒ¡ã‚¿ãƒ«ãƒ»ã‚®ã‚¢ãƒ»ã‚½ãƒªãƒƒãƒ‰ (Asia) (Pilot Disc) {PAPX-90044} ]
 ; [ Metal Gear Solid: Integral (Japan, Asia) {SCPS-45412 | SCPS-45413 | SCPS-45414} ]
 
-; [ Metal Gear Solid: Special Missions (Europe) {SLES-02136} ]
-:SLES-02136
-#Infinite Health
-800B757E 0600
-800B7580 0600
-#Never Get A Cold
-800B7582 0000
-#Infinite Air
-800ACAAC 03E7
-#Radar Not Jammed When Spotted
-800ACA78 0000
-#Never Reload
-800ACA64 0019
-#Never Have Time Bomb In Pocket
-800B5E7E 0000
-#Ghost Mode
-900ACA88 00000000
-#Have Cigs
-800B5E5A 0001
-#Have Scope
-800B5E5C 0001
-#Have C. Box A
-800B5E5E 0001
-#Have C. Box B
-800B5E60 0001
-#Have C. Box c
-800B5E62 0001
-#Have Night Vision Goggles
-800B5E64 0001
-#Have Thermal Goggles
-800B5E66 0001
-#Have Gas Mask
-800B5E68 0001
-#Have Body Armor
-800B5E6A 0001
-#Have Ketchup
-800B5E6C 0001
-#Have Stealth
-800B5E6E 0001
-#Have Bandana
-800B5E70 0001
-#Have Camera
-800B5E72 0001
-#Have 255 Rations
-800B5E74 03E7
-800B5E8A 03E7
-#Have 255 Medicine
-800B5E76 03E7
-800B5E8C 03E7
-#Have 255 Diazepam
-800B5E78 03E7
-800B5E8E 03E7
-#Have Pal-Key
-800B5E7A 0001
-#Have Level 100 Key Card
-800B5E7C 0064
-#Have Mine Detector
-800B5E80 0001
-#Have Mo-Disc
-800B5E82 0001
-#Have Rope
-800B5E84 0001
-#Have Handker
-800B5E86 0001
-#Have Suppressor Active
-800B5E88 0000
-#Have All Items (Replaces Above Item-Codes)Press L2
-D00AC9CC 0001
-50001202 0000
-800B5E5A 0001
-D00AC9CC 0001
-50000502 0000
-800B5E80 0001
-#Have Socom Pistol
-800B5E32 03E7
-800B5E46 03E7
-#Have Famas
-800B5E34 03E7
-800B5E48 03E7
-#Have Grenades
-800B5E36 03E7
-800B5E4A 03E7
-#Have Nikita
-800B5E38 03E7
-800B5E4C 03E7
-#Have Stinger
-800B5E3A 03E7
-800B5E4E 03E7
-#Have Claymore Mines
-800B5E3C 03E7
-800B5E50 03E7
-#Have C4
-800B5E3E 03E7
-800B5E52 03E7
-#Have Stun-Grenades
-800B5E40 03E7
-800B5E54 03E7
-#Have Chaff Grenades
-800B5E42 03E7
-800B5E56 03E7
-#Have Sniper Rifle
-800B5E44 03E7
-800B5E58 03E7
-#Have Alle Weapons & Ammo Press R2 Use this code or the specified weapon/ammo codes.
-D00AC9CC 0002
-50001402 0000
-800B5E32 03E7
-#Special Mode Codes\All Missions Open
-800E58FC FFFF
-#Special Mode Codes\Vs. 12 Battle All Levels Open & Complete
-800E58FE FFFF
-800E5900 FFFF
-#Special Mode Codes\Ninja All Levels Open & Complete
-900E589C FFFFFFFF
-#Special Mode Codes\Ng Selection All Levels Open & Complete
-800E587E FFFF
-800E5880 FFFF
-#Special Mode Codes\Variety All Levels Open & Complete
-800E591A FFFF
-800E591C FFFF
-#Special Mode Codes\Puzzle All Levels Open & Complete
-800E593A FFFF
-800E593C FFFF
-#Special Mode Codes\Mystery All Levels Open & Complete
-800E594E FFFF
-800E5950 FFFF
-#Special Mode Codes\Vr Mission Complete
-800E5930 1000
-#1 Min. Battle Codes\Vs. Target All Levels Open & Complete
-900E5884 FFFFFFFF
-#1 Min. Battle Codes\Vs. Enemy All Levels Open & Complete
-900E586C FFFFFFFF
-#Sneak Mode - No Weapons\Practice All Levels Opened
-800E5830 FFFE
-#Sneak Mode - No Weapons\Time Attack All Levels Opened
-800E5848 FFFE
-#Sneak Mode - Socom\Practice All Levels Opened
-800E5800 FFFE
-#Sneak Mode - Socom\Time Attack All Levels Opened
-800E5818 FFFE
-#Weapon Mode - Time Attack\All Weapons, All Levels Opened
-800E581A 8FE0
-900E581C F0F83E0F
-900E5820 F83E0F8F
-#Weapon Mode - Practice\All Weapons, All Levels Opened
-800E5802 8FE0
-900E5804 F0F83E0F
-900E5808 F83E0F8F
-#Advanced Mode - Time Attack\All Weapons, All Levels Opened
-800E584A 8FE0
-900E584C F0F83E0F
-900E5850 F83E0F8F
-#Advanced Mode - Practice\All Weapons, All Levels Opened
-800E5832 8FE0
-900E5834 F0F83E0F
-900E5838 F83E0F8F
-
 ; [ Metal Jacket (Japan) {SLPS-00008} ]
 #Infinite Jump Fly Jets
 8007A16C 03E8
@@ -120528,24 +122995,6 @@ E009D913 0000
 800129DA 00FF
 #Infinite Items 1P
 80136EE4 00FF
-
-; [ Micro Machines V3 (Europe) (EDC Value Series) {SLES-00016} ]
-:SLES-00016
-#P1 Infinite Lives
-800129DA 0003
-#Only one lap to race
-8013AB3E 0003
-#Lap time 0:00:00
-800BB5CC 0000
-
-; [ Micro Machines V3 (Europe) {SLES-00016} ]
-:SLES-00016
-#P1 Infinite Lives
-800129DA 0003
-#Only one lap to race
-8013AB3E 0003
-#Lap time 0:00:00
-800BB5CC 0000
 
 ; [ Micro Maniacs (Europe) {SLES-01921} ]
 :SLES-01921
@@ -122067,43 +124516,6 @@ A6032372 00A60001
 800680E8 0023
 
 ; [ Moses: Prince of Egypt (Europe) (Pocket Price Midas, Pocket Price Midas: Value Series) {SLES-02954} ]
-
-; [ Moto Racer (Europe) (EDC Value Series) {SLES-00469} ]
-:SLES-00469
-#1-PLAYER-MODE Infinite checkpoint time On (Press Select & Up)
-D00BCE92 FFEE
-8003B09C 0023
-#Infinite Time
-8008F4D0 D852
-#Extra speed
-800A538E 42A0
-#Select course Fun Fair
-30110440 0006
-#Select course Sea of Sands
-30110440 0007
-#Select course Red City
-30110440 0008
-#Select course Snow Ride
-30110440 0009
-
-; [ Moto Racer (Europe) {SLES-00469} ]
-:SLES-00469
-#1-PLAYER-MODE Infinite checkpoint time On (Press Select & Up)
-D00BCE92 FFEE
-8003B09C 0023
-#Infinite Time
-8008F4D0 D852
-#Extra speed
-800A538E 42A0
-#Select course Fun Fair
-30110440 0006
-#Select course Sea of Sands
-30110440 0007
-#Select course Red City
-30110440 0008
-#Select course Snow Ride
-30110440 0009
-
 ; [ Moto Racer (France) Demo {SLED-01005} ]
 ; [ Moto Racer (Japan) {SLPS-01163} ]
 ; [ Moto Racer 2 (Europe) Demo {SLED-01552} ]
@@ -122145,181 +124557,6 @@ D0047710 1023
 80010040 FFFF
 #Start On 2nd Lap
 A60CF826 07000701
-
-; [ Moto Racer World Tour (Europe) {SCES-03037} ]
-:SCES-03037
-#Unlock Everything Enter a menu in world tour first, then go back and everything will be open. Save on MC and deactivate the code
-50002204 0000
-80159040 0001
-50002204 0000
-80159042 0000
-#Opponents Frozen Press select while the race is loading
-D00DE2FA FFFE
-80057C1A 2A00
-#Infinite Boost
-D00281FE 00E5
-80028200 0000
-D00281FE 00E5
-80028202 0000
-D002826A 0002
-8002826C 0000
-D002826A 0002
-8002826E 0000
-#Speed Championship\250Ccm\Sachsenring\Start At Last Lap/Always First
-D010E7F4 FF00
-3010E7F4 0002
-#Speed Championship\250Ccm\Sachsenring\Always Good Grip
-A617D456 01000000
-A617D456 02000000
-#Speed Championship\250Ccm\Sachsenring\300 Points
-D010E7F4 FF00
-8010E7C0 012C
-#Speed Championship\250Ccm\Suzuka\Start At Last Lap/Always First
-D0111D48 FF00
-30111D48 0002
-#Speed Championship\250Ccm\Suzuka\Always Good Grip
-A61949BE 01000000
-A61949BE 02000000
-#Speed Championship\250Ccm\Suzuka\600 Points
-D0111D48 FF00
-80111D14 0258
-#Speed Championship\250Ccm\Isle Of Man Road\Start At Last Lap/Always First
-D010DDB8 FF00
-3010DDB8 0003
-#Speed Championship\250Ccm\Isle Of Man Road\900 Points
-D010DDB8 FF00
-8010DD84 0384
-#Speed Championship\250Ccm\Eastern Creek\Start At Last Lap/Always First
-D010EED0 FF00
-3010EED0 0002
-#Speed Championship\250Ccm\Eastern Creek\Always Good Grip
-A618471E 01000000
-A618471E 02000000
-#Speed Championship\250Ccm\Eastern Creek\1200 Points
-D010EED0 FF00
-8010EE9C 04B0
-#Speed Championship\500Ccm\Sachsenring\Start At Last Lap/Always First
-D010E7C0 FF00
-3010E7C0 0002
-#Speed Championship\500Ccm\Sachsenring\Always Good Grip
-A617D43E 01000000
-A617D43E 02000000
-#Speed Championship\500Ccm\Sachsenring\300 Points
-D010E7C0 FF00
-8010E78C 012C
-#Speed Championship\500Ccm\Suzuka\Start At Last Lap/Always First
-D0111D14 FF00
-30111D14 0002
-#Speed Championship\500Ccm\Suzuka\Always Good Grip
-A61949A6 01000000
-A61949A6 02000000
-#Speed Championship\500Ccm\Suzuka\600 Points
-D0111D14 FF00
-80111CE0 0258
-#Speed Championship\500Ccm\Isle Of Man Road\Start At Last Lap/Always First
-D010DD70 FF00
-3010DD70 0003
-#Speed Championship\500Ccm\Isle Of Man Road\900 Points
-D010DD70 FF00
-8010DD3C 0384
-#Speed Championship\500Ccm\Eastern Creek\Start At Last Lap/Always First
-D010EE98 FF00
-3010EE98 0002
-#Speed Championship\500Ccm\Eastern Creek\Always Good Grip
-A6184706 01000000
-A6184706 02000000
-#Speed Championship\500Ccm\Eastern Creek\1200 Points
-D010EE98 FF00
-8010EE64 04B0
-#Speed Championship\500Ccm\Isle Of Man Hills\Start At Last Lap/Always First
-D010C098 FF00
-3010C098 0002
-#Speed Championship\500Ccm\Isle Of Man Hills\1500 Points
-D010C098 FF00
-8010C064 05DC
-#Cross Championship\125Ccm\Barcelona\Start At Last Lap/Always First
-D0107C58 FF00
-30107C58 0005
-#Cross Championship\125Ccm\Barcelona\300 Points
-D0107C58 FF00
-80107C24 012C
-#Cross Championship\125Ccm\Usa Park\Start At Last Lap/Always First
-D0114068 FF00
-30114068 0002
-#Cross Championship\125Ccm\Usa Park\600 Points
-D0114068 FF00
-80104034 0258
-#Cross Championship\125Ccm\Stade De France\Start At Last Lap/Always First
-D01089E0 FF00
-301089E0 0003
-#Cross Championship\125Ccm\Stade De France\900 Points
-D01089E0 FF00
-801089AC 0384
-#Cross Championship\125Ccm\Reygades\Start At Last Lap/Always First
-D01115B8 FF00
-301115B8 0001
-#Cross Championship\125Ccm\Reygades\1200 Points
-D01115B8 FF00
-80111584 04B0
-#Cross Championship\250Ccm\Barcelona\Start At Last Lap/Always First
-D0107A30 FF00
-30107A30 0005
-#Cross Championship\250Ccm\Barcelona\300 Points
-D0107A30 FF00
-801079FC 012C
-#Cross Championship\250Ccm\Usa Park\Start At Last Lap/Always First
-D0114008 FF00
-30114008 0002
-#Cross Championship\250Ccm\Usa Park\600 Points
-D0114008 FF00
-80103FD4 0258
-#Cross Championship\250Ccm\Stade De France\Start At Last Lap/Always First
-D01087CC FF00
-301087CC 0003
-#Cross Championship\250Ccm\Stade De France\900 Points
-D01087CC FF00
-80108798 0384
-#Cross Championship\250Ccm\Reygades\Start At Last Lap/Always First
-D0111570 FF00
-30111570 0001
-#Cross Championship\250Ccm\Reygades\1200 Points
-D0111570 FF00
-8011153C 04B0
-#Cross Championship\250Ccm\Belo Horizonte\Start At Last Lap/Always First
-D0107058 FF00
-30107058 0004
-#Cross Championship\250Ccm\Belo Horizonte\1500 Points
-D0107058 FF00
-80107024 05DC
-#World Tour Championship\Isle Of Man Town\Start At Last Lap/Always First %NOTE
-D010D414 FF00
-3010D414 0003
-#World Tour Championship\Isle Of Man Town\1200 Points %NOTE
-D010D414 FF00
-8010D3E0 04B0
-#Dragster Race\1st Track\Start At Last Lap/Always First
-D010AA04 FF00
-3010AA04 0006
-#Dragster Race\1st Track\Always Good Grip
-A6160076 02000000
-#Dragster Race\2nd Track\Start At Last Lap/Always First
-D0110F7C FF00
-30110F7C 0001
-#Dragster Race\2nd Track\Always Good Grip
-A617C02E 02000000
-#Freestyle/ Trial\Timer Stopped
-D005697A 0050
-8005697C 0000
-#Freestyle/ Trial\Hide Stopwatch
-A60526BA 0C013400
-#Traffic\Start At Last Lap/Always First
-A610E864 FF000001
-#Hide Map
-A60525E8 00A8FFFF
-#Good Grip On Sand
-A60304BA A222A220
-#Good Grip On Grass
-A60304EA A222A220
 
 ; [ Motocross Mania (Europe) {SLES-03325} ]
 :SLES-03325
@@ -122412,20 +124649,6 @@ D01FFD28 6363
 801FFD30 0000
 D01FFD28 6363
 801FFD32 0000
-
-; [ Motor Toon Grand Prix 2 (Europe) (EDC 2 Games) {SCES-00245} ]
-:SCES-00245
-#Infinite Coins
-800DC296 0600
-#All Goodies
-900E4444 01010A01
-300E4448 0001
-#Infinite Continues
-800DD0EC 0002
-#Always First
-300DC0EE 0001
-#Infinite Time
-800DD60A 0006
 
 ; [ Motor Toon Grand Prix 2 (Europe) {SCES-00245} ]
 :SCES-00245
@@ -122723,7 +124946,6 @@ A7056056 10401400
 
 ; [ Music 2000 (Europe) Demo {SLED-02539} ]
 ; [ Music 2000 (Europe) {SLES-02224} ]
-; [ Music: Music Creation for the PlayStation (Europe) {SLES-01356} ]
 ; [ Mutekiou Tri-Zenon (Japan) {SLP-86790} ]
 
 ; [ My Dream: On Air ga Matenakute (Japan) {SLPS-00996 | SLPS-00997} ]
@@ -123870,50 +126092,6 @@ A60CACEA 000005F5
 ; [ Necronomicon: O Despertar das Trevas (Portugal) {SLES-03498 | SLES-13498} ]
 ; [ Necronomicon: The Dawning of Darkness (Europe) {SLES-03493 | SLES-13493} ]
 ; [ Nectaris (Japan) {SLPS-01245} ]
-
-; [ Need for Speed II (Europe) {SLES-00658} ]
-:SLES-00658
-#All cars upgraded
-300360A0 0001
-#Bonuslap Hollywood
-800E2C90 0006
-
-; [ Need for Speed III: Hot Pursuit (Europe) {SLES-01154} ]
-:SLES-01154
-#Enable Clk-Gtr And Xjr-15
-80043F0A 0101
-#Enable Ferrari 550 And Diablo Sv
-80043F08 0101
-#Enable Nazca C2
-80043F06 0101
-#Afterburner
-D311DFEA 001F
-8011DFEA 005D
-#All Tracks & Cars
-80125FC0 03F8
-#Select Starting Lap\2
-D011DDE0 0000
-3011DDE0 0001
-#Select Starting Lap\3
-D011DDE0 0000
-3011DDE0 0002
-#Select Starting Lap\4
-D011DDE0 0000
-3011DDE0 0003
-#Fourth Lap Press X & L2 & R2
-D012E3A2 BCFF
-3011DDE0 0003
-#Stopwatch 00:00:00 Press X & L1 & R1
-D012E3A2 B3FF
-80108468 0000
-D012E3A2 B3FF
-8010846A 0000
-#Camera Modifier\Micromachines-Style Press Select & X
-D012E3A2 BFFE
-800F7B40 0010
-D012E3A2 BFFE
-800F7B42 0010
-
 ; [ Need for Speed: High Stakes (Australia) {SLES-01876} ]
 
 ; [ Need for Speed: Porsche 2000 (Europe) {SLES-02689} ]
@@ -125730,23 +127908,6 @@ A606C2AA 0080000A
 
 ; [ No Fear Downhill Mountain Biking (Europe) Demo {SLED-02450} ]
 
-; [ No Fear Downhill Mountain Biking (Europe) {SLES-00849} ]
-:SLES-00849
-#Infinite Energy
-D00D3C3A BFFF
-800D772C EBBF
-#Time 000 1ST
-800CC644 0000
-#Energy Bar Always Full
-800D772C EBBF
-#Have All Extra Bike Parts
-50000402 0000
-800D15AA 0303
-#Trick Mode 9999 Points
-800CC648 270F
-#Trick Trail Mode Freeze Time
-800CC644 6000
-
 ; [ No One Can Stop Mr. Domino (Europe) {SLES-01354} ]
 :SLES-01354
 #Infinite Continues
@@ -126081,13 +128242,6 @@ A61F389E 00080009
 ; [ Oddworld: Abe's Exoddus + Duke Nukem: Time To Kill + B-Movie (Europe) Demo {SLED-01608} ]
 ; [ Oddworld: Abe's Exoddus + Duke Nukem: Time to Kill + Duke Nukem: 3D (France) {SLED-01655} ]
 ; [ Oddworld: Abe's Oddysee (Europe) Demo {SLED-00725} ]
-
-; [ Oddworld: Abe's Oddysee (Europe) {SLES-00664} ]
-:SLES-00664
-#Zero Casualties
-800B3D50 0000
-#Invincibility
-30082286 0001
 
 ; [ Oddworld: Abe's Oddysee (Germany) (Platinum) {SLES-00839} ]
 :SLES-00839
@@ -126707,6 +128861,12 @@ A60E2972 00000803
 80044FAE 0000
 #Infinite Bullets
 8006F3F6 8482
+#Widescreen 16-9
+A71F0F80 10000C00
+#Widescreen 16-9 (Optional Extra)
+A71F0FC0 10000C00
+#Dither Off
+A7088048 02000000
 
 ; [ Overboard! (Europe) {SLES-00865} ]
 :SLES-00865
@@ -127707,6 +129867,10 @@ F40DBC1E 00AA0800
 40AAAAAA AAAAAAAA
 00AAAAAA AAAAAAAA
 AAAAAAAA AAAAAAAA
+#Quick Turn (Up + L2)
+E0071625 00000010
+E0071626 00000001
+61092582 000003E8
 
 ; [ Parasite Eve II (France) {SLES-02559 | SLES-12559} ]
 :SLES-12559
@@ -129233,74 +131397,6 @@ D00E6318 0001
 ; [ Pocket PowerStation PlayStation Cheats CD (UK) {Unlicensed} ]
 ; [ Pocket Tuner (Japan) {SLPS-02218} ]
 ; [ Pocket Zanmai: 3 Title Iri Taikenban (PAQA, PokeTan, Pocket Jiman) (Japan) Demo {PAPX-90094} ]
-; [ Point Blank (Europe) Demo {SCED-00287} ]
-
-; [ Point Blank (Europe) Rev 1 {SCES-00886} ]
-:SCES-00886
-#Infinite Bullets
-800B7418 0010
-800B7434 0010
-#Infinite Hits
-800B4318 00FF
-#Arcade Mode Codes\P1 Infinite Lives
-800C159C 0005
-#Arcade Mode Codes\P2 Infinite Lives
-800C159E 0005
-#Arcade Mode Codes\P1 Infinite Bullets
-800B7418 0063
-#Arcade Mode Codes\P2 Infinite Bullets
-800B741A 0063
-#Arcade Mode Codes\Always Max Hits
-800BE588 00FF
-#Arcade Mode Codes\Infinite Time Press L1 & R1 & Select (On) Press L2 & R2 & Select (Off)
-800B7434 0016
-800AD856 FFFF
-#Quest Mode Codes\Infinite Money
-800AE0D4 FFFF
-#Quest Mode Codes\P1 Quick Level Gain
-800C1918 FFFF
-
-; [ Point Blank (Europe) {SCES-00886} ]
-:SCES-00886
-#Infinite Bullets
-800B7418 0010
-800B7434 0010
-#Infinite Hits
-800B4318 00FF
-#Arcade Mode Codes\P1 Infinite Lives
-800C159C 0005
-#Arcade Mode Codes\P2 Infinite Lives
-800C159E 0005
-#Arcade Mode Codes\P1 Infinite Bullets
-800B7418 0063
-#Arcade Mode Codes\P2 Infinite Bullets
-800B741A 0063
-#Arcade Mode Codes\Always Max Hits
-800BE588 00FF
-#Arcade Mode Codes\Infinite Time Press L1 & R1 & Select (On) Press L2 & R2 & Select (Off)
-800B7434 0016
-800AD856 FFFF
-#Quest Mode Codes\Infinite Money
-800AE0D4 FFFF
-#Quest Mode Codes\P1 Quick Level Gain
-800C1918 FFFF
-
-; [ Point Blank 2 (Europe, Australia) {SCES-02180} ]
-:SCES-02180
-#Point Blank Castle Mode-Codes\P1 Infinite Lives
-800BF328 0009
-#Point Blank Castle Mode-Codes\P2 Infinite Lives
-800BF32A 0009
-#Theme Park Mode Codes\Infinite Lives
-800AAB88 0009
-#Theme Park Mode Codes\Haunted House - Infinite Time
-800B447C 012C
-#Theme Park Mode Codes\Abyss Tours - Max Targets Hits
-A60AAD52 00000063
-#Theme Park Mode Codes\Cosmic Drive - Max Targets Hit
-A60B5088 00000063
-#Theme Park Mode Codes\Superbullet Train - Max Targets Hit
-A60B4EFC 00000FFF
 
 ; [ Point Blank 3 (Europe) {SCES-03383} ]
 :SCES-03383
@@ -129454,15 +131550,6 @@ D00F9642 0000
 
 ; [ Populous: The Beginning (Japan) {SLPS-02085} ]
 
-; [ Porsche Challenge (Europe) {SCES-00409} ]
-:SCES-00409
-#Infinite Time
-800DA334 0608
-#Always First
-800DA31E 0001
-#Widescreen 16-9
-800C9DA4 1222
-
 ; [ Porsche Challenge (Japan) {SIPS-60016} ]
 :SIPS-60016
 #Infinite Time
@@ -129501,7 +131588,6 @@ D00F9642 0000
 8009C658 0000
 
 ; [ Power Shovel ni Norou!! (Japan) {SLP-86629} ]
-; [ Power Source (Europe) {SCES-00667} ]
 ; [ Power Stakes (Japan) {SLP-86032} ]
 ; [ Power Stakes 2 (Japan) {SLP-86079} ]
 ; [ Power Stakes Grade 1 (Japan) {SLP-86050} ]
@@ -130025,15 +132111,6 @@ D0102BE0 0400
 ; [ Pro Mahjong Tsuwamono 2 (Japan) {SLPS-01987} ]
 ; [ Pro Mahjong Tsuwamono 3 (Japan) (EPV (Excellent Price Version)) {SLPS-03464} ]
 ; [ Pro Mahjong Tsuwamono Series: Joryuu Janshi ni Chousen: Watashi-tachi ni Chousen Shite ne! (Japan) (BPV (Best Price Version)) {SLPS-03218} ]
-
-; [ Pro Pinball: Big Race USA (Europe) {SLES-01211} ]
-:SLES-01211
-#P1 Infinite Balls
-A60AABE0 00020001
-#Ballsaver always active
-800AC004 0800
-#Airbag always active
-800AC010 0800
 
 ; [ Pro Pinball: Fantastic Journey (Europe) {SLES-02466} ]
 :SLES-02466
@@ -133358,30 +135435,6 @@ D01FFC80 0001
 
 ; [ Rescue Heroes: Helden in Gefahr (Germany) {SLES-03726} ]
 ; [ Rescue Heroes: Molten Menace (Europe) {SLES-03724} ]
-
-; [ Rescue Shot (Europe) {SCES-02569} ]
-:SCES-02569
-#Acorn-Bullets Increase
-A6045B3C FFFF0001
-#Infinite Life-Bar
-D00421C6 0062
-800421C8 0000
-D00421C6 0062
-800421CA 0000
-D0043586 0801
-80043584 0000
-A6043586 08010000
-#Max Life-Bar
-A6034D30 06061414
-#P1 Infinite $
-80034DC8 0063
-#P2 Infinite $
-80034DD8 0063
-#P1 Infinite Ammo
-30052AB5 0063
-#P2 Infinite Ammo
-30052AC5 0063
-
 ; [ Rescue Shot Bubibo & Biohazard: Gun Survivor: GunCon Taiou Shooting Taikenban (Japan) Demo {SLP-80522} ]
 
 ; [ Rescue Shot Bubibo (Japan) {SLPS-02555} ]
@@ -133402,44 +135455,6 @@ D0032C90 0001
 A614726C 00050006
 #Infinite Life In Stage 2
 A6157C38 00050006
-
-; [ Resident Evil (Europe) (EDC White Label) {SLES-00200} ]
-:SLES-00200
-#Infinite Health
-800C51AC 00C8
-#L1 + X Button For Save Anywhere (May need 1 ink ribbon to save)
-D00Cf844 0044
-800C8456 0002
-800343F2 2400
-8003446E 2400
-#Infinite Ammo Gun
-800C8786 0F02
-#Have All Maps and Files
-300C8714 003F
-900C871C FFFF0FFF
-300C8721 00CF
-800C8722 FFFF
-#Infinite Ink ribbons when you get one
-800345FA 2402
-
-; [ Resident Evil (Europe) {SLES-00200} ]
-:SLES-00200
-#Infinite Health
-800C51AC 00C8
-#L1 + X Button For Save Anywhere (May need 1 ink ribbon to save)
-D00Cf844 0044
-800C8456 0002
-800343F2 2400
-8003446E 2400
-#Infinite Ammo Gun
-800C8786 0F02
-#Have All Maps and Files
-300C8714 003F
-900C871C FFFF0FFF
-300C8721 00CF
-800C8722 FFFF
-#Infinite Ink ribbons when you get one
-800345FA 2402
 
 ; [ Resident Evil (Europe, Australia) Demo {SLES-00335} ]
 
@@ -134049,116 +136064,6 @@ D00C54A4 0001
 
 ; [ Resident Evil 2 (USA) (Trade Demo) {SLUS-80421} ]
 
-; [ Resident Evil 3: Nemesis (Europe) {SLES-02529} ]
-:SLES-02529
-#Infinite Health
-800CEA48 00C8
-#Always 1 First Aid Pack
-300D3EFD 0001
-#Machinegun 100% This code can crash the game while loading
-300D3EED 0064
-#Condition Fine
-300CEA4F 0004
-#Save Anywhere Press L1+Triangle
-D0082AD2 0014
-800D3AD0 169C
-D0082AD2 0014
-800D3AD2 8005
-#Infinite Rocket Launcher
-900D3F58 0001990A
-#Infinite Gatling Gun
-900D3F58 0001990B
-#Infinite Western Custom
-900D3F58 00019910
-#Infinite Benelli M3S
-900D3F58 00019913
-#Infinite M97F Eagle
-900D3F58 00019912
-#Infinite Mine Thrower
-900D3F58 00019914
-#Infinite Eagle 6.0
-900D3F58 0001990D
-#Infinite Magnum
-900D3F58 00019914
-#Infinite Merc's Handgun
-900D3F58 00019902
-#Infinite Hanggun
-900D3F58 00019903
-#Infinite Grenade Launcher (Explocive Rounds)
-900D3F58 00019906
-#Infinite Grenade Launcher (Acid Rounds)
-900D3F58 00019909
-#Infinite Grenade Launcher (Flame Rounds)
-900D3F58 00019907
-#Hyper Mode
-800D6304 0002
-#Quick Ending Press L1+L2+R1+R2
-D00CE5E8 000F
-800CEA10 C000
-D00CE5E8 000F
-800CEA12 0001
-#Rapid Fire Press R1+R2+X
-D00CE5E8 004A
-300CEA45 001E
-#Total Time 0:00 .Get Grade S
-900D3CE0 00000000
-#Secret Mode With this code, it starts a new game with new weapons in chest and all weapons and infinite ink ribbons and a key to Boutique with all costumes!
-800D3CEA FFE0
-#Enhanced/Extra Ammo
-900D4018 01F401F4
-800D401E 01F4
-900D4020 01F401F4
-800D4024 01F4
-#Makes Game Think You Never Saved
-800D3CF8 0000
-#Select Character\Carlos
-800D3D3E 0008
-#Select Character\Mikhall
-800D3D3E 0009
-#Select Character\Nichotai
-800D3D3E 000A
-#Select Character\Tofu
-800D3D3E 000F
-#Sudden Death Enemies
-A604502C 00060001
-#Almost All Doors Open
-D0082AD2 0014
-800D3AD0 169C
-D0082AD2 0014
-800D3AD2 8005
-50000502 0000
-800D3E84 FFFF
-#Walk Thru Walls Activate with L1+R2, deactivate with L2+R2
-D0082AD2 0003
-80033CD6 1040
-D0082AD2 0003
-8004B576 12A0
-D0082AD2 0005
-80033CD6 1000
-D0082AD2 0005
-8004B576 1000
-#Mercenaries Always get Reward
-800CE60A FFFF
-#Mercenaries Infinite Money
-900D43A4 0098967F
-#Mercenaries Infinite Time
-D00D3D50 0077
-300D3D50 0078
-#Auto Dodge Zombies (Hold L3)
-D5000000 00000200
-F4104BD0 00AA7000
-05004234 040062AE
-AAAAAAAA AAAAAAAA
-010DAAAA AAAAAAAA
-AAAAAAAA AAAAAAAA
-00000000 0000FFFF
-D6000000 00000200
-F4104BD0 00AA7000
-010D4234 040062AE
-AAAAAAAA AAAAAAAA
-0500AAAA AAAAAAAA
-AAAAAAAA AAAAAAAA
-
 ; [ Resident Evil 3: Nemesis (France) {SLES-02530} ]
 :SLES-02530
 #Infinite Health
@@ -134448,18 +136353,6 @@ A60C8784 0001FF0A
 #Besitze Colt Python
 800C8786 6404
 
-; [ Resident Evil: Survivor (Europe) {SLES-02732} ]
-:SLES-02732
-#Infinite Health
-800A8734 00C8
-#Ammo Won't Decrease
-D006FD9C 0002
-8006FD98 0000
-#OK Status
-800A8736 0000
-#Widescreen 16-9
-80065B80 0C00
-
 ; [ Resident Evil: Survivor (France) {SLES-02744} ]
 
 ; [ Restaurant Dream (Japan) {SLPS-01974} ]
@@ -134592,19 +136485,6 @@ E20857A4 0002
 80067896 08FF
 #Ridge Racer Enhanced Turbo Mode\Infinite Time
 80085D84 09AF
-
-; [ Ridge Racer Revolution (Europe) (EDC Original) {SCES-00242} ]
-:SCES-00242
-#Always First
-8007C750 0001
-#Infinite Checkpoint time
-80194BAC 05DC
-#Course select
-801DCC14 0707
-#12 cars
-801DE564 0028
-#Buggies
-801E65DC 0028
 
 ; [ Ridge Racer Revolution (Europe) {SCES-00242} ]
 :SCES-00242
@@ -138493,60 +140373,6 @@ D00C7940 0002
 
 ; [ Silent Hill (Australia) Demo {SLED-02186} ]
 ; [ Silent Hill (Europe) Demo {SLED-01735} ]
-
-; [ Silent Hill (Europe) {SLES-01514} ]
-:SLES-01514
-#Infinite Health
-800B96AE 0006
-#Infinite Ammo & No Reloads
-800B95F8 0063
-#Have All Weapons
-800BC098 0180
-800BC09C 0181
-800BC0A4 0184
-800BC0A8 0185
-800BC0B0 0187
-800BC0B4 FFA0
-800BC0B8 FFA1
-800BC0C0 FFA3
-800BC0BC FFA2
-#Slide & Glide Mode
-800B9722 3800
-#Have Map
-300BC188 0002
-#Map Complete
-50000402 FFFF
-800BC1F8 0000
-#Flassh light Always on
-300BB94D 0001
-#Invincibility
-8008BEA2 1000
-#Infinite Health (ASM)
-8007CB5E 2400
-#Infinite Ammo (ASM)
-80074A6E 2400
-#Total Time = 00:00
-900BC274 00000000
-#Saves = 0
-800BC0CA 0000
-#Have All Maps
-800BC188 FFFE
-300BC18A 00FF
-50006201 0000
-300BC1F8 00FF
-#Perfect Game Results
-800BC260 00CC
-50000702 0000
-800BC288 0000
-300BC29F 0000
-#Start New Game at Cafe (skip chasing Cheryl down the alley intro part)
-900BC18C FFFFFFFF
-#Language Option Always Available
-801E7698 0001
-#Widescreen 16-9
-A70C65D0 10000C00
-A70C65E0 10000C00
-
 ; [ Silent Hill (Germany) Demo {SLED-01774} ]
 
 ; [ Silent Hill (Japan) (Trial Version) {SLP-80363} ]
@@ -138560,6 +140386,14 @@ A70C9510 10000C00
 A70C9520 10000C00
 #Dither Off
 A7019810 02000000
+#Select Fog Distance\1999
+8003F52C 1999
+#Select Fog Distance\1444
+8003F52C 1444
+#Select Fog Colour Influence\0A00
+8003FAFC 0A00
+#Select Fog Colour Influence\0000
+8003FAFC 0000
 
 ; [ Silent Hill (USA) Demo {SLUS-90050} ]
 
@@ -141046,30 +142880,11 @@ D1069102 0000
 #Infinite Checkpoint time
 80104508 0063
 
-; [ Sphere 360Â° (Europe) (Bundled with ASCII Sphere 360Â° Controller) {SLED-01711} ]
-; [ Spice World (Europe) (Preview) {SCES-00883} ]
 ; [ Spice World (Europe) {SCES-00883} ]
 ; [ Spice World (France) {SCES-01231} ]
 ; [ Spice World (Germany) {SCES-01232} ]
 ; [ Spice World (Italy) {SCES-01233} ]
 ; [ Spice World (Spain) {SCES-01234} ]
-
-; [ Spider-Man (Europe) {SLES-02886} ]
-:SLES-02886
-#Invulnerable
-300EA335 0056
-#Infinite Web Carts
-801B7599 2400
-#Countdown Time Frozen
-800EA486 C100
-#Unlock All
-5004FFDA F5F4
-800F9AA0 FFFF
-#Level Select
-300EA319 0001
-#Enable What If Contest
-800EA325 0001
-
 ; [ Spider-Man (France) (Platinum) {SLES-02887} ]
 
 ; [ Spider-Man (Germany) {SLES-02888} ]
@@ -141372,21 +143187,6 @@ D006C6F4 0000
 
 ; [ Spyro 2: Ripto's Rage! + Crash Team Racing (USA) {SCUS-94632} ]
 
-; [ Spyro the Dragon (Europe) {SCES-01438} ]
-:SCES-01438
-#Infinite Lives
-8007C100 000F
-#Infinite Health
-8007F54C 0003
-#Infinite Time
-8007C110 0A00
-#Moon Jump
-E007DD10 0040
-8007F468 0000
-#Have All found
-50000404 0000
-8007EFC0 0008
-
 ; [ Spyro the Dragon (Japan) (Shokai Genteiban) {SCPS-10083} ]
 :SCPS-10083
 #Infinite Timer
@@ -141430,496 +143230,6 @@ E007DD10 0040
 8006C464 070A
 #And (rising gradually to jump) airborne
 8006CC44 05FF
-
-; [ Spyro: Year of the Dragon (Europe) Rev 1 {SCES-02835} ]
-:SCES-02835
-#Have 999 jewels
-8006F9F8 03E7
-#Have 15000 jewels
-8006F9F8 3A98
-#Have 20000 jewels
-8006F9F8 4e20
-#Have all eggs
-8006F93C 0096
-#Infinite Health
-A60738A4 00020003
-#Infinite Lives
-A606FA60 00030004
-#Moon Jump (Press Up & X)
-D0074736 BFEF
-3007362D 00A0
-#Boarding More Time(Press L1 & L2)
-D0074736 FAFF
-8018BCD0 2312
-#Start With Lots Of Points
-A618A160 00002710
-#Sunrise Spring Worlds Unlocked
-3007546C 0001
-#Sunny Villa Unlocked
-3007546D 0001
-#Cloud Spires Unlocked
-3007546E 0001
-#Molten Crater Unlocked
-3007546F 0001
-#Seashell Shore Unlocked
-30075470 0001
-#Mushroom Speedway Unlocked
-30075471 0001
-#Sheila's Alp Unlocked
-30075472 0001
-#Buzz's Dungeon Unlocked
-30075473 0001
-#Midday Garden Worlds Unlocked
-30075475 0001
-#Icy Peak Unlocked
-30075476 0001
-#Enchanted Towers Unlocked
-30075477 0001
-#Spooky Swamp Unlocked
-30075478 0001
-#Bamboo Terrace Unlocked
-30075479 0001
-#Country Speedway Unlocked
-3007547A 0001
-#Sgt. Byrd's Base Unlocked
-3007547B 0001
-#Spike's Arena Unlocked
-3007547C 0001
-#Evening Lake Worlds Unlocked
-3007547E 0001
-#Frozen Altars Unlocked
-3007547F 0001
-#Last Fleet Unlocked
-30075480 0001
-#Firewords Factory Unlocked
-30075481 0001
-#Charmed Ridge Unlocked
-30075482 0001
-#Honey Speedway Unlocked
-30075483 0001
-#Bentley's Outpost Unlocked
-30075484 0001
-#Scorch's Pit Unlocked
-30075485 0001
-#Midnight Mountain Worlds Unlocked
-30075487 0001
-#Crystal Islands Unlocked
-30075488 0001
-#Desert Ruins Unlocked
-30075489 0001
-#Haunted Tomb Unlocked
-3007548A 0001
-#Dino Mines Unlocked
-3007548B 0001
-#Harbor Speedway Unlocked
-3007548C 0001
-#Agent 9's Lab Unlocked
-3007548D 0001
-#Sorceress's Lair Unlocked
-3007548E 0001
-#Sparx Worlds Unlocked
-30075474 0001
-#Spider Town Unlocked
-3007547D 0001
-#Starfish Reef Unlocked
-30075486 0001
-#Bugbot Factory Unlocked
-3007548F 0001
-#Super Bonus World Unlocked
-30075490 0001
-#Have All Eggs Codes\Sunrise Spring Home
-300735FC 001F
-#Have All Eggs Codes\Sunny Villa
-300735FD 003F
-#Have All Eggs Codes\Cloud Spires
-300735FE 003F
-#Have All Eggs Codes\Molten Crater
-300735FF 003F
-#Have All Eggs Codes\Seashell Shore
-30073600 003F
-#Have All Eggs Codes\Mushroom Speedway
-30073601 0007
-#Have All Eggs Codes\Sheila's Alp
-30073602 0007
-#Have All Eggs Codes\Buzz's Dungeon
-30073603 0001
-#Have All Eggs Codes\Crawdad Farm
-30073604 0001
-#Have All Eggs Codes\Midday Garden Home
-30073605 001F
-#Have All Eggs Codes\Icy Peak
-30073606 003F
-#Have All Eggs Codes\Enchanted Towers
-30073607 003F
-#Have All Eggs Codes\Spooky Swamp
-30073608 003F
-#Have All Eggs Codes\Bamboo Terrace
-30073609 003F
-#Have All Eggs Codes\Country Speedway
-3007360A 0007
-#Have All Eggs Codes\Sgt. Byrd's Base
-3007360B 0007
-#Have All Eggs Codes\Spike's Arena
-3007360C 0001
-#Have All Eggs Codes\Spider Town
-3007360D 0001
-#Have All Eggs Codes\Evening Lake Home
-3007360E 001F
-#Have All Eggs Codes\Frozen Altars
-3007360F 003F
-#Have All Eggs Codes\Last Fleet
-30073610 003F
-#Have All Eggs Codes\Firewords Factory
-30073611 003F
-#Have All Eggs Codes\Charmed Ridge
-30073612 003F
-#Have All Eggs Codes\Honey Speedway
-30073613 0007
-#Have All Eggs Codes\Bentley's Outpost
-30073614 0007
-#Have All Eggs Codes\Scorch's Pit
-30073615 0001
-#Have All Eggs Codes\Starfish Reef
-30073616 0001
-#Have All Eggs Codes\Midnight Mountain Home
-30073617 003F
-#Have All Eggs Codes\Crystal Islands
-30073618 003F
-#Have All Eggs Codes\Desert Ruins
-30073619 003F
-#Have All Eggs Codes\Haunted Tomb
-3007361A 003F
-#Have All Eggs Codes\Dino Mines
-3007361B 003F
-#Have All Eggs Codes\Harbor Speedway
-3007361C 0007
-#Have All Eggs Codes\Agent 9's Lab
-3007361D 0007
-#Have All Eggs Codes\Sorceress' Lair
-3007361E 0001
-#Have All Eggs Codes\Bugbot Factory
-3007361F 0001
-#Have All Eggs Codes\Super Bonus World
-30073620 0001
-#Max Gems Codes\Sunrise Spring Home
-80074ECC 0190
-#Max Gems Codes\Sunny Villa
-80074ED0 0190
-#Max Gems Codes\Cloud Spires
-80074ED4 0190
-#Max Gems Codes\Molten Crater
-80074ED8 0190
-#Max Gems Codes\Seashell Shore
-80074EDC 0190
-#Max Gems Codes\Mushroom Speedway
-80074EE0 0190
-#Max Gems Codes\Sheila's Alp
-80074EE4 0190
-#Max Gems Codes\Buzz's Dungeon
-80074EE8 0000
-#Max Gems Codes\Crawdad Farm
-80074EEC 00C8
-#Max Gems Codes\Midday Garden Home
-80074EF0 0190
-#Max Gems Codes\Icy Peak
-80074EF4 01F4
-#Max Gems Codes\Enchanted Towers
-80074EF8 01F4
-#Max Gems Codes\Spooky Swamp
-80074EFC 01F4
-#Max Gems Codes\Bamboo Terrace
-80074F00 01F4
-#Max Gems Codes\Country Speedway
-80074F04 0190
-#Max Gems Codes\Sgt. Byrd's Base
-80074F08 01F4
-#Max Gems Codes\Spike's Arena
-80074F0C 0000
-#Max Gems Codes\Spider Town
-80074F10 00C8
-#Max Gems Codes\Evening Lake Home
-80074F14 0190
-#Max Gems Codes\Frozen Altars
-80074F18 0258
-#Max Gems Codes\Last Fleet
-80074F1C 0258
-#Max Gems Codes\Firewords Factory
-80074F20 0258
-#Max Gems Codes\Charmed Ridge
-80074F24 0258
-#Max Gems Codes\Honey Speedway
-80074F28 0190
-#Max Gems Codes\Bentley's Outpost
-80074F2C 0258
-#Max Gems Codes\Scorch's Pit
-80074F30 0000
-#Max Gems Codes\Starfish Reef
-80074F34 00C8
-#Max Gems Codes\Midnight Mountain Home
-80074F38 0190
-#Max Gems Codes\Crystal Islands
-80074F3C 02BC
-#Max Gems Codes\Desert Ruins
-80074F40 02BC
-#Max Gems Codes\Haunted Tomb
-80074F44 02BC
-#Max Gems Codes\Dino Mines
-80074F48 02BC
-#Max Gems Codes\Harbor Speedway
-80074F4C 0190
-#Max Gems Codes\Agent 9's Lab
-80074F50 02BC
-#Max Gems Codes\Sorceress' Lair
-80074F54 0000
-#Max Gems Codes\Bugbot Factory
-80074F58 00C8
-#Max Gems Codes\Extra bonus world
-80074F5C 1388
-
-; [ Spyro: Year of the Dragon (Europe) {SCES-02835} ]
-:SCES-02835
-#Have 999 jewels
-8006F9F8 03E7
-#Have 15000 jewels
-8006F9F8 3A98
-#Have 20000 jewels
-8006F9F8 4e20
-#Have all eggs
-8006F93C 0096
-#Infinite Health
-A60738A4 00020003
-#Infinite Lives
-A606FA60 00030004
-#Moon Jump (Press Up & X)
-D0074736 BFEF
-3007362D 00A0
-#Boarding More Time(Press L1 & L2)
-D0074736 FAFF
-8018BCD0 2312
-#Start With Lots Of Points
-A618A160 00002710
-#Sunrise Spring Worlds Unlocked
-3007546C 0001
-#Sunny Villa Unlocked
-3007546D 0001
-#Cloud Spires Unlocked
-3007546E 0001
-#Molten Crater Unlocked
-3007546F 0001
-#Seashell Shore Unlocked
-30075470 0001
-#Mushroom Speedway Unlocked
-30075471 0001
-#Sheila's Alp Unlocked
-30075472 0001
-#Buzz's Dungeon Unlocked
-30075473 0001
-#Midday Garden Worlds Unlocked
-30075475 0001
-#Icy Peak Unlocked
-30075476 0001
-#Enchanted Towers Unlocked
-30075477 0001
-#Spooky Swamp Unlocked
-30075478 0001
-#Bamboo Terrace Unlocked
-30075479 0001
-#Country Speedway Unlocked
-3007547A 0001
-#Sgt. Byrd's Base Unlocked
-3007547B 0001
-#Spike's Arena Unlocked
-3007547C 0001
-#Evening Lake Worlds Unlocked
-3007547E 0001
-#Frozen Altars Unlocked
-3007547F 0001
-#Last Fleet Unlocked
-30075480 0001
-#Firewords Factory Unlocked
-30075481 0001
-#Charmed Ridge Unlocked
-30075482 0001
-#Honey Speedway Unlocked
-30075483 0001
-#Bentley's Outpost Unlocked
-30075484 0001
-#Scorch's Pit Unlocked
-30075485 0001
-#Midnight Mountain Worlds Unlocked
-30075487 0001
-#Crystal Islands Unlocked
-30075488 0001
-#Desert Ruins Unlocked
-30075489 0001
-#Haunted Tomb Unlocked
-3007548A 0001
-#Dino Mines Unlocked
-3007548B 0001
-#Harbor Speedway Unlocked
-3007548C 0001
-#Agent 9's Lab Unlocked
-3007548D 0001
-#Sorceress's Lair Unlocked
-3007548E 0001
-#Sparx Worlds Unlocked
-30075474 0001
-#Spider Town Unlocked
-3007547D 0001
-#Starfish Reef Unlocked
-30075486 0001
-#Bugbot Factory Unlocked
-3007548F 0001
-#Super Bonus World Unlocked
-30075490 0001
-#Have All Eggs Codes\Sunrise Spring Home
-300735FC 001F
-#Have All Eggs Codes\Sunny Villa
-300735FD 003F
-#Have All Eggs Codes\Cloud Spires
-300735FE 003F
-#Have All Eggs Codes\Molten Crater
-300735FF 003F
-#Have All Eggs Codes\Seashell Shore
-30073600 003F
-#Have All Eggs Codes\Mushroom Speedway
-30073601 0007
-#Have All Eggs Codes\Sheila's Alp
-30073602 0007
-#Have All Eggs Codes\Buzz's Dungeon
-30073603 0001
-#Have All Eggs Codes\Crawdad Farm
-30073604 0001
-#Have All Eggs Codes\Midday Garden Home
-30073605 001F
-#Have All Eggs Codes\Icy Peak
-30073606 003F
-#Have All Eggs Codes\Enchanted Towers
-30073607 003F
-#Have All Eggs Codes\Spooky Swamp
-30073608 003F
-#Have All Eggs Codes\Bamboo Terrace
-30073609 003F
-#Have All Eggs Codes\Country Speedway
-3007360A 0007
-#Have All Eggs Codes\Sgt. Byrd's Base
-3007360B 0007
-#Have All Eggs Codes\Spike's Arena
-3007360C 0001
-#Have All Eggs Codes\Spider Town
-3007360D 0001
-#Have All Eggs Codes\Evening Lake Home
-3007360E 001F
-#Have All Eggs Codes\Frozen Altars
-3007360F 003F
-#Have All Eggs Codes\Last Fleet
-30073610 003F
-#Have All Eggs Codes\Firewords Factory
-30073611 003F
-#Have All Eggs Codes\Charmed Ridge
-30073612 003F
-#Have All Eggs Codes\Honey Speedway
-30073613 0007
-#Have All Eggs Codes\Bentley's Outpost
-30073614 0007
-#Have All Eggs Codes\Scorch's Pit
-30073615 0001
-#Have All Eggs Codes\Starfish Reef
-30073616 0001
-#Have All Eggs Codes\Midnight Mountain Home
-30073617 003F
-#Have All Eggs Codes\Crystal Islands
-30073618 003F
-#Have All Eggs Codes\Desert Ruins
-30073619 003F
-#Have All Eggs Codes\Haunted Tomb
-3007361A 003F
-#Have All Eggs Codes\Dino Mines
-3007361B 003F
-#Have All Eggs Codes\Harbor Speedway
-3007361C 0007
-#Have All Eggs Codes\Agent 9's Lab
-3007361D 0007
-#Have All Eggs Codes\Sorceress' Lair
-3007361E 0001
-#Have All Eggs Codes\Bugbot Factory
-3007361F 0001
-#Have All Eggs Codes\Super Bonus World
-30073620 0001
-#Max Gems Codes\Sunrise Spring Home
-80074ECC 0190
-#Max Gems Codes\Sunny Villa
-80074ED0 0190
-#Max Gems Codes\Cloud Spires
-80074ED4 0190
-#Max Gems Codes\Molten Crater
-80074ED8 0190
-#Max Gems Codes\Seashell Shore
-80074EDC 0190
-#Max Gems Codes\Mushroom Speedway
-80074EE0 0190
-#Max Gems Codes\Sheila's Alp
-80074EE4 0190
-#Max Gems Codes\Buzz's Dungeon
-80074EE8 0000
-#Max Gems Codes\Crawdad Farm
-80074EEC 00C8
-#Max Gems Codes\Midday Garden Home
-80074EF0 0190
-#Max Gems Codes\Icy Peak
-80074EF4 01F4
-#Max Gems Codes\Enchanted Towers
-80074EF8 01F4
-#Max Gems Codes\Spooky Swamp
-80074EFC 01F4
-#Max Gems Codes\Bamboo Terrace
-80074F00 01F4
-#Max Gems Codes\Country Speedway
-80074F04 0190
-#Max Gems Codes\Sgt. Byrd's Base
-80074F08 01F4
-#Max Gems Codes\Spike's Arena
-80074F0C 0000
-#Max Gems Codes\Spider Town
-80074F10 00C8
-#Max Gems Codes\Evening Lake Home
-80074F14 0190
-#Max Gems Codes\Frozen Altars
-80074F18 0258
-#Max Gems Codes\Last Fleet
-80074F1C 0258
-#Max Gems Codes\Firewords Factory
-80074F20 0258
-#Max Gems Codes\Charmed Ridge
-80074F24 0258
-#Max Gems Codes\Honey Speedway
-80074F28 0190
-#Max Gems Codes\Bentley's Outpost
-80074F2C 0258
-#Max Gems Codes\Scorch's Pit
-80074F30 0000
-#Max Gems Codes\Starfish Reef
-80074F34 00C8
-#Max Gems Codes\Midnight Mountain Home
-80074F38 0190
-#Max Gems Codes\Crystal Islands
-80074F3C 02BC
-#Max Gems Codes\Desert Ruins
-80074F40 02BC
-#Max Gems Codes\Haunted Tomb
-80074F44 02BC
-#Max Gems Codes\Dino Mines
-80074F48 02BC
-#Max Gems Codes\Harbor Speedway
-80074F4C 0190
-#Max Gems Codes\Agent 9's Lab
-80074F50 02BC
-#Max Gems Codes\Sorceress' Lair
-80074F54 0000
-#Max Gems Codes\Bugbot Factory
-80074F58 00C8
-#Max Gems Codes\Extra bonus world
-80074F5C 1388
 
 ; [ Spyro: Year of the Dragon (USA) Demo {SCUS-94615} ]
 ; [ Square Maniacs '98 (Japan) {SLP-80306} ]
@@ -143289,34 +144599,6 @@ A605EB5C FFFF0001
 800A1E92 0006
 #Race As Yuki
 800A1E92 0004
-
-; [ Street Skater 2 (Europe) {SLES-02703} ]
-:SLES-02703
-#Each Trick is Worth Max Points
-90085548 2402FFFF
-#Mega Boost With Up
-E00388C1 0010
-8003883C 1400
-#Great Trick Score
-8003872E 0098
-#Infinite Time L1 for 15 points/L2 for 0 points
-80038724 1200
-#Bonus Points
-D00988C0 0004
-801FAC00 000F
-D00988C0 0001
-801FAC00 0000
-#Max Character-Codes
-50000501 0000
-301FA9F0 000F
-#Unlock All Levels
-8008D3F8 FFFF
-#Unlock All Characters
-8008D400 FFFF
-#Unlock All Boards
-9008D404 FFFFFFFF
-#Unlock Movieplayer
-8008D3F4 0002
 
 ; [ Street Skater aka Street Sk8er (Europe) {SLES-01759} ]
 :SLES-01759
@@ -145692,47 +146974,6 @@ D00A1A54 0002
 #Unlocked Go-Kart-Mode
 300100B5 0001
 
-; [ TOCA World Touring Cars (Europe) {SLES-02572} ]
-:SLES-02572
-#Activate Bonuses Menu Always Open
-300A1778 0001
-#only one lap to race / always first
-D00F936E 0003
-300F936C 0003
-D00F936E 0004
-300F936C 0004
-D00F936E 0005
-300F936C 0005
-D00F936E 0006
-300F936C 0006
-D00F936E 0008
-300F936C 0008
-#Always 6 races won
-30059279 0006
-#Always get 100 points per season
-D10592C0 0000
-800592C0 0064
-#Other drivers can't score
-50000B04 0000
-800592C4 0000
-#Max career-points
-D105938C 0000
-8005938C 02C6
-#All boni available (Press L1 & L2 & R1 & R2)
-D0054056 F0FF
-800581C8 FFFF
-#Time trial stop timer
-80057A0C 00CF
-#Auto Pilot - Press x & Select
-D0053E58 4001
-800F938A 0100
-#Auto Pilot Deactivate - Press Select
-D0053E58 0001
-800F938A 1030
-#Nitro Boost - Press x & Up
-D0053E58 4010
-800FD1D2 0001
-
 ; [ TOCA World Touring Cars (Europe) {SLES-02573} ]
 
 ; [ TRL: The Rail Loaders (Japan) {SLPS-02626} ]
@@ -146332,108 +147573,6 @@ D1112762 0000
 ; [ Tekken 2 + Fade to Black + F1 + V-CD (Germany) {SCED-00494} ]
 ; [ Tekken 2 + Fade to Black + V-CD (France) {SCED-00467} ]
 
-; [ Tekken 3 (Europe) (Platinum) {SCES-01237} ]
-:SCES-01237
-#P1 Infinite Health
-800A95E6 0082
-#P2 Infinite Health
-800AAE72 0082
-#Enable Theatre Mode
-30097EEF 0003
-#Enable All Movies In Theatre
-90097EC0 FFFFFFFF
-80097EC4 FFFF
-#Enable Tekken Ball Mode
-30097EEE 0003
-#Enable All Characters
-90097EB8 FFFFFFFF
-80097EBC FFFF
-#Enable Tiger Characters .To select to fight with Tiger you must select Eddy with START button.
-80097EBC 0382
-#No Health Enemies Tekken Force Mode .This code also effects Player 2 health in other modes.
-800AAE72 0000
-800AC6FE 0000
-#Infinite Time To Choose
-80118764 03FF
-#Infinite Time In Force Mode
-800ADB94 134F
-#P1 No Health
-300A95E6 0000
-#P2 No Health
-300AAE72 0000
-#P1 1-Hit Death
-A60A95E6 008C0001
-#P2 1-Hit Death
-A60AAE72 008C0001
-#P1 Invincibility
-800AAADA 1000
-800AAAE0 1000
-800AAAFE 1000
-800AAB04 0000
-#Arcade Mode Stage Select 1
-D00AFA74 0000
-300AFA74 0000
-#Arcade Mode Stage Select 2
-D00AFA74 0000
-300AFA74 0001
-#Arcade Mode Stage Select 3
-D00AFA74 0000
-300AFA74 0002
-#Arcade Mode Stage Select 4
-D00AFA74 0000
-300AFA74 0003
-#Arcade Mode Stage Select 5
-D00AFA74 0000
-300AFA74 0004
-#Arcade Mode Stage Select 6
-D00AFA74 0000
-300AFA74 0005
-#Arcade Mode Stage Select 7
-D00AFA74 0000
-300AFA74 0006
-#Arcade Mode Stage Select 8
-D00AFA74 0000
-300AFA74 0007
-#Arcade Mode Stage Select 9
-D00AFA74 0000
-300AFA74 0008
-#Arcade Mode Stage Select 10
-D00AFA74 0000
-300AFA74 0009
-#P1 Grip Of Death
-800A924A 0017
-#P1 The Glow
-800A9312 006F
-800A924E 00FF
-#Neon Glow
-8009E5B4 FFFF
-#Enable Final Stage In Force Mode .This code will only work if Dr. Boskonovitch has NOT been enabled.
-80097EE0 0103
-#P1 is Dr. Boskonovitch
-300ADD24 0013
-#P1 Press L1 To Gain Power
-D00A90F8 0004
-200A95E6 0001
-#P1 Press L2 To Lose Power
-D00A90F8 0001
-210A95E6 0001
-#P2 Press R1 To Gain Power
-D00A90F8 0008
-200AAE72 0001
-#P2 Press R2 To Lose Power
-D00A90F8 0002
-210AAE72 0001
-#Hit Opponent Anywhere On Screen (Both Players)
-80047802 2400
-80047772 2400
-80047B1E 2400
-#Cpu's Back Is Always Turned .Using this code, the P2 character's back will always be turned, so he can't hit you.
-300AAB43 0001
-#No Black Backgrounds (For True Ogre Fights).This code will remove the darkness that covers Backgrounds during True Ogre fights.
-300AFA68 0000
-#Play As The Cpu In Arcade Mode .Using this code, the P2 pad will control the opponent in 1P Arcade Mode.
-300AAB41 0000
-
 ; [ Tekken 3 (Europe) {SCES-01237} ]
 :SCES-01237
 #P1 Infinite Health
@@ -146692,8 +147831,6 @@ D00411B8 FFFF
 
 ; [ Tenchu 2: Birth of the Stealth Assassins (Italy) {SLES-02464} ]
 ; [ Tenchu 2: Birth of the Stealth Assassins (Spain) {SLES-02465} ]
-; [ Tenchu: Stealth Assassins (Europe) Demo {SLED-01467} ]
-
 ; [ Tenchu: Stealth Assassins (Europe) {SLES-01374} ]
 :SLES-01374
 #Ayame Codes\All Levels
@@ -147231,52 +148368,6 @@ A607F1D2 000003E8
 8009108C 1334
 
 ; [ Test Drive 5 (Japan) {SLPS-01964} ]
-
-; [ Test Drive 6 (Europe) {SLES-02752} ]
-:SLES-02752
-#Infinite Money & All Cars And Stages Unlocked
-D009EFF8 9C40
-8009EFFA 0DC8
-A609EFF8 9C4021B8
-#Infinite Checkpoint Time
-800471F4 0000
-#Total Time 00:00:00/Always 1st
-90046FFC 00000000
-#Always First (Display)
-30018982 0020
-#Enable Pitbull Cup
-300A6A70 0001
-#Enable Masters Cup
-300A6A71 0001
-#Enable Ultimate Cup
-30096A72 0001
-#Enable Cop Chase Mode
-300A6A73 0001
-#Enable Challenge Cup
-800A6A6E 0100
-#Global Car Reflection Intensity
-80039FB8 ????
-80039FBA 3406
-#Red Reflection Intensity
-8003A0B0 ????
-8003A0B2 3402
-#Green Reflection Intensity
-8003A0DC ????
-8003A0DE 3402
-#Blue Reflection Intensity
-8003A100 ????
-8003A102 3402
-#Bomb Detonation Time Modifier
-8002313C ????
-#Remote Detonate Bombs (Press L3)
-80022EC8 0000
-E1098080 0002
-80022ECA 2400
-E0098080 0002
-80022ECA 3402
-#Widescreen 16-9
-8009806C 0C00
-
 ; [ Test Drive Off-Road (Europe) {SLES-00194} ]
 
 ; [ Test Drive Off-Road 2 (Japan) {SLPS-01965} ]
@@ -149077,15 +150168,6 @@ D007A92C 0801
 800B4352 1000
 #Clear scenario
 800C6296 1000
-
-; [ Theme Park World (Europe) {SLES-02688} ]
-:SLES-02688
-#Infinite Money
-801D56B8 A120
-#Number Of Visitors Max
-801D69C4 0FFF
-#Have 5 Golden Tickets
-80103984 0005
 
 ; [ Theme Park World (Japan) {SLPS-02643} ]
 
@@ -151787,30 +152869,6 @@ D00A60BA FEFE
 50000202 0909
 800AD016 0000
 
-; [ Tomb Raider: The Last Revelation (Europe, Australia) {SLES-02238} ]
-:SLES-02238
-#Infinite Oxygen
-300AB2CE 0708
-#Infinite Health
-90051F9C 340203E8
-90051FA0 A6020022
-#Stage Select Press Select at the title screen to have access to all levels and after loading one level end it and then you can select the level you wanted.
-D00AA120 0F00
-800A6AEE 0200
-#Infinite Large Medi-Packs
-300AB2CE 00FC
-#Infinite Flares
-800AB400 00FF
-#Have all weapons
-50000402 FFFF
-800AB3D4 0000
-#Infinite Ammo UZI
-800AB404 00FF
-#Infinite Ammo Normal gun
-800AB408 00FF
-#8 golden skulls (Training-level)
-300AB3E3 0008
-
 ; [ Tomb Raider: The Last Revelation (France) Demo {SLED-02418} ]
 ; [ Tomb Raider: The Last Revelation (Italy) {SLES-02241} ]
 
@@ -154144,130 +155202,6 @@ D007885E 0020
 80119328 0000
 
 ; [ Unstack (Japan) {SLPS-00302} ]
-
-; [ Urban Chaos (Europe) {SLES-02071} ]
-:SLES-02071
-#Enable All Levels
-8010C2EC 0001
-#Stop Timer
-D002C660 0004
-8002C662 3C00
-#Infinite Ammo
-D005AF08 000A
-8005AF0A 3C00
-D005AE30 000C
-8005AE32 3C00
-#Gatecrasher Level\Infinite Health
-80191A24 00C8
-#Arms Breaker Level\Infinite Health
-80195194 00C8
-#Arms Breaker Level\Infinite Pistol Ammo
-80195192 010C
-#Arms Breaker Level\Infinite Shotgun Ammo
-80199300 0005
-#Media Trouble Level\Infinite Health
-801955A4 00C8
-#Media Trouble Level\Infinite Pistol Ammo
-801955A2 010F
-#Media Trouble Level\Infinite Shotgun Ammo
-8019907C 0005
-#Urban Shakedown Level\Infinite Health
-80195908 00C8
-#Urban Shakedown Level\Infinite Pistol Ammo
-80195906 010F
-#Urban Shakedown Level\Infinite Shotgun Ammo
-801985A0 0005
-#Auto-Destruct Level\Infinite Health
-80196F0C 00C8
-#Auto-Destruct Level\Infinite Pistol Ammo
-8010A03C 010F
-#Auto-Destruct Level\Infinite Shotgun Ammo
-8019A044 0005
-#Grim Gardens\Infinite Health
-80195A40 00C8
-#Grim Gardens\Infinite Pistol Ammo
-80195A3E 010F
-#Semtex\Infinite Health
-80194DCC 00C8
-#Semtex\Infinite Pistol Ammo
-80194DCA 010F
-#Semtex\Infinite Shotgun Ammo
-801992FC 0005
-#Cop Killers\Infinite Health
-8019121C 00C8
-#Cop Killers\Infinite Shotgun Ammo
-8019582C 0005
-#Cop Killers\Infinite Shotgun Ammo For Roper
-80194E54 0005
-#Southside Offensive\Infinite Health
-80194954 00C8
-#Southside Offensive\Infinite Shotgun Ammo
-80199234 0005
-#Southside Offensive\Infinite Shotgun Ammo
-80199234 0005
-#Psycho Park\Infinite Health
-801947BC 00C8
-#Psycho Park\Infinite Shotgun Ammo
-80199640 0005
-#The Fallen\Infinite Health
-80194EF0 00C8
-#The Fallen\Infinite Shotgun Ammo
-801993A4 0005
-#Stern Revenge\Infinite Shotgun Ammo
-80198334 0005
-#Transmission Terminated\Infinite Health
-80192CEC 00C8
-#Transmission Terminated\Infinite Shotgun Ammo
-80197630 0005
-#Estate Of Emergency\Infinite Health
-8019288C 00C8
-#Estate Of Emergency\Infinite Health For Roper
-8019490C 0190
-#Seek, Sneak And Seize\Infinite Health
-801982BC 00C8
-#Target Uc\Infinite Health
-801964D4 00C8
-#Target Uc\Stop Timer
-800F7E34 1400
-80194A60 A380
-80194F00 8C1A
-#Headline Hostage\Infinite Health
-80195A78 00C8
-#Headline Hostage\Stop Timer
-800F7E34 13C0
-801928E8 29A4
-#Insane Assault\Infinite Health
-801918A8 00C8
-#Day Of Reckoning\Infinite Health
-8018B09C 00C8
-#Day Of Reckoning\Infinite Health For Roper
-8018A89C 0190
-#Day Of Reckoning\Stop First Timer
-80189108 AF2D
-#Day Of Reckoning\Stop Second Timer
-801894C8 128E
-800F7E34 1440
-#Gangaland / Rat Catch Infinite Health
-80197704 00C8
-#Gangaland / Rat Catch Suddendeath
-A61960A8 00C80000
-#Gangaland / Nitro Car Infinite Health
-8019798C 00C8
-#Gangaland / Nitro Car No Car Damage
-80196FE6 012C
-#Gangaland / Auto-Destruct Stop Time
-8019350D 0122
-8019B2A9 1E23
-#Gangaland / Auto-Destruct Infinite Energy
-80196F0C 00C8
-#Gangaland / Assassin Infinite Energy
-801966F4 00C8
-#Infinite Ammo
-D005AF08 000A
-8005AF0A 3C00
-D005AE30 000C
-8005AE32 3C00
-
 ; [ Urban Chaos (France) {SLES-02354} ]
 
 ; [ Urban Chaos (Germany) {SLES-02355} ]
@@ -155137,45 +156071,6 @@ D0007572 F5FF
 
 ; [ Vandal Hearts II: Tenjou no Mon (Japan) {SLP-86251} ]
 ; [ Vandal Hearts: Ushinawareta Kodai Bunmei (Japan) {SLP-86007} ]
-
-; [ Vanishing Point (Europe) {SLES-02534} ]
-:SLES-02534
-#Always 1st
-80010CC8 0000
-#Always Have 100 Points
-80010CC6 0000
-#Stage Time 00:00:00 / Always First
-3002BDC6 0000
-#Unlock All Cars
-50000202 0000
-8003CE94 FFFF
-#Unock All Stages
-50000402 0000
-8003CEA0 FFFF
-#Unlock Tune Up Shop
-8003CEAC FFFF
-#Unlock Series-Option
-3003CEAA 0001
-#Unlock Aggressive Traffic
-3003CEAA 0002
-#Unlock Both
-3003CEAA 0003
-#Unlock All Intros, Fmvs & Dias
-8003CEAE 3FFF
-#Unlock Cwg-Rally
-3003CDA0 0001
-#Stunt driver All Events Time 0'00'00
-50000F04 0000
-8003FE30 0000
-#Stunt driver All Events Have 100 Points
-50000F04 0000
-8003FE32 6400
-#Stunt driver Always get 100 points (even when failed)
-D0094634 1021
-80094638 0064
-D0094634 1021
-8009463A 3403
-
 ; [ Vanishing Point (Italy) {SLES-02796} ]
 
 ; [ Vegas Casino (Europe) (Pocket Price Midas) {SLES-02918} ]
@@ -155270,6 +156165,8 @@ A6049D44 05C80000
 A6049D46 AF800000
 A6049D48 31278C62
 A6049D4A 0C010C00
+#Widescreen 16-9
+A707F624 10000C00
 
 ; [ Victory Boxing (Japan) {SLPS-02740} ]
 ; [ Victory Boxing 2 (Europe) Demo {SLED-01529} ]
@@ -156011,36 +156908,6 @@ D00CFACA FF7E
 
 ; [ Vzlomchik Kodov 9000 aka Ð’Ð·Ð»Ð¾Ð¼Ñ‰Ð¸Ðº ÐºÐ¾Ð´Ð¾Ð² 9000 (Russia) {Unlicensed} ]
 ; [ WCW Backstage Assault (Europe) {SLES-03168} ]
-
-; [ WCW Mayhem (Europe) {SLES-02193} ]
-:SLES-02193
-#Player on left has full Momentum meter
-800F9D1A 0000
-800F9D1C 0000
-#Player on right has full Momentum meter
-800F9D1A 00FF
-800F9D1C 00FF
-#Quest-Cheat Enabled (Press R1 in Start-Menu)
-D00AD6A2 F7FF
-3009CFF5 002F
-#Unlock all fighters ( press L1 in the Wrestlers Select menu)
-D00AD6A2 FBFF
-3009CFF5 0001
-#Stamina bar switch (Press Select & L1)
-D00AD6A2 FBFE
-3009CFF5 0020
-#Classic TNT Nitro set unlock ( Press R2 in the Start menu)
-D00AD6A2 FDFF
-3009CFF5 008F
-#P1 max stamina
-D009D700 0002
-800F9B78 07D0
-#P2 max stamina
-D009D700 0002
-800F9D18 07D0
-#P2 no stamina
-D009D700 0002
-800F9D18 0000
 
 ; [ WCW Nitro (Europe) {SLES-01137} ]
 :SLES-01137
@@ -157344,27 +158211,6 @@ A6092534 000101F4
 #Current lap 5
 300AE3FA 0005
 
-; [ Warpath: Jurassic Park (Europe) {SLES-02253} ]
-:SLES-02253
-#P1 Quick win
-9006144C 14800003
-8006145A 3C00
-#Start on final Stage
-800313B6 0008
-#Unlock all characters
-50000601 0000
-300313CD 0001
-#Unlock all levels
-50000401 0000
-300313F9 0001
-#Unlock all Extra Modes
-3003143F 0001
-#P1 only needs 1 win
-E00313A7 0000
-300313A7 0001
-#Widescreen 16-9
-80041BA8 0C00
-
 ; [ Warriors of Might and Magic (Europe) {SLES-03263} ]
 :SLES-03263
 #Infinite Health
@@ -158427,32 +159273,6 @@ D018E092 0820
 801F628A 0C01
 #P2 Always Have Full Shield Energy
 801E5B98 0000
-
-; [ WipEout (Europe) Rev 1 {SCES-00010} ]
-:SCES-00010
-#Only one lap to race & always first (Press L1 & L2)
-D007F43E FAFF
-30036734 0003
-D007F43E FAFF
-3003671C 0003
-#Instant win (Press R1 & R2)
-D007F43E F5FF
-30036734 0004
-D007F43E F5FF
-3003671C 0004
-#Rapier-Mode On
-A61F7018 00000001
-#Rapier-Level On This code enables you to play the extra levels in rapier mode
-D01F7018 0001
-801F7042 0101
-#Infinite Retries (Only for One Player Weapon ClassChampionship# AB SystemsJohn Dekka)
-A61F7014 08020803
-#Infinite Turbo Level 1 (Only for One Player Weapon ClassChampionship# AB SystemsJohn Dekka)
-A613CB42 FF00FF09
-#Infinite Turbo Level 2 (Only for One Player Weapon ClassChampionship# AB SystemsJohn Dekka)
-A6124096 FF00FF09
-#Infinite Turbo Level 3 (Only for One Player Weapon ClassChampionship# AB SystemsJohn Dekka)
-A611ED3A FF00FF09
 
 ; [ WipEout (Europe) {SCES-00010} ]
 :SCES-00010
@@ -159525,7 +160345,6 @@ D01EA61A 0001
 8009BEF8 1333
 
 ; [ Wu-Tang: Taste the Pain (Italy) {SLES-02173} ]
-; [ X Games Pro Boarder (Europe) Rev 1 {SCES-01556} ]
 ; [ X Games Pro Boarder (Europe) {SCES-01556} ]
 ; [ X Games Pro Boarder (Japan) Demo {SLP-80393} ]
 ; [ X Games Pro Boarder (Japan) {SLPS-01944} ]
@@ -161034,40 +161853,6 @@ A603D708 0007000C
 ; [ radicalgames@psygnosis (Europe) {SLED-00966} ]
 ; [ radicalgames@psygnosis v.2 (Europe) {SLED-00990} ]
 
-; [ Airgrave {SLPS-00559} ]
-:SLPS-00559
-#Invincibility
-800B4F9C 0006
-#Shield Has A Comeback
-8002F692 8C23
-#Infinite Credit
-80027BC2 8022
-#Infinite Overdrive
-800B52E4 0100
-
-; [ Fox Hunt {SLUS-00101 | SLUS-00175 | SLUS-00176} ]
-:SLUS-00101
-:SLUS-00175
-:SLUS-00176
-#Disc One Codes\Always Have Vidbook
-801EDA24 0001
-#Disc One Codes\Always Have Kitchen Knife
-801EEE24 0001
-#Disc One Codes\Always Have Taco
-801EE564 0001
-#Disc One Codes\Always Have Cia Card
-801EF004 0001
-#Disc One Codes\Always Have Knife
-801EF1E4 0001
-#Disc One Codes\Always Have Bullet
-801EEC44 0001
-#Disc One Codes\Always Have Skis
-801EC544 0001
-#Disc One Codes\Always Have Feather
-801EE294 0001
-#Disc One Codes\Always Have Medal
-801EEB54 0001
-
 ; [ King's Field III Japan Pilot Style {SLPM-80029} ]
 :SLPM-80029
 #Invincibility
@@ -161080,4 +161865,70 @@ E01A244D 00000002
 8002C3CE 00002400
 E01A244D 00000004
 8002C3CE 00000C00
+
+; [ Magic Castle {NYMC-02020} ]
+:NYMC-02020
+#English Cheats\Knight Infinite HP
+90175A40 03E703E7
+#English Cheats\Knight Infinite SP
+90175A44 00630063
+#English Cheats\Wizard Infinite HP
+90172BE0 03E703E7
+#English Cheats\Wizard Infinite SP
+90172BE4 00630063
+#English Cheats\Fighter Infinite HP
+90155A10 03E703E7
+#English Cheats\Fighter Infinite SP
+90155A14 00630063
+#English Cheats\Archer Infinite HP
+901743B0 03E703E7
+#English Cheats\Archer Infinite SP
+901743B4 00630063
+#Portugese Cheats\Warrior Infinite HP
+90175FE0 03E703E7
+#Portugese Cheats\Warrior Infinite SP
+90175FE4 00630063
+#Portugese Cheats\Wizard Infinite HP
+90173180 03E703E7
+#Portugese Cheats\Wizard Infinite SP
+90173184 00630063
+#Portugese Cheats\Fighter Infinite HP
+9015AFB0 03E703E7
+#Portugese Cheats\Fighter Infinite SP
+9015AFB4 00630063
+#Portugese Cheats\Archer Infinite HP
+90174950 03E703E7
+#Portugese Cheats\Archer Infinite SP
+90174954 00630063
+
+
+#Spanish Cheats\Warrior Infinite HP
+90175E10 03E703E7
+#Spanish Cheats\Warrior Infinite SP
+90175E14 00630063
+
+#Italian Cheats\Warrior Infinite HP
+90175FF0 03E703E7
+#Italian Cheats\Warrior Infinite SP
+90175FF4 00630063
+
+#Turkish Cheats\Warrior Infinite HP
+90175D30 03E703E7
+#Turkish Cheats\Warrior Infinite SP
+90175D34 00630063
+
+#Japanese Cheats\Warrior Infinite HP
+901756D0 03E703E7
+#Japanese Cheats\Warrior Infinite SP
+901756D4 00630063
+
+#Invincibility (Partial)
+A70FC6CA 12221000
+#One Hit Kills
+A70FA626 1C401400
+#Widescreen 16-9
+A7063F0C 10000C00
+#Dither Off
+A70F13C4 02000000
+
 

--- a/src/core/cheats.h
+++ b/src/core/cheats.h
@@ -45,6 +45,7 @@ struct CheatCode
     CompareGreater8 = 0xE3,
     Slide = 0x50,
     MemoryCopy = 0xC2,
+    ExtImprovedSlide = 0x53,
 
     // Extension opcodes, not present on original GameShark.
     ExtConstantWrite32 = 0x90,
@@ -63,6 +64,8 @@ struct CheatCode
     ExtConstantForceRangeRollRound16 = 0xF2,
     ExtConstantForceRange16 = 0xF3,
     ExtFindAndReplace = 0xF4,
+    ExtConstantSwap16 = 0xF5,
+
     ExtConstantBitSet8 = 0x31,
     ExtConstantBitClear8 = 0x32,
     ExtConstantBitSet16 = 0x81,
@@ -76,7 +79,8 @@ struct CheatCode
     ExtSkipIfNotLess16 = 0xC5,
     ExtSkipIfNotGreater16 = 0xC6,
 
-    ExtTempVariable = 0x51,
+    ExtCheatRegisters = 0x51,
+    ExtCheatRegistersCompare = 0x52,
   };
 
   union Instruction


### PR DESCRIPTION
Chtdb.txt
=========
Updated the header to document all the new cheat types, added some more cheats
and cleaned up others.

New Cheat Types:-
=================
F5 - 16-Bit toggle cheat, predominatly used with the D7 cheat to enable/disable
      ASM cheats with the same key presses. See chtdb.txt for more information.

52 - Register Block Conditionals for use with the type 51 cheats. There are 128 
      sub types. See chtdb.txt for more information.
      
53 - Improved Slide Code cheat type, with support for 65536 addresses and a 16
      bit step and easily configurable step direction for value and address.
      See chtdb.txt for more information.      

Other Changes:-
===============
51 - Cleaned up - renumbered/renamed, Tested & Bugfixed. See chtdb.txt for more 
      information.