### PR TITLE
Printf-like improvements

### DIFF
--- a/src/common/cd_image_memory.cpp
+++ b/src/common/cd_image_memory.cpp
@@ -61,7 +61,7 @@ bool CDImageMemory::CopyImage(CDImage* image, ProgressCallback* progress)
     static_cast<u8*>(std::malloc(static_cast<size_t>(RAW_SECTOR_SIZE) * static_cast<size_t>(m_memory_sectors)));
   if (!m_memory)
   {
-    progress->DisplayFormattedModalError("Failed to allocate memory for %llu sectors", m_memory_sectors);
+    progress->DisplayFormattedModalError("Failed to allocate memory for %u sectors", m_memory_sectors);
     return false;
   }
 

--- a/src/common/error.h
+++ b/src/common/error.h
@@ -43,11 +43,11 @@ public:
   void SetErrno(int err);
   void SetSocket(int err);
   void SetMessage(const char* msg);
-  void SetFormattedMessage(const char* format, ...) printflike(2, 3);
+  void SetFormattedMessage(const char* format, ...) __printflike(2, 3);
   void SetUser(int err, const char* msg);
   void SetUser(const char* code, const char* message);
-  void SetUserFormatted(int err, const char* format, ...) printflike(3, 4);
-  void SetUserFormatted(const char* code, const char* format, ...) printflike(3, 4);
+  void SetUserFormatted(int err, const char* format, ...) __printflike(3, 4);
+  void SetUserFormatted(const char* code, const char* format, ...) __printflike(3, 4);
 #ifdef _WIN32
   void SetWin32(unsigned long err);
   void SetHResult(long err);
@@ -58,11 +58,11 @@ public:
   static Error CreateErrno(int err);
   static Error CreateSocket(int err);
   static Error CreateMessage(const char* msg);
-  static Error CreateMessageFormatted(const char* format, ...) printflike(1, 2);
+  static Error CreateMessageFormatted(const char* format, ...) __printflike(1, 2);
   static Error CreateUser(int err, const char* msg);
   static Error CreateUser(const char* code, const char* message);
-  static Error CreateUserFormatted(int err, const char* format, ...) printflike(2, 3);
-  static Error CreateUserFormatted(const char* code, const char* format, ...) printflike(2, 3);
+  static Error CreateUserFormatted(int err, const char* format, ...) __printflike(2, 3);
+  static Error CreateUserFormatted(const char* code, const char* format, ...) __printflike(2, 3);
 #ifdef _WIN32
   static Error CreateWin32(unsigned long err);
   static Error CreateHResult(long err);

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -46,7 +46,7 @@ void SetFilterLevel(LOGLEVEL level);
 
 // writes a message to the log
 void Write(const char* channelName, const char* functionName, LOGLEVEL level, const char* message);
-void Writef(const char* channelName, const char* functionName, LOGLEVEL level, const char* format, ...) printflike(4, 5);
+void Writef(const char* channelName, const char* functionName, LOGLEVEL level, const char* format, ...) __printflike(4, 5);
 void Writev(const char* channelName, const char* functionName, LOGLEVEL level, const char* format, va_list ap);
 } // namespace Log
 

--- a/src/common/progress_callback.h
+++ b/src/common/progress_callback.h
@@ -23,7 +23,7 @@ public:
   virtual void SetProgressValue(u32 value) = 0;
   virtual void IncrementProgressValue() = 0;
 
-  void SetFormattedStatusText(const char* Format, ...);
+  void SetFormattedStatusText(const char* Format, ...) __printflike(2, 3);
 
   virtual void DisplayError(const char* message) = 0;
   virtual void DisplayWarning(const char* message) = 0;
@@ -34,13 +34,13 @@ public:
   virtual bool ModalConfirmation(const char* message) = 0;
   virtual void ModalInformation(const char* message) = 0;
 
