### PR TITLE
Add an "Increase Safe Zone" option to move OSD messages further away from screen edges

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -365,4 +365,6 @@
     <string name="menu_edit_game_directories_force_saf">Force Scoped Storage</string>
     <string name="settings_expand_to_cutout">Expand To Cutout Area</string>
     <string name="settings_summary_expand_to_cutout">Expands the display area to include the cutout (or notch) area.</string>
+    <string name="settings_osd_increase_safe_zone">Increase Safe Zone</string>
+    <string name="settings_summary_osd_increase_safe_zone">Increase the margin of on-screen messages, prevents them being cut off on phones with rounded corners.</string>
 </resources>

--- a/android/app/src/main/res/xml/display_preferences.xml
+++ b/android/app/src/main/res/xml/display_preferences.xml
@@ -126,5 +126,11 @@
         app:defaultValue="false"
         app:summary="@string/settings_summary_osd_show_inputs"
         app:iconSpaceReserved="false" />
+    <SwitchPreferenceCompat
+        app:key="Display/IncreaseSafeZone"
+        app:title="@string/settings_osd_increase_safe_zone"
+        app:defaultValue="false"
+        app:summary="@string/settings_summary_osd_increase_safe_zone"
+        app:iconSpaceReserved="false" />
 
 </PreferenceScreen>

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -236,6 +236,7 @@ void Settings::Load(SettingsInterface& si)
   display_show_vps = si.GetBoolValue("Display", "ShowVPS", false);
   display_show_speed = si.GetBoolValue("Display", "ShowSpeed", false);
   display_show_resolution = si.GetBoolValue("Display", "ShowResolution", false);
+  display_increase_safe_zone = si.GetBoolValue("Display", "IncreaseSafeZone", false);
   display_all_frames = si.GetBoolValue("Display", "DisplayAllFrames", false);
   video_sync_enabled = si.GetBoolValue("Display", "VSync", DEFAULT_VSYNC_VALUE);
   display_post_process_chain = si.GetStringValue("Display", "PostProcessChain", "");
@@ -409,6 +410,7 @@ void Settings::Save(SettingsInterface& si) const
   si.SetBoolValue("Display", "ShowVPS", display_show_vps);
   si.SetBoolValue("Display", "ShowSpeed", display_show_speed);
   si.SetBoolValue("Display", "ShowResolution", display_show_resolution);
+  si.SetBoolValue("Display", "IncreaseSafeZone", display_increase_safe_zone);
   si.SetBoolValue("Display", "DisplayAllFrames", display_all_frames);
   si.SetBoolValue("Display", "VSync", video_sync_enabled);
   if (display_post_process_chain.empty())

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -145,6 +145,7 @@ struct Settings
   bool display_show_vps = false;
   bool display_show_speed = false;
   bool display_show_resolution = false;
+  bool display_increase_safe_zone = false;
   bool display_all_frames = false;
   bool video_sync_enabled = DEFAULT_VSYNC_VALUE;
   float display_max_fps = DEFAULT_DISPLAY_MAX_FPS;

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1067,7 +1067,7 @@ void CommonHostInterface::DrawImGuiWindows()
 
 void CommonHostInterface::DrawFPSWindow()
 {
-  if (!(g_settings.display_show_fps | g_settings.display_show_vps | g_settings.display_show_speed |
+  if (!(g_settings.display_show_fps || g_settings.display_show_vps || g_settings.display_show_speed ||
         g_settings.display_show_resolution))
   {
     return;
@@ -1075,8 +1075,8 @@ void CommonHostInterface::DrawFPSWindow()
 
   const float scale = ImGui::GetIO().DisplayFramebufferScale.x;
   const float shadow_offset = 1.0f * scale;
-  float margin = 10.0f * scale;
-  float spacing = 5.0f * scale;
+  const float margin = (g_settings.display_increase_safe_zone ? 25.0f : 10.0f) * scale;
+  const float spacing = 5.0f * scale;
   float position_y = margin;
   ImDrawList* dl = ImGui::GetBackgroundDrawList();
   ImFont* font = ImGui::GetFont();
@@ -1229,7 +1229,7 @@ void CommonHostInterface::DrawOSDMessages()
 
   const float scale = ImGui::GetIO().DisplayFramebufferScale.x;
   const float spacing = 5.0f * scale;
-  const float margin = 10.0f * scale;
+  const float margin = (g_settings.display_increase_safe_zone ? 25.0f : 10.0f) * scale;
   const float padding = 8.0f * scale;
   const float rounding = 5.0f * scale;
   const float max_width = ImGui::GetIO().DisplaySize.x - margin;

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -3195,7 +3195,7 @@ void DrawStatsOverlay()
     return;
   }
 
-  const float margin = LayoutScale(10.0f);
+  const float margin = LayoutScale(g_settings.display_increase_safe_zone ? 25.0f : 10.0f);
   const float shadow_offset = DPIScale(1.0f);
   float position_y = ImGuiFullscreen::g_menu_bar_size + margin;
   ImDrawList* dl = ImGui::GetBackgroundDrawList();
@@ -3280,7 +3280,7 @@ void DrawOSDMessages()
 
   const float max_width = LayoutScale(1080.0f);
   const float spacing = LayoutScale(4.0f);
-  const float margin = LayoutScale(10.0f);
+  const float margin = LayoutScale(g_settings.display_increase_safe_zone ? 25.0f : 10.0f);
   const float padding = LayoutScale(10.0f);
   float position_x = margin;
   float position_y = margin + ImGuiFullscreen::g_menu_bar_size;


### PR DESCRIPTION
Useful for phones with rounded edges, as currently OSD messages are being cut off.

Untested, let's see what comes out of CI.