### PR TITLE
Warn about the high performance cost of JINC2 and xBR filtering

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -886,9 +886,9 @@ static constexpr auto s_texture_filter_names =
   make_array("Nearest", "Bilinear", "BilinearBinAlpha", "JINC2", "JINC2BinAlpha", "xBR", "xBRBinAlpha");
 static constexpr auto s_texture_filter_display_names =
   make_array(TRANSLATABLE("GPUTextureFilter", "Nearest-Neighbor"), TRANSLATABLE("GPUTextureFilter", "Bilinear"),
-             TRANSLATABLE("GPUTextureFilter", "Bilinear (No Edge Blending)"), TRANSLATABLE("GPUTextureFilter", "JINC2"),
-             TRANSLATABLE("GPUTextureFilter", "JINC2 (No Edge Blending)"), TRANSLATABLE("GPUTextureFilter", "xBR"),
-             TRANSLATABLE("GPUTextureFilter", "xBR (No Edge Blending)"));
+             TRANSLATABLE("GPUTextureFilter", "Bilinear (No Edge Blending)"), TRANSLATABLE("GPUTextureFilter", "JINC2 (Slow)"),
+             TRANSLATABLE("GPUTextureFilter", "JINC2 (Slow, No Edge Blending)"), TRANSLATABLE("GPUTextureFilter", "xBR (Very Slow)"),
+             TRANSLATABLE("GPUTextureFilter", "xBR (Very Slow, No Edge Blending)"));
 
 std::optional<GPUTextureFilter> Settings::ParseTextureFilterName(const char* str)
 {

--- a/src/duckstation-qt/enhancementsettingswidget.cpp
+++ b/src/duckstation-qt/enhancementsettingswidget.cpp
@@ -85,8 +85,8 @@ EnhancementSettingsWidget::EnhancementSettingsWidget(SettingsDialog* dialog, QWi
   dialog->registerWidgetHelp(
     m_ui.textureFiltering, tr("Texture Filtering"),
     qApp->translate("GPUTextureFilter", Settings::GetTextureFilterDisplayName(GPUTextureFilter::Nearest)),
-    tr("Smooths out the blockyness of magnified textures on 3D object by using filtering. <br>Will have a "
-       "greater effect on higher resolution scales. Only applies to the hardware renderers."));
+    tr("Smooths out the blockiness of magnified textures on 3D object by using filtering. <br>Will have a "
+       "greater effect on higher resolution scales. Only applies to the hardware renderers. <br>The JINC2 and especially xBR filtering modes are very demanding, and may not be worth the speed penalty."));
   dialog->registerWidgetHelp(
     m_ui.widescreenHack, tr("Widescreen Hack"), tr("Unchecked"),
     tr("Scales vertex positions in screen-space to a widescreen aspect ratio, essentially "

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -3362,8 +3362,9 @@ void FullscreenUI::DrawDisplaySettingsPage()
     "ResolutionScale", 1, resolution_scales.data(), resolution_scales.size(), 0, is_hardware);
 
   DrawEnumSetting(bsi, "Texture Filtering",
-                  "Smooths out the blockyness of magnified textures on 3D objects. Will have a greater effect "
-                  "on higher resolution scales.",
+                  "Smooths out the blockiness of magnified textures on 3D objects. Will have a greater effect "
+                  "on higher resolution scales. The JINC2 and especially xBR filtering modes are very demanding,"
+                  "and may not be worth the speed penalty.",
                   "GPU", "TextureFilter", Settings::DEFAULT_GPU_TEXTURE_FILTER, &Settings::ParseTextureFilterName,
                   &Settings::GetTextureFilterName, &Settings::GetTextureFilterDisplayName, GPUTextureFilter::Count,
                   is_hardware);


### PR DESCRIPTION
These options (especially xBR) have a very high cost. In my experience, xBR has a greater impact on the framerate than enabling 4× SSAA or PGXP in CPU mode (whose quality increase is much more obvious).

These options are also essentially unusable on mobile, regardless of how powerful your device is. As a result, this adds warnings both in the option names and the description.

Bilinear filtering is not affected by this performance cost, as GPUs can perform this in hardware without having to emulate filtering through a shader.

## Benchmark

<details>
<summary>System information</summary>

### System

**OS:** Fedora 36
**CPU:** Intel Core i7-6700K (4.4 GHz)
**GPU:** GeForce GTX 1080 (NVIDIA 515.65.01)

### DuckStation settings

**Renderer:** Vulkan
**Resolution scale:** 6× (+ 16:9 widescreen)
**Crop:** All Borders
**PGXP:** Enabled (with Culling Correction, Texture Correction, Preserve Projection Precision, Vertex Cache)
</details>

***Note:** "No Edge Blending" modes perform identically to the standard modes.*

### Nearest-Neighbor

![2022-09-22_14 13 31](https://user-images.githubusercontent.com/180032/191747172-8b0dd600-e8a7-42f1-a6b0-1073d71d1a9e.png)

### Bilinear

![2022-09-22_14 13 57](https://user-images.githubusercontent.com/180032/191747177-23854530-45e0-4f63-9c06-e1430cb0d872.png)

### JINC2

![2022-09-22_14 14 40](https://user-images.githubusercontent.com/180032/191747180-f2e28bd6-7ac3-423c-8782-7e3b45cd85ec.png)

### xBR

![2022-09-22_14 15 02](https://user-images.githubusercontent.com/180032/191747182-9344f42d-99ee-4097-b837-668094762fe0.png)