### PR TITLE
Cheat list fixes

### DIFF
--- a/src/duckstation-qt/cheatmanagerdialog.cpp
+++ b/src/duckstation-qt/cheatmanagerdialog.cpp
@@ -179,6 +179,8 @@ void CheatManagerDialog::connectUi()
   connect(m_ui.watchTable, &QTableWidget::currentItemChanged, this, &CheatManagerDialog::watchCurrentItemChanged);
   connect(m_ui.scanTable, &QTableWidget::itemChanged, this, &CheatManagerDialog::scanItemChanged);
   connect(m_ui.watchTable, &QTableWidget::itemChanged, this, &CheatManagerDialog::watchItemChanged);
+
+  connect(QtHostInterface::GetInstance(), &QtHostInterface::cheatEnabled, this, &CheatManagerDialog::setCheatCheckState);
 }
 
 void CheatManagerDialog::showEvent(QShowEvent* event)
@@ -488,17 +490,22 @@ void CheatManagerDialog::activateCheat(u32 index)
   }
 
   const bool new_enabled = !cc.enabled;
-  QTreeWidgetItem* item = getItemForCheatIndex(index);
-  if (item)
-  {
-    QSignalBlocker sb(m_ui.cheatList);
-    item->setCheckState(0, new_enabled ? Qt::Checked : Qt::Unchecked);
-  }
+  setCheatCheckState(index, new_enabled);
 
   QtHostInterface::GetInstance()->executeOnEmulationThread([index, new_enabled]() {
     System::GetCheatList()->SetCodeEnabled(index, new_enabled);
     QtHostInterface::GetInstance()->SaveCheatList();
   });
+}
+
+void CheatManagerDialog::setCheatCheckState(u32 index, bool checked)
+{
+  QTreeWidgetItem* item = getItemForCheatIndex(index);
+  if (item)
+  {
+    QSignalBlocker sb(m_ui.cheatList);
+    item->setCheckState(0, checked ? Qt::Checked : Qt::Unchecked);
+  }
 }
 
 void CheatManagerDialog::newCategoryClicked()

--- a/src/duckstation-qt/cheatmanagerdialog.h
+++ b/src/duckstation-qt/cheatmanagerdialog.h
@@ -31,6 +31,7 @@ private Q_SLOTS:
   void cheatListItemActivated(QTreeWidgetItem* item);
   void cheatListItemChanged(QTreeWidgetItem* item, int column);
   void activateCheat(u32 index);
+  void setCheatCheckState(u32 index, bool checked);
   void newCategoryClicked();
   void addCodeClicked();
   void editCodeClicked();

--- a/src/duckstation-qt/qthostinterface.cpp
+++ b/src/duckstation-qt/qthostinterface.cpp
@@ -1279,6 +1279,7 @@ void QtHostInterface::setCheatEnabled(quint32 index, bool enabled)
   }
 
   SetCheatCodeState(index, enabled, g_settings.auto_load_cheats);
+  emit cheatEnabled(index, enabled);
 }
 
 void QtHostInterface::applyCheat(quint32 index)

--- a/src/duckstation-qt/qthostinterface.h
+++ b/src/duckstation-qt/qthostinterface.h
@@ -148,6 +148,7 @@ Q_SIGNALS:
   void inputProfileLoaded();
   void mouseModeRequested(bool relative, bool hide_cursor);
   void achievementsLoaded(quint32 id, const QString& game_info_string, quint32 total, quint32 points);
+  void cheatEnabled(quint32 index, bool enabled);
 
 public Q_SLOTS:
   void setDefaultSettings();

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -3891,6 +3891,8 @@ void CommonHostInterface::SetCheatCodeState(u32 index, bool enabled, bool save_t
     return;
 
   cc.enabled = enabled;
+  if (!enabled)
+    cc.ApplyOnDisable();
 
   if (enabled)
   {


### PR DESCRIPTION
Fixes two bugs with the dropdown cheat list:

1. Toggling cheats off from this list would not fire `ApplyOnDisable`, so it was inconsistent with the Cheat Manager.
2. Toggling cheats on/off from this list would not update the visual state of the Cheat Manager.