### PR TITLE
Two bugfixes and slight refactor of the boot parameter code as a followup to #2210

### DIFF
--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -914,8 +914,7 @@ void HostInterface::CheckForSettingsChanges(const Settings& old_settings)
 
 void HostInterface::SetUserDirectoryToProgramDirectory()
 {
-  const std::string program_directory(FileSystem::GetProgramPath());
-  m_user_directory = program_directory;
+  m_user_directory = m_program_directory;
 }
 
 void HostInterface::OnHostDisplayResized()

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -20,15 +20,18 @@ class CheatList;
 struct SystemBootParameters
 {
   SystemBootParameters();
+  SystemBootParameters(const SystemBootParameters& other);
   SystemBootParameters(SystemBootParameters&& other);
-  SystemBootParameters(std::string filename_);
+  explicit SystemBootParameters(std::string filename_);
   ~SystemBootParameters();
 
+  bool hasFile() const;
+
   std::string filename;
+  std::string state_filename;
   std::optional<bool> override_fast_boot;
   std::optional<bool> override_fullscreen;
   std::optional<bool> override_start_paused;
-  std::unique_ptr<ByteStream> state_stream;
   u32 media_playlist_index = 0;
   bool load_image_to_ram = false;
   bool force_software_renderer = false;

--- a/src/duckstation-nogui/nogui_host_interface.cpp
+++ b/src/duckstation-nogui/nogui_host_interface.cpp
@@ -260,7 +260,7 @@ void NoGUIHostInterface::ReportError(const char* message)
   if (!m_display)
     return;
 
-  const bool was_in_frame = GImGui->FrameCount != GImGui->FrameCountEnded;
+  const bool was_in_frame = GImGui->FrameCount && GImGui->FrameCount != GImGui->FrameCountEnded;
   if (was_in_frame)
     ImGui::EndFrame();
 

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -478,12 +478,12 @@ void MainWindow::onStartDiscActionTriggered()
   if (filename.isEmpty())
     return;
 
-  m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(filename.toStdString()));
+  m_host_interface->bootSystem(SystemBootParameters(filename.toStdString()));
 }
 
 void MainWindow::onStartBIOSActionTriggered()
 {
-  m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>());
+  m_host_interface->bootSystem(SystemBootParameters());
 }
 
 void MainWindow::onChangeDiscFromFileActionTriggered()
@@ -656,18 +656,18 @@ void MainWindow::onGameListContextMenuRequested(const QPoint& point, const GameL
       menu.addSeparator();
 
       connect(menu.addAction(tr("Default Boot")), &QAction::triggered, [this, entry]() {
-        m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(entry->path));
+        m_host_interface->bootSystem(SystemBootParameters(entry->path));
       });
 
       connect(menu.addAction(tr("Fast Boot")), &QAction::triggered, [this, entry]() {
-        auto boot_params = std::make_shared<SystemBootParameters>(entry->path);
-        boot_params->override_fast_boot = true;
+        auto boot_params = SystemBootParameters(entry->path);
+        boot_params.override_fast_boot = true;
         m_host_interface->bootSystem(std::move(boot_params));
       });
 
       connect(menu.addAction(tr("Full Boot")), &QAction::triggered, [this, entry]() {
-        auto boot_params = std::make_shared<SystemBootParameters>(entry->path);
-        boot_params->override_fast_boot = false;
+        auto boot_params = SystemBootParameters(entry->path);
+        boot_params.override_fast_boot = false;
         m_host_interface->bootSystem(std::move(boot_params));
       });
 
@@ -676,8 +676,8 @@ void MainWindow::onGameListContextMenuRequested(const QPoint& point, const GameL
         connect(menu.addAction(tr("Boot and Debug")), &QAction::triggered, [this, entry]() {
           m_open_debugger_on_start = true;
 
-          auto boot_params = std::make_shared<SystemBootParameters>(entry->path);
-          boot_params->override_start_paused = true;
+          auto boot_params = SystemBootParameters(entry->path);
+          boot_params.override_start_paused = true;
           m_host_interface->bootSystem(std::move(boot_params));
         });
       }
@@ -976,7 +976,7 @@ void MainWindow::startGameOrChangeDiscs(const std::string& path)
     if (m_host_interface->CanResumeSystemFromFile(path.c_str()))
       m_host_interface->resumeSystemFromState(QString::fromStdString(path), true);
     else
