### PR TITLE
UI QT: set helpText height to 136

### DIFF
--- a/src/duckstation-qt/settingsdialog.ui
+++ b/src/duckstation-qt/settingsdialog.ui
@@ -77,13 +77,13 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>100</height>
+       <height>136</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>100</height>
+       <height>136</height>
       </size>
      </property>
      <property name="readOnly">


### PR DESCRIPTION
now the tooltip for forcing 24-bit color depth fits exactly. 
Note: each new line in the standard font/formatting takes exactly additional 18px to fit.