-  void DisplayFormattedError(const char* format, ...);
-  void DisplayFormattedWarning(const char* format, ...);
-  void DisplayFormattedInformation(const char* format, ...);
-  void DisplayFormattedDebugMessage(const char* format, ...);
-  void DisplayFormattedModalError(const char* format, ...);
-  bool DisplayFormattedModalConfirmation(const char* format, ...);
-  void DisplayFormattedModalInformation(const char* format, ...);
+  void DisplayFormattedError(const char* format, ...) __printflike(2, 3);
+  void DisplayFormattedWarning(const char* format, ...) __printflike(2, 3);
+  void DisplayFormattedInformation(const char* format, ...) __printflike(2, 3);
+  void DisplayFormattedDebugMessage(const char* format, ...) __printflike(2, 3);
+  void DisplayFormattedModalError(const char* format, ...) __printflike(2, 3);
+  bool DisplayFormattedModalConfirmation(const char* format, ...) __printflike(2, 3);
+  void DisplayFormattedModalInformation(const char* format, ...) __printflike(2, 3);
 
   void UpdateProgressFromStream(ByteStream* stream);
 

--- a/src/common/string.h
+++ b/src/common/string.h
@@ -104,7 +104,7 @@ public:
   void AppendSubString(const char* appendText, s32 Offset = 0, s32 Count = std::numeric_limits<s32>::max());
 
   // append formatted string to this string
-  void AppendFormattedString(const char* FormatString, ...);
+  void AppendFormattedString(const char* FormatString, ...) __printflike(2, 3);
   void AppendFormattedStringVA(const char* FormatString, va_list ArgPtr);
 
   // append a single character to this string
@@ -122,7 +122,7 @@ public:
   void PrependSubString(const char* appendText, s32 Offset = 0, s32 Count = std::numeric_limits<s32>::max());
 
   // append formatted string to this string
-  void PrependFormattedString(const char* FormatString, ...);
+  void PrependFormattedString(const char* FormatString, ...) __printflike(2, 3);
   void PrependFormattedStringVA(const char* FormatString, va_list ArgPtr);
 
   // insert a string at the specified offset
@@ -133,7 +133,7 @@ public:
   void InsertString(s32 offset, const std::string_view& appendStr);
 
   // set to formatted string
-  void Format(const char* FormatString, ...);
+  void Format(const char* FormatString, ...) __printflike(2, 3);
   void FormatVA(const char* FormatString, va_list ArgPtr);
 
   // compare one string to another
@@ -229,7 +229,7 @@ public:
   }
 
   // creates a new string from the specified format
-  static String FromFormat(const char* FormatString, ...);
+  static String FromFormat(const char* FormatString, ...) __printflike(1, 2);
 
   // accessor operators
   // const char &operator[](u32 i) const { DebugAssert(i < m_pStringData->StringLength); return
@@ -345,7 +345,7 @@ public:
   }
 
   // Override the fromstring method
