### PR TITLE
Add option to disable CRT aspect ratio accuracy correction

### DIFF
--- a/src/core/gpu.cpp
+++ b/src/core/gpu.cpp
@@ -526,9 +526,6 @@ float GPU::GetDisplayAspectRatio() const
     if (m_crtc_state.display_width == 0 || m_crtc_state.display_height == 0)
       return 4.0f / 3.0f;
 
-    if (g_settings.display_crt_pillarboxing)
-      return static_cast<float>(m_crtc_state.display_vram_width) / static_cast<float>(m_crtc_state.display_height);
-
     return static_cast<float>(m_crtc_state.display_width) / static_cast<float>(m_crtc_state.display_height);
   }
   else

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -482,6 +482,8 @@ protected:
     // Size of the simulated screen in pixels. Depending on crop mode, this may include overscan area.
     u16 display_width;
     u16 display_height;
+    u16 display_full_width;
+    u16 display_full_height;
 
     // Top-left corner in screen coordinates where the outputted portion of VRAM is first visible.
     u16 display_origin_left;

--- a/src/core/gpu_hw_d3d11.cpp
+++ b/src/core/gpu_hw_d3d11.cpp
@@ -854,7 +854,7 @@ void GPU_HW_D3D11::UpdateDisplay()
                                         m_vram_texture.GetWidth(), m_vram_texture.GetHeight());
     }
 
-    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT,
+    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT, VRAM_WIDTH, VRAM_HEIGHT,
                                          static_cast<float>(VRAM_WIDTH) / static_cast<float>(VRAM_HEIGHT));
   }
   else
@@ -862,6 +862,7 @@ void GPU_HW_D3D11::UpdateDisplay()
     g_host_display->SetDisplayParameters(m_crtc_state.display_width, m_crtc_state.display_height,
                                          m_crtc_state.display_origin_left, m_crtc_state.display_origin_top,
                                          m_crtc_state.display_vram_width, m_crtc_state.display_vram_height,
+                                         m_crtc_state.display_full_width, m_crtc_state.display_full_height,
                                          GetDisplayAspectRatio());
 
     const u32 resolution_scale = m_GPUSTAT.display_area_color_depth_24 ? 1 : m_resolution_scale;

--- a/src/core/gpu_hw_d3d12.cpp
+++ b/src/core/gpu_hw_d3d12.cpp
@@ -878,7 +878,7 @@ void GPU_HW_D3D12::UpdateDisplay()
                                         m_vram_texture.GetHeight(), 0, 0, m_vram_texture.GetWidth(),
                                         m_vram_texture.GetHeight());
     }
-    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT,
+    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT, VRAM_WIDTH, VRAM_HEIGHT,
                                          static_cast<float>(VRAM_WIDTH) / static_cast<float>(VRAM_HEIGHT));
   }
   else
@@ -886,6 +886,7 @@ void GPU_HW_D3D12::UpdateDisplay()
     g_host_display->SetDisplayParameters(m_crtc_state.display_width, m_crtc_state.display_height,
                                          m_crtc_state.display_origin_left, m_crtc_state.display_origin_top,
                                          m_crtc_state.display_vram_width, m_crtc_state.display_vram_height,
+                                         m_crtc_state.display_full_width, m_crtc_state.display_full_height,
                                          GetDisplayAspectRatio());
 
     const u32 resolution_scale = m_GPUSTAT.display_area_color_depth_24 ? 1 : m_resolution_scale;

--- a/src/core/gpu_hw_opengl.cpp
+++ b/src/core/gpu_hw_opengl.cpp
@@ -881,7 +881,7 @@ void GPU_HW_OpenGL::UpdateDisplay()
                                         static_cast<s32>(m_vram_texture.GetHeight()), 0, m_vram_texture.GetHeight(),
                                         m_vram_texture.GetWidth(), -static_cast<s32>(m_vram_texture.GetHeight()));
     }
-    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT,
+    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT, VRAM_WIDTH, VRAM_HEIGHT,
                                          static_cast<float>(VRAM_WIDTH) / static_cast<float>(VRAM_HEIGHT));
   }
   else
@@ -889,6 +889,7 @@ void GPU_HW_OpenGL::UpdateDisplay()
     g_host_display->SetDisplayParameters(m_crtc_state.display_width, m_crtc_state.display_height,
                                          m_crtc_state.display_origin_left, m_crtc_state.display_origin_top,
                                          m_crtc_state.display_vram_width, m_crtc_state.display_vram_height,
+                                         m_crtc_state.display_full_width, m_crtc_state.display_full_height,
                                          GetDisplayAspectRatio());
 
     const u32 resolution_scale = m_GPUSTAT.display_area_color_depth_24 ? 1 : m_resolution_scale;

--- a/src/core/gpu_hw_vulkan.cpp
+++ b/src/core/gpu_hw_vulkan.cpp
@@ -1444,7 +1444,7 @@ void GPU_HW_Vulkan::UpdateDisplay()
                                         m_vram_texture.GetHeight(), 0, 0, m_vram_texture.GetWidth(),
                                         m_vram_texture.GetHeight());
     }
