### PR TITLE
fix throttler and vsync related issues

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -2210,13 +2210,6 @@ void System::UpdateSpeedLimiterState()
     }
   }
 
-  const bool video_sync_enabled = ShouldUseVSync();
-  const float max_display_fps = (!IsRunning() || m_throttler_enabled) ? 0.0f : g_settings.display_max_fps;
-  Log_InfoPrintf("Target speed: %f%%", target_speed * 100.0f);
-  Log_InfoPrintf("Using vsync: %s", video_sync_enabled ? "YES" : "NO");
-  Log_InfoPrintf("Max display fps: %f (%s)", max_display_fps,
-                 m_display_all_frames ? "displaying all frames" : "skipping displaying frames when needed");
-
   if (IsValid())
   {
     AudioStream* stream = g_spu.GetOutputStream();
@@ -2235,6 +2228,13 @@ void System::UpdateSpeedLimiterState()
     ResetThrottler();
   }
 
+  const bool video_sync_enabled = ShouldUseVSync();
+  const float max_display_fps = (!IsRunning() || m_throttler_enabled) ? 0.0f : g_settings.display_max_fps;
+  Log_InfoPrintf("Target speed: %f%%", target_speed * 100.0f);
+  Log_InfoPrintf("Using vsync: %s", video_sync_enabled ? "YES" : "NO");
+  Log_InfoPrintf("Max display fps: %f (%s)", max_display_fps,
+      m_display_all_frames ? "displaying all frames" : "skipping displaying frames when needed");
+
   g_host_display->SetDisplayMaxFPS(max_display_fps);
   g_host_display->SetVSync(video_sync_enabled);
 
@@ -2251,7 +2251,7 @@ void System::UpdateSpeedLimiterState()
 
 bool System::ShouldUseVSync()
 {
-  return (!IsRunning() || (m_throttler_enabled && g_settings.video_sync_enabled && !IsRunningAtNonStandardSpeed()));
+  return (!IsRunning() || (g_settings.video_sync_enabled && !IsRunningAtNonStandardSpeed()));
 }
 
 bool System::IsFastForwardEnabled()


### PR DESCRIPTION
This commit may fix issues like below:

  * VSYNC will be disabled after pause (including disc change, etc.)
  * 'Unlimited' setting for fast-forward / turbo not working. (And it seems other speed setting also not working..)

This commit fixes below functions:

  * System::UpdateSpeedLimiterState()
    * m_throttler_enabled should be set if target_speed != 1.0f, not 0.0f. 
      - m_throttler_enabled was set to true even in case emulator is running at 100%.
      - m_throttler_enabled was set to false in case fast_forward/turbo was enabled but set to 'Unlimited'
    * ShouldUseVSync() should be called after s_target_speed is updated with target_speed.
      - ShouldUseVSync() uses IsRunningAtNonStandardSpeed() internally, and it refers s_target_speed. 

  * System::ShouldUseVSync()
    * I guess this function should return 'true' in case 'g_settings.video_sync_enabled == true' && 'm_throttler_enabled == false'. but current implementation returns false.