### PR TITLE
Prevent shutdown hotkey from bypassing the state on shutdown setting

### DIFF
--- a/src/frontend-common/common_host.cpp
+++ b/src/frontend-common/common_host.cpp
@@ -713,7 +713,7 @@ DEFINE_HOTKEY("TogglePause", TRANSLATABLE("Hotkeys", "General"), TRANSLATABLE("H
 DEFINE_HOTKEY("PowerOff", TRANSLATABLE("Hotkeys", "General"), TRANSLATABLE("Hotkeys", "Power Off System"),
               [](s32 pressed) {
                 if (!pressed)
-                  Host::RequestSystemShutdown(true, true);
+                  Host::RequestSystemShutdown(true, g_settings.save_state_on_exit);
               })
 #endif
 


### PR DESCRIPTION
Currently if you have "Save State on Shutdown" disabled, if you use the "Power Off" hotkey to close a game it will create a state anyway. I'm not sure if this is the best way to handle this, but with this PR it seems to work fine from my tests, and the state is not created if "Save State on Shutdown" is disabled.