-    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT,
+    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT, VRAM_WIDTH, VRAM_HEIGHT,
                                          static_cast<float>(VRAM_WIDTH) / static_cast<float>(VRAM_HEIGHT));
   }
   else
@@ -1452,6 +1452,7 @@ void GPU_HW_Vulkan::UpdateDisplay()
     g_host_display->SetDisplayParameters(m_crtc_state.display_width, m_crtc_state.display_height,
                                          m_crtc_state.display_origin_left, m_crtc_state.display_origin_top,
                                          m_crtc_state.display_vram_width, m_crtc_state.display_vram_height,
+                                         m_crtc_state.display_full_width, m_crtc_state.display_full_height,
                                          GetDisplayAspectRatio());
 
     const u32 resolution_scale = m_GPUSTAT.display_area_color_depth_24 ? 1 : m_resolution_scale;

--- a/src/core/gpu_sw.cpp
+++ b/src/core/gpu_sw.cpp
@@ -511,6 +511,7 @@ void GPU_SW::UpdateDisplay()
     g_host_display->SetDisplayParameters(m_crtc_state.display_width, m_crtc_state.display_height,
                                          m_crtc_state.display_origin_left, m_crtc_state.display_origin_top,
                                          m_crtc_state.display_vram_width, m_crtc_state.display_vram_height,
+                                         m_crtc_state.display_full_width, m_crtc_state.display_full_height,
                                          GetDisplayAspectRatio());
 
     if (IsDisplayDisabled())
@@ -556,7 +557,7 @@ void GPU_SW::UpdateDisplay()
   else
   {
     CopyOut15Bit(m_16bit_display_format, 0, 0, VRAM_WIDTH, VRAM_HEIGHT, 0, false, false);
-    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT,
+    g_host_display->SetDisplayParameters(VRAM_WIDTH, VRAM_HEIGHT, 0, 0, VRAM_WIDTH, VRAM_HEIGHT, VRAM_WIDTH, VRAM_HEIGHT,
                                          static_cast<float>(VRAM_WIDTH) / static_cast<float>(VRAM_HEIGHT));
   }
 }

--- a/src/core/host_display.cpp
+++ b/src/core/host_display.cpp
@@ -228,9 +228,12 @@ void HostDisplay::CalculateDrawRect(s32 window_width, s32 window_height, float* 
 {
   const float window_ratio = static_cast<float>(window_width) / static_cast<float>(window_height);
   const float display_aspect_ratio = g_settings.display_stretch ? window_ratio : m_display_aspect_ratio;
+  const float no_pillarbox_scale = static_cast<float>(m_display_full_width) / static_cast<float>(m_display_active_width);
   const float x_scale =
     apply_aspect_ratio ?
-      (display_aspect_ratio / (static_cast<float>(m_display_width) / static_cast<float>(m_display_height))) :
+      (g_settings.display_crt_pillarboxing ?
+        (display_aspect_ratio / (static_cast<float>(m_display_width) / static_cast<float>(m_display_height))) :
+        (display_aspect_ratio / (static_cast<float>(m_display_width) / static_cast<float>(m_display_height))) * no_pillarbox_scale) :
       1.0f;
   const float display_width = static_cast<float>(m_display_width) * x_scale;
   const float display_height = static_cast<float>(m_display_height);
@@ -589,7 +592,11 @@ bool HostDisplay::WriteDisplayTextureToFile(std::string filename, bool full_reso
     const float ss_width_scale = static_cast<float>(m_display_active_width) / static_cast<float>(m_display_width);
     const float ss_height_scale = static_cast<float>(m_display_active_height) / static_cast<float>(m_display_height);
     const float ss_aspect_ratio = m_display_aspect_ratio * ss_width_scale / ss_height_scale;
-    resize_width = static_cast<s32>(static_cast<float>(resize_height) * ss_aspect_ratio);
+    const float ss_no_pillarbox_scale = static_cast<float>(m_display_full_width) / static_cast<float>(m_display_active_width);
+    resize_width =
+      g_settings.display_crt_pillarboxing ?
+        static_cast<s32>(static_cast<float>(resize_height) * ss_aspect_ratio) :
+        static_cast<s32>(static_cast<float>(resize_height) * ss_aspect_ratio * ss_no_pillarbox_scale);
   }
   else
   {

--- a/src/core/host_display.h
+++ b/src/core/host_display.h
@@ -185,7 +185,7 @@ public:
   }
 
   void SetDisplayParameters(s32 display_width, s32 display_height, s32 active_left, s32 active_top, s32 active_width,
-                            s32 active_height, float display_aspect_ratio)
+                            s32 active_height, s32 display_full_width, s32 display_full_height, float display_aspect_ratio)
   {
     m_display_width = display_width;
     m_display_height = display_height;
@@ -193,6 +193,8 @@ public:
     m_display_active_top = active_top;
     m_display_active_width = active_width;
     m_display_active_height = active_height;
+    m_display_full_width = display_full_width;
+    m_display_full_height = display_full_height;
     m_display_aspect_ratio = display_aspect_ratio;
     m_display_changed = true;
   }
@@ -278,6 +280,8 @@ protected:
   s32 m_display_active_top = 0;
   s32 m_display_active_width = 0;
   s32 m_display_active_height = 0;
+  s32 m_display_full_width = 0;
+  s32 m_display_full_height = 0;
   float m_display_aspect_ratio = 1.0f;
   float m_display_frame_interval = 0.0f;
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -249,6 +249,7 @@ void Settings::Load(SettingsInterface& si)
   display_linear_filtering = si.GetBoolValue("Display", "LinearFiltering", true);
   display_integer_scaling = si.GetBoolValue("Display", "IntegerScaling", false);
   display_stretch = si.GetBoolValue("Display", "Stretch", false);
+  display_crt_pillarboxing = si.GetBoolValue("Display", "CRTPillarboxing", true);
   display_post_processing = si.GetBoolValue("Display", "PostProcessing", false);
   display_show_osd_messages = si.GetBoolValue("Display", "ShowOSDMessages", true);
   display_show_fps = si.GetBoolValue("Display", "ShowFPS", false);
@@ -456,6 +457,7 @@ void Settings::Save(SettingsInterface& si) const
   si.SetBoolValue("Display", "LinearFiltering", display_linear_filtering);
   si.SetBoolValue("Display", "IntegerScaling", display_integer_scaling);
   si.SetBoolValue("Display", "Stretch", display_stretch);
+  si.SetBoolValue("Display", "CRTPillarboxing", display_crt_pillarboxing);
   si.SetBoolValue("Display", "PostProcessing", display_post_processing);
   si.SetBoolValue("Display", "ShowOSDMessages", display_show_osd_messages);
   si.SetBoolValue("Display", "ShowFPS", display_show_fps);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -123,6 +123,7 @@ struct Settings
   bool display_linear_filtering = true;
   bool display_integer_scaling = false;
   bool display_stretch = false;
+  bool display_crt_pillarboxing = true;
   bool display_post_processing = false;
   bool display_show_osd_messages = true;
   bool display_show_fps = false;

--- a/src/duckstation-qt/displaysettingswidget.cpp
+++ b/src/duckstation-qt/displaysettingswidget.cpp
@@ -42,6 +42,7 @@ DisplaySettingsWidget::DisplaySettingsWidget(SettingsDialog* dialog, QWidget* pa
   SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.displayLinearFiltering, "Display", "LinearFiltering", true);
   SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.displayIntegerScaling, "Display", "IntegerScaling", false);
   SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.displayStretch, "Display", "Stretch", false);
