### PR TITLE
Make appimage respect "QT_QPA_PLATFORM" env var.

### DIFF
--- a/scripts/generate_appimages.sh
+++ b/scripts/generate_appimages.sh
@@ -95,11 +95,11 @@ cp /usr/lib/x86_64-linux-gnu/dri/swrast_dri.so ${BUILD_DIR}/duckstation-qt.AppDi
 cp -r /usr/lib/x86_64-linux-gnu/qt5/plugins/{xcbglintegrations,platforms,wayland-graphics-integration-client,wayland-decoration-client,wayland-shell-integration} ${BUILD_DIR}/duckstation-qt.AppDir/usr/plugins
 
 cat <<'EOF'>> ${BUILD_DIR}/duckstation-qt.AppDir/apprun-hooks/linuxdeploy-plugin-qt-hook.sh
-case "${WAYLAND_DISPLAY}" in
-	*wayland*)
+if [ ! -z "${WAYLAND_DISPLAY}" ]; then
+	if [ -z ${QT_QPA_PLATFORM} ]; then
 		export QT_QPA_PLATFORM=wayland
-		;;
-esac
+	fi
+fi
 EOF
   
 UPDATE_INFORMATION="zsync|https://github.com/stenzek/duckstation/releases/download/latest/duckstation-qt-x64.AppImage.zsync" \

--- a/scripts/generate_appimages.sh
+++ b/scripts/generate_appimages.sh
@@ -95,7 +95,7 @@ cp /usr/lib/x86_64-linux-gnu/dri/swrast_dri.so ${BUILD_DIR}/duckstation-qt.AppDi
 cp -r /usr/lib/x86_64-linux-gnu/qt5/plugins/{xcbglintegrations,platforms,wayland-graphics-integration-client,wayland-decoration-client,wayland-shell-integration} ${BUILD_DIR}/duckstation-qt.AppDir/usr/plugins
 
 cat <<'EOF'>> ${BUILD_DIR}/duckstation-qt.AppDir/apprun-hooks/linuxdeploy-plugin-qt-hook.sh
-if [ ! -z "${WAYLAND_DISPLAY}" ]; then
+if [[ "${WAYLAND_DISPLAY}" == "wayland"* ]]; then
 	if [ -z ${QT_QPA_PLATFORM} ]; then
 		export QT_QPA_PLATFORM=wayland
 	fi


### PR DESCRIPTION
This is so users who want to opt out from using wayland by using `QT_QPA_PLATFORM=xcb` don't get confused.