### PR TITLE
Add usage description for Show CPU Usage

### DIFF
--- a/src/duckstation-qt/displaysettingswidget.cpp
+++ b/src/duckstation-qt/displaysettingswidget.cpp
@@ -147,6 +147,9 @@ DisplaySettingsWidget::DisplaySettingsWidget(SettingsDialog* dialog, QWidget* pa
   dialog->registerWidgetHelp(m_ui.showResolution, tr("Show Resolution"), tr("Unchecked"),
                              tr("Shows the resolution of the game in the top-right corner of the display."));
   dialog->registerWidgetHelp(
+    m_ui.showCPU, tr("Show CPU Usage"), tr("Unchecked"),
+    tr("Shows the host's CPU usage based on threads in the top-right corner of the display. This does not display the emulated system CPU's usage. If a value close to 100% is being displayed, this means your host's CPU is likely the bottleneck. In this case, you should reduce enhancement-related settings such as overclocking."));
+  dialog->registerWidgetHelp(
     m_ui.showInput, tr("Show Controller Input"), tr("Unchecked"),
     tr("Shows the current controller state of the system in the bottom-left corner of the display."));
 

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -2364,7 +2364,7 @@ void FullscreenUI::DrawInterfaceSettingsPage()
                     "corner of the display.",
                     "Display", "ShowFPS", false);
   DrawToggleSetting(bsi, ICON_FA_BATTERY_HALF " Show CPU Usage",
-                    "Shows the CPU usage based on threads in the top-right corner of the display.", "Display",
+                    "Shows the host's CPU usage based on threads in the top-right corner of the display.", "Display",
                     "ShowCPU", false);
   DrawToggleSetting(bsi, ICON_FA_SPINNER " Show GPU Usage",
                     "Shows the host's GPU usage in the top-right corner of the display.", "Display", "ShowGPU", false);


### PR DESCRIPTION
Unlike other display options, this one was missing a description.

This clarifies the option's purpose and the fact that it displays the host's CPU usage, not the emulated system's CPU usage.