### PR TITLE
Improve Integer Scaling and Native Resolution Screenshot behavior

### DIFF
--- a/src/core/host_display.cpp
+++ b/src/core/host_display.cpp
@@ -227,39 +227,18 @@ void HostDisplay::CalculateDrawRect(s32 window_width, s32 window_height, float* 
     apply_aspect_ratio ?
       (display_aspect_ratio / (static_cast<float>(m_display_width) / static_cast<float>(m_display_height))) :
       1.0f;
-  const float display_width_stretched = static_cast<float>(m_display_width) * x_scale;
-  const float display_width_pre =
-    (display_width_stretched > static_cast<float>(m_display_width)) ?
-      display_width_stretched : static_cast<float>(m_display_width);
-  const float display_width = g_settings.display_always_stretch_horizontally ? display_width_stretched :
-    display_width_pre;
-  const float active_left_stretched = static_cast<float>(m_display_active_left) * x_scale;
-  const float active_left_pre =
-    (display_width_stretched > static_cast<float>(m_display_width)) ?
-      active_left_stretched : static_cast<float>(m_display_active_left);
-  const float active_left = g_settings.display_always_stretch_horizontally ? active_left_stretched :
-    active_left_pre;
-  const float active_width_stretched = static_cast<float>(m_display_active_width) * x_scale;
-  const float active_width_pre =
-    (display_width_stretched > static_cast<float>(m_display_width)) ?
-      active_width_stretched : static_cast<float>(m_display_active_width);
-  const float active_width = g_settings.display_always_stretch_horizontally ? active_width_stretched :
-    active_width_pre;
-  const float display_height_pre =
-    (display_width_stretched < static_cast<float>(m_display_width)) ?
-      static_cast<float>(m_display_height) / x_scale : static_cast<float>(m_display_height);
-  const float display_height = g_settings.display_always_stretch_horizontally ?
-    static_cast<float>(m_display_height) : display_height_pre;
-  const float active_top_pre =
-    (display_width_stretched < static_cast<float>(m_display_width)) ?
-      static_cast<float>(m_display_active_top) / x_scale : static_cast<float>(m_display_active_top);
-  const float active_top = g_settings.display_always_stretch_horizontally ?
-    static_cast<float>(m_display_active_top) : active_top_pre;
-  const float active_height_pre =
-    (display_width_stretched < static_cast<float>(m_display_width)) ?
-      static_cast<float>(m_display_active_height) / x_scale : static_cast<float>(m_display_active_height);
-  const float active_height = g_settings.display_always_stretch_horizontally ?
-    static_cast<float>(m_display_active_height) : active_height_pre;
+  const float display_width = g_settings.display_stretch_vertically ?
+    static_cast<float>(m_display_width) : static_cast<float>(m_display_width) * x_scale;
+  const float display_height = g_settings.display_stretch_vertically ?
+    static_cast<float>(m_display_height) / x_scale : static_cast<float>(m_display_height);
+  const float active_left = g_settings.display_stretch_vertically ?
+    static_cast<float>(m_display_active_left) : static_cast<float>(m_display_active_left) * x_scale;
+  const float active_top = g_settings.display_stretch_vertically ?
+    static_cast<float>(m_display_active_top) / x_scale : static_cast<float>(m_display_active_top);
+  const float active_width = g_settings.display_stretch_vertically ?
+    static_cast<float>(m_display_active_width) : static_cast<float>(m_display_active_width) * x_scale;
+  const float active_height = g_settings.display_stretch_vertically ?
+    static_cast<float>(m_display_active_height) / x_scale : static_cast<float>(m_display_active_height);
   if (out_x_scale)
     *out_x_scale = x_scale;
 
@@ -387,17 +366,8 @@ std::tuple<float, float> HostDisplay::ConvertWindowCoordinatesToDisplayCoordinat
   const float scaled_display_y = static_cast<float>(window_y) - top_padding;
 
   // scale back to internal resolution
-  const float display_x_stretched = scaled_display_x / scale / x_scale;
-  const float display_x_pre =
-    (display_x_stretched > (scaled_display_x / scale)) ?
-      display_x_stretched : (scaled_display_x / scale);
-  const float display_x = g_settings.display_always_stretch_horizontally ?
-    display_x_stretched : display_x_pre;
-  const float display_y_pre =
-    (display_x_stretched < (scaled_display_x / scale)) ?
-      scaled_display_y / scale * x_scale : scaled_display_y / scale;
-  const float display_y = g_settings.display_always_stretch_horizontally ?
-    scaled_display_y / scale : display_y_pre;
+  const float display_x = scaled_display_x / scale / x_scale;
+  const float display_y = scaled_display_y / scale;
 
   return std::make_tuple(display_x, display_y);
 }
