### PR TITLE
CommonHostInterface: Fix broken word wrap in DrawOSDMessages

### DIFF
--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -1504,8 +1504,8 @@ void CommonHostInterface::DrawOSDMessages()
       break;
 
     const ImVec2 pos(position_x, position_y);
-    const ImVec2 text_size(
-      font->CalcTextSizeA(font->FontSize, max_width, -1.0f, msg.text.c_str(), msg.text.c_str() + msg.text.length()));
+    const ImVec2 text_size(font->CalcTextSizeA(font->FontSize, std::numeric_limits<float>::max(), max_width,
+                                               msg.text.c_str(), msg.text.c_str() + msg.text.length()));
     const ImVec2 size(text_size.x + padding * 2.0f, text_size.y + padding * 2.0f);
     const ImVec4 text_rect(pos.x + padding, pos.y + padding, pos.x + size.x - padding, pos.y + size.y - padding);
 


### PR DESCRIPTION
Fixes a regression introduced in e6ea6358a00c0689d9c4345c4d522e7929c83d0a where long OSD messages did not calculate the rect size with word wrap in mind, but they tried to draw with wrap, resulting in messages cut off like so:

![image](https://user-images.githubusercontent.com/7947461/133154155-5240ea39-88b0-4495-abc6-a081d7dd9d61.png)

Now word wrap works as expected again:
![image](https://user-images.githubusercontent.com/7947461/133154222-f98a406e-18f2-4867-a93d-cc36530f155a.png)
