### PR TITLE
core / system: Disc-Region Fix For Netplay

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -1173,9 +1173,9 @@ bool System::BootSystem(SystemBootParameters parameters)
         return false;
       }
 
+      disc_region = GetRegionForImage(disc.get());
       if (s_region == ConsoleRegion::Auto)
       {
-        disc_region = GetRegionForImage(disc.get());
         if (disc_region != DiscRegion::Other)
         {
           s_region = GetConsoleRegionForDiscRegion(disc_region);


### PR DESCRIPTION
Fixes an issue which is only really valid for netplay since can start from an non-auto region sinc eit pulls it from the host.