### PR TITLE
RetroAchievements Leaderboards implementation

### DIFF
--- a/dep/rcheevos/include/rc_url.h
+++ b/dep/rcheevos/include/rc_url.h
@@ -7,9 +7,11 @@
 extern "C" {
 #endif
 
-int rc_url_award_cheevo(char* buffer, size_t size, const char* user_name, const char* login_token, unsigned cheevo_id, int hardcore, const char* game_hash);
+int rc_url_award_cheevo(char* buffer, size_t size, const char* user_name, const char* login_token, unsigned cheevo_id,
+                        int hardcore, const char* game_hash);
 
-int rc_url_submit_lboard(char* buffer, size_t size, const char* user_name, const char* login_token, unsigned lboard_id, int value);
+int rc_url_submit_lboard(char* buffer, size_t size, const char* user_name, const char* login_token, unsigned lboard_id,
+                         int value);
 
 int rc_url_get_gameid(char* buffer, size_t size, const char* hash);
 
@@ -21,12 +23,21 @@ int rc_url_login_with_password(char* buffer, size_t size, const char* user_name,
 
 int rc_url_login_with_token(char* buffer, size_t size, const char* user_name, const char* login_token);
 
-int rc_url_get_unlock_list(char* buffer, size_t size, const char* user_name, const char* login_token, unsigned gameid, int hardcore);
+int rc_url_get_unlock_list(char* buffer, size_t size, const char* user_name, const char* login_token, unsigned gameid,
+                           int hardcore);
 
 int rc_url_post_playing(char* buffer, size_t size, const char* user_name, const char* login_token, unsigned gameid);
 
 int rc_url_ping(char* url_buffer, size_t url_buffer_size, char* post_buffer, size_t post_buffer_size,
                 const char* user_name, const char* login_token, unsigned gameid, const char* rich_presence);
+
+// Custom exports, static in upstream rcheevos
+int rc_url_append_unum(char* buffer, size_t buffer_size, size_t* buffer_offset, const char* param, unsigned value);
+
+int rc_url_append_str(char* buffer, size_t buffer_size, size_t* buffer_offset, const char* param, const char* value);
+
+int rc_url_build_dorequest(char* url_buffer, size_t url_buffer_size, size_t* buffer_offset, const char* api,
+                           const char* user_name);
 
 #ifdef __cplusplus
 }

--- a/dep/rcheevos/src/rurl/url.c
+++ b/dep/rcheevos/src/rurl/url.c
@@ -293,7 +293,7 @@ static int rc_url_append_param_equals(char* buffer, size_t buffer_size, size_t b
   return written + (int)buffer_offset;
 }
 
-static int rc_url_append_unum(char* buffer, size_t buffer_size, size_t* buffer_offset, const char* param, unsigned value)
+int rc_url_append_unum(char* buffer, size_t buffer_size, size_t* buffer_offset, const char* param, unsigned value)
 {
   int written = rc_url_append_param_equals(buffer, buffer_size, *buffer_offset, param);
   if (written > 0) {
@@ -311,7 +311,7 @@ static int rc_url_append_unum(char* buffer, size_t buffer_size, size_t* buffer_o
   return -1;
 }
 
-static int rc_url_append_str(char* buffer, size_t buffer_size, size_t* buffer_offset, const char* param, const char* value)
+int rc_url_append_str(char* buffer, size_t buffer_size, size_t* buffer_offset, const char* param, const char* value)
 {
   int written = rc_url_append_param_equals(buffer, buffer_size, *buffer_offset, param);
   if (written > 0)
@@ -330,7 +330,7 @@ static int rc_url_append_str(char* buffer, size_t buffer_size, size_t* buffer_of
   return -1;
 }
 
-static int rc_url_build_dorequest(char* url_buffer, size_t url_buffer_size, size_t* buffer_offset,
+int rc_url_build_dorequest(char* url_buffer, size_t url_buffer_size, size_t* buffer_offset,
    const char* api, const char* user_name)
 {
   const char* base_url = "https://retroachievements.org/dorequest.php";

--- a/src/frontend-common/cheevos.h
+++ b/src/frontend-common/cheevos.h
@@ -28,6 +28,14 @@ struct Achievement
   bool active;
 };
 
+struct Leaderboard
+{
+  u32 id;
+  std::string title;
+  std::string description;
+  std::string format;
+};
+
 extern bool g_active;
 extern bool g_challenge_mode;
 extern u32 g_game_id;
@@ -91,5 +99,6 @@ u32 GetMaximumPointsForGame();
 u32 GetCurrentPointsForGame();
 
 void UnlockAchievement(u32 achievement_id, bool add_notification = true);
+void SubmitLeaderboard(u32 leaderboard_id, int value);
 
 } // namespace Cheevos

--- a/src/frontend-common/cheevos.h
+++ b/src/frontend-common/cheevos.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "core/types.h"
 #include <functional>
+#include <optional>
 #include <string>
 
 class CDImage;
@@ -33,7 +34,15 @@ struct Leaderboard
   u32 id;
   std::string title;
   std::string description;
-  std::string format;
+  int format;
+};
+
+struct LeaderboardEntry
+{
+  std::string user;
+  std::string formatted_score;
+  u32 rank;
+  bool is_self;
 };
 
 extern bool g_active;
@@ -97,6 +106,12 @@ u32 GetUnlockedAchiementCount();
 u32 GetAchievementCount();
 u32 GetMaximumPointsForGame();
 u32 GetCurrentPointsForGame();
+
+bool EnumerateLeaderboards(std::function<bool(const Leaderboard&)> callback);
+std::optional<bool> TryEnumerateLeaderboardEntries(u32 id, std::function<bool(const LeaderboardEntry&)> callback);
+const Leaderboard* GetLeaderboardByID(u32 id);
+u32 GetLeaderboardCount();
+bool IsLeaderboardTimeType(const Leaderboard& leaderboard);
 
 void UnlockAchievement(u32 achievement_id, bool add_notification = true);
 void SubmitLeaderboard(u32 leaderboard_id, int value);

--- a/src/frontend-common/fullscreen_ui.h
+++ b/src/frontend-common/fullscreen_ui.h
@@ -19,6 +19,7 @@ enum class MainWindowType
   Settings,
   QuickMenu,
   Achievements,
+  Leaderboards,
 };
 
 enum class SettingsPage


### PR DESCRIPTION
This PR expands the existing RetroAchievements support to also cover leaderboards, a feature present in numerous games.

Example of a RA leaderboard for a PS1 game:
https://retroachievements.org/leaderboardinfo.php?i=19974

* Leaderboards adhere to the Test Mode - when enabled, no scores are submitted to the server.
* There is currently **no** paging support, I populate each leaderboard with a single request to obtain the top 15 entries (+ user's score, as that's how RA returns data). Paging may be added in the future, but it will require issuing additional requests to the RA server.
* Scores are not cached locally beyond the simplest possible cache - leaderboard results are persisted if the user keeps opening the same leaderboard over and over, and discarded upon opening a new leaderboard or submitting any new leaderboard score.
* UI is fully implemented, with every leaderboard previewable in a new Leaderboards menu. Leaderboards are populated asynchronously, and during that (brief) period of time the user will see a "Downloading leaderboard data..." message. Clicking the X button when a specific leaderboard is shown will **not** close the menu, instead it will take the user back to the "main" leaderboards list. I feel like this is preferable over closing the pause menu completely, as it'll allow the user to quickly preview multiple leaderboards.

![duckstation-qt-x64-DebugFast_3Jp7ttHVLY](https://user-images.githubusercontent.com/7947461/122623744-99942d80-d09d-11eb-920d-b35caa103153.png)
![duckstation-qt-x64-DebugFast_mDelVDKzsk](https://user-images.githubusercontent.com/7947461/122623749-9d27b480-d09d-11eb-97ef-b7af94931464.png)
![duckstation-qt-x64-DebugFast_xODBbBRXwp](https://user-images.githubusercontent.com/7947461/122623750-a022a500-d09d-11eb-91fb-477b04eb2d2c.png)
