### PR TITLE
Update gamesettings.ini

### DIFF
--- a/data/database/gamesettings.ini
+++ b/data/database/gamesettings.ini
@@ -273,12 +273,6 @@ DisableAnalogModeForcing = true
 DisableAnalogModeForcing = true
 
 
-# SLUS-00355 (Duke Nukem - Total Meltdown (USA))
-[SLUS-00355]
-DisableUpscaling = true
-DisableAnalogModeForcing = true
-
-
 # SLUS-00106 (Grand Theft Auto (USA))
 [SLUS-00106]
 DisableAnalogModeForcing = true


### PR DESCRIPTION
Removed duplicate entry for Duke Nukem: Total Meltdown.
And this game supports DualShock analog so no need for DisableAnalogModeForcing = true.