+  SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.displayCRTPillarboxing, "Display", "CRTPillarboxing", true);
   SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.internalResolutionScreenshots, "Display",
                                                "InternalResolutionScreenshots", false);
   SettingWidgetBinder::BindWidgetToBoolSetting(sif, m_ui.vsync, "Display", "VSync", false);

--- a/src/duckstation-qt/displaysettingswidget.ui
+++ b/src/duckstation-qt/displaysettingswidget.ui
@@ -171,7 +171,7 @@
       <item row="2" column="1">
        <widget class="QComboBox" name="gpuDownsampleMode"/>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="3" column="0" colspan="3">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
          <widget class="QCheckBox" name="displayIntegerScaling">
@@ -195,6 +195,13 @@
          </widget>
         </item>
         <item row="1" column="1">
+         <widget class="QCheckBox" name="displayCRTPillarboxing">
+          <property name="text">
+           <string>CRT Pillarboxing</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
          <widget class="QCheckBox" name="internalResolutionScreenshots">
           <property name="text">
            <string>Internal Resolution Screenshots</string>

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -3412,6 +3412,10 @@ void FullscreenUI::DrawDisplaySettingsPage()
                     "Fills the window with the active display area, regardless of the aspect ratio.", "Display",
                     "Stretch", false);
 
+  DrawToggleSetting(bsi, "CRT Pillarboxing",
+                    "", "Display",
+                    "CRTPillarboxing", true);
+
   DrawToggleSetting(bsi, "Internal Resolution Screenshots",
                     "Saves screenshots at internal render resolution and without postprocessing.", "Display",
                     "InternalResolutionScreenshots", false);


### PR DESCRIPTION
DuckStation's aspect ratio stretching doesn't actually stretch the game display to match the resolution of the ratio, e.g. a game doesn't get stretched to 320x240 when the aspect ratio is set to 4:3, as it also makes the image thinner to more closely match what is displayed on CRTs, i.e. a 512px-framebuffer game set to 4:3 will be 292 pixels wide. Some games are built around the actual aspect ratio displayed on CRT screens, and for the games that aren't I added a setting for retaining the ordinary aspect ratio.

Notes:
Labelled as "CRT Pillarboxing" in settings, but it might need a better name. It also lacks a description in both Qt UI and big picture mode.
While I made sure the code worked for every aspect ratio, resolution upscale, and crop mode, two errors slipped past myself at the last minute: the display is erroneously stretched when the aspect ratio is set to 1:1 PAR, and when the "Stretch To Fill" setting is enabled, it doesn't fill the entire screen, meaning there will often be a sort of letterboxing effect.