### PR TITLE
Add "Advanced Settings" option for rounding texture coordinates from an upscaled internal resolution

### DIFF
--- a/src/core/gpu_hw.cpp
+++ b/src/core/gpu_hw.cpp
@@ -73,6 +73,7 @@ bool GPU_HW::Initialize()
   m_chroma_smoothing = g_settings.gpu_24bit_chroma_smoothing;
   m_downsample_mode = GetDownsampleMode(m_resolution_scale);
   m_disable_color_perspective = m_supports_disable_color_perspective && ShouldDisableColorPerspective();
+  m_round_upscale_coordinates = g_settings.gpu_round_upscale_coordinates;
 
   if (m_multisamples != g_settings.gpu_multisamples)
   {
@@ -161,7 +162,8 @@ void GPU_HW::UpdateHWSettings(bool* framebuffer_changed, bool* shaders_changed)
      m_scaled_dithering != g_settings.gpu_scaled_dithering || m_texture_filtering != g_settings.gpu_texture_filter ||
      m_using_uv_limits != use_uv_limits || m_chroma_smoothing != g_settings.gpu_24bit_chroma_smoothing ||
      m_downsample_mode != downsample_mode || m_pgxp_depth_buffer != g_settings.UsingPGXPDepthBuffer() ||
-     m_disable_color_perspective != disable_color_perspective);
+     m_disable_color_perspective != disable_color_perspective ||
+     m_round_upscale_coordinates != g_settings.gpu_round_upscale_coordinates);
 
   if (m_resolution_scale != resolution_scale)
   {
@@ -198,6 +200,7 @@ void GPU_HW::UpdateHWSettings(bool* framebuffer_changed, bool* shaders_changed)
   m_chroma_smoothing = g_settings.gpu_24bit_chroma_smoothing;
   m_downsample_mode = downsample_mode;
   m_disable_color_perspective = disable_color_perspective;
+  m_round_upscale_coordinates = g_settings.gpu_round_upscale_coordinates;
 
   if (!m_supports_dual_source_blend && TextureFilterRequiresDualSourceBlend(m_texture_filtering))
     m_texture_filtering = GPUTextureFilter::Nearest;

--- a/src/core/gpu_hw.h
+++ b/src/core/gpu_hw.h
@@ -389,6 +389,7 @@ protected:
   GPUTextureFilter m_texture_filtering = GPUTextureFilter::Nearest;
   GPUDownsampleMode m_downsample_mode = GPUDownsampleMode::Disabled;
   bool m_using_uv_limits = false;
+  bool m_round_upscale_coordinates = false;
   bool m_pgxp_depth_buffer = false;
 
   BatchConfig m_batch;

--- a/src/core/gpu_hw_d3d11.cpp
+++ b/src/core/gpu_hw_d3d11.cpp
@@ -493,7 +493,8 @@ bool GPU_HW_D3D11::CompileShaders()
 
   GPU_HW_ShaderGen shadergen(g_host_display->GetRenderAPI(), m_resolution_scale, m_multisamples, m_per_sample_shading,
                              m_true_color, m_scaled_dithering, m_texture_filtering, m_using_uv_limits,
-                             m_pgxp_depth_buffer, m_disable_color_perspective, m_supports_dual_source_blend);
+                             m_pgxp_depth_buffer, m_disable_color_perspective, m_round_upscale_coordinates,
+                             m_supports_dual_source_blend);
 
   ShaderCompileProgressTracker progress("Compiling Shaders",
                                         1 + 1 + 2 + (4 * 9 * 2 * 2) + 1 + (2 * 2) + 4 + (2 * 3) + 1);

