### PR TITLE
"Set Dumped VRAM Write Alpha Channel" should be true when resetting advanced settings

### DIFF
--- a/src/duckstation-qt/advancedsettingswidget.cpp
+++ b/src/duckstation-qt/advancedsettingswidget.cpp
@@ -321,7 +321,7 @@ void AdvancedSettingsWidget::onResetToDefaultClicked()
     setBooleanTweakOption(m_ui.tweakOptionTable, i++, false); // VRAM write texture replacement
     setBooleanTweakOption(m_ui.tweakOptionTable, i++, false); // Preload texture replacements
     setBooleanTweakOption(m_ui.tweakOptionTable, i++, false); // Dump replacable VRAM writes
-    setBooleanTweakOption(m_ui.tweakOptionTable, i++, false); // Set dumped VRAM write alpha channel
+    setBooleanTweakOption(m_ui.tweakOptionTable, i++, true);  // Set dumped VRAM write alpha channel
     setIntRangeTweakOption(m_ui.tweakOptionTable, i++,
                            Settings::DEFAULT_VRAM_WRITE_DUMP_WIDTH_THRESHOLD); // Minimum dumped VRAM width
     setIntRangeTweakOption(m_ui.tweakOptionTable, i++,


### PR DESCRIPTION
Hey, currently when you click "Reset To Default" in the advanced settings, "Set Dumped VRAM Write Alpha Channel" will be disabled, I'm guessing this is a mistake since it's set to true everywhere else in the code by default.

There's also something wrong with the "PGXP Depth Clear Threshold" setting, if you start on a clean install (or if you delete "settings.ini"), it will be set to "4096" in the UI and "1228800" inside "settings.ini", but if you click "Reset To Default" it will be set to "300", which seems to be the desired value: https://github.com/stenzek/duckstation/blob/591e8b5b7a9e1c503df5674b0b0d0203d7eef6a7/src/core/settings.h#L430

I'm not sure to understand why that setting is multiplied/divised by 4096: https://github.com/stenzek/duckstation/blob/591e8b5b7a9e1c503df5674b0b0d0203d7eef6a7/src/core/settings.h#L284-L291 so I don't want to mess with it, too afraid to break something :p I just wanted to warn you about this!