@@ -524,20 +494,12 @@ bool HostDisplay::WriteDisplayTextureToFile(std::string filename, bool full_reso
     const float ss_width_scale = static_cast<float>(m_display_active_width) / static_cast<float>(m_display_width);
     const float ss_height_scale = static_cast<float>(m_display_active_height) / static_cast<float>(m_display_height);
     const float ss_aspect_ratio = m_display_aspect_ratio * ss_width_scale / ss_height_scale;
-    const float resize_width_stretched = static_cast<float>(resize_height) * ss_aspect_ratio;
-    const float resize_width_pre =
-      (static_cast<s32>(resize_width_stretched) > m_display_texture_view_width) ?
-        resize_width_stretched : static_cast<float>(m_display_texture_view_width);
-    resize_width = g_settings.display_always_stretch_horizontally ?
-      static_cast<s32>(resize_width_stretched) : static_cast<s32>(resize_width_pre);
-    if (!g_settings.display_always_stretch_horizontally)
-    {
-      resize_height =
-        (static_cast<s32>(resize_width_stretched) < m_display_texture_view_width) ?
-          static_cast<s32>(static_cast<float>(resize_height) /
-            (m_display_aspect_ratio / (static_cast<float>(m_display_width) / static_cast<float>(m_display_height)))) :
-          resize_height;
-    }
+    resize_width = g_settings.display_stretch_vertically ?
+      m_display_texture_view_width : static_cast<s32>(static_cast<float>(resize_height) * ss_aspect_ratio);
+    resize_height = g_settings.display_stretch_vertically ?
+      static_cast<s32>(static_cast<float>(resize_height) /
+      (m_display_aspect_ratio / (static_cast<float>(m_display_width) / static_cast<float>(m_display_height)))) :
+      resize_height;
   }
   else
   {

--- a/src/core/host_display.cpp
+++ b/src/core/host_display.cpp
@@ -227,12 +227,39 @@ void HostDisplay::CalculateDrawRect(s32 window_width, s32 window_height, float* 
     apply_aspect_ratio ?
       (display_aspect_ratio / (static_cast<float>(m_display_width) / static_cast<float>(m_display_height))) :
       1.0f;
-  const float display_width = static_cast<float>(m_display_width) * x_scale;
-  const float display_height = static_cast<float>(m_display_height);
-  const float active_left = static_cast<float>(m_display_active_left) * x_scale;
-  const float active_top = static_cast<float>(m_display_active_top);
-  const float active_width = static_cast<float>(m_display_active_width) * x_scale;
-  const float active_height = static_cast<float>(m_display_active_height);
+  const float display_width_stretched = static_cast<float>(m_display_width) * x_scale;
+  const float display_width_pre =
+    (display_width_stretched > static_cast<float>(m_display_width)) ?
+      display_width_stretched : static_cast<float>(m_display_width);
+  const float display_width = g_settings.display_always_stretch_horizontally ? display_width_stretched :
+    display_width_pre;
+  const float active_left_stretched = static_cast<float>(m_display_active_left) * x_scale;
+  const float active_left_pre =
+    (display_width_stretched > static_cast<float>(m_display_width)) ?
+      active_left_stretched : static_cast<float>(m_display_active_left);
+  const float active_left = g_settings.display_always_stretch_horizontally ? active_left_stretched :
+    active_left_pre;
+  const float active_width_stretched = static_cast<float>(m_display_active_width) * x_scale;
+  const float active_width_pre =
+    (display_width_stretched > static_cast<float>(m_display_width)) ?
+      active_width_stretched : static_cast<float>(m_display_active_width);
+  const float active_width = g_settings.display_always_stretch_horizontally ? active_width_stretched :
+    active_width_pre;
+  const float display_height_pre =
+    (display_width_stretched < static_cast<float>(m_display_width)) ?
+      static_cast<float>(m_display_height) / x_scale : static_cast<float>(m_display_height);
+  const float display_height = g_settings.display_always_stretch_horizontally ?
+    static_cast<float>(m_display_height) : display_height_pre;
+  const float active_top_pre =
+    (display_width_stretched < static_cast<float>(m_display_width)) ?
+      static_cast<float>(m_display_active_top) / x_scale : static_cast<float>(m_display_active_top);
+  const float active_top = g_settings.display_always_stretch_horizontally ?
+    static_cast<float>(m_display_active_top) : active_top_pre;
+  const float active_height_pre =
+    (display_width_stretched < static_cast<float>(m_display_width)) ?
+      static_cast<float>(m_display_active_height) / x_scale : static_cast<float>(m_display_active_height);
+  const float active_height = g_settings.display_always_stretch_horizontally ?
+    static_cast<float>(m_display_active_height) : active_height_pre;
   if (out_x_scale)
     *out_x_scale = x_scale;
 
@@ -360,8 +387,17 @@ std::tuple<float, float> HostDisplay::ConvertWindowCoordinatesToDisplayCoordinat
   const float scaled_display_y = static_cast<float>(window_y) - top_padding;
 
   // scale back to internal resolution
-  const float display_x = scaled_display_x / scale / x_scale;
-  const float display_y = scaled_display_y / scale;
+  const float display_x_stretched = scaled_display_x / scale / x_scale;
+  const float display_x_pre =
+    (display_x_stretched > (scaled_display_x / scale)) ?
+      display_x_stretched : (scaled_display_x / scale);
+  const float display_x = g_settings.display_always_stretch_horizontally ?
+    display_x_stretched : display_x_pre;
+  const float display_y_pre =
+    (display_x_stretched < (scaled_display_x / scale)) ?
+      scaled_display_y / scale * x_scale : scaled_display_y / scale;
+  const float display_y = g_settings.display_always_stretch_horizontally ?
+    scaled_display_y / scale : display_y_pre;
 
   return std::make_tuple(display_x, display_y);
 }
@@ -488,7 +524,20 @@ bool HostDisplay::WriteDisplayTextureToFile(std::string filename, bool full_reso
     const float ss_width_scale = static_cast<float>(m_display_active_width) / static_cast<float>(m_display_width);
     const float ss_height_scale = static_cast<float>(m_display_active_height) / static_cast<float>(m_display_height);
     const float ss_aspect_ratio = m_display_aspect_ratio * ss_width_scale / ss_height_scale;
-    resize_width = static_cast<s32>(static_cast<float>(resize_height) * ss_aspect_ratio);
+    const float resize_width_stretched = static_cast<float>(resize_height) * ss_aspect_ratio;
+    const float resize_width_pre =
+      (static_cast<s32>(resize_width_stretched) > m_display_texture_view_width) ?
+        resize_width_stretched : static_cast<float>(m_display_texture_view_width);
+    resize_width = g_settings.display_always_stretch_horizontally ?
+      static_cast<s32>(resize_width_stretched) : static_cast<s32>(resize_width_pre);
+    if (!g_settings.display_always_stretch_horizontally)
+    {
+      resize_height =
+        (static_cast<s32>(resize_width_stretched) < m_display_texture_view_width) ?
+          static_cast<s32>(static_cast<float>(resize_height) /
+            (m_display_aspect_ratio / (static_cast<float>(m_display_width) / static_cast<float>(m_display_height)))) :
+          resize_height;
+    }
   }
   else
   {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -270,7 +270,7 @@ void Settings::Load(SettingsInterface& si)
   display_show_enhancements = si.GetBoolValue("Display", "ShowEnhancements", false);
   display_all_frames = si.GetBoolValue("Display", "DisplayAllFrames", false);
   display_internal_resolution_screenshots = si.GetBoolValue("Display", "InternalResolutionScreenshots", false);
-  display_always_stretch_horizontally = si.GetBoolValue("Display", "AlwaysStretchHorizontally", false);
+  display_stretch_vertically = si.GetBoolValue("Display", "StretchVertically", false);
   video_sync_enabled = si.GetBoolValue("Display", "VSync", DEFAULT_VSYNC_VALUE);
   display_post_process_chain = si.GetStringValue("Display", "PostProcessChain", "");
   display_max_fps = si.GetFloatValue("Display", "MaxFPS", DEFAULT_DISPLAY_MAX_FPS);
@@ -488,7 +488,7 @@ void Settings::Save(SettingsInterface& si) const
   si.SetBoolValue("Display", "ShowEnhancements", display_show_enhancements);
   si.SetBoolValue("Display", "DisplayAllFrames", display_all_frames);
   si.SetBoolValue("Display", "InternalResolutionScreenshots", display_internal_resolution_screenshots);
-  si.SetBoolValue("Display", "AlwaysStretchHorizontally", display_always_stretch_horizontally);
+  si.SetBoolValue("Display", "StretchVertically", display_stretch_vertically);
   si.SetBoolValue("Display", "VSync", video_sync_enabled);
   if (display_post_process_chain.empty())
     si.DeleteValue("Display", "PostProcessChain");

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -270,6 +270,7 @@ void Settings::Load(SettingsInterface& si)
   display_show_enhancements = si.GetBoolValue("Display", "ShowEnhancements", false);
   display_all_frames = si.GetBoolValue("Display", "DisplayAllFrames", false);
   display_internal_resolution_screenshots = si.GetBoolValue("Display", "InternalResolutionScreenshots", false);
+  display_always_stretch_horizontally = si.GetBoolValue("Display", "AlwaysStretchHorizontally", false);
   video_sync_enabled = si.GetBoolValue("Display", "VSync", DEFAULT_VSYNC_VALUE);
   display_post_process_chain = si.GetStringValue("Display", "PostProcessChain", "");
   display_max_fps = si.GetFloatValue("Display", "MaxFPS", DEFAULT_DISPLAY_MAX_FPS);
@@ -487,6 +488,7 @@ void Settings::Save(SettingsInterface& si) const
   si.SetBoolValue("Display", "ShowEnhancements", display_show_enhancements);
   si.SetBoolValue("Display", "DisplayAllFrames", display_all_frames);
   si.SetBoolValue("Display", "InternalResolutionScreenshots", display_internal_resolution_screenshots);
+  si.SetBoolValue("Display", "AlwaysStretchHorizontally", display_always_stretch_horizontally);
   si.SetBoolValue("Display", "VSync", video_sync_enabled);
   if (display_post_process_chain.empty())
     si.DeleteValue("Display", "PostProcessChain");

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -143,6 +143,7 @@ struct Settings
   bool display_show_enhancements = false;
   bool display_all_frames = false;
   bool display_internal_resolution_screenshots = false;
+  bool display_always_stretch_horizontally = false;
   bool video_sync_enabled = DEFAULT_VSYNC_VALUE;
   float display_osd_scale = 100.0f;
   float display_max_fps = DEFAULT_DISPLAY_MAX_FPS;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -143,7 +143,7 @@ struct Settings
   bool display_show_enhancements = false;
   bool display_all_frames = false;
   bool display_internal_resolution_screenshots = false;
-  bool display_always_stretch_horizontally = false;
+  bool display_stretch_vertically = false;
   bool video_sync_enabled = DEFAULT_VSYNC_VALUE;
   float display_osd_scale = 100.0f;
   float display_max_fps = DEFAULT_DISPLAY_MAX_FPS;

--- a/src/duckstation-qt/advancedsettingswidget.cpp
+++ b/src/duckstation-qt/advancedsettingswidget.cpp
@@ -288,8 +288,8 @@ void AdvancedSettingsWidget::addTweakOptions()
   addBooleanTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Use Debug Host GPU Device"), "GPU", "UseDebugDevice",
                         false);
 
-  addBooleanTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Always Stretch Display Horizontally"), "Display",
-                        "AlwaysStretchHorizontally", false);
+  addBooleanTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Stretch Display Vertically"), "Display",
+                        "StretchVertically", false);
 
   addBooleanTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Increase Timer Resolution"), "Main",
                         "IncreaseTimerResolution", true);