--- a/src/core/gpu_hw_d3d12.cpp
+++ b/src/core/gpu_hw_d3d12.cpp
@@ -411,7 +411,8 @@ bool GPU_HW_D3D12::CompilePipelines()
 
   GPU_HW_ShaderGen shadergen(g_host_display->GetRenderAPI(), m_resolution_scale, m_multisamples, m_per_sample_shading,
                              m_true_color, m_scaled_dithering, m_texture_filtering, m_using_uv_limits,
-                             m_pgxp_depth_buffer, m_disable_color_perspective, m_supports_dual_source_blend);
+                             m_pgxp_depth_buffer, m_disable_color_perspective, m_round_upscale_coordinates,
+                             m_supports_dual_source_blend);
 
   ShaderCompileProgressTracker progress("Compiling Pipelines", 2 + (4 * 9 * 2 * 2) + (2 * 4 * 5 * 9 * 2 * 2) + 1 +
                                                                  (2 * 2) + 2 + 2 + 1 + 1 + (2 * 3) + 1);

--- a/src/core/gpu_hw_opengl.cpp
+++ b/src/core/gpu_hw_opengl.cpp
@@ -497,7 +497,8 @@ bool GPU_HW_OpenGL::CompilePrograms()
   const bool use_binding_layout = GPU_HW_ShaderGen::UseGLSLBindingLayout();
   GPU_HW_ShaderGen shadergen(g_host_display->GetRenderAPI(), m_resolution_scale, m_multisamples, m_per_sample_shading,
                              m_true_color, m_scaled_dithering, m_texture_filtering, m_using_uv_limits,
-                             m_pgxp_depth_buffer, m_disable_color_perspective, m_supports_dual_source_blend);
+                             m_pgxp_depth_buffer, m_disable_color_perspective, m_round_upscale_coordinates,
+                             m_supports_dual_source_blend);
 
   ShaderCompileProgressTracker progress("Compiling Programs", (4 * 9 * 2 * 2) + (2 * 3) + (2 * 2) + 1 + 1 + 1 + 1 + 1);
 

--- a/src/core/gpu_hw_shadergen.h
+++ b/src/core/gpu_hw_shadergen.h
@@ -10,7 +10,8 @@ class GPU_HW_ShaderGen : public ShaderGen
 public:
   GPU_HW_ShaderGen(RenderAPI render_api, u32 resolution_scale, u32 multisamples, bool per_sample_shading,
                    bool true_color, bool scaled_dithering, GPUTextureFilter texture_filtering, bool uv_limits,
-                   bool pgxp_depth, bool disable_color_perspective, bool supports_dual_source_blend);
+                   bool pgxp_depth, bool disable_color_perspective, bool round_upscale_coordinates,
+                   bool supports_dual_source_blend);
   ~GPU_HW_ShaderGen();
 
   std::string GenerateBatchVertexShader(bool textured);
@@ -46,4 +47,5 @@ private:
   bool m_uv_limits;
   bool m_pgxp_depth;
   bool m_disable_color_perspective;
+  bool m_round_upscale_coordinates;
 };

--- a/src/core/gpu_hw_vulkan.cpp
+++ b/src/core/gpu_hw_vulkan.cpp
@@ -917,7 +917,8 @@ bool GPU_HW_Vulkan::CompilePipelines()
 
   GPU_HW_ShaderGen shadergen(g_host_display->GetRenderAPI(), m_resolution_scale, m_multisamples, m_per_sample_shading,
                              m_true_color, m_scaled_dithering, m_texture_filtering, m_using_uv_limits,
-                             m_pgxp_depth_buffer, m_disable_color_perspective, m_supports_dual_source_blend);
+                             m_pgxp_depth_buffer, m_disable_color_perspective, m_round_upscale_coordinates,
+                             m_supports_dual_source_blend);
 
   ShaderCompileProgressTracker progress("Compiling Pipelines", 2 + (4 * 9 * 2 * 2) + (3 * 4 * 5 * 9 * 2 * 2) + 1 + 2 +
                                                                  (2 * 2) + 2 + 1 + 1 + (2 * 3) + 1);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -222,6 +222,7 @@ void Settings::Load(SettingsInterface& si)
   gpu_force_ntsc_timings = si.GetBoolValue("GPU", "ForceNTSCTimings", false);
   gpu_widescreen_hack = si.GetBoolValue("GPU", "WidescreenHack", false);
   gpu_24bit_chroma_smoothing = si.GetBoolValue("GPU", "ChromaSmoothing24Bit", false);
