### PR TITLE
Update gamedb with hashes for two titles

### DIFF
--- a/gamedb/t.json
+++ b/gamedb/t.json
@@ -12384,7 +12384,7 @@
   "serial": "SLUS-01019",
   "name": "Threads of Fate (USA)",
   "codes": [
-   "SLUS-01019"
+   "HASH-1F5FE335F35BED3D"
   ],
   "languages": [
    "English"

--- a/gamedb/u.json
+++ b/gamedb/u.json
@@ -3802,7 +3802,7 @@
   "serial": "SLUS-01091",
   "name": "Urban Chaos (USA)",
   "codes": [
-   "SLUS-01091"
+   "HASH-E19CC0BCDFD57C06"
   ],
   "languages": [
    "English"


### PR DESCRIPTION
Update Urban Chaos (USA) and Threads of Fate (USA) to prevent Urban Chaos being picked up as Threads of Fate