### PR TITLE
New F6 Cheat Type (IF,ELSE IF, ELSE structure)

### DIFF
--- a/src/core/cheats.h
+++ b/src/core/cheats.h
@@ -78,9 +78,13 @@ struct CheatCode
     ExtSkipIfNotGreater8 = 0xC4,
     ExtSkipIfNotLess16 = 0xC5,
     ExtSkipIfNotGreater16 = 0xC6,
+    ExtMultiConditionals = 0xF6,
 
     ExtCheatRegisters = 0x51,
     ExtCheatRegistersCompare = 0x52,
+    
+    ExtCompareBitsSet8 = 0xE4,   //Only used inside ExtMultiConditionals
+    ExtCompareBitsClear8 = 0xE5, //Only used inside ExtMultiConditionals
   };
 
   union Instruction


### PR DESCRIPTION
Cheat Type F6 lets you perform cheats in IF / ELSE IF / ELSE constructs along 
with multiple conditions for each one.

It supports conditions  D0, D1, D2, D3, E0, E1, E2, E3, A0, A1, A2, A3, D7 and 
two new types that will only be available in the F6 conditions :- 
E4 & E5 which are bit comparisons on bytes (set and clear). 

Any of those types which are "block conditionals" like D7 will be treated as a 
single condition with the other conditions so you wont need to worry about 
extra 00000000 FFFFs just for them (infact you can drop them completely apart
from the last 00000000 FFFF, which you can also drop if you have no trailing
cheat lines after the end of the construct.


#IF / ELSE IF / ELSE Statement Example with Notes
80001000 00000001   Setup Test Condition 1
80001004 00000002   Setup Test Condition 2
80001008 00000003   Setup Test Condition 3
8000100C 00000004   Setup Test Condition 4

                    1F = IF, last two digits determine the number of conditions to check
                    F600000x  x = 0 All conditions must be true, x = 1 At least One condition must be true                  
F6000000 1F000004   Check the next 4 lines as the conditions for the IF loop to be taken

D0001000 00000001  )
D0001004 00000002  )Conditions
D0001008 00000003  )
D000100C 00000004  )

80001010 00005555    Poke(s)
00000000 0000FFFF  End of IF Statement

F6000000 E15E1F02  E15E1F = ELSE IF (same format as IF) - Can have multiple ELSE IF Blocks or none at all
D0001008 00000003  )
D000100C 00000005  )Conditions
80001010 00008888     Poke(s)
00000000 0000FFFF  End of ELSE IF Statement 

F6000000 E15E0000  E15E = ELSE (no need for conditions - this will poke if the others dont)
80001010 0000AAAA    Poke(s)
00000000 0000FFFF End of ELSE Statement



#Multiple Test Using Joypad Left Thumb Directions, Look at Address 1100 in Debugger
F6000000 1F000001  
D7020002 00100000
90001100 50205055
90001104 53534552 
90001108 20204445
9000110C 20202020
F6000000 E15E1F01
D7020002 00400000
90001100 4E574F44
90001104 45525020
90001108 44455353
9000110C 20202020
F6000000 E15E1F01
D7020002 00800000
90001100 5446454C
90001104 45525020
90001108 44455353
9000110C 20202020
F6000000 E15E1F01
D7020002 00200000
90001100 48474952
90001104 52502054
90001108 45535345
9000110C 20202044
F6000000 E15E0000
90001100 20202020
90001104 20202020
90001108 20202020
9000110C 20202020
00000000 0000FFFF