+  gpu_round_upscale_coordinates = si.GetBoolValue("GPU", "RoundUpscaleCoordinates", false);
   gpu_pgxp_enable = si.GetBoolValue("GPU", "PGXPEnable", false);
   gpu_pgxp_culling = si.GetBoolValue("GPU", "PGXPCulling", true);
   gpu_pgxp_texture_correction = si.GetBoolValue("GPU", "PGXPTextureCorrection", true);
@@ -451,6 +452,7 @@ void Settings::Save(SettingsInterface& si) const
   si.SetBoolValue("GPU", "ForceNTSCTimings", gpu_force_ntsc_timings);
   si.SetBoolValue("GPU", "WidescreenHack", gpu_widescreen_hack);
   si.SetBoolValue("GPU", "ChromaSmoothing24Bit", gpu_24bit_chroma_smoothing);
+  si.SetBoolValue("GPU", "RoundUpscaleCoordinates", gpu_round_upscale_coordinates);
   si.SetBoolValue("GPU", "PGXPEnable", gpu_pgxp_enable);
   si.SetBoolValue("GPU", "PGXPCulling", gpu_pgxp_culling);
   si.SetBoolValue("GPU", "PGXPTextureCorrection", gpu_pgxp_texture_correction);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -127,6 +127,7 @@ struct Settings
   s8 display_line_end_offset = 0;
   bool display_force_4_3_for_24bit = false;
   bool gpu_24bit_chroma_smoothing = false;
+  bool gpu_round_upscale_coordinates = false;
   bool display_linear_filtering = true;
   bool display_integer_scaling = false;
   bool display_stretch = false;

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -3257,6 +3257,7 @@ void System::CheckForSettingsChanges(const Settings& old_settings)
         g_settings.gpu_force_ntsc_timings != old_settings.gpu_force_ntsc_timings ||
         g_settings.gpu_24bit_chroma_smoothing != old_settings.gpu_24bit_chroma_smoothing ||
         g_settings.gpu_downsample_mode != old_settings.gpu_downsample_mode ||
+        g_settings.gpu_round_upscale_coordinates != old_settings.gpu_round_upscale_coordinates ||
         g_settings.display_crop_mode != old_settings.display_crop_mode ||
         g_settings.display_aspect_ratio != old_settings.display_aspect_ratio ||
         g_settings.display_alignment != old_settings.display_alignment ||

--- a/src/duckstation-qt/advancedsettingswidget.cpp
+++ b/src/duckstation-qt/advancedsettingswidget.cpp
@@ -233,6 +233,9 @@ void AdvancedSettingsWidget::addTweakOptions()
 
   addMSAATweakOption(m_dialog, m_ui.tweakOptionTable, tr("Multisample Antialiasing"));
 