-      m_host_interface->bootSystem(std::make_shared<const SystemBootParameters>(path));
+      m_host_interface->bootSystem(SystemBootParameters(path));
   }
   else
   {

--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -52,7 +52,7 @@ Log_SetChannel(QtHostInterface);
 
 QtHostInterface::QtHostInterface(QObject* parent) : QObject(parent), CommonHostInterface()
 {
-  qRegisterMetaType<std::shared_ptr<const SystemBootParameters>>();
+  qRegisterMetaType<SystemBootParameters>();
   qRegisterMetaType<const GameListEntry*>();
   qRegisterMetaType<GPURenderer>();
 }
@@ -333,17 +333,16 @@ void QtHostInterface::setMainWindow(MainWindow* window)
   m_main_window = window;
 }
 
-void QtHostInterface::bootSystem(std::shared_ptr<const SystemBootParameters> params)
+void QtHostInterface::bootSystem(SystemBootParameters params)
 {
   if (!isOnWorkerThread())
   {
-    QMetaObject::invokeMethod(this, "bootSystem", Qt::QueuedConnection,
-                              Q_ARG(std::shared_ptr<const SystemBootParameters>, std::move(params)));
+    QMetaObject::invokeMethod(this, "bootSystem", Qt::QueuedConnection, Q_ARG(SystemBootParameters, std::move(params)));
     return;
   }
 
   emit emulationStarting();
-  if (!BootSystem(*params))
+  if (!BootSystem(params))
     return;
 
   // force a frame to be drawn to repaint the window

--- a/src/duckstation-qt/qthostinterface.h
+++ b/src/duckstation-qt/qthostinterface.h
@@ -32,7 +32,7 @@ class INISettingsInterface;
 class MainWindow;
 class QtDisplayWidget;
 
-Q_DECLARE_METATYPE(std::shared_ptr<const SystemBootParameters>);
+Q_DECLARE_METATYPE(SystemBootParameters);
 Q_DECLARE_METATYPE(const GameListEntry*);
 Q_DECLARE_METATYPE(GPURenderer);
 
@@ -149,7 +149,7 @@ public Q_SLOTS:
   void applySettings(bool display_osd_messages = false);
   void updateInputMap();
   void applyInputProfile(const QString& profile_path);
-  void bootSystem(std::shared_ptr<const SystemBootParameters> params);
+  void bootSystem(SystemBootParameters params);
   void resumeSystemFromState(const QString& filename, bool boot_on_failure);
   void resumeSystemFromMostRecentState();
   void powerOffSystem();

--- a/src/frontend-common/common_host_interface.h
+++ b/src/frontend-common/common_host_interface.h
@@ -156,7 +156,7 @@ public:
   ALWAYS_INLINE bool IsFullscreenUIEnabled() const { return m_fullscreen_ui_enabled; }
 
   /// Parses command line parameters for all frontends.
-  bool ParseCommandLineParameters(int argc, char* argv[], std::unique_ptr<SystemBootParameters>* out_boot_params);
+  std::optional<SystemBootParameters> ParseCommandLineParameters(int argc, char* argv[]);
 
   /// Returns a path where an input profile with the specified name would be saved.
   std::string GetSavePathForInputProfile(const char* name) const;

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -551,9 +551,7 @@ static void DoStartPath(const std::string& path, bool allow_resume)
     return;
   }
 
-  SystemBootParameters params;
-  params.filename = path;
-  s_host_interface->BootSystem(params);
+  s_host_interface->BootSystem(SystemBootParameters(path));
 }
 
 static void DoStartFile()
@@ -572,8 +570,7 @@ static void DoStartFile()
 static void DoStartBIOS()
 {
   s_host_interface->RunLater([]() {
-    SystemBootParameters boot_params;
-    s_host_interface->BootSystem(boot_params);
+    s_host_interface->BootSystem(SystemBootParameters());
   });
   ClearImGuiFocus();
 }


### PR DESCRIPTION
Don't open resume file during command line parsing, do it from the scope that calls LoadState in order to minimize the scope of filesystem locks.
Stopped using pointers for boot params since they aren't shared and are now all stack data.

Up to you if you actually want to merge this since it's just meant as minor code cleanup. The two smaller commits are fixing actual bugs though, so if you don't want the larger refactor, you can cherry-pick those two, or I can submit a separate PR if you prefer.