### PR TITLE
M3U: Preloading to RAM for single-disc playlists.

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -655,7 +655,7 @@ std::unique_ptr<CDImage> OpenCDImage(const char* path, Common::Error* error, boo
 
   if (force_preload || g_settings.cdrom_load_image_to_ram)
   {
-    if (media->HasSubImages())
+    if (media->HasSubImages() && media->GetSubImageCount() > 1)
     {
       g_host_interface->AddFormattedOSDMessage(
         15.0f,


### PR DESCRIPTION
HasSubImages will return false when the playlist has only a single sub-image.