+  addBooleanTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Always Round Upscaled Texture Coordinates"), "GPU",
+                        "RoundUpscaleCoordinates", false);
+
   if (m_dialog->isPerGameSettings())
   {
     addIntRangeTweakOption(m_dialog, m_ui.tweakOptionTable, tr("Display Active Start Offset"), "Display",
@@ -359,6 +362,7 @@ void AdvancedSettingsWidget::onResetToDefaultClicked()
   sif->DeleteValue("Display", "LineEndOffset");
   sif->DeleteValue("Display", "StretchVertically");
   sif->DeleteValue("GPU", "Multisamples");
+  sif->DeleteValue("GPU", "RoundUpscaleCoordinates");
   sif->DeleteValue("GPU", "PerSampleShading");
   sif->DeleteValue("GPU", "PGXPVertexCache");
   sif->DeleteValue("GPU", "PGXPTolerance");

--- a/src/frontend-common/fullscreen_ui.cpp
+++ b/src/frontend-common/fullscreen_ui.cpp
@@ -4508,6 +4508,9 @@ void FullscreenUI::DrawAdvancedSettingsPage()
   DrawToggleSetting(bsi, "Stretch Display Vertically",
                     "Stretches the display to match the aspect ratio by multiplying vertically instead of horizontally.",
                     "Display", "StretchVertically", false);
+  DrawToggleSetting(bsi, "Always Round Upscaled Texture Coordinates",
+                    "Forces texture coordinates to be rounded when the game's resolution is upscaled. Works better for certain games, but may require PGXP.",
+                    "GPU", "RoundUpscaleCoordinates", false);
 
   MenuHeading("PGXP Settings");
 


### PR DESCRIPTION
### The problem

In order to prevent issues with displaying textures in games with upscaled internal resolutions, DuckStation floors all texture coordinates whenever vertex offset values are multiplied according to the internal resolution upscaling option. To my understanding, at least.

Flooring the texture coordinates doesn't work best for certain games, however. The Crash Bandicoot series of platformers shows jagged edges on the textures of crates whenever the game is upscaled, which is a pretty noticeable error throughout the entire games. For these games, rounding the texture coordinates instead of flooring them provides more "accurate" behavior, in regards to looking the closest to what the game looks like with its internal resolution unchanged.

These are screenshots I took of the games _Crash Bandicoot_, _Crash Bandicoot 2: Cortex Strikes Back_, and _Crash Bandicoot: WARPED_. Beyond the settings mentioned in each screenshot, I also enabled the "True Color" option to disable dithering.

<img src="https://user-images.githubusercontent.com/8278830/215596095-3d56173e-d780-4f58-9be1-b8b216f46d8e.png" width=256></img><img src="https://user-images.githubusercontent.com/8278830/215598438-0ca27613-0862-4e04-8df6-08a991deb91f.png" width=256></img><img src="https://user-images.githubusercontent.com/8278830/215598529-da1340cc-9a32-4f61-ae33-032faf4f3122.png" width=256></img>
_1x Internal Resolution_

<img src="https://user-images.githubusercontent.com/8278830/215596217-5cbe61e8-31ed-40b4-a035-1bdb67747905.png" width=256></img><img src="https://user-images.githubusercontent.com/8278830/215596954-07887a40-08c1-44b4-a755-b3c8ed1af518.png" width=256></img><img src="https://user-images.githubusercontent.com/8278830/215598946-9d33c7dc-5d2f-45b8-bb06-789ffc3918e4.png" width=256></img>
_4x Internal Resolution (texture coordinates are floored, normal DuckStation behavior)_

<img src="https://user-images.githubusercontent.com/8278830/215596833-6d0a18bc-67fb-4a86-8480-f2b1ede1ccf5.png" width=256></img><img src="https://user-images.githubusercontent.com/8278830/215597038-2f73e76d-406d-4248-8f83-045c357071ed.png" width=256></img><img src="https://user-images.githubusercontent.com/8278830/215598960-cf479c4d-7e09-4f8e-bbe5-5239b5958c5f.png" width=256></img>
_4x Internal Resolution (texture coordinates are rounded, modified DuckStation behavior)_

### What this commit does

This commit adds an option to force texture coordinates to always be rounded even when the internal resolution of the game is upscaled, found in the "Advanced Settings" category. While it would seem like a no-brainer to force this setting to be enabled for the games that look better with it, such as _Crash Bandicoot_...

<img src="https://user-images.githubusercontent.com/8278830/215599671-8bebc759-5077-4e5a-825d-d5e0d68f9970.png" width=256></img>

It isn't actually perfect. Errors like these can be fixed simply by enabling PGXP, but, of course, that only benefits the people that wish to play with PGXP on. For such users, however, this option would be a no-brainer to enable.

P.S. the above screenshots were all with PGXP off, the game only looks bad right about there

Thanks to @ManDude for tipping me off on this problem and its (band-aid) solution.