### PR TITLE
core/types: Convert GPUDownsampleMode into an enum class

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -75,7 +75,7 @@ enum class GPUTextureFilter : u8
   Count
 };
 
-enum GPUDownsampleMode : u8
+enum class GPUDownsampleMode : u8
 {
   Disabled,
   Box,


### PR DESCRIPTION
Prevents some generic-sounding identifiers from being put into the global namespace.