### PR TITLE
Misc improvements

### DIFF
--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -83,14 +83,14 @@ s32 HostInterface::GetAudioOutputVolume() const
   return g_settings.audio_output_muted ? 0 : g_settings.audio_output_volume;
 }
 
-bool HostInterface::BootSystem(const SystemBootParameters& parameters)
+bool HostInterface::BootSystem(std::shared_ptr<SystemBootParameters> parameters)
 {
-  if (!parameters.state_stream)
+  if (!parameters->state_stream)
   {
-    if (parameters.filename.empty())
+    if (parameters->filename.empty())
       Log_InfoPrintf("Boot Filename: <BIOS/Shell>");
     else
-      Log_InfoPrintf("Boot Filename: %s", parameters.filename.c_str());
+      Log_InfoPrintf("Boot Filename: %s", parameters->filename.c_str());
   }
 
   if (!AcquireHostDisplay())
@@ -108,7 +108,7 @@ bool HostInterface::BootSystem(const SystemBootParameters& parameters)
   // create the audio stream. this will never fail, since we'll just fall back to null
   CreateAudioStream();
 
-  if (!System::Boot(parameters))
+  if (!System::Boot(*parameters))
   {
     if (!System::IsStartupCancelled())
     {
@@ -417,9 +417,9 @@ bool HostInterface::LoadState(const char* filename)
   }
   else
   {
-    SystemBootParameters boot_params;
-    boot_params.state_stream = std::move(stream);
-    if (!BootSystem(boot_params))
+    auto boot_params = std::make_shared<SystemBootParameters>();
+    boot_params->state_stream = std::move(stream);
+    if (!BootSystem(std::move(boot_params)))
       return false;
   }
 
@@ -1164,9 +1164,9 @@ void HostInterface::RecreateSystem()
 
   DestroySystem();
 
-  SystemBootParameters boot_params;
-  boot_params.state_stream = std::move(stream);
-  if (!BootSystem(boot_params))
+  auto boot_params = std::make_shared<SystemBootParameters>();
+  boot_params->state_stream = std::move(stream);
+  if (!BootSystem(std::move(boot_params)))
   {
     ReportError("Failed to boot system after recreation.");
     return;

--- a/src/core/host_interface.h
+++ b/src/core/host_interface.h
@@ -51,7 +51,7 @@ public:
   /// Shuts down the emulator frontend.
   virtual void Shutdown();
 
-  virtual bool BootSystem(const SystemBootParameters& parameters);
+  virtual bool BootSystem(std::shared_ptr<SystemBootParameters> parameters);
   virtual void PauseSystem(bool paused);
   virtual void ResetSystem();
   virtual void DestroySystem();

--- a/src/duckstation-nogui/main.cpp
+++ b/src/duckstation-nogui/main.cpp
@@ -68,8 +68,7 @@ static int Run(std::unique_ptr<NoGUIHostInterface> host_interface, std::unique_p
   }
 
   if (boot_params)
-    host_interface->BootSystem(*boot_params);
-  boot_params.reset(); // Need to free resume file handle so auto save on exit works
+    host_interface->BootSystem(std::move(boot_params));
 
   int result;
   if (System::IsValid() || !host_interface->InBatchMode())

--- a/src/duckstation-qt/gamepropertiesdialog.cpp
+++ b/src/duckstation-qt/gamepropertiesdialog.cpp
@@ -311,6 +311,7 @@ void GamePropertiesDialog::populateGameSettings()
 
   populateBooleanUserSetting(m_ui.userEnableCPUClockSpeedControl, gs.cpu_overclock_enable);
   populateBooleanUserSetting(m_ui.userEnable8MBRAM, gs.enable_8mb_ram);
+  m_ui.userCPUClockSpeed->setEnabled(m_ui.userEnableCPUClockSpeedControl->checkState() != Qt::Unchecked);
   updateCPUClockSpeedLabel();
 
   if (gs.cdrom_read_speedup.has_value())
@@ -567,7 +568,7 @@ void GamePropertiesDialog::connectUi()
   connectBooleanUserSetting(m_ui.userEnableCPUClockSpeedControl, &m_game_settings.cpu_overclock_enable);
   connectBooleanUserSetting(m_ui.userEnable8MBRAM, &m_game_settings.enable_8mb_ram);
   connect(m_ui.userEnableCPUClockSpeedControl, &QCheckBox::stateChanged, this,
-          &GamePropertiesDialog::updateCPUClockSpeedLabel);
+          &GamePropertiesDialog::onEnableCPUClockSpeedControlChecked);
 
   connect(m_ui.userCPUClockSpeed, &QSlider::valueChanged, [this](int value) {
     if (value == 100)
@@ -856,9 +857,16 @@ void GamePropertiesDialog::connectUi()
 
 void GamePropertiesDialog::updateCPUClockSpeedLabel()
 {
-  const int percent = m_ui.userCPUClockSpeed->value();
+  const int percent =
+    m_ui.userEnableCPUClockSpeedControl->checkState() != Qt::Unchecked ? m_ui.userCPUClockSpeed->value() : 100;
   const double frequency = (static_cast<double>(System::MASTER_CLOCK) * static_cast<double>(percent)) / 100.0;
   m_ui.userCPUClockSpeedLabel->setText(tr("%1% (%2MHz)").arg(percent).arg(frequency / 1000000.0, 0, 'f', 2));
+}
+
+void GamePropertiesDialog::onEnableCPUClockSpeedControlChecked(int state)
+{
+  m_ui.userCPUClockSpeed->setEnabled(state != Qt::Unchecked);
+  updateCPUClockSpeedLabel();
 }
 
 void GamePropertiesDialog::onUserAspectRatioChanged()

--- a/src/duckstation-qt/gamepropertiesdialog.h
+++ b/src/duckstation-qt/gamepropertiesdialog.h
@@ -37,6 +37,7 @@ private Q_SLOTS:
   void onVerifyDumpClicked();
   void onExportCompatibilityInfoClicked();
   void updateCPUClockSpeedLabel();
+  void onEnableCPUClockSpeedControlChecked(int state);
 
 private:
   void setupAdditionalUi();

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -478,12 +478,12 @@ void MainWindow::onStartDiscActionTriggered()
   if (filename.isEmpty())
     return;
 
-  m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(filename.toStdString()));
+  m_host_interface->bootSystem(std::make_shared<SystemBootParameters>(filename.toStdString()));
 }
 
 void MainWindow::onStartBIOSActionTriggered()
 {
-  m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>());
+  m_host_interface->bootSystem(std::make_shared<SystemBootParameters>());
 }
 
 void MainWindow::onChangeDiscFromFileActionTriggered()
@@ -655,9 +655,8 @@ void MainWindow::onGameListContextMenuRequested(const QPoint& point, const GameL
       m_host_interface->populateGameListContextMenu(entry, this, &menu);
       menu.addSeparator();
 
-      connect(menu.addAction(tr("Default Boot")), &QAction::triggered, [this, entry]() {
-        m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(entry->path));
-      });
+      connect(menu.addAction(tr("Default Boot")), &QAction::triggered,
+              [this, entry]() { m_host_interface->bootSystem(std::make_shared<SystemBootParameters>(entry->path)); });
 
       connect(menu.addAction(tr("Fast Boot")), &QAction::triggered, [this, entry]() {
         auto boot_params = std::make_shared<SystemBootParameters>(entry->path);
@@ -976,7 +975,7 @@ void MainWindow::startGameOrChangeDiscs(const std::string& path)
     if (m_host_interface->CanResumeSystemFromFile(path.c_str()))
       m_host_interface->resumeSystemFromState(QString::fromStdString(path), true);
     else
-      m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(path));
+      m_host_interface->bootSystem(std::make_shared<SystemBootParameters>(path));
   }
   else
   {

--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -52,7 +52,7 @@ Log_SetChannel(QtHostInterface);
 
 QtHostInterface::QtHostInterface(QObject* parent) : QObject(parent), CommonHostInterface()
 {
-  qRegisterMetaType<std::shared_ptr<const SystemBootParameters>>();
+  qRegisterMetaType<std::shared_ptr<SystemBootParameters>>();
   qRegisterMetaType<const GameListEntry*>();
   qRegisterMetaType<GPURenderer>();
 }
@@ -333,17 +333,17 @@ void QtHostInterface::setMainWindow(MainWindow* window)
   m_main_window = window;
 }
 
-void QtHostInterface::bootSystem(std::shared_ptr<const SystemBootParameters> params)
+void QtHostInterface::bootSystem(std::shared_ptr<SystemBootParameters> params)
 {
   if (!isOnWorkerThread())
   {
     QMetaObject::invokeMethod(this, "bootSystem", Qt::QueuedConnection,
-                              Q_ARG(std::shared_ptr<const SystemBootParameters>, std::move(params)));
+                              Q_ARG(std::shared_ptr<SystemBootParameters>, std::move(params)));
     return;
   }
 
   emit emulationStarting();
-  if (!BootSystem(*params))
+  if (!BootSystem(std::move(params)))
     return;
 
   // force a frame to be drawn to repaint the window

--- a/src/duckstation-qt/qthostinterface.h
+++ b/src/duckstation-qt/qthostinterface.h
@@ -32,7 +32,7 @@ class INISettingsInterface;
 class MainWindow;
 class QtDisplayWidget;
 
-Q_DECLARE_METATYPE(std::shared_ptr<const SystemBootParameters>);
+Q_DECLARE_METATYPE(std::shared_ptr<SystemBootParameters>);
 Q_DECLARE_METATYPE(const GameListEntry*);
 Q_DECLARE_METATYPE(GPURenderer);
 
@@ -149,7 +149,7 @@ public Q_SLOTS:
   void applySettings(bool display_osd_messages = false);
   void updateInputMap();
   void applyInputProfile(const QString& profile_path);
-  void bootSystem(std::shared_ptr<const SystemBootParameters> params);
+  void bootSystem(std::shared_ptr<SystemBootParameters> params);
   void resumeSystemFromState(const QString& filename, bool boot_on_failure);
   void resumeSystemFromMostRecentState();
   void powerOffSystem();

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -168,13 +168,13 @@ void CommonHostInterface::InitializeUserDirectory()
     ReportError("Failed to create one or more user directories. This may cause issues at runtime.");
 }
 
