### PR TITLE
Add keys to more OSD messages

### DIFF
--- a/src/core/gpu_hw.cpp
+++ b/src/core/gpu_hw.cpp
@@ -149,8 +149,9 @@ void GPU_HW::UpdateHWSettings(bool* framebuffer_changed, bool* shaders_changed)
 
   if (m_resolution_scale != resolution_scale)
   {
-    g_host_interface->AddFormattedOSDMessage(
-      10.0f, g_host_interface->TranslateString("OSDMessage", "Resolution scale set to %ux (display %ux%u, VRAM %ux%u)"),
+    g_host_interface->AddKeyedFormattedOSDMessage(
+      "ResolutionScale", 10.0f,
+      g_host_interface->TranslateString("OSDMessage", "Resolution scale set to %ux (display %ux%u, VRAM %ux%u)"),
       resolution_scale, m_crtc_state.display_vram_width * resolution_scale,
       resolution_scale * m_crtc_state.display_vram_height, VRAM_WIDTH * resolution_scale,
       VRAM_HEIGHT * resolution_scale);
@@ -160,14 +161,15 @@ void GPU_HW::UpdateHWSettings(bool* framebuffer_changed, bool* shaders_changed)
   {
     if (per_sample_shading)
     {
-      g_host_interface->AddFormattedOSDMessage(
-        10.0f, g_host_interface->TranslateString("OSDMessage", "Multisample anti-aliasing set to %ux (SSAA)."),
-        multisamples);
+      g_host_interface->AddKeyedFormattedOSDMessage(
+        "Multisampling", 10.0f,
+        g_host_interface->TranslateString("OSDMessage", "Multisample anti-aliasing set to %ux (SSAA)."), multisamples);
     }
     else
     {
-      g_host_interface->AddFormattedOSDMessage(
-        10.0f, g_host_interface->TranslateString("OSDMessage", "Multisample anti-aliasing set to %ux."), multisamples);
+      g_host_interface->AddKeyedFormattedOSDMessage(
+        "Multisampling", 10.0f,
+        g_host_interface->TranslateString("OSDMessage", "Multisample anti-aliasing set to %ux."), multisamples);
     }
   }
 

--- a/src/core/host_interface.cpp
+++ b/src/core/host_interface.cpp
@@ -1074,8 +1074,8 @@ void HostInterface::ToggleSoftwareRendering()
 
   const GPURenderer new_renderer = g_gpu->IsHardwareRenderer() ? GPURenderer::Software : g_settings.gpu_renderer;
 
-  AddFormattedOSDMessage(5.0f, TranslateString("OSDMessage", "Switching to %s renderer..."),
-                         Settings::GetRendererDisplayName(new_renderer));
+  AddKeyedFormattedOSDMessage("SoftwareRendering", 5.0f, TranslateString("OSDMessage", "Switching to %s renderer..."),
+                              Settings::GetRendererDisplayName(new_renderer));
   System::RecreateGPU(new_renderer);
   OnDisplayInvalidated();
 }

--- a/src/frontend-common/common_host_interface.cpp
+++ b/src/frontend-common/common_host_interface.cpp
@@ -2594,24 +2594,25 @@ void CommonHostInterface::RegisterGraphicsHotkeys()
                    if (pressed && System::IsValid())
                    {
                      g_settings.gpu_pgxp_cpu = !g_settings.gpu_pgxp_cpu;
+                     if (!g_settings.gpu_pgxp_enable)
+                       return;
+
                      g_gpu->RestoreGraphicsAPIState();
                      g_gpu->UpdateSettings();
                      g_gpu->ResetGraphicsAPIState();
                      System::ClearMemorySaveStates();
-                     AddOSDMessage(g_settings.gpu_pgxp_cpu ?
-                                     TranslateStdString("OSDMessage", "PGXP CPU mode is now enabled.") :
-                                     TranslateStdString("OSDMessage", "PGXP CPU mode is now disabled."),
-                                   5.0f);
+                     AddKeyedOSDMessage("TogglePGXPCPU",
+                                        g_settings.gpu_pgxp_cpu ?
+                                          TranslateStdString("OSDMessage", "PGXP CPU mode is now enabled.") :
+                                          TranslateStdString("OSDMessage", "PGXP CPU mode is now disabled."),
+                                        5.0f);
 
-                     if (g_settings.gpu_pgxp_enable)
-                     {
-                       PGXP::Shutdown();
-                       PGXP::Initialize();
+                     PGXP::Shutdown();
+                     PGXP::Initialize();
 
-                       // we need to recompile all blocks if pgxp is toggled on/off
-                       if (g_settings.IsUsingCodeCache())
-                         CPU::CodeCache::Flush();
-                     }
+                     // we need to recompile all blocks if pgxp is toggled on/off
+                     if (g_settings.IsUsingCodeCache())
+                       CPU::CodeCache::Flush();
                    }
                  });
 }