-  static StackString FromFormat(const char* FormatString, ...)
+  static StackString FromFormat(const char* FormatString, ...)  __printflike(1, 2)
   {
     va_list argPtr;
     va_start(argPtr, FormatString);

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -21,7 +21,7 @@
 namespace StringUtil {
 
 /// Constructs a std::string from a format string.
-std::string StdStringFromFormat(const char* format, ...);
+std::string StdStringFromFormat(const char* format, ...) __printflike(1, 2);
 std::string StdStringFromFormatV(const char* format, std::va_list ap);
 
 /// Checks if a wildcard matches a search string.

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -57,7 +57,7 @@ char (&__countof_ArraySizeHelper(T (&array)[N]))[N];
   __attribute__((format(printf, n, m)))
 #endif
 #else
-#define printflike(n,m)
+#define __printflike(n,m)
 #endif
 
 // disable warnings that show up at warning level 4

--- a/src/common/types.h
+++ b/src/common/types.h
@@ -50,7 +50,12 @@ char (&__countof_ArraySizeHelper(T (&array)[N]))[N];
 #endif
 
 #ifdef __GNUC__
-#define printflike(n,m) __attribute__((format(printf,n,m)))
+// use system-provided __printflike if possible.
+#include <sys/cdefs.h>
+#ifndef __printflike
+#define __printflike(n, m) \
+  __attribute__((format(printf, n, m)))
+#endif
 #else
 #define printflike(n,m)
 #endif

--- a/src/common/vulkan/util.h
+++ b/src/common/vulkan/util.h
@@ -74,7 +74,7 @@ VkShaderModule CompileAndCreateFragmentShader(std::string_view source_code);
 VkShaderModule CompileAndCreateComputeShader(std::string_view source_code);
 
 const char* VkResultToString(VkResult res);
-void LogVulkanResult(int level, const char* func_name, VkResult res, const char* msg, ...);
+void LogVulkanResult(int level, const char* func_name, VkResult res, const char* msg, ...)  __printflike(4, 5);
 
 #define LOG_VULKAN_ERROR(res, ...) ::Vulkan::Util::LogVulkanResult(1, __func__, res, __VA_ARGS__)
 

--- a/src/core/cpu_core.h
+++ b/src/core/cpu_core.h
@@ -148,7 +148,7 @@ void DisassembleAndLog(u32 addr);
 void DisassembleAndPrint(u32 addr, u32 instructions_before, u32 instructions_after);
 
 // Write to CPU execution log file.
-void WriteToExecutionLog(const char* format, ...);
+void WriteToExecutionLog(const char* format, ...) __printflike(1, 2);
 
 // Trace Routines
 bool IsTraceEnabled();

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -101,7 +101,7 @@ bool HostInterface::BootSystem(const SystemBootParameters& parameters)
 
   if (!AcquireHostDisplay())
   {
-    ReportFormattedError(g_host_interface->TranslateString("System", "Failed to acquire host display."));
+    ReportError(g_host_interface->TranslateString("System", "Failed to acquire host display."));
     OnSystemDestroyed();
     return false;
   }
@@ -118,7 +118,7 @@ bool HostInterface::BootSystem(const SystemBootParameters& parameters)
   {
     if (!System::IsStartupCancelled())
     {
-      ReportFormattedError(
+      ReportError(
         g_host_interface->TranslateString("System", "System failed to boot. The log may contain more information."));
     }
 

--- a/src/core/host_interface.h
+++ b/src/core/host_interface.h
@@ -64,23 +64,23 @@ public:
   virtual void ReportDebuggerMessage(const char* message);
   virtual bool ConfirmMessage(const char* message);
 
-  void ReportFormattedError(const char* format, ...);
-  void ReportFormattedMessage(const char* format, ...);
-  void ReportFormattedDebuggerMessage(const char* format, ...);
-  bool ConfirmFormattedMessage(const char* format, ...);
+  void ReportFormattedError(const char* format, ...) __printflike(2, 3);
+  void ReportFormattedMessage(const char* format, ...) __printflike(2, 3);
+  void ReportFormattedDebuggerMessage(const char* format, ...) __printflike(2, 3);
+  bool ConfirmFormattedMessage(const char* format, ...) __printflike(2, 3);
 
   /// Adds OSD messages, duration is in seconds.
   virtual void AddOSDMessage(std::string message, float duration = 2.0f);
-  void AddFormattedOSDMessage(float duration, const char* format, ...);
+  void AddFormattedOSDMessage(float duration, const char* format, ...) __printflike(3, 4);
 
   /// Returns the base user directory path.
   ALWAYS_INLINE const std::string& GetUserDirectory() const { return m_user_directory; }
 
   /// Returns a path relative to the user directory.
-  std::string GetUserDirectoryRelativePath(const char* format, ...) const;
+  std::string GetUserDirectoryRelativePath(const char* format, ...) const __printflike(2, 3);
 
   /// Returns a path relative to the application directory (for system files).
-  std::string GetProgramDirectoryRelativePath(const char* format, ...) const;
+  std::string GetProgramDirectoryRelativePath(const char* format, ...) const __printflike(2, 3);
 
   /// Returns a string which can be used as part of a filename, based on the current date/time.
   static TinyString GetTimestampStringForFileName();


### PR DESCRIPTION
* Rename `printflike` to `__printflike`, and use system `__printflike` if available.
* * this is used to make Xcode, the IDE of my choice, show the actual function in drop-down menus instead of just _printflike()_.
* Adds more `__printflike` macros in more places.
* Correct a few improper uses of formatting strings.