### PR TITLE
QoL changes for Touch Gliding

### DIFF
--- a/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerView.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerView.java
@@ -461,11 +461,11 @@ public class TouchscreenControllerView extends FrameLayout {
                 final int y = (int) event.getY(i);
                 if (rect.contains(x, y)) {
                     buttonView.setPressed(true);
-                    int pointerID = event.getPointerId(i);
-                    if (!mGlidePairs.containsKey(pointerID) && !mGlidePairs.containsValue(buttonView)) {
+                    final int pointerId = event.getPointerId(i);
+                    if (!mGlidePairs.containsKey(pointerId) && !mGlidePairs.containsValue(buttonView)) {
                         if (buttonView.getIsGlidable())
-                            mGlidePairs.put(pointerID, buttonView);
-                        else { mGlidePairs.put(pointerID, null); }
+                            mGlidePairs.put(pointerId, buttonView);
+                        else { mGlidePairs.put(pointerId, null); }
                     }
                     pressed = true;
                     break;
@@ -494,6 +494,7 @@ public class TouchscreenControllerView extends FrameLayout {
                         (axisView.isPressed() && axisView.getPointerId() == pointerId)) {
                     axisView.setPressed(pointerId, x, y);
                     pressed = true;
+                    mGlidePairs.put(pointerId, null);
                     break;
                 }
             }
@@ -526,9 +527,9 @@ public class TouchscreenControllerView extends FrameLayout {
             case MotionEvent.ACTION_DOWN:
             case MotionEvent.ACTION_POINTER_DOWN:
             case MotionEvent.ACTION_POINTER_UP: {
-                int pointerID = event.getPointerId(event.getActionIndex());
-                if (mGlidePairs.containsKey(pointerID))
-                    mGlidePairs.remove(pointerID);
+                final int pointerId = event.getPointerId(event.getActionIndex());
+                if (mGlidePairs.containsKey(pointerId))
+                    mGlidePairs.remove(pointerId);
 
                 return updateTouchButtonsFromEvent(event);
             }

--- a/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerView.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/TouchscreenControllerView.java
@@ -465,6 +465,7 @@ public class TouchscreenControllerView extends FrameLayout {
                     if (!mGlidePairs.containsKey(pointerID) && !mGlidePairs.containsValue(buttonView)) {
                         if (buttonView.getIsGlidable())
                             mGlidePairs.put(pointerID, buttonView);
+                        else { mGlidePairs.put(pointerID, null); }
                     }
                     pressed = true;
                     break;


### PR DESCRIPTION
If you press a button that ignores touch gliding (d-pad) or an axis, and then slide to a button, gliding will not activate. This should address issues raised by testers of the feature.

This PR also changes some of the related codenames and turns regular ints to final ints.