### PR TITLE
UI improvements

### DIFF
--- a/src/duckstation-qt/achievementlogindialog.cpp
+++ b/src/duckstation-qt/achievementlogindialog.cpp
@@ -7,6 +7,9 @@ AchievementLoginDialog::AchievementLoginDialog(QWidget* parent) : QDialog(parent
 {
   m_ui.setupUi(this);
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+  m_login = m_ui.buttonBox->addButton(tr("&Login"), QDialogButtonBox::AcceptRole);
+  m_login->setEnabled(false);
   connectUi();
 }
 
@@ -48,10 +51,10 @@ void AchievementLoginDialog::processLoginResult(bool result)
 
 void AchievementLoginDialog::connectUi()
 {
-  connect(m_ui.login, &QPushButton::clicked, this, &AchievementLoginDialog::loginClicked);
-  connect(m_ui.cancel, &QPushButton::clicked, this, &AchievementLoginDialog::cancelClicked);
+  connect(m_ui.buttonBox, &QDialogButtonBox::accepted, this, &AchievementLoginDialog::loginClicked);
+  connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &AchievementLoginDialog::cancelClicked);
 
-  auto enableLoginButton = [this](const QString&) { m_ui.login->setEnabled(canEnableLoginButton()); };
+  auto enableLoginButton = [this](const QString&) { m_login->setEnabled(canEnableLoginButton()); };
   connect(m_ui.userName, &QLineEdit::textChanged, enableLoginButton);
   connect(m_ui.password, &QLineEdit::textChanged, enableLoginButton);
 }
@@ -60,8 +63,8 @@ void AchievementLoginDialog::enableUI(bool enabled)
 {
   m_ui.userName->setEnabled(enabled);
   m_ui.password->setEnabled(enabled);
-  m_ui.cancel->setEnabled(enabled);
-  m_ui.login->setEnabled(enabled && canEnableLoginButton());
+  m_ui.buttonBox->button(QDialogButtonBox::Cancel)->setEnabled(enabled);
+  m_login->setEnabled(enabled && canEnableLoginButton());
 }
 
 bool AchievementLoginDialog::canEnableLoginButton() const

--- a/src/duckstation-qt/achievementlogindialog.h
+++ b/src/duckstation-qt/achievementlogindialog.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "ui_achievementlogindialog.h"
 #include <QtWidgets/QDialog>
+#include <QtWidgets/QPushButton>
 
 class AchievementLoginDialog : public QDialog
 {
@@ -21,4 +22,5 @@ private:
   bool canEnableLoginButton() const;
 
   Ui::AchievementLoginDialog m_ui;
+  QPushButton* m_login;
 };

--- a/src/duckstation-qt/achievementlogindialog.ui
+++ b/src/duckstation-qt/achievementlogindialog.ui
@@ -115,7 +115,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
      <item>
       <widget class="QLabel" name="status">
        <property name="text">
@@ -124,22 +124,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="login">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>&amp;Login</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancel">
-       <property name="text">
-        <string>&amp;Cancel</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel</set>
        </property>
       </widget>
      </item>

--- a/src/duckstation-qt/cheatcodeeditordialog.cpp
+++ b/src/duckstation-qt/cheatcodeeditordialog.cpp
@@ -84,6 +84,6 @@ void CheatCodeEditorDialog::fillUi()
 
 void CheatCodeEditorDialog::connectUi()
 {
-  connect(m_ui.save, &QPushButton::clicked, this, &CheatCodeEditorDialog::saveClicked);
-  connect(m_ui.cancel, &QPushButton::clicked, this, &CheatCodeEditorDialog::cancelClicked);
+  connect(m_ui.buttonBox, &QDialogButtonBox::accepted, this, &CheatCodeEditorDialog::saveClicked);
+  connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &CheatCodeEditorDialog::cancelClicked);
 }