@@ -4056,14 +4057,14 @@ void CommonHostInterface::TogglePostProcessing()
   g_settings.display_post_processing = !g_settings.display_post_processing;
   if (g_settings.display_post_processing)
   {
-    AddOSDMessage(TranslateStdString("OSDMessage", "Post-processing is now enabled."), 10.0f);
+    AddKeyedOSDMessage("PostProcessing", TranslateStdString("OSDMessage", "Post-processing is now enabled."), 10.0f);
 
     if (!m_display->SetPostProcessingChain(g_settings.display_post_process_chain))
       AddOSDMessage(TranslateStdString("OSDMessage", "Failed to load post processing shader chain."), 20.0f);
   }
   else
   {
-    AddOSDMessage(TranslateStdString("OSDMessage", "Post-processing is now disabled."), 10.0f);
+    AddKeyedOSDMessage("PostProcessing", TranslateStdString("OSDMessage", "Post-processing is now disabled."), 10.0f);
     m_display->SetPostProcessingChain({});
   }
 }
@@ -4112,15 +4113,17 @@ void CommonHostInterface::ToggleWidescreen()
 
   if (g_settings.gpu_widescreen_hack)
   {
-    AddFormattedOSDMessage(
-      5.0f, TranslateString("OSDMessage", "Widescreen hack is now enabled, and aspect ratio is set to %s."),
+    AddKeyedFormattedOSDMessage(
+      "WidescreenHack", 5.0f,
+      TranslateString("OSDMessage", "Widescreen hack is now enabled, and aspect ratio is set to %s."),
       TranslateString("DisplayAspectRatio", Settings::GetDisplayAspectRatioName(g_settings.display_aspect_ratio))
         .GetCharArray());
   }
   else
   {
-    AddFormattedOSDMessage(
-      5.0f, TranslateString("OSDMessage", "Widescreen hack is now disabled, and aspect ratio is set to %s."),
+    AddKeyedFormattedOSDMessage(
+      "WidescreenHack", 5.0f,
+      TranslateString("OSDMessage", "Widescreen hack is now disabled, and aspect ratio is set to %s."),
       TranslateString("DisplayAspectRatio", Settings::GetDisplayAspectRatioName(g_settings.display_aspect_ratio))
         .GetCharArray());
   }


### PR DESCRIPTION
The following actions, bindable to hotkeys, previously did not have keys for their OSD messages.

* Resolution scale
* Multisampling
* Switching software/hardware rendering
* Switching PGXP CPU
* Switching post processing
* Switching widescreen hack

This means that bashing hotkeys back and forth could result in spam like this, where all but the last message are meaningless:
![image](https://user-images.githubusercontent.com/7947461/167503800-d3faf1fb-7fa2-47f0-8b2e-b3060503e45f.png)

This also makes behaviour more consistent as e.g. PGXP, PGXP depth buffer toggles already were keyed, but e.g. PGXP CPU was not.