@@ -357,7 +357,7 @@ void AdvancedSettingsWidget::onResetToDefaultClicked()
   sif->DeleteValue("Display", "ActiveEndOffset");
   sif->DeleteValue("Display", "LineStartOffset");
   sif->DeleteValue("Display", "LineEndOffset");
-  sif->DeleteValue("Display", "AlwaysStretchHorizontally");
+  sif->DeleteValue("Display", "StretchVertically");
   sif->DeleteValue("GPU", "Multisamples");
   sif->DeleteValue("GPU", "PerSampleShading");
   sif->DeleteValue("GPU", "PGXPVertexCache");

--- a/src/duckstation-qt/advancedsettingswidget.cpp
+++ b/src/duckstation-qt/advancedsettingswidget.cpp
@@ -288,6 +288,9 @@ void AdvancedSettingsWidget::addTweakOptions()
   addBooleanTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Use Debug Host GPU Device"), "GPU", "UseDebugDevice",
                         false);
 
+  addBooleanTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Always Stretch Display Horizontally"), "Display",
+                        "AlwaysStretchHorizontally", false);
+
   addBooleanTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Increase Timer Resolution"), "Main",
                         "IncreaseTimerResolution", true);
 
@@ -354,6 +357,7 @@ void AdvancedSettingsWidget::onResetToDefaultClicked()
   sif->DeleteValue("Display", "ActiveEndOffset");
   sif->DeleteValue("Display", "LineStartOffset");
   sif->DeleteValue("Display", "LineEndOffset");
