### PR TITLE
Fix 4k on series consoles

### DIFF
--- a/src/duckstation-uwp/uwp_host_interface.cpp
+++ b/src/duckstation-uwp/uwp_host_interface.cpp
@@ -145,14 +145,11 @@ bool UWPHostInterface::CreateDisplay(bool fullscreen)
         GAMING_DEVICE_MODEL_INFORMATION gdinfo = {};
         if (SUCCEEDED(GetGamingDeviceModelInformation(&gdinfo)) && gdinfo.vendorId == GAMING_DEVICE_VENDOR_ID_MICROSOFT)
         {
-          if (gdinfo.deviceId != GAMING_DEVICE_DEVICE_ID_XBOX_ONE)
-          {
-            Log_InfoPrintf("Overriding core window size %ux%u with HDMI size %ux%u", wi.surface_width,
-                           wi.surface_height, hdmi_width, hdmi_height);
-            wi.surface_scale *= static_cast<float>(hdmi_width) / static_cast<float>(wi.surface_width);
-            wi.surface_width = hdmi_width;
-            wi.surface_height = hdmi_height;
-          }
+          Log_InfoPrintf("Overriding core window size %ux%u with HDMI size %ux%u", wi.surface_width,
+                         wi.surface_height, hdmi_width, hdmi_height);
+          wi.surface_scale *= static_cast<float>(hdmi_width) / static_cast<float>(wi.surface_width);
+          wi.surface_width = hdmi_width;
+          wi.surface_height = hdmi_height;
         }
       }
     }


### PR DESCRIPTION
Remove check for original Xbox One as it doesn't work on series consoles as they would be detected as original model Xboxes meaning that 4k wouldn't work.
Getting rid of this check has no adverse effects on the original Xbox one and makes 4k work properly on series x.
@gamr13 has validated that 4k now works on Xbox series consoles and I have validated that there are no adverse effects to original model Xbox ones.
![image](https://user-images.githubusercontent.com/26260613/135659202-c7ee1a1d-0622-4f07-a6d7-a5f29cd861a5.png)
