### PR TITLE
Add sensor-based screen orientation for Android

### DIFF
--- a/android/app/src/main/java/com/github/stenzek/duckstation/EmulationActivity.java
+++ b/android/app/src/main/java/com/github/stenzek/duckstation/EmulationActivity.java
@@ -388,6 +388,8 @@ public class EmulationActivity extends AppCompatActivity implements SurfaceHolde
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT);
         else if (orientation.equals("landscape"))
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE);
+        else if (orientation.equals("sensor"))
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
         else
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
     }

--- a/android/app/src/main/res/values/arrays.xml
+++ b/android/app/src/main/res/values/arrays.xml
@@ -404,11 +404,13 @@
         <item>Use Device Setting</item>
         <item>Portrait</item>
         <item>Landscape</item>
+		<item>Sensor Based</item>
     </string-array>
     <string-array name="settings_emulation_screen_orientation_values">
         <item>unspecified</item>
         <item>portrait</item>
         <item>landscape</item>
+        <item>sensor</item>
     </string-array>
     <string-array name="settings_language_entries">
         <item>Use Device Setting</item>

--- a/android/app/src/main/res/values/arrays.xml
+++ b/android/app/src/main/res/values/arrays.xml
@@ -404,7 +404,7 @@
         <item>Use Device Setting</item>
         <item>Portrait</item>
         <item>Landscape</item>
-		<item>Sensor Based</item>
+        <item>Sensor Based</item>
     </string-array>
     <string-array name="settings_emulation_screen_orientation_values">
         <item>unspecified</item>


### PR DESCRIPTION
This PR will make it so the emulation activity will auto-rotate regardless of your system orientation. To enable, select "Sensor Based" under Emulation Screen Orientation.