+  sif->DeleteValue("Display", "AlwaysStretchHorizontally");
   sif->DeleteValue("GPU", "Multisamples");
   sif->DeleteValue("GPU", "PerSampleShading");
   sif->DeleteValue("GPU", "PGXPVertexCache");

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -4506,6 +4506,9 @@ void FullscreenUI::DrawAdvancedSettingsPage()
   DrawFloatRangeSetting(bsi, "Display FPS Limit",
                         "Limits how many frames are displayed to the screen. These frames are still rendered.",
                         "Display", "MaxFPS", Settings::DEFAULT_DISPLAY_MAX_FPS, 0.0f, 500.0f, "%.2f FPS");
+  DrawToggleSetting(bsi, "Always Stretch Display Horizontally",
+                    "Enables old DuckStation behavior for Integer Scaling, where the display is always stretched horizontally.",
+                    "Display", "AlwaysStretchHorizontally", false);
 
   MenuHeading("PGXP Settings");
 

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -4506,9 +4506,9 @@ void FullscreenUI::DrawAdvancedSettingsPage()
   DrawFloatRangeSetting(bsi, "Display FPS Limit",
                         "Limits how many frames are displayed to the screen. These frames are still rendered.",
                         "Display", "MaxFPS", Settings::DEFAULT_DISPLAY_MAX_FPS, 0.0f, 500.0f, "%.2f FPS");
