### PR TITLE
Fix a crash when shutting down emulation from the Hardcore mode confirmation prompt

### DIFF
--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -1203,6 +1203,7 @@ static bool ConfirmChallengeModeEnable()
   if (!s_host_interface->ConfirmMessage(message))
     return false;
 
+  SaveAndApplySettings();
   s_host_interface->PowerOffSystem(s_host_interface->ShouldSaveResumeState());
   return true;
 }
@@ -2266,8 +2267,6 @@ void DrawSettingsWindow()
           s_host_interface->RunLater([]() {
             if (!ConfirmChallengeModeEnable())
               s_host_interface->GetSettingsInterface()->SetBoolValue("Cheevos", "Enabled", false);
-            else
-              SaveAndApplySettings();
           });
         }
 
@@ -2293,8 +2292,6 @@ void DrawSettingsWindow()
           s_host_interface->RunLater([]() {
             if (!ConfirmChallengeModeEnable())
               s_host_interface->GetSettingsInterface()->SetBoolValue("Cheevos", "ChallengeMode", false);
-            else
-              SaveAndApplySettings();
           });
         }
 


### PR DESCRIPTION
This fixes a crash after the following steps:

1. Run DuckStation and start the game. Fullscreen UI has to be enabled, either by running the game from a NoGUI executable or by having the Fullscreen UI enabled for the Qt frontend.
2. Go to Achievement Settings and enable Hardcore Mode.
3. Say Yes when prompted for confirmation.
4. DuckStation crashes.