### PR TITLE
Common/DimensionalArray: Re-revert the workaround

### DIFF
--- a/src/common/dimensional_array.h
+++ b/src/common/dimensional_array.h
@@ -29,8 +29,8 @@ namespace detail {
 template<typename T, std::size_t rank, std::size_t... sizes>
 struct DimensionalArrayExplicitRank;
 
-// Workaround for MSVC
-#if defined(_MSC_VER)
+// Workaround for VS2017 & VS 16.9.x
+#if defined(_MSC_VER) && (_MSC_VER < 1920 || _MSC_VER == 1928)
 
 template<std::size_t rank, std::size_t... sizes>
 struct GetRankSize


### PR DESCRIPTION
VS16.10 fixes the regression and bumps up _MSC_VER, so make only VS2017 and VS16.9 use the workaround