-  DrawToggleSetting(bsi, "Always Stretch Display Horizontally",
-                    "Enables old DuckStation behavior for Integer Scaling, where the display is always stretched horizontally.",
-                    "Display", "AlwaysStretchHorizontally", false);
+  DrawToggleSetting(bsi, "Stretch Display Vertically",
+                    "Stretches the display to match the aspect ratio by multiplying vertically instead of horizontally.",
+                    "Display", "StretchVertically", false);
 
   MenuHeading("PGXP Settings");
 


### PR DESCRIPTION
as discussed in the PSX.DEV discord server

**The problem:** DuckStation currently stretches displays to match a given aspect ratio by stretching horizontally only; when enabling Integer Scaling, this means that you'll have a display of 292px width in games with 512px wide framebuffers, such as the entire Crash and Spyro series of games; at this point this can no longer be considered a "native" resolution, as image data is lost unlike what would happen when playing these games on a CRT.

**What this PR does:** Modifies the parts of the DuckStation display code that stretch the display by checking for if the final horizontally stretched display is lower in width than that of the unstretched display: if the width is lower, it increases the vertical dimension by the same rate instead. This means that games such as Crash Bandicoot, with framebuffers wider than that of the aspect ratio they're set to (e.g. 512x216), get increased vertically (e.g. 512x377) as opposed to being decreased horizontally (e.g. 292x216). Also affects games with 320x240 framebuffers as well, actually, as they get decreased to 292x240 to account for vertical overscan; they now get increased vertically as well.

This also modifies the Native Resolution Screenshot option by applying the same aforementioned improvements to what DuckStation considers to be the minimum resolution in a game. I also added an advanced setting to revert this behavior for both options back to what it is in current DuckStation.