### PR TITLE
Allow submitting entries to Leaderboards only in Hardcore Mode.

### DIFF
--- a/src/frontend-common/cheevos.cpp
+++ b/src/frontend-common/cheevos.cpp
@@ -587,6 +587,19 @@ static void DisplayAchievementSummary()
   {
     summary = GetHostInterface()->TranslateString("Cheevos", "This game has no achievements.");
   }
+  if (GetLeaderboardCount() > 0)
+  {
+    summary.push_back('\n');
+    if (g_challenge_mode)
+    {
+      summary.append(GetHostInterface()->TranslateString("Cheevos", "Leaderboards are enabled."));
+    }
+    else
+    {
+      summary.append(
+        GetHostInterface()->TranslateString("Cheevos", "Leaderboards are DISABLED because Hardcore Mode is off."));
+    }
+  }
 
   ImGuiFullscreen::AddNotification(10.0f, std::move(title), std::move(summary), s_game_icon);
 }
@@ -1343,6 +1356,13 @@ void SubmitLeaderboard(u32 leaderboard_id, int value)
   if (s_test_mode)
   {
     Log_WarningPrintf("Skipping sending leaderboard %u result to server because of test mode.", leaderboard_id);
+    return;
+  }
+
+  if (!g_challenge_mode)
+  {
+    Log_WarningPrintf("Skipping sending leaderboard %u result to server because Challenge mode is off.",
+                      leaderboard_id);
     return;
   }
 

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -4505,6 +4505,18 @@ void DrawLeaderboardsWindow()
       ImGui::PushFont(g_medium_font);
       ImGui::RenderTextClipped(summary_bb.Min, summary_bb.Max, text.GetCharArray(),
                                text.GetCharArray() + text.GetLength(), nullptr, ImVec2(0.0f, 0.0f), &summary_bb);
+
+      if (!IsCheevosHardcoreModeActive())
+      {
+        const ImRect hardcore_warning_bb(ImVec2(left, top), ImVec2(right, top + g_medium_font->FontSize));
+        top += g_medium_font->FontSize + spacing;
+
+        ImGui::RenderTextClipped(
+          hardcore_warning_bb.Min, hardcore_warning_bb.Max,
+          "Submitting scores is DISABLED because Hardcore Mode is off. Leaderboards are read-only.", nullptr, nullptr,
+          ImVec2(0.0f, 0.0f), &hardcore_warning_bb);
+      }
+
       ImGui::PopFont();
     }
 


### PR DESCRIPTION
This is a requirement from RetroAchievements I didn't account for previously.

Also updated the UI with (hopefully) sufficient warnings telling the player that leaderboards are read-only when booting in "softcore" mode:

![image](https://user-images.githubusercontent.com/7947461/122646957-2aace800-d122-11eb-9301-a4ec87a3dfb6.png)
![image](https://user-images.githubusercontent.com/7947461/122646961-2c76ab80-d122-11eb-84cc-0ee943f1b5b6.png)
