### PR TITLE
Fix "MSAA" and "SSAA" texts being swapped in enhancements overlay

### DIFF
--- a/src/frontend-common/imgui_overlays.cpp
+++ b/src/frontend-common/imgui_overlays.cpp
@@ -270,7 +270,7 @@ void ImGuiManager::DrawEnhancementsOverlay()
   if (g_settings.gpu_multisamples != 1)
   {
     text.AppendFormattedString(" %ux%s", g_settings.gpu_multisamples,
-                               g_settings.gpu_per_sample_shading ? "MSAA" : "SSAA");
+                               g_settings.gpu_per_sample_shading ? "SSAA" : "MSAA");
   }
   if (g_settings.gpu_true_color)
     text.AppendString(" TrueCol");


### PR DESCRIPTION
Previously, when you selected MSAA in the advanced options, you got MSAA but the enhancements display showed "SSAA". The opposite happened when you selected SSAA.

(This checks out as per-sample shading refers to SSAA, while MSAA is only per-sample *coverage*.)