### PR TITLE
Fix usage of `free` for stack variable

### DIFF
--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -213,7 +213,7 @@ static ALWAYS_INLINE void FormatLogMessageAndPrintW(const char* channelName, con
   callback(wmessage_buf, wmessage_buflen);
 
   if (wmessage_buf != wbuf)
-    std::free(wbuf);
+    std::free(wmessage_buf);
 
   if (message_buf != buf)
     std::free(message_buf);


### PR DESCRIPTION
Based on warning from pvs static analyzer (https://habr.com/ru/company/pvs-studio/blog/586700/)