### PR TITLE
Set DSRINPUTLEVEL and CTSINPUTLEVEL to true for Armored Core

### DIFF
--- a/src/core/sio.cpp
+++ b/src/core/sio.cpp
@@ -114,6 +114,8 @@ void SIO::SoftReset()
 {
   m_SIO_CTRL.bits = 0;
   m_SIO_STAT.bits = 0;
+  m_SIO_STAT.DSRINPUTLEVEL = true;
+  m_SIO_STAT.CTSINPUTLEVEL = true;
   m_SIO_STAT.TXDONE = true;
   m_SIO_STAT.TXRDY = true;
   m_SIO_MODE.bits = 0;


### PR DESCRIPTION
Without this fix, Armored Core will assume that a link cable is plugged in and make the local multiplayer unavailable.
In the future, we should have proper link support but for now, let's just do this instead to at least allow people to play it locally.

Without the fix :
![no](https://user-images.githubusercontent.com/8717966/138585701-60342f35-7df7-4740-9572-b7605e99c7d2.png)

With the fix
![ar](https://user-images.githubusercontent.com/8717966/138585708-dd9878c5-cae5-4527-82ed-f6e84ea91a70.png)
