### PR TITLE
Update chtdb.txt

### DIFF
--- a/data/database/chtdb.txt
+++ b/data/database/chtdb.txt
@@ -113590,7 +113590,6 @@ A0010A4C 00008021
 90010A4C 8C70006C
 00000000 FFFF
 00000000 FFFF
-
 #True Endurance tweak (NTSC-J 1.1)
 ;"Help" the game unload segments that normally are left unwritten to,
 ;so further cheat detection is more reliable. This is safe as it overwrites dead code.

--- a/data/database/chtdb.txt
+++ b/data/database/chtdb.txt
@@ -28034,6 +28034,92 @@ A7016A7A 02250000
 D121F88A AEB4
 A7016A88 80000000
 00000000 FFFF
+#L3 to toggle Mirror (tap) and HUD (hold)
+A403EC74 02602021
+D7010001 00000200
+A0029524 1040000C
+;Always on
+90029524 00000001
+A0029524 0800A556
+;Default
+90029524 1040000C
+A0029524 00000000
+;Always off
+90029524 0800A556
+;Fixup canary
+A0029524 00000001
+90029524 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC74 02602021
+D701003C 00000200
+F5029434 0022A530
+F5029436 14400800
+F5029424 BA060000
+F5029426 0C000000
+00000000 FFFF
+00000000 FFFF
+#Enable extra cameras in race
+A401F888 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+;Replay off
+C30A92BC 0001
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F888 AEB40008
+;Hold R1 to trigger a cinematic camera
+;Replay off
+C30A92BC 0001
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+;Restore everything when replay is enabled
+A401F888 AEB40008
+C40A92BC 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+#True Endurance tweak
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A00529DC 801EFB39
+80057054 0000
+;Reset the race overlay for Simulation
+A0052A70 000000F6
+80057054 0000
+;Sets 2h Rome Endurance to 255 laps and hides the lap counter
+A4057054 260201C0
+;Set the endurance flag manually for 255 lap races, so replays work properly
+E01D586B 00FF
+E0046F69 0000
+30046F69 0001
+;Time limited race off
+E0046F69 0000
+;Restore the max laps counter
+A602CE24 00020006
+;Time limited race on
+C4046F69 0000
+;Turn off the max laps counter
+A702CE24 00060002
+;Set laps to 255
+E01D586B 0063
+301D586B 00FF
+00000000 FFFF
+00000000 FFFF
 
 ; [ Gran Turismo 2 (USA, v1.1) (1999) (Sony Computer Entertainment America) {SCUS-94455} <gt2a> ]
 :SCUS-94455
@@ -28130,18 +28216,7 @@ A61D5476 00020001
 A61FFA82 02000300
 #More Misc.\Replay Screen Clear (Arcade Disc)
 A61FFA8A 02000300
-#Widescreen 16-9
-D0010000 FFE8
-8007B2FC 0156
-D0010000 FFD0
-8007B2FC 03DE
-D0010000 FFE0
-8007B2FC 01AC
-8007B2FE 3402
-#Widescreen 16-9 option Better Graphics
-8006744C 0060
-8006744E 3404
-#16:9 Widescreen 2.0
+#16:9 Widescreen
 ;"Help" the game unload segments that normally are left unwritten to,
 ;so further cheat detection is more reliable. This is safe as it overwrites dead code.
 ;Reset the race overlay for Arcade
@@ -28213,7 +28288,7 @@ A701CDF4 00B30086
 A701CDFC FFCEFFDB
 A701CE04 03200258
 00000000 FFFF
-#21:9 Widescreen 2.0
+#21:9 Widescreen
 ;"Help" the game unload segments that normally are left unwritten to,
 ;so further cheat detection is more reliable. This is safe as it overwrites dead code.
 ;Reset the race overlay for Arcade
@@ -28410,6 +28485,92 @@ D121F88A AEB4
 A7016A7A 02250000
 D121F88A AEB4
 A7016A88 80000000
+00000000 FFFF
+#L3 to toggle Mirror (tap) and HUD (hold)
+A403EC6C 02602021
+D7010001 00000200
+A002951C 1040000C
+;Always on
+9002951C 00000001
+A002951C 0800A554
+;Default
+9002951C 1040000C
+A002951C 00000000
+;Always off
+9002951C 0800A554
+;Fixup canary
+A002951C 00000001
+9002951C 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC6C 02602021
+D701003C 00000200
+F502942C 0022A52E
+F502942E 14400800
+F502941C BA040000
+F502941E 0C000000
+00000000 FFFF
+00000000 FFFF
+#Enable extra cameras in race
+A401F888 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+;Replay off
+C30A92BC 0001
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F888 AEB40008
+;Hold R1 to trigger a cinematic camera
+;Replay off
+C30A92BC 0001
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+;Restore everything when replay is enabled
+A401F888 AEB40008
+C40A92BC 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+#True Endurance tweak
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+A0052A64 801EF8EF
+;Reset the race overlay for Arcade
+80057010 0000
+;Reset the race overlay for Simulation
+A0052B20 000000E7
+80057010 0000
+;Sets 2h Rome Endurance to 255 laps and hides the lap counter
+A4057010 260201C0
+;Set the endurance flag manually for 255 lap races, so replays work properly
+E01D563B 00FF
+E0046ED5 0000
+30046ED5 0001
+;Time limited race off
+E0046ED5 0000
+;Restore the max laps counter
+A602CE1C 00020006
+;Time limited race on
+C4046ED5 0000
+;Turn off the max laps counter
+A702CE1C 00060002
+;Set laps to 255
+E01D563B 0063
+301D563B 00FF
+00000000 FFFF
 00000000 FFFF
 
 ; [ Gran Turismo 2 (USA, v1.0) (1999) (Sony Computer Entertainment America) {SCUS-94455} <gt2b> ]
@@ -84650,18 +84811,7 @@ D01C97DA FFFE
 #Play Any Race With Any Car In Simulation Mode
 D0014908 000C
 8001490A 1000
-#Widescreen 16-9
-D0010000 FFE8
-8007B3E0 0156
-D0010000 FFD0
-8007B3E0 03DE
-D0010000 FFE0
-8007B3E0 01AC
-8007B3E2 3402
-#Widescreen 16-9 Better Graphics (Optional)
-8006752C 0060
-8006752E 3404
-#16:9 Widescreen 2.0
+#16:9 Widescreen
 ;"Help" the game unload segments that normally are left unwritten to,
 ;so further cheat detection is more reliable. This is safe as it overwrites dead code.
 ;Reset the race overlay for Arcade
