### PR TITLE
Add 5106, 5146, 5186 codes for indirect reads from a register code

### DIFF
--- a/data/database/chtdb.txt
+++ b/data/database/chtdb.txt
@@ -267,10 +267,6 @@
 ;                      It will then poke all following codes for rest of cheat
 ;  00000000 FFFF       or until it reaches the 00000000 FFFF line.
 ;
-;* 52XXXXXX YYYYYYYY - Register Master Code, if ($XXXXXX) contains 0xYYYYYYYY poke
-;  00000000 FFFF       all following codes for rest of the cheat or until it reaches
-;                      the 00000000 FFFF line.
-;
 ;  Other Code Types
 ;  ****************
 ;  These are only needed on hardware when you can't enable & disable codes after
@@ -304,21 +300,25 @@
 ;* 510000XX TTTTTTTT - 8-Bit Address Write from Register, Poke address TTTTTTTT
 ;                      with the 8-bit contents of Register XX. 
 ;                      u8Poke TTTTTTTT, RegXX
-;* 510100XX TTTTTTTT - 8-Bit Address Read to Register, Peek the 8bit contents of
+;* 510100XX TTTTTTTT - 8-Bit Address Read to Register, Peek the 8-bit contents of
 ;                      address TTTTTTTT and store it in Register XX.
 ;                      u8Poke RegXX, (TTTTTTTT) 
 ;* 510200XX 000000ZZ - 8-Bit Indirect Register Write, poke ZZ to the 32-Bit 
 ;                      address stored in Register XX.
 ;                      u8Poke (RegXX), ZZ 
-;* 5103YYXX 000000ZZ - 8-Bit Register Addition, add ZZ and the 8 bit contents 
+;* 5103YYXX 000000ZZ - 8-Bit Register Addition, add ZZ and the 8-bit contents 
 ;                      of Register YY together and write it to Register XX.
 ;                      u8Poke RegXX, RegYY + ZZ                  
 ;* 5104YYXX 000000ZZ - 8-Bit Indirect Register Write with addition, add ZZ and  
-;                      the 8 bit contents of Register YY together and write it  
+;                      the 8-bit contents of Register YY together and write it  
 ;                      to the 32-Bit address stored in Register XX.
 ;                      u8Poke (RegXX), RegYY + ZZ  
 ;* 510500XX 000000ZZ - 8-Bit Direct Register Write, poke ZZ to Register XX.
 ;                      u8Poke RegXX, ZZ  
+;* 5106YYXX ZZZZZZZZ - 8-Bit Indirect Register Read, Peek the 8-bit contents
+;                      of (32-Bit address in Register YY + ZZZZZZZZ) and write it
+;                      to Register XX.
+;                      u8Poke RegXX, (RegYY + ZZZZZZZZ)
 ;
 ; 16 BIT operations:
 ; ==================
@@ -340,6 +340,10 @@
 ;                      u16Poke (RegXX), RegYY + ZZZZ 
 ;* 514500XX 0000ZZZZ - 16-Bit Direct Register Write, poke ZZZZ to Register XX.
 ;                      u16Poke RegXX, ZZZZ  
+;* 5146YYXX ZZZZZZZZ - 16-Bit Indirect Register Read, Peek the 16-bit contents
+;                      of (32-Bit address in Register YY + ZZZZZZZZ) and write it
+;                      to Register XX.
+;                      u16Poke RegXX, (RegYY + ZZZZZZZZ)
 ;
 ; 32 BIT operations:
 ; ==================
@@ -363,6 +367,10 @@
 ;* 518500XX ZZZZZZZZ - 32-Bit Direct Register Write, poke ZZZZZZZZ to Register XX.
 ;                      u32Poke RegXX, ZZZZZZZZ. Note: This is useful to write
 ;                      the actual address to a register.  
+;* 5186YYXX ZZZZZZZZ - 32-Bit Indirect Register Read, Peek the 32-bit contents
+;                      of (32-Bit address in Register YY + ZZZZZZZZ) and write it
+;                      to Register XX.
+;                      u32Poke RegXX, (RegYY + ZZZZZZZZ)
 ;
 ; Generic Register Operations:
 ; ============================

--- a/src/core/cheats.cpp
+++ b/src/core/cheats.cpp
@@ -1492,6 +1492,10 @@ void CheatCode::Apply() const
           case 0x05: // Write the u8 poke value to cht_register[cht_reg_no1]
             cht_register[cht_reg_no1] = Truncate8(poke_value & 0xFFu);
             break;
+          case 0x06: // Read the u8 value from the address (cht_register[cht_reg_no2] + poke_value) to
+                     // cht_register[cht_reg_no1]
+            cht_register[cht_reg_no1] = DoMemoryRead<u8>(cht_register[cht_reg_no2] + poke_value);
+            break;
 
           case 0x40: // Write the u16 from cht_register[cht_reg_no1] to address
             DoMemoryWrite<u16>(inst.value32, Truncate16(cht_register[cht_reg_no1] & 0xFFFFu));
@@ -1515,6 +1519,10 @@ void CheatCode::Apply() const
           case 0x45: // Write the u16 poke value to cht_register[cht_reg_no1]
             cht_register[cht_reg_no1] = Truncate16(poke_value & 0xFFFFu);
             break;
+          case 0x46: // Read the u16 value from the address (cht_register[cht_reg_no2] + poke_value) to
+                     // cht_register[cht_reg_no1]
+            cht_register[cht_reg_no1] = DoMemoryRead<u16>(cht_register[cht_reg_no2] + poke_value);
+            break;
 
           case 0x80: // Write the u32 from cht_register[cht_reg_no1] to address
             DoMemoryWrite<u32>(inst.value32, cht_register[cht_reg_no1]);
@@ -1535,6 +1543,10 @@ void CheatCode::Apply() const
             break;
           case 0x85: // Write the u32 poke value to cht_register[cht_reg_no1]
             cht_register[cht_reg_no1] = poke_value;
+            break;
+          case 0x86: // Read the u32 value from the address (cht_register[cht_reg_no2] + poke_value) to
+                     // cht_register[cht_reg_no1]
+            cht_register[cht_reg_no1] = DoMemoryRead<u32>(cht_register[cht_reg_no2] + poke_value);
             break;
 
           case 0xC0: // Reg3 = Reg2 + Reg1


### PR DESCRIPTION
Register codes had an option to write to an address stored in a register, but there is no way to **read** from an address stored in a register. This PR implements 5106, 5146, 5186 codes doing this.

All 3 codes are implemented in a form of
`5186YYXX ZZZZZZZZ - Poke RegXX, (RegYY + ZZZZZZZZ)`
This allows to easily read fields of dynamically allocated structures - first read the pointer to a register, then make more indirect reads with offset from that register. Effectively, this allows for dealing with pointers of **any** indirection.

Example code for Gran Turismo 2 - the code does the following:
1. Reads a pointer from `0002F4F4` to `X`
2. Reads a `u8` value from `X+0x2EE` to `Y` (implemented in this PR)
3. Increments `Y` with a wraparound check if `Y > 5`
4. Writes `Y` back to `X+0x2EE`.


```
[*R3 to switch BGM in race]
51050003 00
A403EC74 02602021
D7010001 02000400
51810003 0002F4F4
00000000 FFFF
00000000 FFFF
52910003 00000000
51060304 000002EE # Added in this PR
51030404 01
52120004 05
51050004 00
00000000 FFFF
00000000 FFFF
52910003 00000000
51830303 000002EE
51040403 00
00000000 FFFF
```