--- a/src/duckstation-qt/cheatcodeeditordialog.ui
+++ b/src/duckstation-qt/cheatcodeeditordialog.ui
@@ -61,38 +61,11 @@
     <widget class="QPlainTextEdit" name="instructions"/>
    </item>
    <item row="5" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="save">
-       <property name="text">
-        <string>Save</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="cancel">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/duckstation-qt/gamepropertiesdialog.cpp
+++ b/src/duckstation-qt/gamepropertiesdialog.cpp
@@ -90,7 +90,7 @@ void GamePropertiesDialog::populate(const GameListEntry* ge)
     m_ui.comments->setDisabled(true);
     m_ui.versionTested->setDisabled(true);
     m_ui.setToCurrent->setDisabled(true);
-    m_ui.exportCompatibilityInfo->setDisabled(true);
+    m_exportCompatibilityInfo->setDisabled(true);
   }
   else
   {
@@ -127,6 +127,9 @@ void GamePropertiesDialog::populateCompatibilityInfo(const std::string& game_cod
 
 void GamePropertiesDialog::setupAdditionalUi()
 {
+  m_computeHashes = m_ui.buttonBox->addButton(tr("Compute && Verify Hashes"), QDialogButtonBox::ActionRole);
+  m_exportCompatibilityInfo = m_ui.buttonBox->addButton(tr("Export Compatibility Info"), QDialogButtonBox::ActionRole);
+
   for (u8 i = 0; i < static_cast<u8>(DiscRegion::Count); i++)
     m_ui.region->addItem(qApp->translate("DiscRegion", Settings::GetDiscRegionDisplayName(static_cast<DiscRegion>(i))));
 
@@ -555,14 +558,14 @@ void GamePropertiesDialog::connectUi()
   connect(m_ui.upscalingIssues, &QLineEdit::editingFinished, this,
           &GamePropertiesDialog::saveCompatibilityInfoIfChanged);
   connect(m_ui.setToCurrent, &QPushButton::clicked, this, &GamePropertiesDialog::onSetVersionTestedToCurrentClicked);
-  connect(m_ui.computeHashes, &QPushButton::clicked, this, &GamePropertiesDialog::onComputeHashClicked);
-  connect(m_ui.exportCompatibilityInfo, &QPushButton::clicked, this,
+  connect(m_computeHashes, &QPushButton::clicked, this, &GamePropertiesDialog::onComputeHashClicked);
+  connect(m_exportCompatibilityInfo, &QPushButton::clicked, this,
           &GamePropertiesDialog::onExportCompatibilityInfoClicked);
-  connect(m_ui.close, &QPushButton::clicked, this, &QDialog::close);
+  connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &QDialog::close);
   connect(m_ui.tabWidget, &QTabWidget::currentChanged, [this](int index) {
     const bool show_buttons = index == 0;
-    m_ui.computeHashes->setVisible(show_buttons);
-    m_ui.exportCompatibilityInfo->setVisible(show_buttons);
+    m_computeHashes->setVisible(show_buttons);
+    m_exportCompatibilityInfo->setVisible(show_buttons);
   });
 
   connect(m_ui.userRunaheadFrames, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index) {
@@ -937,7 +940,7 @@ void GamePropertiesDialog::onComputeHashClicked()
     computeTrackHashes(m_redump_search_keyword);
 
     if (!m_redump_search_keyword.empty())
-      m_ui.computeHashes->setText(tr("Search on Redump.org"));
+      m_computeHashes->setText(tr("Search on Redump.org"));
   }
   else
   {

--- a/src/duckstation-qt/gamepropertiesdialog.h
+++ b/src/duckstation-qt/gamepropertiesdialog.h
@@ -2,6 +2,7 @@
 #include "frontend-common/game_settings.h"
 #include "ui_gamepropertiesdialog.h"
 #include <QtWidgets/QDialog>
+#include <QtWidgets/QPushButton>
 #include <array>
 
 struct GameListEntry;
@@ -54,6 +55,8 @@ private:
 
   Ui::GamePropertiesDialog m_ui;
   std::array<QCheckBox*, static_cast<u32>(GameSettings::Trait::Count)> m_trait_checkboxes{};
+  QPushButton* m_exportCompatibilityInfo;
+  QPushButton* m_computeHashes;
 
   QtHostInterface* m_host_interface;
 

--- a/src/duckstation-qt/gamepropertiesdialog.ui
+++ b/src/duckstation-qt/gamepropertiesdialog.ui
@@ -1124,45 +1124,11 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="computeHashes">
-       <property name="text">
-        <string>Compute &amp;&amp; Verify Hashes</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="exportCompatibilityInfo">
-       <property name="text">
-        <string>Export Compatibility Info</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="close">
-       <property name="text">
-        <string>Close</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/duckstation-qt/inputbindingdialog.ui
+++ b/src/duckstation-qt/inputbindingdialog.ui
@@ -61,19 +61,6 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
         <set>QDialogButtonBox::Close</set>

--- a/src/duckstation-qt/memorycardeditordialog.cpp
+++ b/src/duckstation-qt/memorycardeditordialog.cpp
@@ -19,16 +19,24 @@ MemoryCardEditorDialog::MemoryCardEditorDialog(QWidget* parent) : QDialog(parent
   m_ui.setupUi(this);
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
+  m_deleteFile = m_ui.centerButtonBox->addButton(tr("Delete File"), QDialogButtonBox::ActionRole);
+  m_undeleteFile = m_ui.centerButtonBox->addButton(tr("Undelete File"), QDialogButtonBox::ActionRole);
+  m_exportFile = m_ui.centerButtonBox->addButton(tr("Export File"), QDialogButtonBox::ActionRole);
+  m_moveLeft = m_ui.centerButtonBox->addButton(tr("<<"), QDialogButtonBox::ActionRole);
+  m_moveRight = m_ui.centerButtonBox->addButton(tr(">>"), QDialogButtonBox::ActionRole);
+
   m_card_a.path_cb = m_ui.cardAPath;
   m_card_a.table = m_ui.cardA;
   m_card_a.blocks_free_label = m_ui.cardAUsage;
-  m_card_a.save_button = m_ui.saveCardA;
   m_card_b.path_cb = m_ui.cardBPath;
   m_card_b.table = m_ui.cardB;
   m_card_b.blocks_free_label = m_ui.cardBUsage;
-  m_card_b.save_button = m_ui.saveCardB;
 
+  createCardButtons(&m_card_a, m_ui.buttonBoxA);
+  createCardButtons(&m_card_b, m_ui.buttonBoxB);
   connectUi();
+  connectCardUi(&m_card_a, m_ui.buttonBoxA);
+  connectCardUi(&m_card_b, m_ui.buttonBoxB);
   populateComboBox(m_ui.cardAPath);
   populateComboBox(m_ui.cardBPath);
 
@@ -98,14 +106,30 @@ void MemoryCardEditorDialog::closeEvent(QCloseEvent* ev)
   m_card_b.path_cb->setCurrentIndex(0);
 }
 
+void MemoryCardEditorDialog::createCardButtons(Card* card, QDialogButtonBox* buttonBox)
+{
+  card->format_button = buttonBox->addButton(tr("Format Card"), QDialogButtonBox::ActionRole);
+  card->import_file_button = buttonBox->addButton(tr("Import File..."), QDialogButtonBox::ActionRole);
+  card->import_button = buttonBox->addButton(tr("Import Card..."), QDialogButtonBox::ActionRole);
+  card->save_button = buttonBox->addButton(tr("Save"), QDialogButtonBox::ActionRole);
+}
+
+void MemoryCardEditorDialog::connectCardUi(Card* card, QDialogButtonBox* buttonBox)
+{
+  connect(card->save_button, &QPushButton::clicked, [this, card] { saveCard(card); });
+  connect(card->format_button, &QPushButton::clicked, [this, card] { formatCard(card); });
+  connect(card->import_file_button, &QPushButton::clicked, [this, card] { importSaveFile(card); });
+  connect(card->import_button, &QPushButton::clicked, [this, card] { importCard(card); });
+}
+
 void MemoryCardEditorDialog::connectUi()
 {
   connect(m_ui.cardA, &QTableWidget::itemSelectionChanged, this, &MemoryCardEditorDialog::onCardASelectionChanged);
   connect(m_ui.cardB, &QTableWidget::itemSelectionChanged, this, &MemoryCardEditorDialog::onCardBSelectionChanged);
-  connect(m_ui.moveLeft, &QPushButton::clicked, this, &MemoryCardEditorDialog::doCopyFile);
-  connect(m_ui.moveRight, &QPushButton::clicked, this, &MemoryCardEditorDialog::doCopyFile);
-  connect(m_ui.deleteFile, &QPushButton::clicked, this, &MemoryCardEditorDialog::doDeleteFile);
-  connect(m_ui.undeleteFile, &QPushButton::clicked, this, &MemoryCardEditorDialog::doUndeleteFile);
+  connect(m_moveLeft, &QPushButton::clicked, this, &MemoryCardEditorDialog::doCopyFile);
+  connect(m_moveRight, &QPushButton::clicked, this, &MemoryCardEditorDialog::doCopyFile);
+  connect(m_deleteFile, &QPushButton::clicked, this, &MemoryCardEditorDialog::doDeleteFile);
+  connect(m_undeleteFile, &QPushButton::clicked, this, &MemoryCardEditorDialog::doUndeleteFile);
 
   connect(m_ui.cardAPath, QOverload<int>::of(&QComboBox::currentIndexChanged),
           [this](int index) { loadCardFromComboBox(&m_card_a, index); });
@@ -115,15 +139,7 @@ void MemoryCardEditorDialog::connectUi()
   connect(m_ui.newCardB, &QPushButton::clicked, [this]() { newCard(&m_card_b); });
   connect(m_ui.openCardA, &QPushButton::clicked, [this]() { openCard(&m_card_a); });
   connect(m_ui.openCardB, &QPushButton::clicked, [this]() { openCard(&m_card_b); });
-  connect(m_ui.saveCardA, &QPushButton::clicked, [this]() { saveCard(&m_card_a); });
-  connect(m_ui.saveCardB, &QPushButton::clicked, [this]() { saveCard(&m_card_b); });
-  connect(m_ui.importCardA, &QPushButton::clicked, [this]() { importCard(&m_card_a); });
-  connect(m_ui.importCardB, &QPushButton::clicked, [this]() { importCard(&m_card_b); });
-  connect(m_ui.formatCardA, &QPushButton::clicked, [this]() { formatCard(&m_card_a); });
-  connect(m_ui.formatCardB, &QPushButton::clicked, [this]() { formatCard(&m_card_b); });
-  connect(m_ui.exportFile, &QPushButton::clicked, this, &MemoryCardEditorDialog::doExportSaveFile);
-  connect(m_ui.importFileToCardA, &QPushButton::clicked, [this]() { importSaveFile(&m_card_a); });
-  connect(m_ui.importFileToCardB, &QPushButton::clicked, [this]() { importSaveFile(&m_card_b); });
+  connect(m_exportFile, &QPushButton::clicked, this, &MemoryCardEditorDialog::doExportSaveFile);
 }
 
 void MemoryCardEditorDialog::populateComboBox(QComboBox* cb)
@@ -580,15 +596,11 @@ void MemoryCardEditorDialog::updateButtonState()
   const bool card_a_present = !m_card_a.filename.empty();
   const bool card_b_present = !m_card_b.filename.empty();
   const bool both_cards_present = card_a_present && card_b_present;
-  m_ui.deleteFile->setEnabled(has_selection);
-  m_ui.undeleteFile->setEnabled(is_deleted);
-  m_ui.exportFile->setEnabled(has_selection);
-  m_ui.moveLeft->setEnabled(both_cards_present && has_selection && is_card_b);
-  m_ui.moveRight->setEnabled(both_cards_present && has_selection && !is_card_b);
-  m_ui.importCardA->setEnabled(card_a_present);
-  m_ui.importCardB->setEnabled(card_b_present);
-  m_ui.importFileToCardA->setEnabled(card_a_present);
-  m_ui.importFileToCardB->setEnabled(card_b_present);
-  m_ui.formatCardA->setEnabled(card_a_present);
-  m_ui.formatCardB->setEnabled(card_b_present);
+  m_deleteFile->setEnabled(has_selection);
+  m_undeleteFile->setEnabled(is_deleted);
+  m_exportFile->setEnabled(has_selection);
+  m_moveLeft->setEnabled(both_cards_present && has_selection && is_card_b);
+  m_moveRight->setEnabled(both_cards_present && has_selection && !is_card_b);
+  m_ui.buttonBoxA->setEnabled(card_a_present);
+  m_ui.buttonBoxB->setEnabled(card_b_present);
 }

--- a/src/duckstation-qt/memorycardeditordialog.cpp
+++ b/src/duckstation-qt/memorycardeditordialog.cpp
@@ -222,6 +222,7 @@ bool MemoryCardEditorDialog::loadCard(const QString& filename, Card* card)
 
 static void setCardTableItemProperties(QTableWidgetItem* item, const MemoryCardImage::FileInfo& fi)
 {
+  item->setFlags(item->flags() & ~(Qt::ItemIsEditable));
   if (fi.deleted)
   {
     item->setBackground(Qt::darkRed);

--- a/src/duckstation-qt/memorycardeditordialog.h
+++ b/src/duckstation-qt/memorycardeditordialog.h
@@ -3,6 +3,7 @@
 #include "ui_memorycardeditordialog.h"
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QDialog>
+#include <QtWidgets/QDialogButtonBox>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QPushButton>
 #include <QtWidgets/QTableWidget>
@@ -44,7 +45,13 @@ private:
     QTableWidget* table = nullptr;
     QLabel* blocks_free_label = nullptr;
     QPushButton* save_button = nullptr;
+    QPushButton* import_button = nullptr;
+    QPushButton* import_file_button = nullptr;
+    QPushButton* format_button = nullptr;
   };
+
+  void createCardButtons(Card* card, QDialogButtonBox* buttonBox);
+  void connectCardUi(Card* card, QDialogButtonBox* buttonBox);
 
   void connectUi();
   void populateComboBox(QComboBox* cb);
@@ -68,6 +75,11 @@ private:
   void updateButtonState();
 
   Ui::MemoryCardEditorDialog m_ui;
+  QPushButton* m_deleteFile;
+  QPushButton* m_undeleteFile;
+  QPushButton* m_exportFile;
+  QPushButton* m_moveLeft;
+  QPushButton* m_moveRight;
 
   Card m_card_a;
   Card m_card_b;

--- a/src/duckstation-qt/memorycardeditordialog.ui
+++ b/src/duckstation-qt/memorycardeditordialog.ui
@@ -97,7 +97,7 @@
     </layout>
    </item>
    <item row="2" column="3">
-    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0,0,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0">
      <item>
       <widget class="QLabel" name="cardBUsage">
        <property name="text">
@@ -106,49 +106,16 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="formatCardB">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Format Card</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="importFileToCardB">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Import File...</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="importCardB">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Import Card...</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="saveCardB">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Save</string>
+      <widget class="QDialogButtonBox" name="buttonBoxB">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::NoButton</set>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0,0,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="1,0">
      <item>
       <widget class="QLabel" name="cardAUsage">
        <property name="text">
@@ -157,42 +124,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="formatCardA">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Format Card</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="importFileToCardA">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Import File...</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="importCardA">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Import Card...</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="saveCardA">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Save</string>
+      <widget class="QDialogButtonBox" name="buttonBoxA">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::NoButton</set>
        </property>
       </widget>
      </item>
@@ -276,72 +210,15 @@
      </column>
     </widget>
    </item>
-   <item row="1" column="2">
-    <layout class="QVBoxLayout" name="verticalLayout_3">
-     <item>
-      <widget class="QPushButton" name="deleteFile">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Delete File</string>
-       </property>
-      </widget>
-     </item>
-    <item>
-      <widget class="QPushButton" name="undeleteFile">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Undelete File</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="exportFile">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Export File</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="moveLeft">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>&lt;&lt;</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="moveRight">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>&gt;&gt;</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+   <item row="1" column="1">
+    <widget class="QDialogButtonBox" name="centerButtonBox">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::NoButton</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/duckstation-qt/postprocessingshaderconfigwidget.cpp
+++ b/src/duckstation-qt/postprocessingshaderconfigwidget.cpp
@@ -1,8 +1,8 @@
 #include "postprocessingshaderconfigwidget.h"
 #include <QtWidgets/QCheckBox>
+#include <QtWidgets/QDialogButtonBox>
 #include <QtWidgets/QGridLayout>
 #include <QtWidgets/QLabel>
-#include <QtWidgets/QPushButton>
 #include <QtWidgets/QSlider>
 
 using FrontendCommon::PostProcessingShader;
@@ -129,9 +129,9 @@ void PostProcessingShaderConfigWidget::createUi()
     }
   }
 
-  QPushButton* reset_button = new QPushButton(tr("Reset to Defaults"), this);
-  connect(reset_button, &QPushButton::clicked, this, &PostProcessingShaderConfigWidget::onResetToDefaultsClicked);
-  m_layout->addWidget(reset_button, row, 0, 1, 1);
+  QDialogButtonBox* button_box = new QDialogButtonBox(QDialogButtonBox::RestoreDefaults, this);
+  connect(button_box, &QDialogButtonBox::clicked, this, &PostProcessingShaderConfigWidget::onResetToDefaultsClicked);
+  m_layout->addWidget(button_box, row, 0, 1, -1);
 
   row++;
   m_layout->addItem(new QSpacerItem(1, 1, QSizePolicy::Minimum, QSizePolicy::Expanding), row, 0, 1, 3);
@@ -157,9 +157,9 @@ PostProcessingShaderConfigDialog::PostProcessingShaderConfigDialog(QWidget* pare
   connect(m_widget, &PostProcessingShaderConfigWidget::configChanged, this,
           &PostProcessingShaderConfigDialog::onConfigChanged);
 
-  QPushButton* close_button = new QPushButton(tr("Close"), this);
-  connect(close_button, &QPushButton::clicked, this, &PostProcessingShaderConfigDialog::onCloseClicked);
-  m_widget->getLayout()->addWidget(close_button, m_widget->getLayout()->rowCount() - 1, 2, 1, 2);
+  QDialogButtonBox* button_box = new QDialogButtonBox(QDialogButtonBox::Close, this);
+  connect(button_box, &QDialogButtonBox::rejected, this, &PostProcessingShaderConfigDialog::onCloseClicked);
+  m_widget->getLayout()->addWidget(button_box, m_widget->getLayout()->rowCount() - 1, 2, 1, 2);
 }
 
 PostProcessingShaderConfigDialog::~PostProcessingShaderConfigDialog() = default;

--- a/src/duckstation-qt/settingsdialog.cpp
+++ b/src/duckstation-qt/settingsdialog.cpp
@@ -76,8 +76,13 @@ SettingsDialog::SettingsDialog(QtHostInterface* host_interface, QWidget* parent 
   m_ui.settingsContainer->setCurrentIndex(0);
   m_ui.helpText->setText(m_category_help_text[0]);
   connect(m_ui.settingsCategory, &QListWidget::currentRowChanged, this, &SettingsDialog::onCategoryCurrentRowChanged);
-  connect(m_ui.closeButton, &QPushButton::clicked, this, &SettingsDialog::accept);
-  connect(m_ui.restoreDefaultsButton, &QPushButton::clicked, this, &SettingsDialog::onRestoreDefaultsClicked);
+  connect(m_ui.buttonBox, &QDialogButtonBox::rejected, this, &SettingsDialog::accept);
+  connect(m_ui.buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button) {
+    if (m_ui.buttonBox->buttonRole(button) == QDialogButtonBox::ResetRole)
+    {
+      onRestoreDefaultsClicked();
+    }
+  });
 
   connect(m_console_settings, &ConsoleSettingsWidget::multitapModeChanged, m_controller_settings,
           &ControllerSettingsWidget::updateMultitapControllerTitles);

--- a/src/duckstation-qt/settingsdialog.ui
+++ b/src/duckstation-qt/settingsdialog.ui
@@ -27,6 +27,21 @@
     <normaloff>:/icons/duck.png</normaloff>:/icons/duck.png</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QStackedWidget" name="settingsContainer">
+     <property name="minimumSize">
+      <size>
+       <width>500</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="page"/>
+     <widget class="QWidget" name="page_2"/>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QListWidget" name="settingsCategory">
      <property name="sizePolicy">
@@ -58,7 +73,8 @@
        <string>General Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="GeneralSettings"/>
+       <iconset theme="GeneralSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -66,7 +82,8 @@
        <string>BIOS Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="BIOSSettings"/>
+       <iconset theme="BIOSSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -74,7 +91,8 @@
        <string>Console Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="ConsoleSettings"/>
+       <iconset theme="ConsoleSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -82,7 +100,8 @@
        <string>Emulation Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="EmulationSettings"/>
+       <iconset theme="EmulationSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -90,7 +109,8 @@
        <string>Game List Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="GamelistSettings"/>
+       <iconset theme="GamelistSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -98,7 +118,8 @@
        <string>Hotkey Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="HotkeySettings"/>
+       <iconset theme="HotkeySettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -106,7 +127,8 @@
        <string>Controller Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="ControllerSettings"/>
+       <iconset theme="ControllerSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -114,7 +136,8 @@
        <string>Memory Card Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="MemorycardSettings"/>
+       <iconset theme="MemorycardSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -122,7 +145,8 @@
        <string>Display Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="DisplaySettings"/>
+       <iconset theme="DisplaySettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -130,7 +154,8 @@
        <string>Enhancement Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="EnhancementSettings"/>
+       <iconset theme="EnhancementSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -138,7 +163,8 @@
        <string>Post-Processing Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="PostprocessingSettings"/>
+       <iconset theme="PostprocessingSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -146,7 +172,8 @@
        <string>Audio Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="AudioSettings"/>
+       <iconset theme="AudioSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -154,7 +181,8 @@
        <string>Achievement Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="AchievementsSettings"/>
+       <iconset theme="AchievementsSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
      <item>
@@ -162,24 +190,17 @@
        <string>Advanced Settings</string>
       </property>
       <property name="icon">
-       <iconset theme="AdvancedSettings"/>
+       <iconset theme="AdvancedSettings">
+        <normaloff>.</normaloff>.</iconset>
       </property>
      </item>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QStackedWidget" name="settingsContainer">
-     <property name="minimumSize">
-      <size>
-       <width>500</width>
-       <height>0</height>
-      </size>
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::RestoreDefaults</set>
      </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page"/>
-     <widget class="QWidget" name="page_2"/>
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
@@ -200,40 +221,6 @@
       <bool>true</bool>
      </property>
     </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="restoreDefaultsButton">
-       <property name="text">
-        <string>Restore Defaults</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="closeButton">
-       <property name="text">
-        <string>Close</string>
-       </property>
-       <property name="default">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
1. Memory Card Editor fields were editable, but they shouldn't be.
2. Migrated most `QPushButton`s to `QDialogButtonBox`. This cuts down on unneccessary translations, as Qt ones may now be used for common phrases like Close/Save/Apply/Restore Defaults, and additionally ensures Qt opts for platform's native button order/alignment.