### PR TITLE
NoGUI: Fix autosave on shutdown when started with -resume

### DIFF
--- a/src/duckstation-nogui/main.cpp
+++ b/src/duckstation-nogui/main.cpp
@@ -69,6 +69,7 @@ static int Run(std::unique_ptr<NoGUIHostInterface> host_interface, std::unique_p
 
   if (boot_params)
     host_interface->BootSystem(*boot_params);
+  boot_params.reset(); // Need to free resume file handle so auto save on exit works
 
   int result;
   if (System::IsValid() || !host_interface->InBatchMode())


### PR DESCRIPTION
Currently, the nogui launcher fails to save resume files when started with the `-resume` arg due to it holding onto the initial file handle in the `boot_params` until program termination, after shutdown hooks and emulation have ended.

This is a simple solution to explicitly release the `boot_params` after they have been read.

I wouldn't consider this solution ideal in terms of overall design though, and I think ideally the pointer usage and ownership of the `boot_params` needs some cleanup. Unless you are against it, or if I find something better to do, I may submit a follow-up PR doing a small refactor of that.