### PR TITLE
CPU/Recompiler: Use MAP_JIT for code space on Apple Silicon

### DIFF
--- a/src/common/jit_code_buffer.cpp
+++ b/src/common/jit_code_buffer.cpp
@@ -13,6 +13,11 @@ Log_SetChannel(JitCodeBuffer);
 #include <sys/mman.h>
 #endif
 
+#if defined(__APPLE__) && defined(__aarch64__)
+// pthread_jit_write_protect_np()
+#include <pthread.h>
+#endif
+
 JitCodeBuffer::JitCodeBuffer() = default;
 
 JitCodeBuffer::JitCodeBuffer(u32 size, u32 far_code_size)
@@ -46,8 +51,13 @@ bool JitCodeBuffer::Allocate(u32 size /* = 64 * 1024 * 1024 */, u32 far_code_siz
     return false;
   }
 #elif defined(__linux__) || defined(__ANDROID__) || defined(__APPLE__) || defined(__HAIKU__) || defined(__FreeBSD__)
-  m_code_ptr = static_cast<u8*>(
-    mmap(nullptr, m_total_size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+#if defined(__APPLE__) && defined(__aarch64__)
+  // MAP_JIT and toggleable write protection is required on Apple Silicon.
+  flags |= MAP_JIT;
+#endif
+
+  m_code_ptr = static_cast<u8*>(mmap(nullptr, m_total_size, PROT_READ | PROT_WRITE | PROT_EXEC, flags, -1, 0));
   if (!m_code_ptr)
   {
     Log_ErrorPrintf("mmap(RWX, %u) for internal buffer failed: %d", m_total_size, errno);
@@ -195,6 +205,8 @@ void JitCodeBuffer::CommitFarCode(u32 length)
 
 void JitCodeBuffer::Reset()
 {
+  WriteProtect(false);
+
   m_free_code_ptr = m_code_ptr + m_guard_size;
   m_code_used = 0;
   std::memset(m_free_code_ptr, 0, m_code_size);
@@ -207,6 +219,8 @@ void JitCodeBuffer::Reset()
     std::memset(m_free_far_code_ptr, 0, m_far_code_size);
     FlushInstructionCache(m_free_far_code_ptr, m_far_code_size);
   }
+
+  WriteProtect(true);
 }
 
 void JitCodeBuffer::Align(u32 alignment, u8 padding_value)
@@ -231,3 +245,26 @@ void JitCodeBuffer::FlushInstructionCache(void* address, u32 size)
 #error Unknown platform.
 #endif
 }
+
+#if defined(__APPLE__) && defined(__aarch64__)
+
+void JitCodeBuffer::WriteProtect(bool enabled)
+{
+  static bool initialized = false;
+  static bool needs_write_protect = false;
+
+  if (!initialized)
+  {
+    initialized = true;
+    needs_write_protect = (pthread_jit_write_protect_supported_np() != 0);
+    if (needs_write_protect)
+      Log_InfoPrint("pthread_jit_write_protect_np() will be used before writing to JIT space.");
+  }
+
+  if (!needs_write_protect)
+    return;
+
+  pthread_jit_write_protect_np(enabled ? 1 : 0);
+}
+
+#endif

--- a/src/common/jit_code_buffer.h
+++ b/src/common/jit_code_buffer.h
@@ -29,6 +29,13 @@ public:
   /// Flushes the instruction cache on the host for the specified range.
   static void FlushInstructionCache(void* address, u32 size);
 
+  /// For Apple Silicon - Toggles write protection on the JIT space.
+#if defined(__APPLE__) && defined(__aarch64__)
+  static void WriteProtect(bool enabled);
+#else
+  ALWAYS_INLINE static void WriteProtect(bool enabled) {}
+#endif
+
 private:
   u8* m_code_ptr = nullptr;
   u8* m_free_code_ptr = nullptr;
@@ -45,4 +52,3 @@ private:
   u32 m_old_protection = 0;
   bool m_owns_buffer = false;
 };
-

--- a/src/core/cpu_recompiler_code_generator_x64.cpp
+++ b/src/core/cpu_recompiler_code_generator_x64.cpp
@@ -785,6 +785,15 @@ void CodeGenerator::EmitDiv(HostReg to_reg_quotient, HostReg to_reg_remainder, H
     // what we want, but swapped, so exchange them
     m_emit->xchg(m_emit->rax, m_emit->rdx);
   }
+  else if (to_reg_quotient != Xbyak::Operand::RAX && to_reg_quotient != Xbyak::Operand::RDX &&
+           to_reg_remainder != Xbyak::Operand::RAX && to_reg_remainder != Xbyak::Operand::RDX)
+  {
+    // store to the registers we want.. this could be optimized better
+    if (to_reg_quotient != HostReg_Count)
+      m_emit->mov(GetHostReg64(to_reg_quotient), m_emit->rax);
+    if (to_reg_remainder != HostReg_Count)
+      m_emit->mov(GetHostReg64(to_reg_remainder), m_emit->rdx);
+  }
   else
   {
     // store to the registers we want.. this could be optimized better


### PR DESCRIPTION
Untested, since I don't own an Intel Mac, let alone an M1 Mac.