### PR TITLE
Android: Add >1 controller, multitap, external controller vibration

### DIFF
--- a/android/app/src/cpp/android_controller_interface.cpp
+++ b/android/app/src/cpp/android_controller_interface.cpp
@@ -1,4 +1,5 @@
 #include "android_controller_interface.h"
+#include "android_host_interface.h"
 #include "common/assert.h"
 #include "common/file_system.h"
 #include "common/log.h"
@@ -34,22 +35,33 @@ void AndroidControllerInterface::PollEvents() {}
 
 void AndroidControllerInterface::ClearBindings()
 {
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
   for (ControllerData& cd : m_controllers)
   {
-    cd.axis_mapping.fill({});
-    cd.button_mapping.fill({});
-    cd.axis_button_mapping.fill({});
-    cd.button_axis_mapping.fill({});
+    cd.axis_mapping.clear();
+    cd.button_mapping.clear();
+    cd.axis_button_mapping.clear();
+    cd.button_axis_mapping.clear();
   }
+}
+
+std::optional<int> AndroidControllerInterface::GetControllerIndex(const std::string_view& device)
+{
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  for (u32 i = 0; i < static_cast<u32>(m_device_names.size()); i++)
+  {
+    if (device == m_device_names[i])
+      return static_cast<int>(i);
+  }
+
+  return std::nullopt;
 }
 
 bool AndroidControllerInterface::BindControllerAxis(int controller_index, int axis_number, AxisSide axis_side,
                                                     AxisCallback callback)
 {
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
   if (static_cast<u32>(controller_index) >= m_controllers.size())
-    return false;
-
-  if (axis_number < 0 || axis_number >= NUM_AXISES)
     return false;
 
   m_controllers[controller_index].axis_mapping[axis_number][axis_side] = std::move(callback);
@@ -58,10 +70,8 @@ bool AndroidControllerInterface::BindControllerAxis(int controller_index, int ax
 
 bool AndroidControllerInterface::BindControllerButton(int controller_index, int button_number, ButtonCallback callback)
 {
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
   if (static_cast<u32>(controller_index) >= m_controllers.size())
-    return false;
-
-  if (button_number < 0 || button_number >= NUM_BUTTONS)
     return false;
 
   m_controllers[controller_index].button_mapping[button_number] = std::move(callback);
@@ -71,10 +81,8 @@ bool AndroidControllerInterface::BindControllerButton(int controller_index, int 
 bool AndroidControllerInterface::BindControllerAxisToButton(int controller_index, int axis_number, bool direction,
                                                             ButtonCallback callback)
 {
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
   if (static_cast<u32>(controller_index) >= m_controllers.size())
-    return false;
-
-  if (axis_number < 0 || axis_number >= NUM_AXISES)
     return false;
 
   m_controllers[controller_index].axis_button_mapping[axis_number][BoolToUInt8(direction)] = std::move(callback);
@@ -84,99 +92,145 @@ bool AndroidControllerInterface::BindControllerAxisToButton(int controller_index
 bool AndroidControllerInterface::BindControllerHatToButton(int controller_index, int hat_number,
                                                            std::string_view hat_position, ButtonCallback callback)
 {
-  // Hats don't exist in XInput
   return false;
 }
 
 bool AndroidControllerInterface::BindControllerButtonToAxis(int controller_index, int button_number,
                                                             AxisCallback callback)
 {
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
   if (static_cast<u32>(controller_index) >= m_controllers.size())
-    return false;
-
-  if (button_number < 0 || button_number >= NUM_BUTTONS)
     return false;
 
   m_controllers[controller_index].button_axis_mapping[button_number] = std::move(callback);
   return true;
 }
 
-bool AndroidControllerInterface::HandleAxisEvent(u32 index, u32 axis, float value)
+void AndroidControllerInterface::SetDeviceNames(std::vector<std::string> device_names)
 {
-  Log_DevPrintf("controller %u axis %u %f", index, static_cast<u32>(axis), value);
-  DebugAssert(index < NUM_CONTROLLERS);
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  m_device_names = std::move(device_names);
+  m_controllers.resize(m_device_names.size());
+}
 
-  if (DoEventHook(Hook::Type::Axis, index, static_cast<u32>(axis), value))
-    return true;
+void AndroidControllerInterface::SetDeviceRumble(u32 index, bool has_vibrator)
+{
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  if (index >= m_controllers.size())
+    return;
 
-  const AxisCallback& cb = m_controllers[index].axis_mapping[static_cast<u32>(axis)][AxisSide::Full];
-  if (cb)
+  m_controllers[index].has_rumble = has_vibrator;
+}
+
+void AndroidControllerInterface::HandleAxisEvent(u32 index, u32 axis, float value)
+{
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  if (index >= m_controllers.size())
+    return;
+
+  Log_DevPrintf("controller %u axis %u %f", index, axis, value);
+  if (DoEventHook(Hook::Type::Axis, index, axis, value))
+    return;
+
+  const ControllerData& cd = m_controllers[index];
+  const auto am_iter = cd.axis_mapping.find(axis);
+  if (am_iter != cd.axis_mapping.end())
   {
-    cb(value);
-    return true;
+    const AxisCallback& cb = am_iter->second[AxisSide::Full];
+    if (cb)
+    {
+      cb(value);
+      return;
+    }
   }
 
   // set the other direction to false so large movements don't leave the opposite on
-  const bool outside_deadzone = (std::abs(value) >= m_controllers[index].deadzone);
+  const bool outside_deadzone = (std::abs(value) >= cd.deadzone);
   const bool positive = (value >= 0.0f);
-  const ButtonCallback& other_button_cb =
-    m_controllers[index].axis_button_mapping[static_cast<u32>(axis)][BoolToUInt8(!positive)];
-  const ButtonCallback& button_cb =
-    m_controllers[index].axis_button_mapping[static_cast<u32>(axis)][BoolToUInt8(positive)];
-  if (button_cb)
+  const auto bm_iter = cd.axis_button_mapping.find(axis);
+  if (bm_iter != cd.axis_button_mapping.end())
   {
-    button_cb(outside_deadzone);
-    if (other_button_cb)
+    const ButtonCallback& other_button_cb = bm_iter->second[BoolToUInt8(!positive)];
+    const ButtonCallback& button_cb = bm_iter->second[BoolToUInt8(positive)];
+    if (button_cb)
+    {
+      button_cb(outside_deadzone);
+      if (other_button_cb)
+        other_button_cb(false);
+      return;
+    }
+    else if (other_button_cb)
+    {
       other_button_cb(false);
-    return true;
-  }
-  else if (other_button_cb)
-  {
-    other_button_cb(false);
-    return true;
-  }
-  else
-  {
-    return false;
+      return;
+    }
   }
 }
 
-bool AndroidControllerInterface::HandleButtonEvent(u32 index, u32 button, bool pressed)
+void AndroidControllerInterface::HandleButtonEvent(u32 index, u32 button, bool pressed)
 {
   Log_DevPrintf("controller %u button %u %s", index, button, pressed ? "pressed" : "released");
-  DebugAssert(index < NUM_CONTROLLERS);
+
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  if (index >= m_controllers.size())
+    return;
 
   if (DoEventHook(Hook::Type::Button, index, button, pressed ? 1.0f : 0.0f))
-    return true;
+    return;
 
-  const ButtonCallback& cb = m_controllers[index].button_mapping[button];
-  if (cb)
+  const ControllerData& cd = m_controllers[index];
+  const auto button_iter = cd.button_mapping.find(button);
+  if (button_iter != cd.button_mapping.end() && button_iter->second)
   {
-    cb(pressed);
-    return true;
+    button_iter->second(pressed);
+    return;
   }
 
-  const AxisCallback& axis_cb = m_controllers[index].button_axis_mapping[button];
-  if (axis_cb)
+  const auto axis_iter = cd.button_axis_mapping.find(button);
+  if (axis_iter != cd.button_axis_mapping.end() && axis_iter->second)
   {
-    axis_cb(pressed ? 1.0f : -1.0f);
+    axis_iter->second(pressed ? 1.0f : -1.0f);
+    return;
   }
-  return true;
+}
+
+bool AndroidControllerInterface::HasButtonBinding(u32 index, u32 button)
+{
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  if (index >= m_controllers.size())
+    return false;
+
+  const ControllerData& cd = m_controllers[index];
+  return (cd.button_mapping.find(button) != cd.button_mapping.end() ||
+          cd.button_axis_mapping.find(button) != cd.button_axis_mapping.end());
 }
 
 u32 AndroidControllerInterface::GetControllerRumbleMotorCount(int controller_index)
 {
-  return 0;
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  if (static_cast<u32>(controller_index) >= m_controllers.size())
+    return false;
+
+  return m_controllers[static_cast<u32>(controller_index)].has_rumble ? NUM_RUMBLE_MOTORS : 0;
 }
 
 void AndroidControllerInterface::SetControllerRumbleStrength(int controller_index, const float* strengths,
                                                              u32 num_motors)
 {
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  if (static_cast<u32>(controller_index) >= m_controllers.size())
+    return;
+
+  const float small_motor = strengths[0];
+  const float large_motor = strengths[1];
+  static_cast<AndroidHostInterface*>(m_host_interface)
+    ->SetControllerVibration(static_cast<u32>(controller_index), small_motor, large_motor);
 }
 
 bool AndroidControllerInterface::SetControllerDeadzone(int controller_index, float size /* = 0.25f */)
 {
-  if (static_cast<u32>(controller_index) >= NUM_CONTROLLERS)
+  std::unique_lock<std::mutex> lock(m_controllers_mutex);
+  if (static_cast<u32>(controller_index) >= m_controllers.size())
     return false;
 
   m_controllers[static_cast<u32>(controller_index)].deadzone = std::clamp(std::abs(size), 0.01f, 0.99f);

--- a/android/app/src/cpp/android_host_interface.h
+++ b/android/app/src/cpp/android_host_interface.h
@@ -21,6 +21,8 @@ class Controller;
 class AndroidHostInterface final : public CommonHostInterface
 {
 public:
+  using CommonHostInterface::UpdateInputMap;
+
   AndroidHostInterface(jobject java_object, jobject context_object, std::string user_directory);
   ~AndroidHostInterface() override;
 
@@ -57,6 +59,8 @@ public:
   void SetControllerAxisState(u32 index, s32 button_code, float value);
   void HandleControllerButtonEvent(u32 controller_index, u32 button_index, bool pressed);
   void HandleControllerAxisEvent(u32 controller_index, u32 axis_index, float value);
+  bool HasControllerButtonBinding(u32 controller_index, u32 button);
+  void SetControllerVibration(u32 controller_index, float small_motor, float large_motor);
   void SetFastForwardEnabled(bool enabled);
 
   void RefreshGameList(bool invalidate_cache, bool invalidate_database, ProgressCallback* progress_callback);
@@ -83,6 +87,7 @@ private:
   void EmulationThreadLoop(JNIEnv* env);
 
   void LoadSettings(SettingsInterface& si) override;
+  void UpdateInputMap(SettingsInterface& si) override;
   void SetVibration(bool enabled);
   void UpdateVibration();
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,9 +43,9 @@
                 android:value="com.github.stenzek.duckstation.MainActivity" />
         </activity>
         <activity
-            android:name=".ControllerMappingActivity"
+            android:name=".ControllerSettingsActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:label="@string/title_activity_settings"
+            android:label="@string/controller_mapping_activity_title"
             android:parentActivityName=".MainActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/android/app/src/main/java/com/github/stenzek/duckstation/AndroidHostInterface.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/AndroidHostInterface.java
@@ -82,9 +82,13 @@ public class AndroidHostInterface {
 
     public static native String[] getControllerAxisNames(String controllerType);
 
+    public static native int getControllerVibrationMotorCount(String controllerType);
+
     public native void handleControllerButtonEvent(int controllerIndex, int buttonIndex, boolean pressed);
 
     public native void handleControllerAxisEvent(int controllerIndex, int axisIndex, float value);
+
+    public native boolean hasControllerButtonBinding(int controllerIndex, int buttonIndex);
 
     public native void toggleControllerAnalogMode();
 
@@ -115,6 +119,7 @@ public class AndroidHostInterface {
     public native void saveResumeState(boolean waitForCompletion);
 
     public native void applySettings();
+    public native void updateInputMap();
 
     public native void setDisplayAlignment(int alignment);
 

--- a/android/app/src/main/java/com/github/stenzek/duckstation/ControllerBindingDialog.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/ControllerBindingDialog.java
@@ -1,13 +1,11 @@
 package com.github.stenzek.duckstation;
 
 import android.app.AlertDialog;
-import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.util.ArraySet;
-import android.util.Log;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -15,16 +13,20 @@ import android.view.MotionEvent;
 import androidx.annotation.NonNull;
 
 import java.util.HashMap;
+import java.util.List;
 
 public class ControllerBindingDialog extends AlertDialog {
-    private boolean mIsAxis;
-    private String mSettingKey;
+    final static float DETECT_THRESHOLD = 0.25f;
+    private final ControllerBindingPreference.Type mType;
+    private final String mSettingKey;
     private String mCurrentBinding;
+    private int mUpdatedAxisCode = -1;
+    private final HashMap<Integer, float[]> mStartingAxisValues = new HashMap<>();
 
-    public ControllerBindingDialog(Context context, String buttonName, String settingKey, String currentBinding, boolean isAxis) {
+    public ControllerBindingDialog(Context context, String buttonName, String settingKey, String currentBinding, ControllerBindingPreference.Type type) {
         super(context);
 
-        mIsAxis = isAxis;
+        mType = type;
         mSettingKey = settingKey;
         mCurrentBinding = currentBinding;
         if (mCurrentBinding == null)
@@ -42,10 +44,7 @@ public class ControllerBindingDialog extends AlertDialog {
         setOnKeyListener(new DialogInterface.OnKeyListener() {
             @Override
             public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
-                if (onKeyDown(keyCode, event))
-                    return true;
-
-                return false;
+                return onKeyDown(keyCode, event);
             }
         });
     }
@@ -73,57 +72,53 @@ public class ControllerBindingDialog extends AlertDialog {
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (mIsAxis || !EmulationSurfaceView.isDPadOrButtonEvent(event))
+        if (!EmulationSurfaceView.isBindableDevice(event.getDevice()) || !EmulationSurfaceView.isBindableKeyCode(event.getKeyCode())) {
+            return super.onKeyUp(keyCode, event);
+        }
+
+        if (mType == ControllerBindingPreference.Type.BUTTON)
+            mCurrentBinding = String.format("%s/Button%d", event.getDevice().getDescriptor(), event.getKeyCode());
+        else if (mType == ControllerBindingPreference.Type.VIBRATION)
+            mCurrentBinding = event.getDevice().getDescriptor();
+        else
             return super.onKeyUp(keyCode, event);
 
-        int buttonIndex = EmulationSurfaceView.getButtonIndexForKeyCode(keyCode);
-        if (buttonIndex < 0)
-            return super.onKeyUp(keyCode, event);
-
-        // TODO: Multiple controllers
-        final int controllerIndex = 0;
-        mCurrentBinding = String.format("Controller%d/Button%d", controllerIndex, buttonIndex);
         updateMessage();
         updateBinding();
         dismiss();
         return true;
     }
 
-    private int mUpdatedAxisCode = -1;
-
-    private void setAxisCode(int axisCode, boolean positive) {
-        final int axisIndex = EmulationSurfaceView.getAxisIndexForAxisCode(axisCode);
-        if (mUpdatedAxisCode >= 0 || axisIndex < 0)
+    private void setAxisCode(InputDevice device, int axisCode, boolean positive) {
+        if (mUpdatedAxisCode >= 0)
             return;
 
         mUpdatedAxisCode = axisCode;
 
         final int controllerIndex = 0;
-        if (mIsAxis)
-            mCurrentBinding = String.format("Controller%d/Axis%d", controllerIndex, axisIndex);
+        if (mType == ControllerBindingPreference.Type.AXIS)
+            mCurrentBinding = String.format("%s/Axis%d", device.getDescriptor(), axisCode);
         else
-            mCurrentBinding = String.format("Controller%d/%cAxis%d", controllerIndex, (positive) ? '+' : '-', axisIndex);
+            mCurrentBinding = String.format("%s/%cAxis%d", device.getDescriptor(), (positive) ? '+' : '-', axisCode);
 
         updateBinding();
         updateMessage();
         dismiss();
     }
 
-    final static float DETECT_THRESHOLD = 0.25f;
-
-    private HashMap<Integer, float[]> mStartingAxisValues = new HashMap<>();
-
     private boolean doAxisDetection(MotionEvent event) {
-        if ((event.getSource() & (InputDevice.SOURCE_JOYSTICK | InputDevice.SOURCE_GAMEPAD | InputDevice.SOURCE_DPAD)) == 0)
+        if (!EmulationSurfaceView.isBindableDevice(event.getDevice()))
             return false;
 
-        final int[] axisCodes = EmulationSurfaceView.getKnownAxisCodes();
-        final int deviceId = event.getDeviceId();
+        final List<InputDevice.MotionRange> motionEventList = event.getDevice().getMotionRanges();
+        if (motionEventList == null || motionEventList.isEmpty())
+            return false;
 
+        final int deviceId = event.getDeviceId();
         if (!mStartingAxisValues.containsKey(deviceId)) {
-            final float[] axisValues = new float[axisCodes.length];
-            for (int axisIndex = 0; axisIndex < axisCodes.length; axisIndex++) {
-                final int axisCode = axisCodes[axisIndex];
+            final float[] axisValues = new float[motionEventList.size()];
+            for (int axisIndex = 0; axisIndex < motionEventList.size(); axisIndex++) {
+                final int axisCode = motionEventList.get(axisIndex).getAxis();
 
                 // these are binary, so start at zero
                 if (axisCode == MotionEvent.AXIS_HAT_X || axisCode == MotionEvent.AXIS_HAT_Y)
@@ -133,13 +128,15 @@ public class ControllerBindingDialog extends AlertDialog {
             }
 
             mStartingAxisValues.put(deviceId, axisValues);
+            return false;
         }
 
         final float[] axisValues = mStartingAxisValues.get(deviceId);
-        for (int axisIndex = 0; axisIndex < axisCodes.length; axisIndex++) {
-            final float newValue = event.getAxisValue(axisCodes[axisIndex]);
+        for (int axisIndex = 0; axisIndex < motionEventList.size(); axisIndex++) {
+            final int axisCode = motionEventList.get(axisIndex).getAxis();
+            final float newValue = event.getAxisValue(axisCode);
             if (Math.abs(newValue - axisValues[axisIndex]) >= DETECT_THRESHOLD) {
-                setAxisCode(axisCodes[axisIndex], newValue >= 0.0f);
+                setAxisCode(event.getDevice(), axisCode, newValue >= 0.0f);
                 break;
             }
         }
@@ -149,6 +146,10 @@ public class ControllerBindingDialog extends AlertDialog {
 
     @Override
     public boolean onGenericMotionEvent(@NonNull MotionEvent event) {
+        if (mType != ControllerBindingPreference.Type.AXIS && mType != ControllerBindingPreference.Type.BUTTON) {
+            return false;
+        }
+
         if (doAxisDetection(event))
             return true;
 

--- a/android/app/src/main/java/com/github/stenzek/duckstation/ControllerBindingPreference.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/ControllerBindingPreference.java
@@ -14,16 +14,25 @@ import androidx.preference.PreferenceViewHolder;
 import java.util.Set;
 
 public class ControllerBindingPreference extends Preference {
-    private enum Type {
+    public enum Type {
         BUTTON,
         AXIS,
+        VIBRATION
+    }
+
+    private enum VisualType {
+        BUTTON,
+        AXIS,
+        VIBRATION,
         HOTKEY
     }
 
     private String mBindingName;
+    private String mDisplayName;
     private String mValue;
     private TextView mValueView;
     private Type mType = Type.BUTTON;
+    private VisualType mVisualType = VisualType.BUTTON;
 
     private static int getIconForButton(String buttonName) {
         if (buttonName.equals("Up")) {
@@ -64,7 +73,16 @@ public class ControllerBindingPreference extends Preference {
     }
 
     private static int getIconForHotkey(String hotkeyDisplayName) {
-        return R.drawable.ic_baseline_category_24;
+        switch (hotkeyDisplayName) {
+            case "FastForward":
+            case "ToggleFastForward":
+            case "Turbo":
+            case "ToggleTurbo":
+                return R.drawable.ic_controller_fast_forward;
+
+            default:
+                return R.drawable.ic_baseline_category_24;
+        }
     }
 
     public ControllerBindingPreference(Context context, AttributeSet attrs) {
@@ -94,7 +112,7 @@ public class ControllerBindingPreference extends Preference {
         mValueView = ((TextView) holder.findViewById(R.id.controller_binding_value));
 
         int drawableId = R.drawable.ic_baseline_radio_button_checked_24;
-        switch (mType) {
+        switch (mVisualType) {
             case BUTTON:
                 drawableId = getIconForButton(mBindingName);
                 break;
@@ -104,37 +122,55 @@ public class ControllerBindingPreference extends Preference {
             case HOTKEY:
                 drawableId = getIconForHotkey(mBindingName);
                 break;
+            case VIBRATION:
+                drawableId = R.drawable.ic_baseline_vibration_24;
+                break;
         }
 
         iconView.setImageDrawable(ContextCompat.getDrawable(getContext(), drawableId));
-        nameView.setText(mBindingName);
+        nameView.setText(mDisplayName);
         updateValue();
     }
 
     @Override
     protected void onClick() {
-        ControllerBindingDialog dialog = new ControllerBindingDialog(getContext(), mBindingName, getKey(), mValue, (mType == Type.AXIS));
+        ControllerBindingDialog dialog = new ControllerBindingDialog(getContext(), mBindingName, getKey(), mValue, mType);
         dialog.setOnDismissListener((dismissedDialog) -> updateValue());
         dialog.show();
     }
 
     public void initButton(int controllerIndex, String buttonName) {
         mBindingName = buttonName;
+        mDisplayName = buttonName;
         mType = Type.BUTTON;
+        mVisualType = VisualType.BUTTON;
         setKey(String.format("Controller%d/Button%s", controllerIndex, buttonName));
         updateValue();
     }
 
     public void initAxis(int controllerIndex, String axisName) {
         mBindingName = axisName;
+        mDisplayName = axisName;
         mType = Type.AXIS;
+        mVisualType = VisualType.AXIS;
         setKey(String.format("Controller%d/Axis%s", controllerIndex, axisName));
         updateValue();
     }
 
+    public void initVibration(int controllerIndex) {
+        mBindingName = "Rumble";
+        mDisplayName = getContext().getString(R.string.controller_binding_device_for_vibration);
+        mType = Type.VIBRATION;
+        mVisualType = VisualType.VIBRATION;
+        setKey(String.format("Controller%d/Rumble", controllerIndex));
+        updateValue();
+    }
+
     public void initHotkey(HotkeyInfo hotkeyInfo) {
-        mBindingName = hotkeyInfo.getDisplayName();
-        mType = Type.HOTKEY;
+        mBindingName = hotkeyInfo.getName();
+        mDisplayName = hotkeyInfo.getDisplayName();
+        mType = Type.BUTTON;
+        mVisualType = VisualType.HOTKEY;
         setKey(hotkeyInfo.getBindingConfigKey());
         updateValue();
     }

--- a/android/app/src/main/java/com/github/stenzek/duckstation/ControllerMappingActivity.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/ControllerMappingActivity.java
@@ -172,9 +172,10 @@ public class ControllerMappingActivity extends AppCompatActivity {
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             final SharedPreferences sp = getPreferenceManager().getSharedPreferences();
             final String defaultControllerType = controllerIndex == 0 ? "DigitalController" : "None";
-            String controllerType = sp.getString(String.format("Controller%d/Type", controllerIndex), defaultControllerType);
-            String[] controllerButtons = AndroidHostInterface.getControllerButtonNames(controllerType);
-            String[] axisButtons = AndroidHostInterface.getControllerAxisNames(controllerType);
+            final String controllerType = sp.getString(String.format("Controller%d/Type", controllerIndex), defaultControllerType);
+            final String[] controllerButtons = AndroidHostInterface.getControllerButtonNames(controllerType);
+            final String[] axisButtons = AndroidHostInterface.getControllerAxisNames(controllerType);
+            final int vibrationMotors = AndroidHostInterface.getControllerVibrationMotorCount(controllerType);
 
             final PreferenceScreen ps = getPreferenceManager().createPreferenceScreen(getContext());
             if (controllerButtons != null) {
@@ -192,6 +193,12 @@ public class ControllerMappingActivity extends AppCompatActivity {
                     ps.addPreference(cbp);
                     activity.mPreferences.add(cbp);
                 }
+            }
+            if (vibrationMotors > 0) {
+                final ControllerBindingPreference cbp = new ControllerBindingPreference(getContext(), null);
+                cbp.initVibration(controllerIndex);
+                ps.addPreference(cbp);
+                activity.mPreferences.add(cbp);
             }
 
             setPreferenceScreen(ps);

--- a/android/app/src/main/java/com/github/stenzek/duckstation/ControllerSettingsActivity.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/ControllerSettingsActivity.java
@@ -30,6 +30,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 public class ControllerSettingsActivity extends AppCompatActivity {
 
@@ -328,10 +329,22 @@ public class ControllerSettingsActivity extends AppCompatActivity {
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             final PreferenceScreen ps = getPreferenceManager().createPreferenceScreen(getContext());
             if (mHotkeyInfo != null) {
+                final HashMap<String, PreferenceCategory> categoryMap = new HashMap<>();
+
                 for (HotkeyInfo hotkeyInfo : mHotkeyInfo) {
+                    PreferenceCategory category = categoryMap.containsKey(hotkeyInfo.getCategory()) ?
+                            categoryMap.get(hotkeyInfo.getCategory()) : null;
+                    if (category == null) {
+                        category = new PreferenceCategory(getContext());
+                        category.setTitle(hotkeyInfo.getCategory());
+                        category.setIconSpaceReserved(false);
+                        categoryMap.put(hotkeyInfo.getCategory(), category);
+                        ps.addPreference(category);
+                    }
+
                     final ControllerBindingPreference cbp = new ControllerBindingPreference(getContext(), null);
                     cbp.initHotkey(hotkeyInfo);
-                    ps.addPreference(cbp);
+                    category.addPreference(cbp);
                     activity.mPreferences.add(cbp);
                 }
             }

--- a/android/app/src/main/java/com/github/stenzek/duckstation/EmulationActivity.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/EmulationActivity.java
@@ -1,7 +1,6 @@
 package com.github.stenzek.duckstation;
 
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
@@ -17,17 +16,14 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 import android.view.View;
-import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ListView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
 
 /**
@@ -155,6 +151,19 @@ public class EmulationActivity extends AppCompatActivity implements SurfaceHolde
         runOnUiThread(() -> {
             showMenu();
         });
+    }
+
+    public String[] getInputDeviceNames() {
+        return (mContentView != null) ? mContentView.getInputDeviceNames() : null;
+    }
+
+    public boolean hasInputDeviceVibration(int controllerIndex) {
+        return (mContentView != null) ? mContentView.hasInputDeviceVibration(controllerIndex) : null;
+    }
+
+    public void setInputDeviceVibration(int controllerIndex, float smallMotor, float largeMotor) {
+        if (mContentView != null)
+            mContentView.setInputDeviceVibration(controllerIndex, smallMotor, largeMotor);
     }
 
     private void doApplySettings() {
@@ -731,8 +740,10 @@ public class EmulationActivity extends AppCompatActivity implements SurfaceHolde
         Log.i("EmulationActivity", "Controller type: " + controllerType);
         Log.i("EmulationActivity", "View type: " + viewType);
 
-        final boolean hasAnyControllers = mContentView.initControllerMapping(controllerType);
+        mContentView.updateInputDevices();
+        AndroidHostInterface.getInstance().updateInputMap();
 
+        final boolean hasAnyControllers = mContentView.hasAnyGamePads();
         if (controllerType.equals("none") || viewType.equals("none") || (hasAnyControllers && autoHideTouchscreenController)) {
             if (mTouchscreenController != null) {
                 activityLayout.removeView(mTouchscreenController);

--- a/android/app/src/main/java/com/github/stenzek/duckstation/EmulationSurfaceView.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/EmulationSurfaceView.java
@@ -2,6 +2,7 @@ package com.github.stenzek.duckstation;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Vibrator;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.InputDevice;
@@ -28,14 +29,43 @@ public class EmulationSurfaceView extends SurfaceView {
         super(context, attrs, defStyle);
     }
 
-    public static boolean isDPadOrButtonEvent(KeyEvent event) {
-        final int source = event.getSource();
-        return (source & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD ||
-                (source & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD ||
-                (source & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK;
+    public static boolean isBindableDevice(InputDevice inputDevice) {
+        if (inputDevice == null)
+            return false;
+
+        final int sources = inputDevice.getSources();
+
+        // Prevent binding pointer devices such as a mouse.
+        if ((sources & InputDevice.SOURCE_CLASS_POINTER) == InputDevice.SOURCE_CLASS_POINTER)
+            return false;
+
+        return ((sources & InputDevice.SOURCE_CLASS_JOYSTICK) == InputDevice.SOURCE_CLASS_JOYSTICK) ||
+                ((sources & InputDevice.SOURCE_CLASS_BUTTON) == InputDevice.SOURCE_CLASS_BUTTON);
     }
 
-    private boolean isExternalKeyCode(int keyCode) {
+    public static boolean isGamepadDevice(InputDevice inputDevice) {
+        final int sources = inputDevice.getSources();
+        return ((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD);
+    }
+
+    public static boolean isBindableKeyCode(int keyCode) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_BACK:
+            case KeyEvent.KEYCODE_HOME:
+            case KeyEvent.KEYCODE_MENU:
+            case KeyEvent.KEYCODE_POWER:
+            case KeyEvent.KEYCODE_CAMERA:
+            case KeyEvent.KEYCODE_CALL:
+            case KeyEvent.KEYCODE_ENDCALL:
+            case KeyEvent.KEYCODE_VOICE_ASSIST:
+                return false;
+
+            default:
+                return true;
+        }
+    }
+
+    private static boolean isExternalKeyCode(int keyCode) {
         switch (keyCode) {
             case KeyEvent.KEYCODE_BACK:
             case KeyEvent.KEYCODE_HOME:
@@ -55,157 +85,146 @@ public class EmulationSurfaceView extends SurfaceView {
         }
     }
 
-    private static final int[] buttonKeyCodes = new int[]{
-            KeyEvent.KEYCODE_BUTTON_A,      // 0/Cross
-            KeyEvent.KEYCODE_BUTTON_B,      // 1/Circle
-            KeyEvent.KEYCODE_BUTTON_X,      // 2/Square
-            KeyEvent.KEYCODE_BUTTON_Y,      // 3/Triangle
-            KeyEvent.KEYCODE_BUTTON_SELECT, // 4/Select
-            KeyEvent.KEYCODE_BUTTON_MODE,   // 5/Analog
-            KeyEvent.KEYCODE_BUTTON_START,  // 6/Start
-            KeyEvent.KEYCODE_BUTTON_THUMBL, // 7/L3
-            KeyEvent.KEYCODE_BUTTON_THUMBR, // 8/R3
-            KeyEvent.KEYCODE_BUTTON_L1,     // 9/L1
-            KeyEvent.KEYCODE_BUTTON_R1,     // 10/R1
-            KeyEvent.KEYCODE_DPAD_UP,       // 11/Up
-            KeyEvent.KEYCODE_DPAD_DOWN,     // 12/Down
-            KeyEvent.KEYCODE_DPAD_LEFT,     // 13/Left
-            KeyEvent.KEYCODE_DPAD_RIGHT,    // 14/Right
-            KeyEvent.KEYCODE_BUTTON_L2,     // 15
-            KeyEvent.KEYCODE_BUTTON_R2,     // 16
-            KeyEvent.KEYCODE_BUTTON_C,      // 17
-            KeyEvent.KEYCODE_BUTTON_Z,      // 18
-            KeyEvent.KEYCODE_VOLUME_DOWN,   // 19
-            KeyEvent.KEYCODE_VOLUME_UP,     // 20
-            KeyEvent.KEYCODE_MENU,          // 21
-            KeyEvent.KEYCODE_CAMERA,        // 22
-    };
-    private static final int[] axisCodes = new int[]{
-            MotionEvent.AXIS_X,             // 0/LeftX
-            MotionEvent.AXIS_Y,             // 1/LeftY
-            MotionEvent.AXIS_Z,             // 2/RightX
-            MotionEvent.AXIS_RZ,            // 3/RightY
-            MotionEvent.AXIS_LTRIGGER,      // 4/L2
-            MotionEvent.AXIS_RTRIGGER,      // 5/R2
-            MotionEvent.AXIS_RX,            // 6
-            MotionEvent.AXIS_RY,            // 7
-            MotionEvent.AXIS_HAT_X,         // 8
-            MotionEvent.AXIS_HAT_Y,         // 9
-            MotionEvent.AXIS_GAS,           // 10
-            MotionEvent.AXIS_BRAKE,         // 11
-    };
+    private class InputDeviceData {
+        private int deviceId;
+        private String descriptor;
+        private int[] axes;
+        private float[] axisValues;
+        private int controllerIndex;
+        private Vibrator vibrator;
 
-    public static int getButtonIndexForKeyCode(int keyCode) {
-        for (int buttonIndex = 0; buttonIndex < buttonKeyCodes.length; buttonIndex++) {
-            if (buttonKeyCodes[buttonIndex] == keyCode)
-                return buttonIndex;
-        }
-
-        Log.e("EmulationSurfaceView", String.format("Button code %d not found", keyCode));
-        return -1;
-    }
-
-    public static int[] getKnownAxisCodes() {
-        return axisCodes;
-    }
-
-    public static int getAxisIndexForAxisCode(int axisCode) {
-        for (int axisIndex = 0; axisIndex < axisCodes.length; axisIndex++) {
-            if (axisCodes[axisIndex] == axisCode)
-                return axisIndex;
-        }
-
-        Log.e("EmulationSurfaceView", String.format("Axis code %d not found", axisCode));
-        return -1;
-    }
-
-
-    private class ButtonMapping {
-        public ButtonMapping(int deviceId, int deviceButton, int controllerIndex, int button) {
-            this.deviceId = deviceId;
-            this.deviceAxisOrButton = deviceButton;
+        public InputDeviceData(InputDevice device, int controllerIndex) {
+            deviceId = device.getId();
+            descriptor = device.getDescriptor();
             this.controllerIndex = controllerIndex;
-            this.buttonMapping = button;
-        }
 
-        public int deviceId;
-        public int deviceAxisOrButton;
-        public int controllerIndex;
-        public int buttonMapping;
-    }
-
-    private class AxisMapping {
-        public AxisMapping(int deviceId, int deviceAxis, InputDevice.MotionRange motionRange, int controllerIndex, int axis) {
-            this.deviceId = deviceId;
-            this.deviceAxisOrButton = deviceAxis;
-            this.deviceMotionRange = motionRange;
-            this.controllerIndex = controllerIndex;
-            this.axisMapping = axis;
-            this.positiveButton = -1;
-            this.negativeButton = -1;
-        }
-
-        public AxisMapping(int deviceId, int deviceAxis, InputDevice.MotionRange motionRange, int controllerIndex, int positiveButton, int negativeButton) {
-            this.deviceId = deviceId;
-            this.deviceAxisOrButton = deviceAxis;
-            this.deviceMotionRange = motionRange;
-            this.controllerIndex = controllerIndex;
-            this.axisMapping = -1;
-            this.positiveButton = positiveButton;
-            this.negativeButton = negativeButton;
-        }
-
-        public int deviceId;
-        public int deviceAxisOrButton;
-        public InputDevice.MotionRange deviceMotionRange;
-        public int controllerIndex;
-        public int axisMapping;
-        public int positiveButton;
-        public int negativeButton;
-    }
-
-    private ArrayList<ButtonMapping> mControllerKeyMapping;
-    private ArrayList<AxisMapping> mControllerAxisMapping;
-
-    private boolean handleControllerKey(int deviceId, int keyCode, int repeatCount, boolean pressed) {
-        boolean result = false;
-        for (ButtonMapping mapping : mControllerKeyMapping) {
-            if (mapping.deviceId != deviceId || mapping.deviceAxisOrButton != keyCode)
-                continue;
-
-            if (repeatCount == 0) {
-                AndroidHostInterface.getInstance().handleControllerButtonEvent(0, mapping.buttonMapping, pressed);
-                Log.d("EmulationSurfaceView", String.format("handleControllerKey %d -> %d %d", keyCode, mapping.buttonMapping, pressed ? 1 : 0));
+            List<InputDevice.MotionRange> motionRanges = device.getMotionRanges();
+            if (motionRanges != null && !motionRanges.isEmpty()) {
+                axes = new int[motionRanges.size()];
+                axisValues = new float[motionRanges.size()];
+                for (int i = 0; i < motionRanges.size(); i++)
+                    axes[i] = motionRanges.get(i).getAxis();
             }
 
-            result = true;
+            // device.getVibrator() always returns null, but might return a "null vibrator".
+            final Vibrator potentialVibrator = device.getVibrator();
+            if (potentialVibrator != null && potentialVibrator.hasVibrator())
+                vibrator = potentialVibrator;
+        }
+    }
+
+    private InputDeviceData[] mInputDevices = null;
+    private boolean mHasAnyGamepads = false;
+
+    public boolean hasAnyGamePads() {
+        return mHasAnyGamepads;
+    }
+
+    public synchronized void updateInputDevices() {
+        mInputDevices = null;
+        mHasAnyGamepads = false;
+
+        final ArrayList<InputDeviceData> inputDeviceIds = new ArrayList<>();
+        for (int deviceId : InputDevice.getDeviceIds()) {
+            final InputDevice device = InputDevice.getDevice(deviceId);
+            if (device == null || !isBindableDevice(device))
+                continue;
+
+            if (isGamepadDevice(device))
+                mHasAnyGamepads = true;
+
+            final int controllerIndex = inputDeviceIds.size();
+            Log.d("EmulationSurfaceView", String.format("Tracking device %d/%s (%s)",
+                    controllerIndex, device.getDescriptor(), device.getName()));
+            inputDeviceIds.add(new InputDeviceData(device, controllerIndex));
         }
 
-        return result;
+        if (inputDeviceIds.isEmpty())
+            return;
+
+        mInputDevices = new InputDeviceData[inputDeviceIds.size()];
+        inputDeviceIds.toArray(mInputDevices);
+    }
+
+    public synchronized String[] getInputDeviceNames() {
+        if (mInputDevices == null)
+            return null;
+
+        final String[] deviceNames = new String[mInputDevices.length];
+        for (int i = 0; i < mInputDevices.length; i++) {
+            deviceNames[i] = mInputDevices[i].descriptor;
+        }
+
+        return deviceNames;
+    }
+
+    public synchronized boolean hasInputDeviceVibration(int controllerIndex) {
+        if (mInputDevices == null || controllerIndex >= mInputDevices.length)
+            return false;
+
+        return (mInputDevices[controllerIndex].vibrator != null);
+    }
+
+    public synchronized void setInputDeviceVibration(int controllerIndex, float smallMotor, float largeMotor) {
+        if (mInputDevices == null || controllerIndex >= mInputDevices.length)
+            return;
+
+        // shouldn't get here
+        final InputDeviceData data = mInputDevices[controllerIndex];
+        if (data.vibrator == null)
+            return;
+
+        final float MINIMUM_INTENSITY = 0.1f;
+        if (smallMotor >= MINIMUM_INTENSITY || largeMotor >= MINIMUM_INTENSITY)
+            data.vibrator.vibrate(1000);
+        else
+            data.vibrator.cancel();
+    }
+
+    public InputDeviceData getDataForDeviceId(int deviceId) {
+        if (mInputDevices == null)
+            return null;
+
+        for (InputDeviceData data : mInputDevices) {
+            if (data.deviceId == deviceId)
+                return data;
+        }
+
+        return null;
+    }
+
+    public int getControllerIndexForDeviceId(int deviceId) {
+        final InputDeviceData data = getDataForDeviceId(deviceId);
+        return (data != null) ? data.controllerIndex : -1;
+    }
+
+    private boolean handleKeyEvent(int keyCode, KeyEvent event, boolean pressed) {
+        if (!isBindableDevice(event.getDevice()))
+            return false;
+
+        /*Log.e("ESV", String.format("Code %d RC %d Pressed %d %s", keyCode,
+                event.getRepeatCount(), pressed? 1 : 0, event.toString()));*/
+
+        final AndroidHostInterface hi = AndroidHostInterface.getInstance();
+        final int controllerIndex = getControllerIndexForDeviceId(event.getDeviceId());
+        if (event.getRepeatCount() == 0 && controllerIndex >= 0)
+            hi.handleControllerButtonEvent(controllerIndex, keyCode, pressed);
+
+        // We don't want to eat external button events unless it's actually bound.
+        if (isExternalKeyCode(keyCode))
+            return (controllerIndex >= 0 && hi.hasControllerButtonBinding(controllerIndex, keyCode));
+        else
+            return true;
     }
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (!isDPadOrButtonEvent(event))
-            return false;
-
-        if (handleControllerKey(event.getDeviceId(), keyCode, event.getRepeatCount(), true))
-            return true;
-
-        // eat non-external button events anyway
-        return !isExternalKeyCode(keyCode);
+        return handleKeyEvent(keyCode, event, true);
     }
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        if (!isDPadOrButtonEvent(event))
-            return false;
-
-        if (handleControllerKey(event.getDeviceId(), keyCode, 0, false))
-            return true;
-
-        // eat non-external button events anyway
-        return !isExternalKeyCode(keyCode);
+        return handleKeyEvent(keyCode, event, false);
     }
 
     private float clamp(float value, float min, float max) {
@@ -214,19 +233,19 @@ public class EmulationSurfaceView extends SurfaceView {
 
     @Override
     public boolean onGenericMotionEvent(MotionEvent event) {
-        final int source = event.getSource();
-        if ((source & (InputDevice.SOURCE_JOYSTICK | InputDevice.SOURCE_GAMEPAD | InputDevice.SOURCE_DPAD)) == 0)
+        if (!isBindableDevice(event.getDevice()))
             return false;
 
-        final int deviceId = event.getDeviceId();
-        for (AxisMapping mapping : mControllerAxisMapping) {
-            if (mapping.deviceId != deviceId)
-                continue;
+        final InputDeviceData data = getDataForDeviceId(event.getDeviceId());
+        if (data == null || data.axes == null)
+            return false;
 
-            final float axisValue = event.getAxisValue(mapping.deviceAxisOrButton);
+        for (int i = 0; i < data.axes.length; i++) {
+            final int axis = data.axes[i];
+            final float axisValue = event.getAxisValue(axis);
             float emuValue;
 
-            switch (mapping.deviceAxisOrButton) {
+            switch (axis) {
                 case MotionEvent.AXIS_BRAKE:
                 case MotionEvent.AXIS_GAS:
                 case MotionEvent.AXIS_LTRIGGER:
@@ -241,109 +260,16 @@ public class EmulationSurfaceView extends SurfaceView {
                     break;
             }
 
-            Log.d("EmulationSurfaceView", String.format("axis %d value %f emuvalue %f", mapping.deviceAxisOrButton, axisValue, emuValue));
+            if (data.axisValues[i] == emuValue)
+                continue;
 
-            if (mapping.axisMapping >= 0) {
-                AndroidHostInterface.getInstance().handleControllerAxisEvent(0, mapping.axisMapping, emuValue);
-            }
+            /*Log.d("EmulationSurfaceView",
+                    String.format("axis %d value %f emuvalue %f", axis, axisValue, emuValue));*/
 
-            final float DEAD_ZONE = 0.25f;
-            if (mapping.negativeButton >= 0) {
-                AndroidHostInterface.getInstance().handleControllerButtonEvent(0, mapping.negativeButton, (emuValue <= -DEAD_ZONE));
-            }
-            if (mapping.positiveButton >= 0) {
-                AndroidHostInterface.getInstance().handleControllerButtonEvent(0, mapping.positiveButton, (emuValue >= DEAD_ZONE));
-            }
+            data.axisValues[i] = emuValue;
+            AndroidHostInterface.getInstance().handleControllerAxisEvent(data.controllerIndex, axis, emuValue);
         }
 
         return true;
     }
-
-    private boolean addControllerKeyMapping(int deviceId, int keyCode, int controllerIndex) {
-        int mapping = getButtonIndexForKeyCode(keyCode);
-        Log.i("EmulationSurfaceView", String.format("Map %d to %d", keyCode, mapping));
-        if (mapping >= 0) {
-            mControllerKeyMapping.add(new ButtonMapping(deviceId, keyCode, controllerIndex, mapping));
-            return true;
-        }
-
-        return false;
-    }
-
-    private boolean addControllerAxisMapping(int deviceId, List<InputDevice.MotionRange> motionRanges, int axis, int controllerIndex) {
-        InputDevice.MotionRange range = null;
-        for (InputDevice.MotionRange curRange : motionRanges) {
-            if (curRange.getAxis() == axis) {
-                range = curRange;
-                break;
-            }
-        }
-        if (range == null)
-            return false;
-
-        int mapping = getAxisIndexForAxisCode(axis);
-        int negativeButton = -1;
-        int positiveButton = -1;
-
-        if (mapping >= 0) {
-            Log.i("EmulationSurfaceView", String.format("Map axis %d to %d", axis, mapping));
-            mControllerAxisMapping.add(new AxisMapping(deviceId, axis, range, controllerIndex, mapping));
-            return true;
-        }
-
-        if (negativeButton >= 0 && negativeButton >= 0) {
-            Log.i("EmulationSurfaceView", String.format("Map axis %d to buttons %d %d", axis, negativeButton, positiveButton));
-            mControllerAxisMapping.add(new AxisMapping(deviceId, axis, range, controllerIndex, positiveButton, negativeButton));
-            return true;
-        }
-
-        Log.w("EmulationSurfaceView", String.format("Axis %d was not mapped", axis));
-        return false;
-    }
-
-    private static boolean isJoystickDevice(int deviceId) {
-        if (deviceId < 0)
-            return false;
-
-        final InputDevice dev = InputDevice.getDevice(deviceId);
-        if (dev == null)
-            return false;
-
-        final int sources = dev.getSources();
-        if ((sources & InputDevice.SOURCE_CLASS_JOYSTICK) != 0)
-            return true;
-
-        if ((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD)
-            return true;
-
-        return (sources & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD;
-    }
-
-    public boolean initControllerMapping(String controllerType) {
-        mControllerKeyMapping = new ArrayList<>();
-        mControllerAxisMapping = new ArrayList<>();
-
-        final int[] deviceIds = InputDevice.getDeviceIds();
-        for (int deviceId : deviceIds) {
-            if (!isJoystickDevice(deviceId))
-                continue;
-
-            InputDevice device = InputDevice.getDevice(deviceId);
-            List<InputDevice.MotionRange> motionRanges = device.getMotionRanges();
-            int controllerIndex = 0;
-
-            for (int keyCode : buttonKeyCodes) {
-                addControllerKeyMapping(deviceId, keyCode, controllerIndex);
-            }
-
-            if (motionRanges != null) {
-                for (int axisCode : axisCodes) {
-                    addControllerAxisMapping(deviceId, motionRanges, axisCode, controllerIndex);
-                }
-            }
-        }
-
-        return !mControllerKeyMapping.isEmpty() || !mControllerKeyMapping.isEmpty();
-    }
-
 }

--- a/android/app/src/main/java/com/github/stenzek/duckstation/GamePropertiesActivity.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/GamePropertiesActivity.java
@@ -1,16 +1,11 @@
 package com.github.stenzek.duckstation;
 
-import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.util.Property;
 import android.view.LayoutInflater;
-import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.EditText;
 import android.widget.ListAdapter;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -20,15 +15,12 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.ListFragment;
 import androidx.preference.PreferenceFragmentCompat;
-import androidx.preference.PreferenceManager;
 import androidx.preference.PreferenceScreen;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
-
-import java.util.ArrayList;
 
 public class GamePropertiesActivity extends AppCompatActivity {
     PropertyListAdapter mPropertiesListAdapter;
@@ -183,7 +175,7 @@ public class GamePropertiesActivity extends AppCompatActivity {
         @Nullable
         @Override
         public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-            return inflater.inflate(R.layout.fragment_controller_mapping, container, false);
+            return inflater.inflate(R.layout.fragment_controller_settings, container, false);
         }
 
         @Override

--- a/android/app/src/main/java/com/github/stenzek/duckstation/MainActivity.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/MainActivity.java
@@ -26,8 +26,6 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentFactory;
 import androidx.preference.PreferenceManager;
 
 import java.io.ByteArrayOutputStream;
@@ -237,8 +235,8 @@ public class MainActivity extends AppCompatActivity {
             Intent intent = new Intent(this, SettingsActivity.class);
             startActivityForResult(intent, REQUEST_SETTINGS);
             return true;
-        } else if (id == R.id.action_controller_mapping) {
-            Intent intent = new Intent(this, ControllerMappingActivity.class);
+        } else if (id == R.id.action_controller_settings) {
+            Intent intent = new Intent(this, ControllerSettingsActivity.class);
             startActivity(intent);
             return true;
         } else if (id == R.id.action_switch_view) {

--- a/android/app/src/main/java/com/github/stenzek/duckstation/SettingsActivity.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/SettingsActivity.java
@@ -107,13 +107,10 @@ public class SettingsActivity extends AppCompatActivity {
                 case 3:     // Enhancements
                     return new SettingsFragment(R.xml.enhancements_preferences);
 
-                case 4:     // Controllers
-                    return new SettingsFragment(R.xml.controllers_preferences);
-
-                case 5:     // Achievements
+                case 4:     // Achievements
                     return new AchievementSettingsFragment();
 
-                case 6:     // Advanced
+                case 5:     // Advanced
                     return new SettingsFragment(R.xml.advanced_preferences);
 
                 default:
@@ -123,7 +120,7 @@ public class SettingsActivity extends AppCompatActivity {
 
         @Override
         public int getItemCount() {
-            return 7;
+            return 6;
         }
     }
 }

--- a/android/app/src/main/res/drawable/ic_baseline_vibration_24.xml
+++ b/android/app/src/main/res/drawable/ic_baseline_vibration_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M0,15h2L2,9L0,9v6zM3,17h2L5,7L3,7v10zM22,9v6h2L24,9h-2zM19,17h2L21,7h-2v10zM16.5,3h-9C6.67,3 6,3.67 6,4.5v15c0,0.83 0.67,1.5 1.5,1.5h9c0.83,0 1.5,-0.67 1.5,-1.5v-15c0,-0.83 -0.67,-1.5 -1.5,-1.5zM16,19L8,19L8,5h8v14z"/>
+</vector>

--- a/android/app/src/main/res/layout/fragment_controller_settings.xml
+++ b/android/app/src/main/res/layout/fragment_controller_settings.xml
@@ -10,7 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:tabTextAppearance="@style/TabTextAppearance"
-        app:tabMode="fixed" />
+        app:tabMinWidth="150dp"
+        app:tabMode="scrollable"  />
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"

--- a/android/app/src/main/res/menu/menu_main.xml
+++ b/android/app/src/main/res/menu/menu_main.xml
@@ -21,12 +21,14 @@
             android:id="@+id/action_switch_view"
             android:icon="@drawable/ic_baseline_settings_24"
             android:orderInCategory="100"
-            android:title="@string/action_settings"
+            android:title="Switch View"
             app:showAsAction="ifRoom" />
         <item
-            android:id="@+id/action_controller_mapping"
+            android:id="@+id/action_controller_settings"
             android:icon="@drawable/ic_baseline_gamepad_24"
-            android:title="@string/action_controller_mapping" />
+            android:orderInCategory="102"
+            android:title="@string/action_controller_mapping"
+            app:showAsAction="ifRoom" />
         <item
             android:id="@+id/action_edit_game_directories"
             android:title="@string/menu_main_edit_game_directories" />

--- a/android/app/src/main/res/values-es/arrays.xml
+++ b/android/app/src/main/res/values-es/arrays.xml
@@ -69,8 +69,11 @@
         <item>xBR (Sin unión de bordes)</item>
     </string-array>
     <string-array name="settings_controller_type_entries">
+        <item>None</item>
         <item>Control Digital (Mando)</item>
         <item>Control Analógico (DualShock)</item>
+        <item>Analog Joystick</item>
+        <item>NeGcon</item>
     </string-array>
     <string-array name="settings_memory_card_mode_entries">
         <item>Sin tarjeta de memoria</item>
@@ -139,7 +142,6 @@
         <item>Pantalla</item>
         <item>Audio</item>
         <item>Mejoras</item>
-        <item>Controles</item>
         <item>Achievements</item>
         <item>Avanzado</item>
     </string-array>

--- a/android/app/src/main/res/values-it/arrays.xml
+++ b/android/app/src/main/res/values-it/arrays.xml
@@ -69,8 +69,11 @@
         <item>xBR (No Blending Bordi)</item>
     </string-array>
     <string-array name="settings_controller_type_entries">
+        <item>None</item>
         <item>Controller Digitale (Gamepad)</item>
         <item>Controller Analogico (DualShock)</item>
+        <item>Analog Joystick</item>
+        <item>NeGcon</item>
     </string-array>
     <string-array name="settings_memory_card_mode_entries">
         <item>No Memory Card</item>
@@ -139,7 +142,6 @@
         <item>Display</item>
         <item>Audio</item>
         <item>Miglioramenti</item>
-        <item>Controller</item>
         <item>Achievements</item>
         <item>Avanzate</item>
     </string-array>

--- a/android/app/src/main/res/values-nl/arrays.xml
+++ b/android/app/src/main/res/values-nl/arrays.xml
@@ -69,8 +69,11 @@
         <item>xBR (Geen Edge Blending)</item>
     </string-array>
     <string-array name="settings_controller_type_entries">
+        <item>None</item>
         <item>Digitale Controller (Gamepad)</item>
         <item>Analoge Controller (DualShock)</item>
+        <item>Analog Joystick</item>
+        <item>NeGcon</item>
     </string-array>
     <string-array name="settings_memory_card_mode_entries">
         <item>Geen Geheugenkaart</item>
@@ -139,7 +142,6 @@
         <item>Weergave</item>
         <item>Audio</item>
         <item>Verbeteringen</item>
-        <item>Controllers</item>
         <item>Achievements</item>
         <item>Geavanceerd</item>
     </string-array>

--- a/android/app/src/main/res/values-pt-rBR/arrays.xml
+++ b/android/app/src/main/res/values-pt-rBR/arrays.xml
@@ -69,8 +69,11 @@
         <item>xBR (Sem ajustes laterais)</item>
     </string-array>
     <string-array name="settings_controller_type_entries">
+        <item>None</item>
         <item>Controle Digital (Gamepad)</item>
         <item>Controle Analógico (DualShock)</item>
+        <item>Analog Joystick</item>
+        <item>NeGcon</item>
     </string-array>
     <string-array name="settings_memory_card_mode_entries">
         <item>Sem Cartão de Memória</item>
@@ -139,7 +142,6 @@
         <item>Vídeo</item>
         <item>Áudio</item>
         <item>Melhorias</item>
-        <item>Controles</item>
         <item>Achievements</item>
         <item>Avançado</item>
     </string-array>

--- a/android/app/src/main/res/values-ru/arrays.xml
+++ b/android/app/src/main/res/values-ru/arrays.xml
@@ -69,8 +69,11 @@
 		<item>xBR (без сглаживания краёв)</item>
 	</string-array>
 	<string-array name="settings_controller_type_entries">
+		<item>None</item>
 		<item>Цифровой</item>
 		<item>Аналоговый (DualShock)</item>
+		<item>Analog Joystick</item>
+		<item>NeGcon</item>
 	</string-array>
 	<string-array name="settings_memory_card_mode_entries">
 		<item>Без карты памяти</item>
@@ -145,7 +148,6 @@
 		<item>Экран</item>
 		<item>Звук</item>
 		<item>Улучшения</item>
-		<item>Контроллеры</item>
 		<item>Достижения</item>
 		<item>Расширенные</item>
 	</string-array>

--- a/android/app/src/main/res/values/arrays.xml
+++ b/android/app/src/main/res/values/arrays.xml
@@ -138,12 +138,18 @@
         <item>xBRBinAlpha</item>
     </string-array>
     <string-array name="settings_controller_type_entries">
+        <item>None</item>
         <item>Digital Controller (Gamepad)</item>
         <item>Analog Controller (DualShock)</item>
+        <item>Analog Joystick</item>
+        <item>NeGcon</item>
     </string-array>
     <string-array name="settings_controller_type_values">
+        <item>None</item>
         <item>DigitalController</item>
         <item>AnalogController</item>
+        <item>AnalogJoystick</item>
+        <item>NeGcon</item>
     </string-array>
     <string-array name="settings_memory_card_mode_entries">
         <item>No Memory Card</item>
@@ -265,7 +271,6 @@
         <item>Display</item>
         <item>Audio</item>
         <item>Enhancements</item>
-        <item>Controllers</item>
         <item>Achievements</item>
         <item>Advanced</item>
     </string-array>

--- a/android/app/src/main/res/values/arrays.xml
+++ b/android/app/src/main/res/values/arrays.xml
@@ -472,4 +472,16 @@
         <item>false</item>
         <item>true</item>
     </string-array>
+    <string-array name="settings_multitap_mode_entries">
+        <item>Disabled</item>
+        <item>Enable on Port 1 Only</item>
+        <item>Enable on Port 2 Only</item>
+        <item>Enable on Ports 1 and 2</item>
+    </string-array>
+    <string-array name="settings_multitap_mode_values">
+        <item>Disabled</item>
+        <item>Port1Only</item>
+        <item>Port2Only</item>
+        <item>BothPorts</item>
+    </string-array>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -273,5 +273,7 @@
     <string name="controller_settings_category_axis_bindings">Axis Bindings</string>
     <string name="controller_settings_category_settings">Settings</string>
     <string name="controller_settings_category_touchscreen_controller">Touchscreen Controller</string>
-    <string name="controller_settings_category_memory_cards">Memory Cards</string>
+    <string name="controller_settings_category_ports">Ports</string>
+    <string name="controller_settings_main_port_format">Port %d</string>
+    <string name="controller_settings_sub_port_format">Port %1$d%2$c</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">DuckStation</string>
     <string name="action_settings">Settings</string>
-    <string name="action_controller_mapping">Controller Mapping</string>
+    <string name="action_controller_mapping">Controller Settings</string>
     <string name="title_activity_settings">Settings</string>
     <string name="settings_console_region">Console Region</string>
     <string name="settings_console_tty_output">Enable TTY Output</string>
@@ -167,7 +167,7 @@
     <string name="controller_binding_dialog_no_binding"><![CDATA[<No Binding>]]></string>
     <string name="controller_binding_dialog_cancel">Cancel</string>
     <string name="controller_binding_dialog_clear">Clear</string>
-    <string name="controller_mapping_activity_title">Controller Mapping</string>
+    <string name="controller_mapping_activity_title">Controller Settings</string>
     <string name="controller_mapping_activity_no_profiles_found">No profiles found.</string>
     <string name="controller_mapping_activity_select_input_profile">Select Input Profile</string>
     <string name="controller_mapping_activity_failed_to_load_profile">Failed to load profile \'%s\'</string>
@@ -267,4 +267,11 @@
     <string name="settings_achievements_confirm_logout_title">Confirm Logout</string>
     <string name="settings_achievements_confirm_logout_message">After logging out, no more achievements will be unlocked until you log back in again. Achievements already unlocked will not be lost.</string>
     <string name="controller_binding_device_for_vibration">Device for Vibration</string>
+    <string name="controller_settings_tab_settings">Settings</string>
+    <string name="controller_settings_tab_hotkeys">Hotkeys</string>
+    <string name="controller_settings_category_button_bindings">Button Bindings</string>
+    <string name="controller_settings_category_axis_bindings">Axis Bindings</string>
+    <string name="controller_settings_category_settings">Settings</string>
+    <string name="controller_settings_category_touchscreen_controller">Touchscreen Controller</string>
+    <string name="controller_settings_category_memory_cards">Memory Cards</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -266,4 +266,5 @@
     <string name="settings_achievements_disclaimer">DuckStation uses RetroAchievements (retroachievements.org) as an achievement database and for tracking progress.</string>
     <string name="settings_achievements_confirm_logout_title">Confirm Logout</string>
     <string name="settings_achievements_confirm_logout_message">After logging out, no more achievements will be unlocked until you log back in again. Achievements already unlocked will not be lost.</string>
+    <string name="controller_binding_device_for_vibration">Device for Vibration</string>
 </resources>

--- a/android/app/src/main/res/xml/controllers_preferences.xml
+++ b/android/app/src/main/res/xml/controllers_preferences.xml
@@ -14,88 +14,64 @@
   ~ limitations under the License.
   -->
 
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ListPreference
-        app:key="Controller1/Type"
-        app:title="@string/settings_controller_type"
-        app:entries="@array/settings_controller_type_entries"
-        app:entryValues="@array/settings_controller_type_values"
-        app:defaultValue="DigitalController"
-        app:useSimpleSummaryProvider="true"
-        app:iconSpaceReserved="false" />
-    <ListPreference
-        app:key="Controller1/TouchscreenControllerView"
-        app:title="@string/settings_touchscreen_controller_view"
-        app:entries="@array/settings_touchscreen_controller_view_entries"
-        app:entryValues="@array/settings_touchscreen_controller_view_values"
-        app:defaultValue="digital"
-        app:useSimpleSummaryProvider="true"
-        app:iconSpaceReserved="false" />
-    <Preference
-        app:title="@string/settings_controller_mapping"
-        app:summary="@string/settings_controller_mapping_summary"
-        app:iconSpaceReserved="false">
-        <intent
-            android:action="android.intent.action.VIEW"
-            android:targetClass="com.github.stenzek.duckstation.ControllerMappingActivity"
-            android:targetPackage="com.github.stenzek.duckstation" />
-    </Preference>
-    <SwitchPreferenceCompat
-        app:key="Controller1/ForceAnalogOnReset"
-        app:title="@string/settings_enable_analog_mode_on_reset"
-        app:summary="@string/settings_summary_enable_analog_mode_on_reset"
-        app:defaultValue="true"
-        app:iconSpaceReserved="false" />
-    <SwitchPreferenceCompat
-        app:key="Controller1/AnalogDPadInDigitalMode"
-        app:title="@string/settings_use_analog_sticks_for_dpad"
-        app:summary="@string/settings_summary_use_analog_sticks_for_dpad"
-        app:defaultValue="true"
-        app:iconSpaceReserved="false" />
-    <SwitchPreferenceCompat
-        app:key="Controller1/AutoHideTouchscreenController"
-        app:title="@string/settings_auto_hide_touchscreen_controller"
-        app:defaultValue="false"
-        app:summary="@string/settings_summary_auto_hide_touchscreen_controller"
-        app:iconSpaceReserved="false" />
-    <SwitchPreferenceCompat
-        app:key="Controller1/HapticFeedback"
-        app:title="@string/settings_vibrate_on_press"
-        app:defaultValue="false"
-        app:summary="@string/settings_summary_vibrate_on_press"
-        app:iconSpaceReserved="false" />
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="@string/controller_settings_category_touchscreen_controller">
+        <ListPreference
+            app:defaultValue="digital"
+            app:entries="@array/settings_touchscreen_controller_view_entries"
+            app:entryValues="@array/settings_touchscreen_controller_view_values"
+            app:iconSpaceReserved="false"
+            app:key="Controller1/TouchscreenControllerView"
+            app:title="@string/settings_touchscreen_controller_view"
+            app:useSimpleSummaryProvider="true" />
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:iconSpaceReserved="false"
+            app:key="Controller1/AutoHideTouchscreenController"
+            app:summary="@string/settings_summary_auto_hide_touchscreen_controller"
+            app:title="@string/settings_auto_hide_touchscreen_controller" />
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:iconSpaceReserved="false"
+            app:key="Controller1/TouchGliding"
+            app:summary="@string/settings_summary_touch_gliding"
+            app:title="@string/settings_touch_gliding" />
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:iconSpaceReserved="false"
+            app:key="Controller1/HapticFeedback"
+            app:summary="@string/settings_summary_vibrate_on_press"
+            app:title="@string/settings_vibrate_on_press" />
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:iconSpaceReserved="false"
+            app:key="Controller1/Vibration"
+            app:summary="@string/settings_summary_enable_vibration"
+            app:title="@string/settings_enable_vibration" />
+    </PreferenceCategory>
 
-    <SwitchPreferenceCompat
-        app:key="Controller1/Vibration"
-        app:title="@string/settings_enable_vibration"
-        app:defaultValue="false"
-        app:summary="@string/settings_summary_enable_vibration"
-        app:iconSpaceReserved="false" />
-
-    <SwitchPreferenceCompat
-        app:key="Controller1/TouchGliding"
-        app:title="@string/settings_touch_gliding"
-        app:defaultValue="false"
-        app:summary="@string/settings_summary_touch_gliding"
-        app:iconSpaceReserved="false" />
-
-    <ListPreference
-        app:key="MemoryCards/Card1Type"
-        app:title="@string/settings_memory_card_1_type"
-        app:entries="@array/settings_memory_card_mode_entries"
-        app:entryValues="@array/settings_memory_card_mode_values"
-        app:defaultValue="PerGameTitle"
-        app:useSimpleSummaryProvider="true"
-        app:iconSpaceReserved="false" />
-    <ListPreference
-        app:key="MemoryCards/Card2Type"
-        app:title="@string/settings_memory_card_2_type"
-        app:entries="@array/settings_memory_card_mode_entries"
-        app:entryValues="@array/settings_memory_card_mode_values"
-        app:defaultValue="None"
-        app:useSimpleSummaryProvider="true"
-        app:iconSpaceReserved="false" />
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="@string/controller_settings_category_memory_cards">
+        <ListPreference
+            app:defaultValue="PerGameTitle"
+            app:entries="@array/settings_memory_card_mode_entries"
+            app:entryValues="@array/settings_memory_card_mode_values"
+            app:iconSpaceReserved="false"
+            app:key="MemoryCards/Card1Type"
+            app:title="@string/settings_memory_card_1_type"
+            app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            app:defaultValue="None"
+            app:entries="@array/settings_memory_card_mode_entries"
+            app:entryValues="@array/settings_memory_card_mode_values"
+            app:iconSpaceReserved="false"
+            app:key="MemoryCards/Card2Type"
+            app:title="@string/settings_memory_card_2_type"
+            app:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
 
 </PreferenceScreen>

--- a/android/app/src/main/res/xml/controllers_preferences.xml
+++ b/android/app/src/main/res/xml/controllers_preferences.xml
@@ -55,7 +55,15 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
-        app:title="@string/controller_settings_category_memory_cards">
+        app:title="@string/controller_settings_category_ports">
+        <ListPreference
+            app:defaultValue="Disabled"
+            app:entries="@array/settings_multitap_mode_entries"
+            app:entryValues="@array/settings_multitap_mode_values"
+            app:iconSpaceReserved="false"
+            app:key="ControllerPorts/MultitapMode"
+            app:title="Multitap Mode"
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             app:defaultValue="PerGameTitle"
             app:entries="@array/settings_memory_card_mode_entries"

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1538,21 +1538,9 @@ bool CommonHostInterface::AddButtonToInputMap(const std::string& binding, const 
     return false;
   }
 
-  if (StringUtil::StartsWith(device, "Controller"))
+  std::optional<int> controller_index;
+  if (m_controller_interface && (controller_index = m_controller_interface->GetControllerIndex(device)))
   {
-    if (!m_controller_interface)
-    {
-      Log_ErrorPrintf("No controller interface set, cannot bind '%s'", binding.c_str());
-      return false;
-    }
-
-    const std::optional<int> controller_index = StringUtil::FromChars<int>(device.substr(10));
-    if (!controller_index || *controller_index < 0)
-    {
-      Log_WarningPrintf("Invalid controller index in button binding '%s'", binding.c_str());
-      return false;
-    }
-
     if (StringUtil::StartsWith(button, "Button"))
     {
       const std::optional<int> button_index = StringUtil::FromChars<int>(button.substr(6));
@@ -1652,21 +1640,9 @@ bool CommonHostInterface::AddAxisToInputMap(const std::string& binding, const st
     }
   }
 
-  if (StringUtil::StartsWith(device, "Controller"))
+  std::optional<int> controller_index;
+  if (m_controller_interface && (controller_index = m_controller_interface->GetControllerIndex(device)))
   {
-    if (!m_controller_interface)
-    {
-      Log_ErrorPrintf("No controller interface set, cannot bind '%s'", binding.c_str());
-      return false;
-    }
-
-    const std::optional<int> controller_index = StringUtil::FromChars<int>(device.substr(10));
-    if (!controller_index || *controller_index < 0)
-    {
-      Log_WarningPrintf("Invalid controller index in axis binding '%s'", binding.c_str());
-      return false;
-    }
-
     if (StringUtil::StartsWith(axis, "Axis") || StringUtil::StartsWith(axis, "+Axis") ||
         StringUtil::StartsWith(axis, "-Axis"))
     {
@@ -1723,21 +1699,9 @@ bool CommonHostInterface::AddAxisToInputMap(const std::string& binding, const st
 
 bool CommonHostInterface::AddRumbleToInputMap(const std::string& binding, u32 controller_index, u32 num_motors)
 {
-  if (StringUtil::StartsWith(binding, "Controller"))
+  std::optional<int> host_controller_index;
+  if (m_controller_interface && (host_controller_index = m_controller_interface->GetControllerIndex(binding)))
   {
-    if (!m_controller_interface)
-    {
-      Log_ErrorPrintf("No controller interface set, cannot bind '%s'", binding.c_str());
-      return false;
-    }
-
-    const std::optional<int> host_controller_index = StringUtil::FromChars<int>(binding.substr(10));
-    if (!host_controller_index || *host_controller_index < 0)
-    {
-      Log_WarningPrintf("Invalid controller index in rumble binding '%s'", binding.c_str());
-      return false;
-    }
-
     AddControllerRumble(controller_index, num_motors,
                         std::bind(&ControllerInterface::SetControllerRumbleStrength, m_controller_interface.get(),
                                   host_controller_index.value(), std::placeholders::_1, std::placeholders::_2));

--- a/src/frontend-common/common_host_interface.h
+++ b/src/frontend-common/common_host_interface.h
@@ -356,7 +356,7 @@ protected:
   void RegisterHotkey(String category, String name, String display_name, InputButtonHandler handler);
   bool HandleHostKeyEvent(HostKeyCode code, HostKeyCode modifiers, bool pressed);
   bool HandleHostMouseEvent(HostMouseButton button, bool pressed);
-  void UpdateInputMap(SettingsInterface& si);
+  virtual void UpdateInputMap(SettingsInterface& si);
   void ClearInputMap();
 
   void AddControllerRumble(u32 controller_index, u32 num_motors, ControllerRumbleCallback callback);

--- a/src/frontend-common/controller_interface.cpp
+++ b/src/frontend-common/controller_interface.cpp
@@ -22,6 +22,22 @@ void ControllerInterface::Shutdown()
   m_host_interface = nullptr;
 }
 
+std::optional<int> ControllerInterface::GetControllerIndex(const std::string_view& device)
+{
+  if (!StringUtil::StartsWith(device, "Controller"))
+    return std::nullopt;
+
+  const std::optional<int> controller_index = StringUtil::FromChars<int>(device.substr(10));
+  if (!controller_index || *controller_index < 0)
+  {
+    Log_WarningPrintf("Invalid controller index in button binding '%*s'", static_cast<int>(device.length()),
+                      device.data());
+    return std::nullopt;
+  }
+
+  return controller_index;
+}
+
 void ControllerInterface::SetHook(Hook::Callback callback)
 {
   std::unique_lock<std::mutex> lock(m_event_intercept_mutex);

--- a/src/frontend-common/controller_interface.h
+++ b/src/frontend-common/controller_interface.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <string_view>
 #include <variant>
 
 class HostInterface;
@@ -70,6 +71,7 @@ public:
   virtual void ClearBindings() = 0;
 
   // Binding to events. If a binding for this axis/button already exists, returns false.
+  virtual std::optional<int> GetControllerIndex(const std::string_view& device);
   virtual bool BindControllerAxis(int controller_index, int axis_number, AxisSide axis_side, AxisCallback callback) = 0;
   virtual bool BindControllerButton(int controller_index, int button_number, ButtonCallback callback) = 0;
   virtual bool BindControllerAxisToButton(int controller_index, int axis_number, bool direction,


### PR DESCRIPTION
What the title says. New controller UI which is more flexible. Needs testing.

Controller descriptors are now used instead of "ControllerN" IDs, so you will need to rebind your controllers.

I've tested a combination of keyboards and DS4/XBox pads. Vibration even works with the XBox pad, but it's only on/off, no small/large motor.