### PR TITLE
Use existing desktop file for AppImage

### DIFF
--- a/scripts/make-appimage.sh
+++ b/scripts/make-appimage.sh
@@ -275,17 +275,7 @@ Plugins = ../lib/plugins
 EOF
 
 echo "Creating desktop..."
-cat > "$OUTDIR/duckstation-qt.desktop" << EOF
-[Desktop Entry]
-Type=Application
-Name=DuckStation
-GenericName=PlayStation 1 Emulator
-Comment=Fast PlayStation 1 emulator
-Icon=duckstation-qt
-TryExec=duckstation-qt
-Exec=duckstation-qt %f
-Categories=Game;Emulator;Qt;
-EOF
+cp "$ROOTDIR/extras/linux-desktop-files/duckstation-qt.desktop" "$OUTDIR"
 cp "$ROOTDIR/extras/icons/icon-256px.png" "$OUTDIR/duckstation-qt.png"
 
 echo "Creating AppRun..."


### PR DESCRIPTION
By looking at the build scripts I noticed that the existing desktop file can be used when building the AppImage.
The field changes are:
- `Name` from `DuckStation` to `DuckStation Qt`
- `Comment` from `Fast PlayStation 1 emulator` to `Fast-ish PlayStation 1 emulator`.

Other than that both files are the same.