### PR TITLE
Add an "Unofficial Test Mode" to allow unlocking non-core achievements

### DIFF
--- a/src/duckstation-qt/achievementsettingswidget.cpp
+++ b/src/duckstation-qt/achievementsettingswidget.cpp
@@ -18,6 +18,8 @@ AchievementSettingsWidget::AchievementSettingsWidget(QtHostInterface* host_inter
 
   SettingWidgetBinder::BindWidgetToBoolSetting(m_host_interface, m_ui.richPresence, "Cheevos", "RichPresence", true);
   SettingWidgetBinder::BindWidgetToBoolSetting(m_host_interface, m_ui.testMode, "Cheevos", "TestMode", false);
+  SettingWidgetBinder::BindWidgetToBoolSetting(m_host_interface, m_ui.unofficialTestMode, "Cheevos",
+                                               "UnofficialTestMode", false);
   SettingWidgetBinder::BindWidgetToBoolSetting(m_host_interface, m_ui.useFirstDiscFromPlaylist, "Cheevos",
                                                "UseFirstDiscFromPlaylist", true);
   m_ui.enable->setChecked(m_host_interface->GetBoolSettingValue("Cheevos", "Enabled", false));
@@ -28,6 +30,10 @@ AchievementSettingsWidget::AchievementSettingsWidget(QtHostInterface* host_inter
   dialog->registerWidgetHelp(m_ui.testMode, tr("Enable Test Mode"), tr("Unchecked"),
                              tr("When enabled, DuckStation will assume all achievements are locked and not send any "
                                 "unlock notifications to the server."));
+  dialog->registerWidgetHelp(
+    m_ui.unofficialTestMode, tr("Test Unofficial Achievements"), tr("Unchecked"),
+    tr("When enabled, DuckStation will list achievements from unofficial sets. Please note that these achievements are "
+       "not tracked by RetroAchievements, so they unlock every time."));
   dialog->registerWidgetHelp(
     m_ui.richPresence, tr("Enable Rich Presence"), tr("Unchecked"),
     tr("When enabled, rich presence information will be collected and sent to the server where supported."));

--- a/src/duckstation-qt/achievementsettingswidget.ui
+++ b/src/duckstation-qt/achievementsettingswidget.ui
@@ -67,6 +67,13 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="unofficialTestMode">
+        <property name="text">
+         <string>Test Unofficial Achievements</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/frontend-common/cheevos.h
+++ b/src/frontend-common/cheevos.h
@@ -23,6 +23,7 @@ struct Achievement
   std::string locked_badge_path;
   std::string unlocked_badge_path;
   u32 points;
+  AchievementCategory category;
   bool locked;
   bool active;
 };
@@ -56,13 +57,15 @@ ALWAYS_INLINE u32 GetGameID()
   return g_game_id;
 }
 
-bool Initialize(bool test_mode, bool use_first_disc_from_playlist, bool enable_rich_presence, bool challenge_mode);
+bool Initialize(bool test_mode, bool use_first_disc_from_playlist, bool enable_rich_presence, bool challenge_mode,
+                bool include_unofficial);
 void Reset();
 void Shutdown();
 void Update();
 
 bool IsLoggedIn();
 bool IsTestModeActive();
+bool IsUnofficialTestModeActive();
 bool IsUsingFirstDiscFromPlaylist();
 bool IsRichPresenceEnabled();
 const std::string& GetUsername();

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -2807,6 +2807,7 @@ void CommonHostInterface::SetDefaultSettings(SettingsInterface& si)
 #ifdef WITH_CHEEVOS
   si.SetBoolValue("Cheevos", "Enabled", false);
   si.SetBoolValue("Cheevos", "TestMode", false);
+  si.SetBoolValue("Cheevos", "UnofficialTestMode", false);
   si.SetBoolValue("Cheevos", "UseFirstDiscFromPlaylist", true);
   si.DeleteValue("Cheevos", "Username");
   si.DeleteValue("Cheevos", "Token");
@@ -3818,11 +3819,13 @@ void CommonHostInterface::UpdateCheevosActive()
 {
   const bool cheevos_enabled = GetBoolSettingValue("Cheevos", "Enabled", false);
   const bool cheevos_test_mode = GetBoolSettingValue("Cheevos", "TestMode", false);
+  const bool cheevos_unofficial_test_mode = GetBoolSettingValue("Cheevos", "UnofficialTestMode", false);
   const bool cheevos_use_first_disc_from_playlist = GetBoolSettingValue("Cheevos", "UseFirstDiscFromPlaylist", true);
   const bool cheevos_rich_presence = GetBoolSettingValue("Cheevos", "RichPresence", true);
   const bool cheevos_hardcore = GetBoolSettingValue("Cheevos", "ChallengeMode", false);
 
   if (cheevos_enabled != Cheevos::IsActive() || cheevos_test_mode != Cheevos::IsTestModeActive() ||
+      cheevos_unofficial_test_mode != Cheevos::IsUnofficialTestModeActive() ||
       cheevos_use_first_disc_from_playlist != Cheevos::IsUsingFirstDiscFromPlaylist() ||
       cheevos_rich_presence != Cheevos::IsRichPresenceEnabled() ||
       cheevos_hardcore != Cheevos::IsChallengeModeEnabled())
@@ -3831,7 +3834,7 @@ void CommonHostInterface::UpdateCheevosActive()
     if (cheevos_enabled)
     {
       if (!Cheevos::Initialize(cheevos_test_mode, cheevos_use_first_disc_from_playlist, cheevos_rich_presence,
-                               cheevos_hardcore))
+                               cheevos_hardcore, cheevos_unofficial_test_mode))
         ReportError("Failed to initialize cheevos after settings change.");
     }
   }

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -2280,6 +2280,11 @@ void DrawSettingsWindow()
                                     "When enabled, DuckStation will assume all achievements are locked and not "
                                     "send any unlock notifications to the server.",
                                     "Cheevos", "TestMode", false);
+        settings_changed |=
+          ToggleButtonForNonSetting(ICON_FA_MEDAL "  Test Unofficial Achievements",
+                                    "When enabled, DuckStation will list achievements from unofficial sets. These "
+                                    "achievements are not tracked by RetroAchievements.",
+                                    "Cheevos", "UnofficialTestMode", false);
         settings_changed |= ToggleButtonForNonSetting(ICON_FA_COMPACT_DISC "  Use First Disc From Playlist",
                                                       "When enabled, the first disc in a playlist will be used for "
                                                       "achievements, regardless of which disc is active.",


### PR DESCRIPTION
As in the title, this PR adds an option to unlock local/unofficial achievements without sending them to the backend server. This behaviour corresponds to an "official" topic about unofficial achievements on RetroAchievements boards:
https://retroachievements.org/viewtopic.php?t=6715

Option not available on Android at the moment, but maybe it should be added?
![image](https://user-images.githubusercontent.com/7947461/121407160-4fa19e00-c95f-11eb-8518-14297566353a.png)
![image](https://user-images.githubusercontent.com/7947461/121406929-094c3f00-c95f-11eb-97a0-d4b9e06c248b.png)