@@ -84733,7 +84883,7 @@ A701CD68 00B30086
 A701CD70 FFCEFFDB
 A701CD78 03200258
 00000000 FFFF
-#21:9 Widescreen 2.0
+#21:9 Widescreen
 ;"Help" the game unload segments that normally are left unwritten to,
 ;so further cheat detection is more reliable. This is safe as it overwrites dead code.
 ;Reset the race overlay for Arcade
@@ -84848,6 +84998,92 @@ D121F886 AEB4
 A7016A76 02250000
 D121F886 AEB4
 A7016A84 80000000
+00000000 FFFF
+#L3 to toggle Mirror (tap) and HUD (hold)
+A403EC50 02602021
+D7010001 00000200
+A0029520 1040000C
+;Always on
+90029520 00000001
+A0029520 0800A555
+;Default
+90029520 1040000C
+A0029520 00000000
+;Always off
+90029520 0800A555
+;Fixup canary
+A0029520 00000001
+90029520 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC50 02602021
+D701003C 00000200
+F5029430 0022A52F
+F5029432 14400800
+F5029420 BA120000
+F5029422 0C000000
+00000000 FFFF
+00000000 FFFF
+#Enable extra cameras in race
+A401F884 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+;Replay off
+C30A954C 0001
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F884 AEB40008
+;Hold R1 to trigger a cinematic camera
+;Replay off
+C30A954C 0001
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+;Restore everything when replay is enabled
+A401F884 AEB40008
+C40A954C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+#True Endurance tweak
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A0052988 801EFB39
+80057090 0000
+;Reset the race overlay for Simulation
+A00529DC 000000F6
+80057090 0000
+;Sets 2h Rome Endurance to 255 laps and hides the lap counter
+A4057090 260201C0
+;Set the endurance flag manually for 255 lap races, so replays work properly
+E01D589B 00FF
+E0046F49 0000
+30046F49 0001
+;Time limited race off
+E0046F49 0000
+;Restore the max laps counter
+A602CE60 00020006
+;Time limited race on
+C4046F49 0000
+;Turn off the max laps counter
+A702CE60 00060002
+;Set laps to 255
+E01D589B 0063
+301D589B 00FF
+00000000 FFFF
 00000000 FFFF
 
 ; [ Grand Theft Auto 2 (Euro, Rev. 1) (1999) (Rockstar Games) {SLES-01404#} <gta2e> ]
@@ -112783,10 +113019,24 @@ D0091238 0000
 8003725C 0000
 
 ; [ Gradius Gaiden (Japan) Rev 1 {SLP-86103} ]
+;:SLP-86103
+;This game currently has no cheats
+
 ; [ Gradius Gaiden (Japan) {SLP-86042} ]
+;:SLP-86042
+;This game currently has no cheats
+
 ; [ Gran Turismo (France) Demo {SCED-01279} ]
+;:SCED-01279
+;This game currently has no cheats
+
 ; [ Gran Turismo (Japan) (Test Drive Disc) {PCPX-96085} ]
+;:PCPX-96085
+;This game currently has no cheats
+
 ; [ Gran Turismo (Japan) Demo {PAPX-90026} ]
+;:PAPX-90026
+;This game currently has no cheats
 
 ; [ Gran Turismo (Japan, Asia) {SCPS-10045} ]
 :SCPS-10045
@@ -112902,28 +113152,6 @@ D01F068A FFFE
 50000B02 0000
 801C9DE8 FFFF
 301C9F45 0001
-#Widescreen 16-9 v1.0
-D0010000 FFE8
-8007AEBC 0156
-D0010000 FFD0
-8007AEBC 03DE
-D0010000 FFE0
-8007AEBC 01AC
-8007AEBE 3402
-#Widescreen 16-9 v1.0 - Better Graphics (Optional)
-80067054 0060
-80067056 3404
-#Widescreen 16-9 V1.1
-D0010000 FFE8
-8007B28C 0156
-D0010000 FFD0
-8007B28C 03DE
-D0010000 FFE0
-8007B28C 01AC
-8007B28E 3402
-#Widescreen 16-9 v1.1 - Better Graphics (Optional)
-800673BC 0060
-800673BE 3404
 #16:9 Widescreen 2.0 (NTSC-J 1.0)
 ;"Help" the game unload segments that normally are left unwritten to,
 ;so further cheat detection is more reliable. This is safe as it overwrites dead code.
@@ -113140,7 +113368,7 @@ A701C9D4 00B30066
 A701C9DC FFCEFFE4
 A701C9E4 032001C9
 00000000 FFFF
-#21:9 Widescreen 2.0 (NTSC-J 1.1)
+#21:9 Widescreen (NTSC-J 1.1)
 ;"Help" the game unload segments that normally are left unwritten to,
 ;so further cheat detection is more reliable. This is safe as it overwrites dead code.
 ;Reset the race overlay for Arcade
@@ -113304,10 +113532,196 @@ A7016A72 02250000
 D121F882 AEB4
 A7016A80 80000000
 00000000 FFFF
+#L3 to toggle Mirror (tap) and HUD (hold) (NTSC-J 1.1)
+A403EBF0 02602021
+D7010001 00000200
+A0029544 1040000C
+;Always on
+90029544 00000001
+A0029544 0800A55E
+;Default
+90029544 1040000C
+A0029544 00000000
+;Always off
+90029544 0800A55E
+;Fixup canary
+A0029544 00000001
+90029544 00000000
+00000000 FFFF
+00000000 FFFF
+A403EBF0 02602021
+D701003C 00000200
+F5029454 0022A538
+F5029456 14400800
+F5029444 BA0E0000
+F5029446 0C000000
+00000000 FFFF
+00000000 FFFF
+#Enable extra cameras in race (Simulation Disc) (NTSC-J 1.1)
+A401F880 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+;Replay off
+C30A937C 0001
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F880 AEB40008
+;Hold R1 to trigger a cinematic camera
+;Replay off
+C30A937C 0001
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FF9AD 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+;Restore everything when replay is enabled
+A401F880 AEB40008
+C40A937C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+
+#True Endurance tweak (NTSC-J 1.1)
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A00527D4 801EF999
+80056F24 0000
+;Reset the race overlay for Simulation
+A005257C 000000F6
+80056F24 0000
+;Sets 2h Rome Endurance to 255 laps and hides the lap counter
+A4056F24 260201C0
+;Set the endurance flag manually for 255 lap races, so replays work properly
+E01D56CB 00FF
+E0046EC5 0000
+30046EC5 0001
+;Time limited race off
+E0046EC5 0000
+;Restore the max laps counter
+A602CE44 00020006
+;Time limited race on
+C4046EC5 0000
+;Turn off the max laps counter
+A702CE44 00060002
+;Set laps to 255
+E01D56CB 0063
+301D56CB 00FF
+00000000 FFFF
+00000000 FFFF
+#L3 to toggle Mirror (tap) and HUD (hold) (NTSC-J 1.0)
+A403EC18 02602021
+D7010001 00000200
+A0029474 1040000C
+;Always on
+90029474 00000001
+A0029474 0800A52A
+;Default
+90029474 1040000C
+A0029474 00000000
+;Always off
+90029474 0800A52A
+;Fixup canary
+A0029474 00000001
+90029474 00000000
+00000000 FFFF
+00000000 FFFF
+A403EC18 02602021
+D701003C 00000200
+F5029384 0022A504
+F5029386 14400800
+F5029374 B9DC0000
+F5029376 0C000000
+00000000 FFFF
+00000000 FFFF
+#Enable extra cameras in race (Simulation Disc) (NTSC-J 1.0)
+A401F794 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+;Replay off
+C30A9D1C 0001
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F794 AEB40008
+;Hold R1 to trigger a cinematic camera
+;Replay off
+C30A9D1C 0001
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA81 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+;Restore everything when replay is enabled
+A401F794 AEB40008
+C40A9D1C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
+#Enable extra cameras in race (Arcade Disc) (NTSC-J 1.0)
+A401F794 AEB40008
+A701031C 00030009
+A7010370 40F045C1
+;Replay off
+C30A9D0C 0001
+A701171C 0106010E
+A7011778 45E945D7
+00000000 FFFF
+00000000 FFFF
+A401F794 AEB40008
+;Hold R1 to trigger a cinematic camera
+;Replay off
+C30A9D0C 0001
+D701001E 01000008
+F5010148 40B6427F
+F5010A4C 006C8021
+F5010A4E 8C700000
+301FFA89 0002
+00000000 FFFF
+00000000 FFFF
+00000000 FFFF
+;Restore everything when replay is enabled
+A401F794 AEB40008
+C40A9D0C 0000
+D001171C 010E
+8001171C 0106
+D0011778 45D7
+80011778 45E9
+A0010A4C 00008021
+90010A4C 8C70006C
+00000000 FFFF
+00000000 FFFF
 
 ; [ Gran Turismo 2 (Disc 2) (Gran Turismo) (Japan) Rev 1 {SCPS-91327} ]
+;:SCPS-91327
+;This game currently has no cheats
+
 ; [ Gran Turismo 2 (Japan) (Test Drive Disc) {PAPX-90054} ]
+;:PAPX-90054
+;This game currently has no cheats
+
 ; [ Gran Turismo 2 (Un CD Bonus) (France) {SCED-02904} ]
+;:SCED-02904
+;This game currently has no cheats
 
 ; [ Grand Theft Auto (Europe) (EDC Platinum, Collector's Edition) {SLES-00032} ]
 :SLES-00032

--- a/data/database/chtdb.txt
+++ b/data/database/chtdb.txt
@@ -27501,6 +27501,12 @@ D004E2AC 0042
 9009B8F4 3B9ACA00
 #Drive through Background
 A70243A2 04411000
+#60 FPS (+Re-enable tire smoke, Re-enable rear view mirror)
+A60B6348 00020001
+A702E548 00020001
+A702AA3C 00020001
+#Simulation timescale in Arcade (100% instead of 125%)
+A7051C6C 007D0064
 
 ; [ Gran Turismo (USA, v1.0) (1998) (Sony Computer Entertainment America) {SCUS-94194} <gt1a> ]
 :SCUS-94194
@@ -27645,6 +27651,10 @@ D004E2AC 0042
 3004E2AC 0002
 #Simulation Mode 1 Billion Dollars
 9009B8F4 3B9ACA00
+#60 FPS (+e-enable tire smoke, re-enable rear view mirror)
+A60B6318 00020001
+A702E580 00020001
+A702AA74 00020001
 
 ; [ Gran Turismo 2 (USA, v1.2) (1999) (Sony Computer Entertainment America) {SCUS-94488} <gt2> ]
 :SCUS-94488
@@ -27756,6 +27766,274 @@ D0010000 FFE0
 #Widescreen 16-9 option Better Graphics
 800674EC 0060
 800674EE 3404
+#16:9 Widescreen 2.0
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A40529DC 801EFB39
+8005D5DC 0000
+80057054 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A4052A70 000000F6
+8005D5DC 0000
+80057054 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A4020A90 3084007F
+A701E578 FF80FF56
+A701E580 008000AA
+;Car Selection 2P Battle (Arcade)
+A70201C4 FF97FF74
+A70201CC 0069008C
+;Pre-race screen (Arcade)
+A701536C 014001AA
+00000000 FFFF
+;Race
+A401F888 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+;Race (Rear view mirror)
+A403EC74 02602021
+A70295EC FFC4FFB0
+A70295F0 003C0050
+00000000 FFFF
+;Post-race screen #1
+A4057054 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A70497CA A485A489
+A7049F48 00C8010A
+A7049F50 302100C8
+A7049F52 00A03406
+A704C194 00C8010A
+A704C19C 302100C8
+A704C19E 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704E07C 00000160
+A704E07E 00002405
+A704E088 022000C4
+A704E08A 8FB2A485
+A704E064 016001D5
+;Results screen
+A7050C14 FF50FF16
+A7050C1C 00B000EA
+00000000 FFFF
+;Post-race screen #2
+A405D5DC 8005A5F8
+A7058070 00C8010A
+A7058078 302100C8
+A705807A 00A03406
+A7058924 00C8010A
+A705892C 302100C8
+A705892E 00A03406
+;Bonus screen (Trophy)
+A7059A08 016001D5
+00000000 FFFF
+;GT Mode screens (Simulation)
+A402442C 800229A8
+A701CDF4 00B30086
+A701CDFC FFCEFFDB
+A701CE04 03200258
+00000000 FFFF
+#21:9 Widescreen 2.0
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A40529DC 801EFB39
+8005D5DC 0000
+80057054 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A4052A70 000000F6
+8005D5DC 0000
+80057054 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A4020A90 3084007F
+A701E578 FF80FF20
+A701E580 008000E0
+;Car Selection 2P Battle (Arcade)
+A70201C4 FF97FF49
+A70201CC 006900B7
+;Pre-race screen (Arcade)
+A701536C 01400230
+00000000 FFFF
+;Race
+A401F888 AEB40008
+A70100D0 FF60FEE8
+A70100D4 00A00118
+00000000 FFFF
+;Race (Rear view mirror)
+A403EC74 02602021
+A70295EC FFC4FF97
+A70295F0 003C0069
+00000000 FFFF
+;Post-race screen #1
+A4057054 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A70497CA A485A489
+A7049F48 00C8015E
+A7049F50 302100C8
+A7049F52 00A03406
+A704C194 00C8015E
+A704C19C 302100C8
+A704C19E 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704E07C 00000160
+A704E07E 00002405
+A704E088 022000C4
+A704E08A 8FB2A485
+A704E064 01600268
+;Results screen
+A7050C14 FF50FECC
+A7050C1C 00B00134
+00000000 FFFF
+;Post-race screen #2
+A405D5DC 8005A5F8
+A7058070 00C8015E
+A7058078 302100C8
+A705807A 00A03406
+A7058924 00C8015E
+A705892C 302100C8
+A705892E 00A03406
+;Bonus screen (Trophy)
+A7059A08 01600268
+00000000 FFFF
+;GT Mode screens (Simulation)
+A402442C 800229A8
+A701CDF4 00B30066
+A701CDFC FFCEFFE4
+A701CE04 032001C9
+00000000 FFFF
+#60 FPS (+Re-enable tire smoke, sky in the read view mirror, rear view mirror)
+E01D5864 0002
+301D5864 0001
+A401F888 AEB40008
+;Re-enable tire smoke
+A70168C8 00020000
+;Re-enable sky in the read view mirror
+A7019644 00020000
+00000000 FFFF
+;Re-enable rear view mirror
+A003EC74 02602021
+A7029550 00020000
+#Metric units (imperial to metric)
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A00529DC 801EFB39
+80057054 0000
+;Reset the race overlay for Simulation
+A0052A70 000000F6
+80057054 0000
+;Localization changes
+;mph text -> km/h text (lap times)
+A71C6C87 706D6D6B
+A71C6C88 0068682F
+;lb text -> kg text (Arcade)
+A70F8677 626C676B
+;lb-ft text -> kgm text (Arcade)
+A70F86AF 626C676B
+A70F86B1 662D2F6D
+A70F86B3 2F746425
+A70F86B5 64257072
+A70F86B7 7072006D
+A70F86C0 626C676B
+A70F86C2 662D2F6D
+A70F86C4 2F74257E
+A70F86C6 257E7264
+A70F86C8 72646D70
+A70F86CA 6D700000
+;lb-ft text -> kgm text (Arcade graph)
+A70F85A6 626C676B
+A70F85A8 662D006D
+;mph launch speed -> km/h launch speed text (License tests)
+A71C7101 706D6D6B
+A71C7103 0068682F
+;lb text -> kg text (Simulation garage)
+A71EF6C3 626C676B
+;lb-ft text -> kgm text (Simulation garage)
+A71C30FF 626C676B
+A71C3101 662D206D
+A71C3103 2074202F
+A71C3105 202F0000
+;Code changes
+A403EC74 02602021
+;mph text -> km/h text (speedometer)
+A702F6FC B0D8A0C0
+A702F6FE 39233922
+;Speed unit scaling
+A7030570 000D0016
+A7030574 FBDD8000
+00000000 FFFF
+A4020A90 3084007F
+;Weight unit scaling (Arcade)
+A7018AE4 13030000
+A7018AE6 00090000
+A7018AEC 30230000
+A7018AEE 00463446
+;Torque unit scaling (Arcade)
+A7018C28 17C30000
+A7018C2A 000234A8
+A7018C3C 40230000
+A7018C3E 00620000
+;Torque graph scaling (Arcade)
+A70197B4 18230004
+A70197B6 00629683
+A70198CE ACC3ACC4
+00000000 FFFF
+;Speed unit scaling (License tests)
+A4057054 260201C0
+A704DA18 37C30000
+A704DA1A 00069506
+A704DA28 30230000
+A704DA2A 00460000
+00000000 FFFF
+A402442C 800229A8
+;Weight unit scaling (Simulation screens)
+A701C968 48100000
+A701C974 302303A4
+A701C976 00468D26
+A701C564 48100000
+A701C570 302303A4
+A701C572 00468D26
+;Torque unit scaling (Simulation screens)
+A701C808 40230000
+A701C80A 00620000
+00000000 FFFF
+#Full level of detail (LOD) AI cars (Needs 8MB RAM enabled)
+A401F888 AEB40008
+A7014344 00405112
+A7014346 16A00800
+;Set to 0003 to force the lowest LOD
+A7014348 00030001
+00000000 FFFF
+#Slightly higher draw distance
+A403EC74 02602021
+A7020420 0004810D
+A7020422 14400800
+00000000 FFFF
+#Use 8MB RAM for polygon buffers (Needs 8MB RAM enabled)
+A401F888 AEB40008
+;Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F88A AEB4
+A7016A6C 000E8020
+D121F88A AEB4
+A7016A70 57000000
+D121F88A AEB4
+A7016A7C 00030007
+D121F88A AEB4
+A7016A78 28210000
+D121F88A AEB4
+A7016A7A 02250000
+D121F88A AEB4
+A7016A88 80000000
+00000000 FFFF
 
 ; [ Gran Turismo 2 (USA, v1.1) (1999) (Sony Computer Entertainment America) {SCUS-94455} <gt2a> ]
 :SCUS-94455
@@ -27863,6 +28141,276 @@ D0010000 FFE0
 #Widescreen 16-9 option Better Graphics
 8006744C 0060
 8006744E 3404
+#16:9 Widescreen 2.0
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A4052A64 801EF8EF
+8005D598 0000
+80057010 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A4052B20 000000E7
+8005D598 0000
+80057010 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A4020A74 3084007F
+A701E55C FF80FF56
+A701E564 008000AA
+;Car Selection 2P Battle (Arcade)
+A70201A8 FF97FF74
+A70201B0 0069008C
+;Pre-race screen (Arcade)
+A7015350 014001AA
+00000000 FFFF
+;Race
+A401F888 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+;Race (Rear view mirror)
+A403EC6C 02602021
+A70295E4 FFC4FFB0
+A70295E8 003C0050
+00000000 FFFF
+;Post-race screen #1
+A4057010 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A7049736 A485A489
+A7049EB4 00C8010A
+A7049EBC 302100C8
+A7049EBE 00A03406
+A704C100 00C8010A
+A704C108 302100C8
+A704C10A 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DFE8 00000160
+A704DFEA 00002405
+A704DFF4 022000C4
+A704DFF6 8FB2A485
+A704DFD0 016001D5
+;Results screen
+A7050B80 FF50FF16
+A7050B88 00B000EA
+00000000 FFFF
+;Post-race screen #2
+A405D598 8005A5B4
+A705802C 00C8010A
+A7058034 302100C8
+A7058036 00A03406
+A70588E0 00C8010A
+A70588E8 302100C8
+A70588EA 00A03406
+;Bonus screen (Trophy)
+A70599C4 016001D5
+00000000 FFFF
+;GT Mode screens (Simulation)
+A40244EC 800229D8
+A701CDF4 00B30086
+A701CDFC FFCEFFDB
+A701CE04 03200258
+00000000 FFFF
+#21:9 Widescreen 2.0
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A4052A64 801EF8EF
+8005D598 0000
+80057010 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A4052B20 000000E7
+8005D598 0000
+80057010 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A4020A74 3084007F
+A701E55C FF80FF20
+A701E564 008000E0
+;Car Selection 2P Battle (Arcade)
+A70201A8 FF97FF49
+A70201B0 006900B7
+;Pre-race screen (Arcade)
+A7015350 01400230
+00000000 FFFF
+;Race
+A401F888 AEB40008
+A70100D0 FF60FEE8
+A70100D4 00A00118
+00000000 FFFF
+;Race (Rear view mirror)
+A403EC6C 02602021
+A70295E4 FFC4FF97
+A70295E8 003C0069
+00000000 FFFF
+;Post-race screen #1
+A4057010 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A7049736 A485A489
+A7049EB4 00C8015E
+A7049EBC 302100C8
+A7049EBE 00A03406
+A704C100 00C8015E
+A704C108 302100C8
+A704C10A 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DFE8 00000160
+A704DFEA 00002405
+A704DFF4 022000C4
+A704DFF6 8FB2A485
+A704DFD0 01600268
+;Results screen
+A7050B80 FF50FECC
+A7050B88 00B00134
+00000000 FFFF
+;Post-race screen #2
+A405D598 8005A5B4
+A705802C 00C8015E
+A7058034 302100C8
+A7058036 00A03406
+A70588E0 00C8015E
+A70588E8 302100C8
+A70588EA 00A03406
+;Bonus screen (Trophy)
+A70599C4 01600268
+00000000 FFFF
+;GT Mode screens (Simulation)
+A40244EC 800229D8
+A701CDF4 00B30066
+A701CDFC FFCEFFE4
+A701CE04 032001C9
+00000000 FFFF
+#60 FPS (+Re-enable tire smoke, sky in the read view mirror, rear view mirror)
+E01D5634 0002
+301D5634 0001
+A401F888 AEB40008
+;Re-enable tire smoke
+A70168C8 00020000
+;Re-enable sky in the read view mirror
+A7019644 00020000
+00000000 FFFF
+;Re-enable rear view mirror
+A003EC6C 02602021
+A7029548 00020000
+#Metric units (imperial to metric)
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A0052A64 801EF8EF
+80057010 0000
+;Reset the race overlay for Simulation
+A0052B20 000000E7
+80057010 0000
+;Localization changes
+;mph text -> km/h text (lap times)
+A71C6A27 706D6D6B
+A71C6A29 0068682F
+;ft text -> m text (Arcade)
+A70F853D 7466006D
+;lb text -> kg text (Arcade)
+A70F8435 626C676B
+;lb-ft text -> kgm text (Arcade)
+A70F8474 626C676B
+A70F8476 662D2F6D
+A70F8478 2F746425
+A70F847A 64257072
+A70F847C 7072006D
+A70F8487 626C676B
+A70F8489 662D2F6D
+A70F848B 2F74257E
+A70F848D 257E7264
+A70F848F 72646D70
+A70F8491 6D700000
+;lb-ft text -> kgm text (Arcade graph)
+A70F835A 626C676B
+A70F835C 662D006D
+;mph launch speed -> km/h launch speed text (License tests)
+A71C6EA9 706D6D6B
+A71C6EAB 0068682F
+;lb text -> kg text (Simulation garage)
+A71EF476 626C676B
+;lb-ft text -> kgm text (Simulation garage)
+A71C2EA7 626C676B
+A71C2EA9 662D206D
+A71C2EAB 2074202F
+A71C2EAD 202F0000
+;Code changes
+A403EC6C 02602021
+;mph text -> km/h text (speedometer)
+A702F6F4 B0D8A0C0
+A702F6F6 39233922
+;Speed unit scaling
+A7030568 000D0016
+A703056C FBDD8000
+00000000 FFFF
+A4020A74 3084007F
+;Weight unit scaling (Arcade)
+A7018AC8 13030000
+A7018ACA 00090000
+A7018AD0 30230000
+A7018AD2 00463446
+;Torque unit scaling (Arcade)
+A7018C0C 17C30000
+A7018C0E 000234A8
+A7018C20 40230000
+A7018C22 00620000
+;Torque graph scaling (Arcade)
+A7019798 18230004
+A701979A 00629683
+A70198B2 ACC3ACC4
+00000000 FFFF
+;Speed unit scaling (License tests)
+A4057010 260201C0
+A704D984 37C30000
+A704D986 00069506
+A704D994 30230000
+A704D996 00460000
+00000000 FFFF
+A40244EC 800229D8
+;Weight unit scaling (Simulation screens)
+A701C968 48100000
+A701C974 302303A4
+A701C976 00468D26
+A701C564 48100000
+A701C570 302303A4
+A701C572 00468D26
+;Torque unit scaling (Simulation screens)
+A701C808 40230000
+A701C80A 00620000
+00000000 FFFF
+#Full level of detail (LOD) AI cars (Needs 8MB RAM enabled)
+A401F888 AEB40008
+A7014344 00405112
+A7014346 16A00800
+;Set to 0003 to force the lowest LOD
+A7014348 00030001
+00000000 FFFF
+#Slightly higher draw distance
+A403EC6C 02602021
+A7020420 0004810D
+A7020422 14400800
+00000000 FFFF
+#Use 8MB RAM for polygon buffers (Needs 8MB RAM enabled)
+A401F888 AEB40008
+;Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F88A AEB4
+A7016A6C 000E8020
+D121F88A AEB4
+A7016A70 57000000
+D121F88A AEB4
+A7016A7C 00030007
+D121F88A AEB4
+A7016A78 28210000
+D121F88A AEB4
+A7016A7A 02250000
+D121F88A AEB4
+A7016A88 80000000
+00000000 FFFF
 
 ; [ Gran Turismo 2 (USA, v1.0) (1999) (Sony Computer Entertainment America) {SCUS-94455} <gt2b> ]
 :SCUS-94455
@@ -84026,6 +84574,12 @@ D00BC016 0002
 800B6DBE 0005
 D00BC016 0002
 800B6D92 0005
+#50 FPS (+Re-enable tire smoke, Re-enable rear view mirror)
+A60B6168 00020001
+A702E560 00020001
+A702AA7C 00020001
+#Simulation timescale in Arcade (100% instead of 125%)
+A7051C80 007D0064
 
 ; [ Gran Turismo 2 (Euro) (2000) (Sony Computer Entertainment Europe) {SCES-02380} <gt2e> ]
 :SCES-02380
@@ -84107,6 +84661,194 @@ D0010000 FFE0
 #Widescreen 16-9 Better Graphics (Optional)
 8006752C 0060
 8006752E 3404
+#16:9 Widescreen 2.0
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A4052988 801EFB69
+8005D624 0000
+80057090 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A40529DC 000000F6
+8005D624 0000
+80057090 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A4020A3C 3084007F
+A701E524 FF80FF56
+A701E52C 008000AA
+;Car Selection 2P Battle (Arcade)
+A7020170 FF97FF74
+A7020178 0069008C
+;Pre-race screen (Arcade)
+A701536C 014001AA
+00000000 FFFF
+;Race
+A401F884 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+;Race (Rear view mirror)
+A403EC50 02602021
+A70295E8 FFC4FFB0
+A70295EC 003C0050
+00000000 FFFF
+;Post-race screen #1
+A4057090 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A7049822 A485A489
+A7049FA0 00C8010A
+A7049FA8 302100C8
+A7049FAA 00A03406
+A704C1EC 00C8010A
+A704C1F4 302100C8
+A704C1F6 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704E09C 00000160
+A704E09E 00002405
+A704E0A8 022000C4
+A704E0AA 8FB2A485
+A704E084 016001D5
+;Results screen
+A7050C48 FF50FF16
+A7050C50 00B000EA
+00000000 FFFF
+;Post-race screen #2
+A405D624 8005A640
+A70580AC 00C8010A
+A70580B4 302100C8
+A70580B6 00A03406
+A7058960 00C8010A
+A7058968 302100C8
+A705896A 00A03406
+;Bonus screen (Trophy)
+A7059A50 016001D5
+00000000 FFFF
+;GT Mode screens (Simulation)
+A4024398 80022914
+A701CD68 00B30086
+A701CD70 FFCEFFDB
+A701CD78 03200258
+00000000 FFFF
+#21:9 Widescreen 2.0
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A4052988 801EFB69
+8005D624 0000
+80057090 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A40529DC 000000F6
+8005D624 0000
+80057090 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A4020A3C 3084007F
+A701E524 FF80FF20
+A701E52C 008000E0
+;Car Selection 2P Battle (Arcade)
+A7020170 FF97FF49
+A7020178 006900B7
+;Pre-race screen (Arcade)
+A701536C 01400230
+00000000 FFFF
+;Race
+A401F884 AEB40008
+A70100D0 FF60FEE8
+A70100D4 00A00118
+00000000 FFFF
+;Race (Rear view mirror)
+A403EC50 02602021
+A70295E8 FFC4FF97
+A70295EC 003C0069
+00000000 FFFF
+;Post-race screen #1
+A4057090 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A7049822 A485A489
+A7049FA0 00C8015E
+A7049FA8 302100C8
+A7049FAA 00A03406
+A704C1EC 00C8015E
+A704C1F4 302100C8
+A704C1F6 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704E09C 00000160
+A704E09E 00002405
+A704E0A8 022000C4
+A704E0AA 8FB2A485
+A704E084 01600268
+;Results screen
+A7050C48 FF50FECC
+A7050C50 00B00134
+00000000 FFFF
+;Post-race screen #2
+A405D624 8005A640
+A70580AC 00C8015E
+A70580B4 302100C8
+A70580B6 00A03406
+A7058960 00C8015E
+A7058968 302100C8
+A705896A 00A03406
+;Bonus screen (Trophy)
+A7059A50 01600268
+00000000 FFFF
+;GT Mode screens (Simulation)
+A4024398 80022914
+A701CD68 00B30066
+A701CD70 FFCEFFE4
+A701CD78 032001C9
+00000000 FFFF
+#50 FPS (+Re-enable tire smoke, sky in the read view mirror, rear view mirror)
+E01D5894 0002
+301D5894 0001
+A401F884 AEB40008
+;Re-enable tire smoke
+A70168C4 00020000
+;Re-enable sky in the read view mirror
+A7019640 00020000
+00000000 FFFF
+;Re-enable rear view mirror
+A003EC50 02602021
+A702954C 00020000
+#Metric units fix (mph launch speed -> km/h launch speed text)
+;mph launch speed -> km/h launch speed text
+A71C7131 706D6D6B
+A71C7133 0068682F
+#Full level of detail (LOD) AI cars (Needs 8MB RAM enabled)
+A401F884 AEB40008
+A7014344 00405112
+A7014346 16A00800
+;Set to 0003 to force the lowest LOD
+A7014348 00030001
+00000000 FFFF
+#Slightly higher draw distance
+A403EC50 02602021
+A702041C 0004810C
+A702041E 14400800
+00000000 FFFF
+#Use 8MB RAM for polygon buffers (Needs 8MB RAM enabled)
+A401F884 AEB40008
+;Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F886 AEB4
+A7016A68 000E8020
+D121F886 AEB4
+A7016A6C 57000000
+D121F886 AEB4
+A7016A78 00030007
+D121F886 AEB4
+A7016A74 28210000
+D121F886 AEB4
+A7016A76 02250000
+D121F886 AEB4
+A7016A84 80000000
+00000000 FFFF
 
 ; [ Grand Theft Auto 2 (Euro, Rev. 1) (1999) (Rockstar Games) {SLES-01404#} <gta2e> ]
 :SLES-01404
@@ -112061,8 +112803,12 @@ D0091238 0000
 90090868 03030303
 #High Racing Points
 9008DD04 05F5E100
+#60 FPS (+Re-enable tire smoke, Re-enable rear view mirror)
+A60AD648 00020001
+A702DD08 00020001
+A702A548 00020001
 
-; [ Gran Turismo 2 (Arcade) (Japan, Asia) {SCPS-10116 | SCPS-10117} ]
+; [ Gran Turismo 2 (Arcade + Gran Turismo Mode) (Japan, Asia) {SCPS-10116 | SCPS-10117} ]
 :SCPS-10116
 :SCPS-10117
 #Simulation Mode Codes\A Ton Of Cash
@@ -112178,6 +112924,386 @@ D0010000 FFE0
 #Widescreen 16-9 v1.1 - Better Graphics (Optional)
 800673BC 0060
 800673BE 3404
+#16:9 Widescreen 2.0 (NTSC-J 1.0)
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A405054C 801EDEA0
+8005D1EC 0000
+80056C64 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A40524D0 00000087
+8005D1EC 0000
+80056C64 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A402085C 3084007F
+A701E374 FF80FF56
+A701E37C 008000AA
+;Car Selection 2P Battle (Arcade)
+A701FF90 FF97FF74
+A701FF98 0069008C
+;Pre-race screen (Arcade)
+A7015340 014001AA
+00000000 FFFF
+;Race
+A401F794 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+;Race (Rear view mirror)
+A403EC18 02602021
+A702953C FFC4FFB0
+A7029540 003C0050
+00000000 FFFF
+;Post-race screen #1
+A4056C64 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A704971A A485A489
+A7049E54 00C8010A
+A7049E5C 302100C8
+A7049E5E 00A03406
+A704C0A0 00C8010A
+A704C0A8 302100C8
+A704C0AA 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DCA8 00000160
+A704DCAA 00002405
+A704DCB4 022000C4
+A704DCB6 8FB2A485
+A704DC90 016001D5
+;Results screen
+A7050804 FF50FF16
+A705080C 00B000EA
+00000000 FFFF
+;Post-race screen #2
+A405D1EC 8005A208
+A7057C80 00C8010A
+A7057C88 302100C8
+A7057C8A 00A03406
+A7058534 00C8010A
+A705853C 302100C8
+A705853E 00A03406
+;Bonus screen (Trophy)
+A7059618 016001D5
+00000000 FFFF
+;GT Mode screens (Simulation)
+A4023F14 800225C8
+A701C9D4 00B30086
+A701C9DC FFCEFFDB
+A701C9E4 03200258
+00000000 FFFF
+#16:9 Widescreen 2.0 (NTSC-J 1.1)
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A40527D4 801EF999
+8005D4AC 0000
+80056F24 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A405257C 000000F6
+8005D4AC 0000
+80056F24 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A4020888 3084007F
+A701E3A0 FF80FF56
+A701E3A8 008000AA
+;Car Selection 2P Battle (Arcade)
+A701FFBC FF97FF74
+A701FFC4 0069008C
+;Pre-race screen (Arcade)
+A701536C 014001AA
+00000000 FFFF
+;Race
+A401F880 AEB40008
+A70100D0 FF60FF2B
+A70100D4 00A000D5
+00000000 FFFF
+;Race (Rear view mirror)
+A403EBF0 02602021
+A702960C FFC4FFB0
+A7029610 003C0050
+00000000 FFFF
+;Post-race screen #1
+A4056F24 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A7049726 A485A489
+A7049EA4 00C8010A
+A7049EAC 302100C8
+A7049EAE 00A03406
+A704C0F0 00C8010A
+A704C0F8 302100C8
+A704C0FA 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DF7C 00000160
+A704DF7E 00002405
+A704DF88 022000C4
+A704DF8A 8FB2A485
+A704DF64 016001D5
+;Results screen
+A7050B14 FF50FF16
+A7050B1C 00B000EA
+00000000 FFFF
+;Post-race screen #2
+A405D4AC 8005A4C8
+A7057F40 00C8010A
+A7057F48 302100C8
+A7057F4A 00A03406
+A70587F4 00C8010A
+A70587FC 302100C8
+A70587FE 00A03406
+;Bonus screen (Trophy)
+A70598D8 016001D5
+00000000 FFFF
+;GT Mode screens (Simulation)
+A4023F98 800225CC
+A701C9D4 00B30086
+A701C9DC FFCEFFDB
+A701C9E4 03200258
+00000000 FFFF
+#21:9 Widescreen 2.0 (NTSC-J 1.0)
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A405054C 801EDEA0
+8005D1EC 0000
+80056C64 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A40524D0 00000087
+8005D1EC 0000
+80056C64 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A402085C 3084007F
+A701E374 FF80FF20
+A701E37C 008000E0
+;Car Selection 2P Battle (Arcade)
+A701FF90 FF97FF49
+A701FF98 006900B7
+;Pre-race screen (Arcade)
+A7015340 01400230
+00000000 FFFF
+;Race
+A401F794 AEB40008
+A70100D0 FF60FEE8
+A70100D4 00A00118
+00000000 FFFF
+;Race (Rear view mirror)
+A403EC18 02602021
+A702953C FFC4FF97
+A7029540 003C0069
+00000000 FFFF
+;Post-race screen #1
+A4056C64 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A704971A A485A489
+A7049E54 00C8015E
+A7049E5C 302100C8
+A7049E5E 00A03406
+A704C0A0 00C8015E
+A704C0A8 302100C8
+A704C0AA 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DCA8 00000160
+A704DCAA 00002405
+A704DCB4 022000C4
+A704DCB6 8FB2A485
+A704DC90 01600268
+;Results screen
+A7050804 FF50FECC
+A705080C 00B00134
+00000000 FFFF
+;Post-race screen #2
+A405D1EC 8005A208
+A7057C80 00C8015E
+A7057C88 302100C8
+A7057C8A 00A03406
+A7058534 00C8015E
+A705853C 302100C8
+A705853E 00A03406
+;Bonus screen (Trophy)
+A7059618 01600268
+00000000 FFFF
+;GT Mode screens (Simulation)
+A4023F14 800225C8
+A701C9D4 00B30066
+A701C9DC FFCEFFE4
+A701C9E4 032001C9
+00000000 FFFF
+#21:9 Widescreen 2.0 (NTSC-J 1.1)
+;"Help" the game unload segments that normally are left unwritten to,
+;so further cheat detection is more reliable. This is safe as it overwrites dead code.
+;Reset the race overlay for Arcade
+A40527D4 801EF999
+8005D4AC 0000
+80056F24 0000
+00000000 FFFF
+;Reset the race overlay for Simulation
+A405257C 000000F6
+8005D4AC 0000
+80056F24 0000
+00000000 FFFF
+;Car Selection (Arcade)
+A4020888 3084007F
+A701E3A0 FF80FF20
+A701E3A8 008000E0
+;Car Selection 2P Battle (Arcade)
+A701FFBC FF97FF49
+A701FFC4 006900B7
+;Pre-race screen (Arcade)
+A701536C 01400230
+00000000 FFFF
+;Race
+A401F880 AEB40008
+A70100D0 FF60FEE8
+A70100D4 00A00118
+00000000 FFFF
+;Race (Rear view mirror)
+A403EBF0 02602021
+A702960C FFC4FF97
+A7029610 003C0069
+00000000 FFFF
+;Post-race screen #1
+A4056F24 260201C0
+;a1 -> t1, *will* change visuals of some screens!
+;Other screens will get slightly resized to compensate for this.
+A7049726 A485A489
+A7049EA4 00C8015E
+A7049EAC 302100C8
+A7049EAE 00A03406
+A704C0F0 00C8015E
+A704C0F8 302100C8
+A704C0FA 00A03406
+;Bonus screen (Licenses)
+;Use free space to re-fit li $a1, 160h \ sh $a1, C4h($a0)
+A704DF7C 00000160
+A704DF7E 00002405
+A704DF88 022000C4
+A704DF8A 8FB2A485
+A704DF64 01600268
+;Results screen
+A7050B14 FF50FECC
+A7050B1C 00B00134
+00000000 FFFF
+;Post-race screen #2
+A405D4AC 8005A4C8
+A7057F40 00C8015E
+A7057F48 302100C8
+A7057F4A 00A03406
+A70587F4 00C8015E
+A70587FC 302100C8
+A70587FE 00A03406
+;Bonus screen (Trophy)
+A70598D8 01600268
+00000000 FFFF
+;GT Mode screens (Simulation)
+A4023F98 800225CC
+A701C9D4 00B30066
+A701C9DC FFCEFFE4
+A701C9E4 032001C9
+00000000 FFFF
+#60 FPS (NTSC-J 1.0 Arcade Disc, +Re-enable tire smoke, sky in the read view mirror, rear view mirror)
+E01D5CB4 0002
+301D5CB4 0001
+A401F794 AEB40008
+;Re-enable tire smoke
+A70167EC 00020000
+;Re-enable sky in the read view mirror
+A7019550 00020000
+00000000 FFFF
+;Re-enable rear view mirror
+A003EC18 02602021
+A70294A0 00020000
+#60 FPS (NTSC-J 1.0 Simulation Disc, +Re-enable tire smoke, sky in the read view mirror, rear view mirror)
+E01D5CC4 0002
+301D5CC4 0001
+A401F794 AEB40008
+;Re-enable tire smoke
+A70167EC 00020000
+;Re-enable sky in the read view mirror
+A7019550 00020000
+00000000 FFFF
+;Re-enable rear view mirror
+A003EC18 02602021
+A70294A0 00020000
+#60 FPS (NTSC-J 1.1 Simulation Disc, +Re-enable tire smoke, sky in the read view mirror, rear view mirror)
+E01D56C4 0002
+301D56C4 0001
+A401F880 AEB40008
+;Re-enable tire smoke
+A70168C0 00020000
+;Re-enable sky in the read view mirror
+A701963C 00020000
+00000000 FFFF
+;Re-enable rear view mirror
+A003EBF0 02602021
+A7029570 00020000
+#Full level of detail (LOD) AI cars (NTSC-J 1.0, Needs 8MB RAM enabled)
+A401F794 AEB40008
+A701430C 00405104
+A701430E 16A00800
+;Set to 0003 to force the lowest LOD
+A7014310 00030001
+00000000 FFFF
+#Full level of detail (LOD) AI cars (NTSC-J 1.1, Needs 8MB RAM enabled)
+A401F880 AEB40008
+A701433C 00405110
+A701433E 16A00800
+;Set to 0003 to force the lowest LOD
+A7014340 00030001
+00000000 FFFF
+#Slightly higher draw distance (NTSC-J 1.0)
+A403EC18 02602021
+A702032C 000480D0
+A702032E 14400800
+00000000 FFFF
+#Slightly higher draw distance (NTSC-J 1.1)
+A403EBF0 02602021
+A7020418 0004810B
+A702041A 14400800
+00000000 FFFF
+#Use 8MB RAM for polygon buffers (NTSC-J 1.0, Needs 8MB RAM enabled)
+A401F794 AEB40008
+;Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F796 AEB4
+A7016990 000E8020
+D121F796 AEB4
+A7016994 57000000
+D121F796 AEB4
+A70169A0 00030007
+D121F796 AEB4
+A701699C 28210000
+D121F796 AEB4
+A701699E 02250000
+D121F796 AEB4
+A70169AC 80000000
+00000000 FFFF
+#Use 8MB RAM for polygon buffers (NTSC-J 1.1, Needs 8MB RAM enabled)
+A401F880 AEB40008
+;Codes will be skipped if RAM mirroring is in place (8MB mode disabled)
+D121F882 AEB4
+A7016A64 000E8020
+D121F882 AEB4
+A7016A68 57000000
+D121F882 AEB4
+A7016A74 00030007
+D121F882 AEB4
+A7016A70 28210000
+D121F882 AEB4
+A7016A72 02250000
+D121F882 AEB4
+A7016A80 80000000
+00000000 FFFF
 
 ; [ Gran Turismo 2 (Disc 2) (Gran Turismo) (Japan) Rev 1 {SCPS-91327} ]
 ; [ Gran Turismo 2 (Japan) (Test Drive Disc) {PAPX-90054} ]


### PR DESCRIPTION
Adds the following cheats to Gran Turismo 1 & 2:

Gran Turismo 1:
- 60 FPS (NTSC-U 1.1, NTSC-U 1.0, PAL, JP NTSC-J)
- Simulation timescale in Arcade (NTSC-U 1.1, PAL)

Gran Turismo 2:
- 16:9 Widescreen Hack 2.0 (NTSC-U 1.2, NTSC-U 1.1, PAL, NTSC-J 1.1, NTSC-J 1.0)
- 21:9 Widescreen Hack 2.0 (NTSC-U 1.2, NTSC-U 1.1, PAL, NTSC-J 1.1, NTSC-J 1.0)
- 60 FPS (NTSC-U 1.2, NTSC-U 1.1, PAL, Arcade Disc: JP NTSC-J 1.0, Simulation Disc: JP NTSC-J 1.1, NTSC-J 1.0)
- Metric units code (NTSC-U 1.2, NTSC-U 1.1, PAL)
- Full detail AI cars (NTSC-U 1.1, NTSC-U 1.2, PAL, NTSC-J 1.1, NTSC-J 1.0)
- Slightly higher draw distance (NTSC-U 1.2, NTSC-U 1.1, PAL, NTSC-J 1.1, NTSC-J 1.0)
- Use 8MB RAM for polygon buffers (NTSC-U 1.1, NTSC-U 1.2, PAL, NTSC-J 1.1, JP NTSC-J 1.0)

Credits go to cookieplmonster
https://cookieplmonster.github.io/mods/gran-turismo/
https://cookieplmonster.github.io/mods/gran-turismo-2/