-bool CommonHostInterface::BootSystem(const SystemBootParameters& parameters)
+bool CommonHostInterface::BootSystem(std::shared_ptr<SystemBootParameters> parameters)
 {
   // If the fullscreen UI is enabled, make sure it's finished loading the game list so we don't race it.
   if (m_display && m_fullscreen_ui_enabled)
     FullscreenUI::EnsureGameListLoaded();
 
-  ApplyRendererFromGameSettings(parameters.filename);
+  ApplyRendererFromGameSettings(parameters->filename);
 
   if (!HostInterface::BootSystem(parameters))
   {
@@ -186,8 +186,8 @@ bool CommonHostInterface::BootSystem(const SystemBootParameters& parameters)
   }
 
   // enter fullscreen if requested in the parameters
-  if (!g_settings.start_paused && ((parameters.override_fullscreen.has_value() && *parameters.override_fullscreen) ||
-                                   (!parameters.override_fullscreen.has_value() && g_settings.start_fullscreen)))
+  if (!g_settings.start_paused && ((parameters->override_fullscreen.has_value() && *parameters->override_fullscreen) ||
+                                   (!parameters->override_fullscreen.has_value() && g_settings.start_fullscreen)))
   {
     SetFullscreen(true);
   }
@@ -739,9 +739,7 @@ bool CommonHostInterface::CanResumeSystemFromFile(const char* filename)
 
 bool CommonHostInterface::ResumeSystemFromState(const char* filename, bool boot_on_failure)
 {
-  SystemBootParameters boot_params;
-  boot_params.filename = filename;
-  if (!BootSystem(boot_params))
+  if (!BootSystem(std::make_shared<SystemBootParameters>(filename)))
     return false;
 
   const bool global = System::GetRunningCode().empty();

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -2907,6 +2907,11 @@ void CommonHostInterface::FixIncompatibleSettings(bool display_osd_messages)
     g_settings.turbo_speed = (g_settings.turbo_speed != 0.0f) ? std::max(g_settings.turbo_speed, 1.0f) : 0.0f;
     g_settings.rewind_enable = false;
     g_settings.auto_load_cheats = false;
+    if (g_settings.cpu_overclock_enable && g_settings.GetCPUOverclockPercent() < 100)
+    {
+      g_settings.cpu_overclock_enable = false;
+      g_settings.UpdateOverclockActive();
+    }
     g_settings.debugging.enable_gdb_server = false;
     g_settings.debugging.show_vram = false;
     g_settings.debugging.show_gpu_state = false;

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -174,6 +174,11 @@ bool CommonHostInterface::BootSystem(std::shared_ptr<SystemBootParameters> param
   if (m_display && m_fullscreen_ui_enabled)
     FullscreenUI::EnsureGameListLoaded();
 
+  // In Challenge mode, do not allow loading a save state under any circumstances
+  // If it's present, drop it
+  if (IsCheevosChallengeModeActive())
+    parameters->state_stream.reset();
+
   ApplyRendererFromGameSettings(parameters->filename);
 
   if (!HostInterface::BootSystem(parameters))

--- a/src/frontend-common/common_host_interface.h
+++ b/src/frontend-common/common_host_interface.h
@@ -129,7 +129,7 @@ public:
 
   virtual void Shutdown() override;
 
-  virtual bool BootSystem(const SystemBootParameters& parameters) override;
+  virtual bool BootSystem(std::shared_ptr<SystemBootParameters> parameters) override;
   virtual void ResetSystem() override;
   virtual void DestroySystem() override;
 

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -551,9 +551,7 @@ static void DoStartPath(const std::string& path, bool allow_resume)
     return;
   }
 
-  SystemBootParameters params;
-  params.filename = path;
-  s_host_interface->BootSystem(params);
+  s_host_interface->BootSystem(std::make_shared<SystemBootParameters>(path));
 }
 
 static void DoStartFile()
@@ -571,10 +569,7 @@ static void DoStartFile()
 
 static void DoStartBIOS()
 {
-  s_host_interface->RunLater([]() {
-    SystemBootParameters boot_params;
-    s_host_interface->BootSystem(boot_params);
-  });
+  s_host_interface->RunLater([]() { s_host_interface->BootSystem(std::make_shared<SystemBootParameters>()); });
   ClearImGuiFocus();
 }
 

--- a/src/frontend-common/save_state_selector_ui.cpp
+++ b/src/frontend-common/save_state_selector_ui.cpp
@@ -278,12 +278,16 @@ void SaveStateSelectorUI::Draw()
       ImGui::SetCursorPosX(padding);
       ImGui::BeginTable("table", 2);
 
+      const bool hide_load_button = m_host_interface->IsCheevosChallengeModeActive();
       ImGui::TableNextColumn();
-      ImGui::TextUnformatted(m_load_legend.c_str());
+      ImGui::TextUnformatted(!hide_load_button ? m_load_legend.c_str() : m_save_legend.c_str());
       ImGui::TableNextColumn();
       ImGui::TextUnformatted(m_prev_legend.c_str());
       ImGui::TableNextColumn();
-      ImGui::TextUnformatted(m_save_legend.c_str());
+      if (!hide_load_button)
+      {
+        ImGui::TextUnformatted(m_save_legend.c_str());
+      }
       ImGui::TableNextColumn();
       ImGui::TextUnformatted(m_next_legend.c_str());
 


### PR DESCRIPTION
A bunch of loosely related improvements:

* Hide the `Load` button in the save state UI when playing in Hardcore mode (as loading save states is impossible).
* Disallow underclocking in Hardcore mode. Any means of slowing the game down are supposed to be blocked, but the user could still try to slow the game down by underclocking the emulated console. Now clock speeds below 100% are forbidden, just like it was already done with game speed settings (faster is OK, slower is not).
* Disallow loading the save state and/or the resume save state via the command line in Hardcore mode. This could be considered an exploit, so it needs to go.
* Unify CPU clock speed behaviour in Game Properties and Console Settings - now the CPU clock slider is greyed out when overclocking is disabled, and the clock speed shows as 100% when overclocking is disabled.