### PR TITLE
Little improvements to the post-processing tab

### DIFF
--- a/src/duckstation-qt/postprocessingsettingswidget.ui
+++ b/src/duckstation-qt/postprocessingsettingswidget.ui
@@ -108,19 +108,6 @@
      </widget>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/src/duckstation-qt/postprocessingshaderconfigwidget.cpp
+++ b/src/duckstation-qt/postprocessingshaderconfigwidget.cpp
@@ -19,7 +19,6 @@ PostProcessingShaderConfigWidget::~PostProcessingShaderConfigWidget() = default;
 void PostProcessingShaderConfigWidget::createUi()
 {
   m_layout = new QGridLayout(this);
-  m_layout->setContentsMargins(0, 0, 0, 0);
   u32 row = 0;
 
   for (PostProcessingShader::Option& option : m_shader->GetOptions())


### PR DESCRIPTION
It was a bit hard to read the shader parameter names when there were no margins.

---
### Before
![Before](https://user-images.githubusercontent.com/5585984/180811580-a0dc6475-4a14-4368-91a2-c372b11082b0.png)

### After
![After](https://user-images.githubusercontent.com/5585984/180811668-f6cb155d-3170-4382-a682-b4f0b9979dee.png)