### PR TITLE
Netplay/Spectating: Drop spectator without having to reset

### DIFF
--- a/dep/ggpo-x/src/backends/p2p.cpp
+++ b/dep/ggpo-x/src/backends/p2p.cpp
@@ -60,12 +60,9 @@ GGPOErrorCode Peer2PeerBackend::AddSpectator(ENetPeer* peer)
    if (_num_spectators == GGPO_MAX_SPECTATORS) {
       return GGPO_ERRORCODE_TOO_MANY_SPECTATORS;
    }
-   /*
-    * Currently, we can only add spectators before the game starts.
-    */
-   if (!_synchronizing) {
-      return GGPO_ERRORCODE_INVALID_REQUEST;
-   }
+
+   _synchronizing = true;
+
    int queue = _num_spectators++;
 
    _spectators[queue].Init(peer, queue + 1000, _local_connect_status);
@@ -164,7 +161,7 @@ Peer2PeerBackend::DoPoll()
                   input.size = _input_size * _num_players;
                   _sync.GetConfirmedInputs(input.bits, _input_size * _num_players, _next_spectator_frame);
                   for (int i = 0; i < _num_spectators; i++) {
-                     _spectators[i].SendInput(input);
+                      _spectators[i].SendInput(input);
                   }
                   _next_spectator_frame++;
                }
@@ -721,6 +718,7 @@ Peer2PeerBackend::CheckInitialSync()
             return;
          }
       }
+
       for (i = 0; i < _num_spectators; i++) {
          if (_spectators[i].IsInitialized() && !_spectators[i].IsSynchronized()) {
             return;

--- a/dep/ggpo-x/src/backends/spectator.cpp
+++ b/dep/ggpo-x/src/backends/spectator.cpp
@@ -18,13 +18,6 @@ SpectatorBackend::SpectatorBackend(GGPOSessionCallbacks* cb, int num_players, in
    }
 
    /*
-    * Initialize the UDP port
-    */
-   // FIXME
-   //abort();
-   //_udp.Init(localport, &_poll, this);
-
-   /*
     * Init the host endpoint
     */
    _host.Init(peer, 0, NULL);

--- a/dep/ggpo-x/src/network/udp_proto.cpp
+++ b/dep/ggpo-x/src/network/udp_proto.cpp
@@ -63,7 +63,7 @@ int UdpProtocol::RemoteFrameDelay()const
 
 void UdpProtocol::Init(ENetPeer* peer, int queue, UdpMsg::connect_status *status)
 {  
-  _peer = peer;
+   _peer = peer;
    _queue = queue;
    _local_connect_status = status;
 
@@ -75,6 +75,12 @@ void UdpProtocol::Init(ENetPeer* peer, int queue, UdpMsg::connect_status *status
 void
 UdpProtocol::SendInput(GameInput &input)
 {
+   // when spectating and you hit the end of the buffer its time to acknowledge that the peer is dead.
+   if (_queue >= 1000 && _pending_output.size() >= 63) {
+      Disconnect();
+      return;
+   }
+
    if (_peer) {
       if (_current_state == Running) {
          /*

--- a/src/core/netplay.cpp
+++ b/src/core/netplay.cpp
@@ -169,6 +169,7 @@ static Common::Timer s_last_host_connection_attempt;
 static std::array<Peer, MAX_SPECTATORS> s_spectators;
 static std::bitset<MAX_SPECTATORS> s_reset_spectators;
 static s32 s_num_spectators = 0;
+static s32 s_spectating_failed_count = 0;
 static bool s_local_spectating;
 
 /// GGPO
@@ -848,6 +849,7 @@ void Netplay::DestroyGGPOSession()
   s_ggpo = nullptr;
   s_save_buffer_pool.clear();
   s_local_handle = GGPO_INVALID_HANDLE;
+  s_spectating_failed_count = 0;
 
   for (Peer& p : s_peers)
     p.ggpo_handle = GGPO_INVALID_HANDLE;
@@ -1072,10 +1074,6 @@ void Netplay::DropSpectator(s32 slot_id, DropPlayerReason reason)
   enet_peer_disconnect_now(s_spectators[slot_id].peer, 0);
   s_spectators[slot_id] = {};
   s_num_spectators--;
-  // sadly we have to reset here. this really sucks for the active players since you dont really want to halt for a spectator.
-  // not resetting seems to be creating index out of bounds errors in the ringbuffer.
-  // TODO ? 
-  Reset();
 }
 
 void Netplay::UpdateConnectingState()
@@ -1771,7 +1769,7 @@ void Netplay::SetSettings(const ConnectResponseMessage* msg)
   si.SetBoolValue("GPU", "UseSoftwareRendererForReadbacks", true);
 
   // No cheats.. yet. Need to serialize them, and that has security risks.
-  si.SetBoolValue("Main", "AutoLoadCheats", false);
+  // si.SetBoolValue("Main", "AutoLoadCheats", false);
 
   // No PCDRV or texture replacements, they require local files.
   si.SetBoolValue("PCDrv", "Enabled", false);
@@ -1973,6 +1971,14 @@ void Netplay::RunFrame()
   if (GGPO_SUCCEEDED(result))
   {
     result = SyncInput(inputs, &disconnect_flags);
+    if (s_local_spectating && result != GGPO_OK)
+    {
+      s_spectating_failed_count++;
+      // after 5 seconds and still not spectating close since you are stuck.
+      if (s_spectating_failed_count >= 300)
+        CloseSessionWithError("Failed to sync spectator. Please try again.");
+    }
+
     if (GGPO_SUCCEEDED(result))
     {
       // enable again when rolling back done

--- a/src/core/netplay.cpp
+++ b/src/core/netplay.cpp
@@ -1971,12 +1971,13 @@ void Netplay::RunFrame()
   if (GGPO_SUCCEEDED(result))
   {
     result = SyncInput(inputs, &disconnect_flags);
+    // check if you get stuck while spectating. if this is the case try to disconnect.
     if (s_local_spectating && result != GGPO_OK)
     {
       s_spectating_failed_count++;
       // after 5 seconds and still not spectating close since you are stuck.
       if (s_spectating_failed_count >= 300)
-        CloseSessionWithError("Failed to sync spectator. Please try again.");
+        CloseSessionWithError("Failed to sync spectator with host. Please try again.");
     }
 
     if (GGPO_SUCCEEDED(result))

--- a/src/core/netplay.cpp
+++ b/src/core/netplay.cpp
@@ -1769,7 +1769,7 @@ void Netplay::SetSettings(const ConnectResponseMessage* msg)
   si.SetBoolValue("GPU", "UseSoftwareRendererForReadbacks", true);
 
   // No cheats.. yet. Need to serialize them, and that has security risks.
-  // si.SetBoolValue("Main", "AutoLoadCheats", false);
+  si.SetBoolValue("Main", "AutoLoadCheats", false);
 
   // No PCDRV or texture replacements, they require local files.
   si.SetBoolValue("PCDrv", "Enabled", false);

--- a/src/duckstation-qt/translations/duckstation-qt_fr.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_fr.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="../aboutdialog.ui" line="14"/>
         <source>About DuckStation</source>
-        <translation>À propos de Duckstation</translation>
+        <translation>À propos de DuckStation</translation>
     </message>
     <message>
         <location filename="../aboutdialog.ui" line="101"/>
@@ -14,27 +14,27 @@
         <translation>DuckStation</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="15"/>
+        <location filename="../aboutdialog.cpp" line="18"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="31"/>
+        <location filename="../aboutdialog.cpp" line="34"/>
         <source>DuckStation is a free and open-source simulator/emulator of the Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt; console, focusing on playability, speed, and long-term maintainability.</source>
-        <translation>DuckStation est un émulateur gratuit et open source simulant la console Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt;, qui se concentre sur la jouabilité, la vitesse et la maintenanibilité à long terme.</translation>
+        <translation>DuckStation est un émulateur gratuit et open source simulant la console Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt;, qui se concentre sur la jouabilité, la vitesse et la maintenabilité à long terme.</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="34"/>
+        <location filename="../aboutdialog.cpp" line="37"/>
         <source>Authors</source>
         <translation>Auteurs</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="35"/>
+        <location filename="../aboutdialog.cpp" line="38"/>
         <source>Icon by</source>
         <translation>Icône par</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="36"/>
+        <location filename="../aboutdialog.cpp" line="39"/>
         <source>License</source>
         <translation>Licence</translation>
     </message>
@@ -45,58 +45,58 @@
         <location filename="../achievementlogindialog.ui" line="29"/>
         <source>RetroAchievements Login</source>
         <comment>Window title</comment>
-        <translation type="unfinished"></translation>
+        <translation>Connexion à RetroAchievements</translation>
     </message>
     <message>
         <location filename="../achievementlogindialog.ui" line="57"/>
         <source>RetroAchievements Login</source>
         <comment>Header text</comment>
-        <translation type="unfinished"></translation>
+        <translation>Connexion à RetroAchievements</translation>
     </message>
     <message>
         <location filename="../achievementlogindialog.ui" line="69"/>
         <source>Please enter user name and password for retroachievements.org below. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>Veuillez entrer un nom d&apos;utilisateur et un mot de passe pour retroachievements.org ci-dessous. Votre mot de passe ne sera pas sauvegardé dans DuckStation, un jeton d&apos;accès sera généré et utilisé à la place.</translation>
     </message>
     <message>
         <location filename="../achievementlogindialog.ui" line="94"/>
         <source>User Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom d&apos;utilisateur :</translation>
     </message>
     <message>
         <location filename="../achievementlogindialog.ui" line="104"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Mot de passe :</translation>
     </message>
     <message>
         <location filename="../achievementlogindialog.ui" line="122"/>
         <source>Ready...</source>
-        <translation type="unfinished"></translation>
+        <translation>Prêt...</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="11"/>
+        <location filename="../achievementlogindialog.cpp" line="14"/>
         <source>&amp;Login</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Connexion</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="24"/>
+        <location filename="../achievementlogindialog.cpp" line="27"/>
         <source>Logging in...</source>
-        <translation type="unfinished"></translation>
+        <translation>Connexion...</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="42"/>
+        <location filename="../achievementlogindialog.cpp" line="45"/>
         <source>Login Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur de connexion</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="43"/>
+        <location filename="../achievementlogindialog.cpp" line="46"/>
         <source>Login failed. Please check your username and password, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>La connexion a échoué. Veuillez vérifier votre nom d&apos;utilisateur et votre mot de passe, et réessayer.</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="44"/>
+        <location filename="../achievementlogindialog.cpp" line="47"/>
         <source>Login failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de connexion.</translation>
     </message>
 </context>
 <context>
@@ -104,229 +104,283 @@
     <message>
         <location filename="../achievementsettingswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../achievementsettingswidget.ui" line="32"/>
         <source>Global Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../achievementsettingswidget.ui" line="38"/>
-        <location filename="../achievementsettingswidget.cpp" line="28"/>
-        <source>Enable Achievements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../achievementsettingswidget.ui" line="45"/>
-        <location filename="../achievementsettingswidget.cpp" line="38"/>
-        <source>Enable Rich Presence</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres Généraux</translation>
     </message>
     <message>
         <location filename="../achievementsettingswidget.ui" line="52"/>
-        <location filename="../achievementsettingswidget.cpp" line="30"/>
+        <location filename="../achievementsettingswidget.cpp" line="35"/>
+        <source>Enable Achievements</source>
+        <translation>Activer les Succès</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="38"/>
+        <location filename="../achievementsettingswidget.cpp" line="45"/>
+        <source>Enable Rich Presence</source>
+        <translation>Activer la Rich Presence</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="80"/>
+        <location filename="../achievementsettingswidget.cpp" line="37"/>
         <source>Enable Test Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../achievementsettingswidget.ui" line="59"/>
-        <location filename="../achievementsettingswidget.cpp" line="41"/>
-        <source>Use First Disc From Playlist</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../achievementsettingswidget.ui" line="66"/>
-        <location filename="../achievementsettingswidget.cpp" line="44"/>
-        <source>Enable Hardcore Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer le Mode Test</translation>
     </message>
     <message>
         <location filename="../achievementsettingswidget.ui" line="73"/>
-        <location filename="../achievementsettingswidget.cpp" line="34"/>
-        <source>Test Unofficial Achievements</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.cpp" line="48"/>
+        <source>Use First Disc From Playlist</source>
+        <translation>Utiliser le premier disque depuis la liste de lecture</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="83"/>
-        <source>Account</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.ui" line="45"/>
+        <location filename="../achievementsettingswidget.cpp" line="61"/>
+        <source>Enable Leaderboards</source>
+        <translation>Activer les classements</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="98"/>
-        <location filename="../achievementsettingswidget.cpp" line="103"/>
-        <source>Login...</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.ui" line="59"/>
+        <location filename="../achievementsettingswidget.cpp" line="51"/>
+        <source>Enable Hardcore Mode</source>
+        <translation>Activer le Mode Hardcore</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="105"/>
-        <source>View Profile...</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.ui" line="66"/>
+        <location filename="../achievementsettingswidget.cpp" line="65"/>
+        <source>Show Challenge Indicators</source>
+        <translation>Aff. les Indics. de Challenge</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="123"/>
-        <source>Game Info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../achievementsettingswidget.ui" line="139"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;DuckStation uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;retroachievements.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../achievementsettingswidget.cpp" line="28"/>
-        <location filename="../achievementsettingswidget.cpp" line="30"/>
-        <location filename="../achievementsettingswidget.cpp" line="34"/>
-        <location filename="../achievementsettingswidget.cpp" line="38"/>
+        <location filename="../achievementsettingswidget.ui" line="87"/>
         <location filename="../achievementsettingswidget.cpp" line="41"/>
-        <location filename="../achievementsettingswidget.cpp" line="44"/>
-        <source>Unchecked</source>
-        <translation type="unfinished">Décoché</translation>
+        <source>Test Unofficial Achievements</source>
+        <translation>Tester les succès non-officiels</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="29"/>
-        <source>When enabled and logged in, DuckStation will scan for achievements on startup.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.ui" line="94"/>
+        <location filename="../achievementsettingswidget.cpp" line="58"/>
+        <source>Enable Sound Effects</source>
+        <translation>Activer les effets sonores</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="31"/>
-        <source>When enabled, DuckStation will assume all achievements are locked and not send any unlock notifications to the server.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.ui" line="101"/>
+        <location filename="../achievementsettingswidget.cpp" line="55"/>
+        <source>Show Notifications</source>
+        <translation>Afficher les notifications</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="111"/>
+        <source>Account</source>
+        <translation>Compte</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="126"/>
+        <location filename="../achievementsettingswidget.cpp" line="158"/>
+        <source>Login...</source>
+        <translation>Connexion...</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="133"/>
+        <source>View Profile...</source>
+        <translation>Voir le Profil...</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="151"/>
+        <source>Game Info</source>
+        <translation>Informations du jeu</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="167"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;DuckStation uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;retroachievements.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;DuckStation utilise RetroAchievements en tant que base de données de succès et pour suivre la progression. Pour utiliser les succès, veuillez vous inscrire sur &lt;a href=&quot;https://retroachievements.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;retroachievements.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;Pour voir la liste des succès en jeu, pressez la touche raccourci pour &lt;span style=&quot; font-weight:600;&quot;&gt;Ouvrir menu pause&lt;/span&gt; et sélectionnez &lt;span style=&quot; font-weight:600;&quot;&gt;Succès&lt;/span&gt; depuis le menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../achievementsettingswidget.cpp" line="35"/>
-        <source>When enabled, DuckStation will list achievements from unofficial sets. Please note that these achievements are not tracked by RetroAchievements, so they unlock every time.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.cpp" line="37"/>
+        <location filename="../achievementsettingswidget.cpp" line="41"/>
+        <location filename="../achievementsettingswidget.cpp" line="45"/>
+        <location filename="../achievementsettingswidget.cpp" line="48"/>
+        <location filename="../achievementsettingswidget.cpp" line="51"/>
+        <source>Unchecked</source>
+        <translation>Décoché</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="39"/>
-        <source>When enabled, rich presence information will be collected and sent to the server where supported.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.cpp" line="36"/>
+        <source>When enabled and logged in, DuckStation will scan for achievements on startup.</source>
+        <translation>Quand activé et connecté, DuckStation scannera les succès au démarrage.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="38"/>
+        <source>When enabled, DuckStation will assume all achievements are locked and not send any unlock notifications to the server.</source>
+        <translation>Quand activé, DuckStation supposera que tous les succès sont verrouillés et n&apos;enverra aucune notification de déverrouillage au serveur.</translation>
     </message>
     <message>
         <location filename="../achievementsettingswidget.cpp" line="42"/>
+        <source>When enabled, DuckStation will list achievements from unofficial sets. Please note that these achievements are not tracked by RetroAchievements, so they unlock every time.</source>
+        <translation>Quand activé, DuckStation listera la liste des succès depuis les ensembles non-officiels. Veuillez noter que ces succès ne sont pas suivis par RetroAchievements, et donc qu&apos;ils se débloquent à chaque fois.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="46"/>
+        <source>When enabled, rich presence information will be collected and sent to the server where supported.</source>
+        <translation>Quand activé, les informations rich presence seront collectées et envoyées au serveur quand supporté.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="49"/>
         <source>When enabled, the first disc in a playlist will be used for achievements, regardless of which disc is active.</source>
-        <translation type="unfinished"></translation>
+        <translation>Quand activé, le premier disque dans la liste de lecture sera utilisé pour les succès, sans regarder quel disque est actif.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="45"/>
-        <source>&quot;Challenge&quot; mode for achievements. Disables save state, cheats, and slowdown functions, but you receive double the achievement points.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../achievementsettingswidget.cpp" line="52"/>
+        <source>&quot;Challenge&quot; mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions.</source>
+        <translation>Le mode &quot;Challenge&quot; pour les succès, incluant suivi de classement. Désactive les save states, codes de triche, et fonctions de ralentissement.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="95"/>
+        <location filename="../achievementsettingswidget.cpp" line="55"/>
+        <location filename="../achievementsettingswidget.cpp" line="58"/>
+        <location filename="../achievementsettingswidget.cpp" line="61"/>
+        <location filename="../achievementsettingswidget.cpp" line="65"/>
+        <source>Checked</source>
+        <translation>Coché</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="56"/>
+        <source>Displays popup messages on events such as achievement unlocks and leaderboard submissions.</source>
+        <translation>Affiche les popups de message lors d&apos;événements tels que le déverrouillage de succès et les soumissions de classement.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="59"/>
+        <source>Plays sound effects for events such as achievement unlocks and leaderboard submissions.</source>
+        <translation>Joue les effets sonores des événements tels que le déverrouillage des succès et les soumissions de classement.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="62"/>
+        <source>Enables tracking and submission of leaderboards in supported games. If leaderboards are disabled, you will still be able to view the leaderboard and scores, but no scores will be uploaded.</source>
+        <translation>Active le suivi et la soumission de classement pour les jeux supportés. Si le classement est désactivé, vous pourrez voir les classements et score, mais aucun score ne sera envoyé.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="66"/>
+        <source>Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active.</source>
+        <translation>Affiche les îcones dans le coin en bas à droite de l&apos;écran quand un challenge/succès primé est actif.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="130"/>
+        <source>Reset System</source>
+        <translation>Réinitialiser le Système</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="131"/>
+        <source>Hardcore mode will not be enabled until the system is reset. Do you want to reset the system now?</source>
+        <translation>Le mode Hardcore ne sera activé qu&apos;après réinitialisation du système. Voulez-vous réinitialiser le système maintenant ?</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="150"/>
         <source>Username: %1
 Login token generated on %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom d&apos;utilisateur : %1
+Jeton de connexion généré sur %2.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="98"/>
+        <location filename="../achievementsettingswidget.cpp" line="153"/>
         <source>Logout</source>
-        <translation type="unfinished"></translation>
+        <translation>Déconnexion</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="102"/>
+        <location filename="../achievementsettingswidget.cpp" line="157"/>
         <source>Not Logged In.</source>
-        <translation type="unfinished"></translation>
+        <translation>Non-connecté.</translation>
     </message>
 </context>
 <context>
     <name>Achievements</name>
     <message>
-        <location filename="../../core/system.cpp" line="925"/>
+        <location filename="../../core/system.cpp" line="1023"/>
         <source>Loading state</source>
-        <translation type="unfinished"></translation>
+        <translation>Chargement de l&apos;état</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1126"/>
+        <location filename="../../core/system.cpp" line="1245"/>
         <source>Resuming state</source>
-        <translation type="unfinished"></translation>
+        <translation>Reprise de l&apos;état</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1814"/>
+        <location filename="../../core/system.cpp" line="2014"/>
         <source>Hardcore mode disabled by state switch.</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode Hardcore désactivé par la bascule d&apos;état.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="481"/>
+        <location filename="../../frontend-common/achievements.cpp" line="505"/>
         <source>Hardcore mode will be enabled on system reset.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le mode Hardcore sera activé sur réinitialisation du système.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="509"/>
+        <location filename="../../frontend-common/achievements.cpp" line="534"/>
         <source>Confirm Hardcore Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmation du mode Hardcore</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="510"/>
+        <location filename="../../frontend-common/achievements.cpp" line="535"/>
         <source>{0} cannot be performed while hardcore mode is active. Do you want to disable hardcore mode? {0} will be cancelled if you select No.</source>
-        <translation type="unfinished"></translation>
+        <translation>{0} ne peut être fait quand le mode Hardcore est actif. Voulez-vous désactiver le mode Hardcore ? {0} sera annulé si vous sélectionnez Non.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="561"/>
+        <location filename="../../frontend-common/achievements.cpp" line="586"/>
         <source>Hardcore mode is now enabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le mode Hardcore est maintenant activé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="562"/>
+        <location filename="../../frontend-common/achievements.cpp" line="587"/>
         <source>Hardcore mode is now disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le mode Hardcore est maintenant désactivé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="966"/>
+        <location filename="../../frontend-common/achievements.cpp" line="1002"/>
         <source>{} (Hardcore Mode)</source>
-        <translation type="unfinished"></translation>
+        <translation>{} (mode Hardcore)</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="974"/>
+        <location filename="../../frontend-common/achievements.cpp" line="1010"/>
         <source>You have earned {} of {} achievements, and {} of {} points.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vous avez remporté {} des {} succès, et {} des {} points.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="980"/>
+        <location filename="../../frontend-common/achievements.cpp" line="1016"/>
         <source>This game has no achievements.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce jeu n&apos;a pas de succès.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="987"/>
-        <source>Leaderboards are enabled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../frontend-common/achievements.cpp" line="991"/>
-        <source>Leaderboards are disabled because hardcore mode is off.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../frontend-common/achievements.cpp" line="1680"/>
+        <location filename="../../frontend-common/achievements.cpp" line="1772"/>
         <source>Your Score: {} (Best: {})
 Leaderboard Position: {} of {}</source>
-        <translation type="unfinished"></translation>
+        <translation>Votre score : {} (Meilleur : {})
+Position dans le classement : {} of {}</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="5209"/>
+        <location filename="../../frontend-common/fullscreen_ui.cpp" line="6953"/>
         <source>This game has {} leaderboards.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce jeu a {} classements.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="5227"/>
+        <location filename="../../frontend-common/fullscreen_ui.cpp" line="6971"/>
         <source>Submitting scores is disabled because hardcore mode is off. Leaderboards are read-only.</source>
-        <translation type="unfinished"></translation>
+        <translation>La soumission des scores est désactivée parce que le mode Hardcore est désactivé. Les classements sont en lecture seule.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="5262"/>
+        <location filename="../../frontend-common/fullscreen_ui.cpp" line="7006"/>
         <source>Time</source>
-        <translation type="unfinished"></translation>
+        <translation>Temps</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="5263"/>
+        <location filename="../../frontend-common/fullscreen_ui.cpp" line="7007"/>
         <source>Score</source>
-        <translation type="unfinished"></translation>
+        <translation>Score</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="5319"/>
+        <location filename="../../frontend-common/fullscreen_ui.cpp" line="7063"/>
         <source>Downloading leaderboard data, please wait...</source>
-        <translation type="unfinished"></translation>
+        <translation>Téléchargement des données de classement, veuillez patienter...</translation>
     </message>
 </context>
 <context>
@@ -353,25 +407,25 @@ Leaderboard Position: {} of {}</source>
     </message>
     <message>
         <location filename="../advancedsettingswidget.ui" line="64"/>
-        <location filename="../advancedsettingswidget.cpp" line="265"/>
+        <location filename="../advancedsettingswidget.cpp" line="255"/>
         <source>Log To System Console</source>
         <translation>Enregistrer vers une console système</translation>
     </message>
     <message>
         <location filename="../advancedsettingswidget.ui" line="71"/>
-        <location filename="../advancedsettingswidget.cpp" line="269"/>
+        <location filename="../advancedsettingswidget.cpp" line="259"/>
         <source>Log To Window</source>
         <translation>Enregistrer dans une fenêtre</translation>
     </message>
     <message>
         <location filename="../advancedsettingswidget.ui" line="78"/>
-        <location filename="../advancedsettingswidget.cpp" line="267"/>
+        <location filename="../advancedsettingswidget.cpp" line="257"/>
         <source>Log To Debug Console</source>
         <translation>Enregistrer vers la console de débogage</translation>
     </message>
     <message>
         <location filename="../advancedsettingswidget.ui" line="85"/>
-        <location filename="../advancedsettingswidget.cpp" line="271"/>
+        <location filename="../advancedsettingswidget.cpp" line="261"/>
         <source>Log To File</source>
         <translation>Enregistrer vers un fichier</translation>
     </message>
@@ -382,7 +436,7 @@ Leaderboard Position: {} of {}</source>
     </message>
     <message>
         <location filename="../advancedsettingswidget.ui" line="103"/>
-        <location filename="../advancedsettingswidget.cpp" line="273"/>
+        <location filename="../advancedsettingswidget.cpp" line="263"/>
         <source>Show Debug Menu</source>
         <translation>Menu de débogage</translation>
     </message>
@@ -407,12 +461,12 @@ Leaderboard Position: {} of {}</source>
         <translation>Remettre par défaut</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="210"/>
+        <location filename="../advancedsettingswidget.cpp" line="278"/>
         <source>Display FPS Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher la limite d&apos;IPS</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="214"/>
+        <location filename="../advancedsettingswidget.cpp" line="294"/>
         <source>PGXP Vertex Cache</source>
         <translation>Cache Vertex PGXP</translation>
     </message>
@@ -425,181 +479,231 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Préserver la précision de la projection PGXP</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="215"/>
+        <location filename="../advancedsettingswidget.cpp" line="295"/>
         <source>PGXP Geometry Tolerance</source>
-        <translation type="unfinished"></translation>
+        <translation>Tolérance de la géométrie PGXP</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="217"/>
+        <location filename="../advancedsettingswidget.cpp" line="297"/>
         <source>PGXP Depth Clear Threshold</source>
-        <translation type="unfinished"></translation>
+        <translation>Seuil de profondeur libre PGXP</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="220"/>
+        <location filename="../advancedsettingswidget.cpp" line="300"/>
         <source>Enable Recompiler Memory Exceptions</source>
-        <translation>Activer les exceptions mémoire du recompileur</translation>
+        <translation>Activer les exceptions mémoire du recompilateur</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="224"/>
+        <location filename="../advancedsettingswidget.cpp" line="304"/>
         <source>Enable Recompiler Fast Memory Access</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer l&apos;accès rapide en mémoire du recompilateur</translation>
     </message>
     <message>
         <source>Enable Recompiler ICache</source>
         <translation type="vanished">Activer le recompileur ICache</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="229"/>
+        <location filename="../advancedsettingswidget.cpp" line="311"/>
         <source>Enable VRAM Write Texture Replacement</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer le remplacement des textures d&apos;écriture VRAM</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="231"/>
+        <location filename="../advancedsettingswidget.cpp" line="313"/>
         <source>Preload Texture Replacements</source>
-        <translation type="unfinished"></translation>
+        <translation>Précharger les remplacements de texture</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="202"/>
+        <location filename="../advancedsettingswidget.cpp" line="271"/>
         <source>Disable All Enhancements</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactiver toutes les améliorations</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="204"/>
-        <source>Show Enhancement Settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="206"/>
+        <location filename="../advancedsettingswidget.cpp" line="273"/>
         <source>Show Status Indicators</source>
-        <translation type="unfinished"></translation>
+        <translation>Aficher les indicateurs de statut</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="208"/>
+        <location filename="../advancedsettingswidget.cpp" line="275"/>
+        <source>Show Frame Times</source>
+        <translation>Afficher les temps d&apos;image</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="276"/>
         <source>Apply Compatibility Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Appliquer les paramètres de compatibilité</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="212"/>
+        <location filename="../advancedsettingswidget.cpp" line="280"/>
         <source>Multisample Antialiasing</source>
-        <translation type="unfinished"></translation>
+        <translation>Anticrénelage multi-échantillons</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="222"/>
+        <location filename="../advancedsettingswidget.cpp" line="284"/>
+        <source>Display Active Start Offset</source>
+        <translation>Afficher la position de début active</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="286"/>
+        <source>Display Active End Offset</source>
+        <translation>Afficher la position de fin active</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="288"/>
+        <source>Display Line Start Offset</source>
+        <translation>Afficher la position de la ligne de début</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="290"/>
+        <source>Display Line End Offset</source>
+        <translation>Afficher la position de la ligne de fin</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="302"/>
         <source>Enable Recompiler Block Linking</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer le bloc d&apos;édition de liens du recompilateur</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="233"/>
+        <location filename="../advancedsettingswidget.cpp" line="309"/>
+        <source>Use Old MDEC Routines</source>
+        <translation>Utiliser les anciennes routines MDEC</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="315"/>
         <source>Dump Replaceable VRAM Writes</source>
-        <translation type="unfinished"></translation>
+        <translation>Décharger les écritures VRAM remplaçables</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="235"/>
+        <location filename="../advancedsettingswidget.cpp" line="317"/>
         <source>Set Dumped VRAM Write Alpha Channel</source>
-        <translation type="unfinished"></translation>
+        <translation>Affeter le canal d&apos;écriture alpha de la VRAM déchargée</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="237"/>
+        <location filename="../advancedsettingswidget.cpp" line="319"/>
         <source>Minimum Dumped VRAM Write Width</source>
-        <translation type="unfinished"></translation>
+        <translation>Longueur minimale de l&apos;écriture de la VRAM déchargée</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="240"/>
+        <location filename="../advancedsettingswidget.cpp" line="322"/>
         <source>Minimum Dumped VRAM Write Height</source>
-        <translation type="unfinished"></translation>
+        <translation>Hauteur minimale de l&apos;écriture de la VRAM déchargée</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="244"/>
+        <location filename="../advancedsettingswidget.cpp" line="326"/>
         <source>DMA Max Slice Ticks</source>
         <translation>Taille maximale de l&apos;écart entre deux transferts DMA</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="246"/>
+        <location filename="../advancedsettingswidget.cpp" line="328"/>
         <source>DMA Halt Ticks</source>
         <translation>Fréquence d&apos;arrêt du transfert DMA</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="248"/>
+        <location filename="../advancedsettingswidget.cpp" line="330"/>
         <source>GPU FIFO Size</source>
         <translation>Taille du tampon FIFO du GPU</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="250"/>
+        <location filename="../advancedsettingswidget.cpp" line="332"/>
         <source>GPU Max Run-Ahead</source>
         <translation>Temps d&apos;avance maximale du GPU</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="252"/>
+        <location filename="../advancedsettingswidget.cpp" line="334"/>
         <source>Use Debug Host GPU Device</source>
         <translation>Utiliser le périphérique GPU hôte de débogage</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="254"/>
-        <source>Increase Timer Resolution</source>
-        <translation type="unfinished">Augmenter la Résolution du Compteur</translation>
+        <location filename="../advancedsettingswidget.cpp" line="337"/>
+        <source>Stretch Display Vertically</source>
+        <translation>Étirer l&apos;affichage verticalement</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="257"/>
+        <location filename="../advancedsettingswidget.cpp" line="340"/>
+        <source>Increase Timer Resolution</source>
+        <translation>Augmenter la Résolution du Compteur</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="343"/>
         <source>Allow Booting Without SBI File</source>
-        <translation type="unfinished"></translation>
+        <translation>Autorise le démarrage sans fichier SBI</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="346"/>
+        <source>Create Save State Backups</source>
+        <translation>Créer des sauvegardes de save state</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="349"/>
+        <source>Enable PCDrv</source>
+        <translation>Activer PCDrv</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="350"/>
+        <source>Enable PCDrv Writes</source>
+        <translation>Activer les écritures PCDrv</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="351"/>
+        <source>PCDrv Root Directory</source>
+        <translation>Répertoire racine PCDrv</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="253"/>
+        <source>Log Level</source>
+        <translation>Niveau de log</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="205"/>
+        <source>Select folder for %1</source>
+        <translation>Sélectionner le dossier pour %1</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="253"/>
+        <source>Information</source>
+        <translation>Information</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="254"/>
+        <source>Sets the verbosity of messages logged. Higher levels will log more messages.</source>
+        <translation>Définie la verbosité des messages loggés. Les niveaux élevés loggeront plus de messages.</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="255"/>
+        <location filename="../advancedsettingswidget.cpp" line="257"/>
+        <location filename="../advancedsettingswidget.cpp" line="259"/>
+        <location filename="../advancedsettingswidget.cpp" line="261"/>
+        <source>User Preference</source>
+        <translation>Préférence utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="256"/>
+        <source>Logs messages to the console window.</source>
+        <translation>Logge les messages dans la fenêtre console.</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="258"/>
+        <source>Logs messages to the debug console where supported.</source>
+        <translation>Logge les messages dans la console de dégogage quand supporté.</translation>
     </message>
     <message>
         <location filename="../advancedsettingswidget.cpp" line="260"/>
-        <source>Create Save State Backups</source>
-        <translation type="unfinished"></translation>
+        <source>Logs messages to the window.</source>
+        <translation>Logge les message dans la fenêtre.</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="262"/>
+        <source>Logs messages to duckstation.log in the user directory.</source>
+        <translation>Logge les messages dans la log duckstation dans le répertoire utilisateur.</translation>
     </message>
     <message>
         <location filename="../advancedsettingswidget.cpp" line="263"/>
-        <source>Log Level</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="263"/>
-        <source>Information</source>
-        <translation type="unfinished">Information</translation>
+        <source>Unchecked</source>
+        <translation>Décoché</translation>
     </message>
     <message>
         <location filename="../advancedsettingswidget.cpp" line="264"/>
-        <source>Sets the verbosity of messages logged. Higher levels will log more messages.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="265"/>
-        <location filename="../advancedsettingswidget.cpp" line="267"/>
-        <location filename="../advancedsettingswidget.cpp" line="269"/>
-        <location filename="../advancedsettingswidget.cpp" line="271"/>
-        <source>User Preference</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="266"/>
-        <source>Logs messages to the console window.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="268"/>
-        <source>Logs messages to the debug console where supported.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="270"/>
-        <source>Logs messages to the window.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="272"/>
-        <source>Logs messages to duckstation.log in the user directory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="273"/>
-        <source>Unchecked</source>
-        <translation type="unfinished">Décoché</translation>
-    </message>
-    <message>
-        <location filename="../advancedsettingswidget.cpp" line="274"/>
         <source>Shows a debug menu bar with additional statistics and quick settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Affiche une barre de menu de débogage avec des statistiques additionnelles et des paramètres rapides.</translation>
     </message>
 </context>
 <context>
@@ -613,14 +717,12 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Le Contrôleur %u a basculé sur le mode Digital.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="266"/>
         <source>Controller %u is locked to analog mode by the game.</source>
-        <translation>Le contrôleur %u est verrouillé en mode Analogique par le jeu.</translation>
+        <translation type="vanished">Le contrôleur %u est verrouillé en mode Analogique par le jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="267"/>
         <source>Controller %u is locked to digital mode by the game.</source>
-        <translation>Le contrôleur %u est verrouillé en mode Digital par le jeu.</translation>
+        <translation type="vanished">Le contrôleur %u est verrouillé en mode Digital par le jeu.</translation>
     </message>
     <message>
         <source>LeftX</source>
@@ -707,56 +809,116 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Analogique</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="104"/>
-        <location filename="../../core/analog_controller.cpp" line="250"/>
+        <location filename="../../core/analog_controller.cpp" line="112"/>
+        <location filename="../../core/analog_controller.cpp" line="299"/>
         <source>Controller {} switched to analog mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrôleur {} changée en mode analogique.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="105"/>
-        <location filename="../../core/analog_controller.cpp" line="251"/>
+        <location filename="../../core/analog_controller.cpp" line="113"/>
+        <location filename="../../core/analog_controller.cpp" line="300"/>
         <source>Controller {} switched to digital mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrôleur {} changée en mode digital.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="783"/>
+        <location filename="../../core/analog_controller.cpp" line="315"/>
+        <source>Controller {} is locked to analog mode by the game.</source>
+        <translation>Contrôleur {} verrouillée en mode analogique par le jeu.</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="316"/>
+        <source>Controller {} is locked to digital mode by the game.</source>
+        <translation>Contrôleur {} verrouillée en mode digital par le jeu.</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="831"/>
+        <source>Not Inverted</source>
+        <translation>Non-inversé</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="832"/>
+        <source>Invert Left/Right</source>
+        <translation>Inverser gauche/droite</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="833"/>
+        <source>Invert Up/Down</source>
+        <translation>Inverser haut/bas</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="834"/>
+        <source>Invert Left/Right + Up/Down</source>
+        <translation>Inverser gauche/droite + haut/bas</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="837"/>
         <source>Force Analog Mode on Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Forcer le mode Analogue quand réinitialisation</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="784"/>
-        <source>Forces the controller to analog mode when the console is reset/powered on. May cause issues with games, so it is recommended to leave this option off.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../core/analog_controller.cpp" line="838"/>
+        <source>Forces the controller to analog mode when the console is reset/powered on.</source>
+        <translation>Force le contrôleur en mode analogique quand la console est réinitialisée/mise sous tension.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="788"/>
+        <location filename="../../core/analog_controller.cpp" line="855"/>
+        <source>Button/Trigger Deadzone</source>
+        <translation>Zone morte bouton/gachette</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="856"/>
+        <source>Sets the deadzone for activating buttons/triggers, i.e. the fraction of the trigger which will be ignored.</source>
+        <translation>Définis la zone morte pour activer les boutons/gachettes, càd la fraction de gachette qui sera ignorée.</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="863"/>
+        <source>Invert Left Stick</source>
+        <translation>Inverser le stick gauche</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="864"/>
+        <source>Inverts the direction of the left analog stick.</source>
+        <translation>Inverse la direction du stick analogique gauche.</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="866"/>
+        <source>Invert Right Stick</source>
+        <translation>Inverser le stick droit</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="867"/>
+        <source>Inverts the direction of the right analog stick.</source>
+        <translation>Inverse la direction du stick analogique droit.</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="841"/>
         <source>Use Analog Sticks for D-Pad in Digital Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser les sticks analogiques pour le D-Pad en mode digital</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="789"/>
+        <location filename="../../core/analog_controller.cpp" line="842"/>
         <source>Allows you to use the analog sticks to control the d-pad in digital mode, as well as the buttons.</source>
-        <translation type="unfinished"></translation>
+        <translation>Permet d&apos;utiliser les sticks analogiques pour contrôler le d-pas en mode digital, tout comme les boutons.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="792"/>
+        <location filename="../../core/analog_controller.cpp" line="845"/>
         <source>Analog Deadzone</source>
-        <translation type="unfinished"></translation>
+        <translation>Zone morte analogique</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="793"/>
+        <location filename="../../core/analog_controller.cpp" line="846"/>
         <source>Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.</source>
-        <translation type="unfinished"></translation>
+        <translation>Définis la zone morte du stick analogique, càd la fraction de mouvement du stick qui sera ignorée.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="796"/>
+        <location filename="../../core/analog_controller.cpp" line="849"/>
         <source>Analog Sensitivity</source>
-        <translation type="unfinished"></translation>
+        <translation>Sensibilité analogique</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="797"/>
+        <location filename="../../core/analog_controller.cpp" line="850"/>
         <source>Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent controllers, e.g. DualShock 4, Xbox One Controller.</source>
-        <translation type="unfinished"></translation>
+        <translation>Définis le facteur d&apos;échelle de l&apos;axe du stick analogique. Une valeur entre 130% et 140% est recommandée pour les manettes récentes, par ex. DualShock 4, manette Xbox One.</translation>
     </message>
     <message>
         <source>Enable Analog Mode on Reset</source>
@@ -775,51 +937,91 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Définit le facteur de mise à l&apos;échelle de l&apos;axe du stick analogique. Une valeur comprise entre 1,30 et 1,40 est recommandée lors de l&apos;utilisation de contrôleurs récents, par ex. DualShock 4, manette Xbox One.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="802"/>
+        <location filename="../../core/analog_controller.cpp" line="859"/>
         <source>Vibration Bias</source>
         <translatorcomment>Le bias est un réglage en général en électronique, et non un alignement.</translatorcomment>
         <translation>Réglage des vibrations</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="803"/>
+        <location filename="../../core/analog_controller.cpp" line="860"/>
         <source>Sets the rumble bias value. If rumble in some games is too weak or not functioning, try increasing this value.</source>
         <translatorcomment>Le bias est un réglage en général en électronique, et non un alignement.</translatorcomment>
-        <translation>Définit la valeur de réglage des vibrations. Si la vibration dans certains jeux est trop faible ou ne fonctionne pas, essayez d&apos;augmenter cette valeur.</translation>
+        <translation>Définis la valeur de réglage des vibrations. Si la vibration dans certains jeux est trop faible ou ne fonctionne pas, essayez d&apos;augmenter cette valeur.</translation>
     </message>
 </context>
 <context>
     <name>AnalogJoystick</name>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="54"/>
-        <location filename="../../core/analog_joystick.cpp" line="188"/>
+        <location filename="../../core/analog_joystick.cpp" line="62"/>
+        <location filename="../../core/analog_joystick.cpp" line="238"/>
         <source>Controller %u switched to analog mode.</source>
-        <translation type="unfinished">Le Contrôleur %u a basculé sur le mode Analogique.</translation>
+        <translation>La contrôleur %u a basculé en mode analogique.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="55"/>
-        <location filename="../../core/analog_joystick.cpp" line="189"/>
+        <location filename="../../core/analog_joystick.cpp" line="63"/>
+        <location filename="../../core/analog_joystick.cpp" line="239"/>
         <source>Controller %u switched to digital mode.</source>
-        <translation type="unfinished">Le Contrôleur %u a basculé sur le mode Digital.</translation>
+        <translation>La contrôleur %u a basculé en mode digital.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="328"/>
+        <location filename="../../core/analog_joystick.cpp" line="377"/>
+        <source>Not Inverted</source>
+        <translation>Non-inversé</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="378"/>
+        <source>Invert Left/Right</source>
+        <translation>Inverser gauche/droite</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="379"/>
+        <source>Invert Up/Down</source>
+        <translation>Inverser haut/bas</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="380"/>
+        <source>Invert Left/Right + Up/Down</source>
+        <translation>Inverser gauche/droite + haut/bas</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="383"/>
         <source>Analog Deadzone</source>
-        <translation type="unfinished"></translation>
+        <translation>Zone morte analogique</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="329"/>
+        <location filename="../../core/analog_joystick.cpp" line="384"/>
         <source>Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.</source>
-        <translation type="unfinished"></translation>
+        <translation>Définis la zone morte du stick analogique, càd la fraction du mouvement du stick qui sera ignorée.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="332"/>
+        <location filename="../../core/analog_joystick.cpp" line="387"/>
         <source>Analog Sensitivity</source>
-        <translation type="unfinished"></translation>
+        <translation>Sensitivité analogique</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="333"/>
+        <location filename="../../core/analog_joystick.cpp" line="388"/>
         <source>Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent controllers, e.g. DualShock 4, Xbox One Controller.</source>
-        <translation type="unfinished"></translation>
+        <translation>Définis le facteur d&apos;échelle de l&apos;axe du stick analogique. Une valeur entre 130% et 140% est recommandée pour les manettes récentes, par ex. DualShock 4, manette Xbox One.</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="393"/>
+        <source>Invert Left Stick</source>
+        <translation>Inverser le stick de gauche</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="394"/>
+        <source>Inverts the direction of the left analog stick.</source>
+        <translation>Inverse la direction du stick analogique gauche.</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="396"/>
+        <source>Invert Right Stick</source>
+        <translation>Inverser le stick droit</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="397"/>
+        <source>Inverts the direction of the right analog stick.</source>
+        <translation>Inverse la direction du stick analogique droit.</translation>
     </message>
     <message>
         <source>LeftX</source>
@@ -917,19 +1119,19 @@ Leaderboard Position: {} of {}</source>
 <context>
     <name>AudioBackend</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1034"/>
+        <location filename="../../core/settings.cpp" line="1138"/>
         <source>Null (No Output)</source>
         <translation>Null (Aucune Sortie)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1036"/>
+        <location filename="../../core/settings.cpp" line="1140"/>
         <source>Cubeb</source>
         <translation>Cubeb</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1039"/>
+        <location filename="../../core/settings.cpp" line="1143"/>
         <source>XAudio2</source>
-        <translation type="unfinished"></translation>
+        <translation>XAudio2</translation>
     </message>
     <message>
         <source>SDL</source>
@@ -949,17 +1151,17 @@ Leaderboard Position: {} of {}</source>
         <translation>Configuration</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="52"/>
+        <location filename="../audiosettingswidget.ui" line="112"/>
         <source>Backend:</source>
         <translation>Moteur de rendu :</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="38"/>
+        <location filename="../audiosettingswidget.ui" line="76"/>
         <source>Buffer Size:</source>
         <translation>Taille du tampon:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="132"/>
+        <location filename="../audiosettingswidget.ui" line="102"/>
         <source>Maximum latency: 0 frames (0.00ms)</source>
         <translation>Latence maximum : 0 image (0.00ms)</translation>
     </message>
@@ -968,90 +1170,95 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Synchroniser avec la sortie</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="45"/>
-        <location filename="../audiosettingswidget.cpp" line="73"/>
+        <location filename="../audiosettingswidget.ui" line="136"/>
+        <location filename="../audiosettingswidget.cpp" line="76"/>
         <source>Start Dumping On Boot</source>
         <translation>Commencer l&apos;enregistrement au démarrage</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="77"/>
+        <location filename="../audiosettingswidget.ui" line="161"/>
         <source>Minimal</source>
-        <translation type="unfinished"></translation>
+        <translation>Minimal</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="90"/>
+        <location filename="../audiosettingswidget.ui" line="84"/>
         <source>Off (Noisy)</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactivé (bruyant)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="95"/>
+        <location filename="../audiosettingswidget.ui" line="89"/>
         <source>Resampling (Pitch Shift)</source>
-        <translation type="unfinished"></translation>
+        <translation>Rééchantillonnage (Pitch Shift)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="100"/>
+        <location filename="../audiosettingswidget.ui" line="94"/>
         <source>Time Stretch (Tempo Change, Best Sound)</source>
-        <translation type="unfinished"></translation>
+        <translation>Étirement temporel (changement de tempo, meilleur son)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="108"/>
+        <location filename="../audiosettingswidget.ui" line="122"/>
         <source>Output Latency:</source>
-        <translation type="unfinished"></translation>
+        <translation>Latence de sortie :</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="118"/>
+        <location filename="../audiosettingswidget.ui" line="129"/>
         <source>Driver:</source>
-        <translation type="unfinished"></translation>
+        <translation>Pilote :</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="125"/>
+        <location filename="../audiosettingswidget.ui" line="69"/>
         <source>Stretch Mode:</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode d&apos;étirement :</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="173"/>
+        <location filename="../audiosettingswidget.ui" line="170"/>
+        <source>Output Device:</source>
+        <translation>Périph. de sortie :</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.ui" line="183"/>
         <source>Controls</source>
         <translation>Contrôles</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="179"/>
+        <location filename="../audiosettingswidget.ui" line="189"/>
         <source>Output Volume:</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume de sortie :</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="264"/>
+        <location filename="../audiosettingswidget.ui" line="274"/>
         <source>Fast Forward Volume:</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume d&apos;avance rapide :</translation>
     </message>
     <message>
         <source>Volume:</source>
         <translation type="vanished">Volume:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="271"/>
-        <location filename="../audiosettingswidget.cpp" line="79"/>
+        <location filename="../audiosettingswidget.ui" line="281"/>
+        <location filename="../audiosettingswidget.cpp" line="82"/>
         <source>Mute All Sound</source>
         <translation>Couper le son</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="278"/>
-        <location filename="../audiosettingswidget.cpp" line="81"/>
+        <location filename="../audiosettingswidget.ui" line="288"/>
+        <location filename="../audiosettingswidget.cpp" line="84"/>
         <source>Mute CD Audio</source>
         <translation>Couper le son du CD Audio</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="213"/>
-        <location filename="../audiosettingswidget.ui" line="252"/>
+        <location filename="../audiosettingswidget.ui" line="223"/>
+        <location filename="../audiosettingswidget.ui" line="262"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="62"/>
+        <location filename="../audiosettingswidget.cpp" line="65"/>
         <source>Audio Backend</source>
         <translation>Moteur de rendu audio</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="63"/>
+        <location filename="../audiosettingswidget.cpp" line="66"/>
         <source>The audio backend determines how frames produced by the emulator are submitted to the host. Cubeb provides the lowest latency, if you encounter issues, try the SDL backend. The null backend disables all host audio output.</source>
         <translation>Le moteur audio détermine comment les images produites par l&apos;émulateur sont soumises à l&apos;hôte. Cubeb fournit une latence basse, si vous rencontrez des problèmes, essayez alors le moteur SDL. Le moteur null désactive toutes les sorties audio de l&apos;hôte.</translation>
     </message>
@@ -1060,7 +1267,7 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Taille du tampon</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="68"/>
+        <location filename="../audiosettingswidget.cpp" line="71"/>
         <source>The buffer size determines the size of the chunks of audio which will be pulled by the host. Smaller values reduce the output latency, but may cause hitches if the emulation speed is inconsistent. Note that the Cubeb backend uses smaller chunks regardless of this value, so using a low value here may not significantly change latency.</source>
         <translation>La taille du tampon détermine la taille des échantillons audio qui seront récupérés par l&apos;hôte. Les plus petites valeurs réduisent la latence de la sortie, mais peuvent créer des saccades si la vitesse d&apos;émulation est incompatible. Remarque: le moteur Cubeb utilise de plus petits échantillons quelque soit sa valeur, donc utiliser une valeur faible ici peut ne pas faire changer de manière significative la latence.</translation>
     </message>
@@ -1073,61 +1280,67 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Réduit la vitesse d&apos;émulation en fonction du moteur audio appelant les trames audio. Ceci peut permettre de réduire les bruits parasites ou craquements si l&apos;émulation devait être trop rapide La synchronisation sera automatiquement désactivée si l&apos;émulation n&apos;est pas constante à 100% de la vitesse.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="67"/>
+        <location filename="../audiosettingswidget.cpp" line="70"/>
         <source>Output Latency</source>
-        <translation type="unfinished"></translation>
+        <translation>Latence de sortie</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="73"/>
-        <location filename="../audiosettingswidget.cpp" line="79"/>
-        <location filename="../audiosettingswidget.cpp" line="81"/>
+        <location filename="../audiosettingswidget.cpp" line="76"/>
+        <location filename="../audiosettingswidget.cpp" line="82"/>
+        <location filename="../audiosettingswidget.cpp" line="84"/>
         <source>Unchecked</source>
         <translation>Décoché</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="74"/>
+        <location filename="../audiosettingswidget.cpp" line="77"/>
         <source>Start dumping audio to file as soon as the emulator is started. Mainly useful as a debug option.</source>
         <translation>Commencer à enregistrer l&apos;audio vers un fichier dès que l&apos;émulateur démarre. Utilisé principalement en tant qu&apos;option de débogage.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="75"/>
-        <source>Output Volume</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../audiosettingswidget.cpp" line="76"/>
-        <source>Controls the volume of the audio played on the host.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../audiosettingswidget.cpp" line="78"/>
+        <source>Output Volume</source>
+        <translation>Volume de sortie</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="79"/>
+        <source>Controls the volume of the audio played on the host.</source>
+        <translation>Contrôle le volume de l&apos;audio joué sur l&apos;hôte.</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="81"/>
         <source>Controls the volume of the audio played on the host when fast forwarding.</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrôle le volume audio joué sur l&apos;hôte en mode avance rapide.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="85"/>
+        <location filename="../audiosettingswidget.cpp" line="88"/>
         <source>Stretch Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode étiré</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="85"/>
+        <location filename="../audiosettingswidget.cpp" line="88"/>
         <source>Time Stretching</source>
-        <translation type="unfinished"></translation>
+        <translation>Étirement temporel</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="86"/>
+        <location filename="../audiosettingswidget.cpp" line="89"/>
         <source>When running outside of 100% speed, adjusts the tempo on audio instead of dropping frames. Produces much nicer fast forward/slowdown audio at a small cost to performance.</source>
-        <translation type="unfinished"></translation>
+        <translation>Quand au-delà d&apos;une vitesse de 100%, ajuste le tempo sur l&apos;audio plûtot que sauter des images. Produit une avance rapide/ralentissement audio plus joli au prix d&apos;un léger impact sur les performances.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="132"/>
+        <location filename="../audiosettingswidget.cpp" line="119"/>
+        <location filename="../audiosettingswidget.cpp" line="137"/>
+        <source>Default</source>
+        <translation>Défaut</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="159"/>
         <source>Maximum Latency: %1 frames / %2 ms (%3ms buffer + %5ms output)</source>
-        <translation type="unfinished"></translation>
+        <translation>Latence maximale : %1 images / %2 ms (%3ms tampon + %5ms sortie)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="140"/>
+        <location filename="../audiosettingswidget.cpp" line="167"/>
         <source>Maximum Latency: %1 frames / %2 ms</source>
-        <translation type="unfinished"></translation>
+        <translation>Latence maximale : %1 images / %2 ms</translation>
     </message>
     <message>
         <source>Volume</source>
@@ -1138,17 +1351,17 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Contrôle du volume de l&apos;audio joué par l&apos;hôte. Les valeurs sont en pourcentage.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="77"/>
+        <location filename="../audiosettingswidget.cpp" line="80"/>
         <source>Fast Forward Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume de l&apos;avance rapide</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="80"/>
+        <location filename="../audiosettingswidget.cpp" line="83"/>
         <source>Prevents the emulator from producing any audible sound.</source>
         <translation>Empêche l&apos;émulateur de produire le moindre son audible.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="82"/>
+        <location filename="../audiosettingswidget.cpp" line="85"/>
         <source>Forcibly mutes both CD-DA and XA audio from the CD-ROM. Can be used to disable background music in some games.</source>
         <translation>Coupure forcée de la lecture audio CD-DA et XA du CD-ROM. Peut être utilisé pour désactiver la musique de fond dans certains jeux.</translation>
     </message>
@@ -1157,8 +1370,8 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Latence maximum : %1 images (%2ms)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="146"/>
-        <location filename="../audiosettingswidget.cpp" line="147"/>
+        <location filename="../audiosettingswidget.cpp" line="173"/>
+        <location filename="../audiosettingswidget.cpp" line="174"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
@@ -1167,8 +1380,8 @@ Leaderboard Position: {} of {}</source>
     <name>AutoUpdaterDialog</name>
     <message>
         <location filename="../autoupdaterdialog.ui" line="17"/>
-        <location filename="../autoupdaterdialog.cpp" line="184"/>
-        <location filename="../autoupdaterdialog.cpp" line="370"/>
+        <location filename="../autoupdaterdialog.cpp" line="187"/>
+        <location filename="../autoupdaterdialog.cpp" line="373"/>
         <source>Automatic Updater</source>
         <translation>Mise à jour automatique</translation>
     </message>
@@ -1203,57 +1416,57 @@ Leaderboard Position: {} of {}</source>
         <translation>Me le rappeler plus tard</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="108"/>
+        <location filename="../autoupdaterdialog.cpp" line="111"/>
         <source>Updater Error</source>
         <translation>Erreur de mise à jour</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="185"/>
+        <location filename="../autoupdaterdialog.cpp" line="188"/>
         <source>No updates are currently available. Please try again later.</source>
         <translation>Aucune mise à jour n&apos;est actuellement disponible. Veuillez réessayer plus tard.</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="237"/>
+        <location filename="../autoupdaterdialog.cpp" line="240"/>
         <source>Current Version: %1 (%2)</source>
         <translation>Version installée: %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="239"/>
+        <location filename="../autoupdaterdialog.cpp" line="242"/>
         <source>New Version: %1 (%2)</source>
         <translation>Dernière version: %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="240"/>
+        <location filename="../autoupdaterdialog.cpp" line="243"/>
         <source>Loading...</source>
         <translation>Téléchargement...</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="296"/>
+        <location filename="../autoupdaterdialog.cpp" line="299"/>
         <source>&lt;h2&gt;Changes:&lt;/h2&gt;</source>
         <translation>&lt;h2&gt;Changements:&lt;/h2&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="329"/>
+        <location filename="../autoupdaterdialog.cpp" line="332"/>
         <source>&lt;h2&gt;Save State Warning&lt;/h2&gt;&lt;p&gt;Installing this update will make your save states &lt;b&gt;incompatible&lt;/b&gt;. Please ensure you have saved your games to memory card before installing this update or you will lose progress.&lt;/p&gt;</source>
         <translation>&lt;h2&gt;Avertissement des sauvegardes d&apos;état&lt;/h2&gt;&lt;p&gt;L&apos;installation de cette mise à jour rendra vos sauvegardes d&apos;états &lt;b&gt;incompatibles&lt;/b&gt;. Veuillez vous assurer que vous avez sauvegardé vos parties sur la carte mémoire avant d&apos;installer cette mise à jour ou vous perdrez votre progression.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="337"/>
+        <location filename="../autoupdaterdialog.cpp" line="340"/>
         <source>&lt;h2&gt;Settings Warning&lt;/h2&gt;&lt;p&gt;Installing this update will reset your program configuration. Please note that you will have to reconfigure your settings after this update.&lt;/p&gt;</source>
         <translation>&lt;h2&gt;Avertissement sur les paramètres&lt;/h2&gt;&lt;p&gt;L&apos;installation de cette mise à jour réinitialisera la configuration de votre programme. Veuillez noter que vous devrez reconfigurer vos paramètres après cette mise à jour.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="341"/>
+        <location filename="../autoupdaterdialog.cpp" line="344"/>
         <source>&lt;h4&gt;Installing this update will download %1 MB through your internet connection.&lt;/h4&gt;</source>
         <translation>&lt;h4&gt;L&apos;installation de cette mise à jour téléchargera %1 MB via votre connexion internet.&lt;/h4&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="369"/>
+        <location filename="../autoupdaterdialog.cpp" line="372"/>
         <source>Downloading %1...</source>
         <translation>Téléchargement %1...</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="369"/>
+        <location filename="../autoupdaterdialog.cpp" line="372"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1317,44 +1530,44 @@ Leaderboard Position: {} of {}</source>
     </message>
     <message>
         <location filename="../biossettingswidget.ui" line="162"/>
-        <location filename="../biossettingswidget.cpp" line="19"/>
+        <location filename="../biossettingswidget.cpp" line="22"/>
         <source>Fast Boot</source>
         <translation>Démarrage rapide</translation>
     </message>
     <message>
         <location filename="../biossettingswidget.ui" line="169"/>
-        <location filename="../biossettingswidget.cpp" line="23"/>
+        <location filename="../biossettingswidget.cpp" line="26"/>
         <source>Enable TTY Output</source>
         <translation>Activer la sortie TTY</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="24"/>
+        <location filename="../biossettingswidget.cpp" line="27"/>
         <source>Patches the BIOS to log calls to printf(). Only use when debugging, can break games.</source>
-        <translation type="unfinished"></translation>
+        <translation>Patche le BIOS pour logger les appels à printf(). Utiliser seulement en débogage, peut casser les jeux.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="91"/>
+        <location filename="../biossettingswidget.cpp" line="94"/>
         <source>Use Global Setting</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser les paramètres globaux</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="93"/>
+        <location filename="../biossettingswidget.cpp" line="96"/>
         <source>Auto-Detect</source>
         <translation>Détection automatique</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="111"/>
+        <location filename="../biossettingswidget.cpp" line="114"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="19"/>
-        <location filename="../biossettingswidget.cpp" line="23"/>
+        <location filename="../biossettingswidget.cpp" line="22"/>
+        <location filename="../biossettingswidget.cpp" line="26"/>
         <source>Unchecked</source>
         <translation>Décoché</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="20"/>
+        <location filename="../biossettingswidget.cpp" line="23"/>
         <source>Patches the BIOS to skip the console&apos;s boot animation. Does not work with all games, but usually safe to enable.</source>
         <translation>Patche le BIOS pour ignorer l&apos;animation de démarrage de la console. Ne fonctionne pas avec tous les jeux, mais généralement sûr.</translation>
     </message>
@@ -1370,37 +1583,37 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Intepréteur (Plus lent)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="749"/>
+        <location filename="../../core/settings.cpp" line="823"/>
         <source>Interpreter (Slowest)</source>
-        <translation type="unfinished"></translation>
+        <translation>Interpréteur (le + lent)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="750"/>
+        <location filename="../../core/settings.cpp" line="824"/>
         <source>Cached Interpreter (Faster)</source>
-        <translation>Intepréteur avec cache (Plus rapide)</translation>
+        <translation>Interpréteur avec cache (+ rapide)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="751"/>
+        <location filename="../../core/settings.cpp" line="825"/>
         <source>Recompiler (Fastest)</source>
-        <translation>Recompileur &apos;(Le plus rapide)</translation>
+        <translation>Recompileur (le + rapide)</translation>
     </message>
 </context>
 <context>
     <name>CPUFastmemMode</name>
     <message>
-        <location filename="../../core/settings.cpp" line="780"/>
+        <location filename="../../core/settings.cpp" line="854"/>
         <source>Disabled (Slowest)</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactivé (le + lent)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="781"/>
+        <location filename="../../core/settings.cpp" line="855"/>
         <source>MMap (Hardware, Fastest, 64-Bit Only)</source>
-        <translation type="unfinished"></translation>
+        <translation>MMap (matériel, le + rapide, 64-Bit uniquement)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="782"/>
+        <location filename="../../core/settings.cpp" line="856"/>
         <source>LUT (Faster)</source>
-        <translation type="unfinished"></translation>
+        <translation>LUT (+ rapide)</translation>
     </message>
 </context>
 <context>
@@ -1408,27 +1621,27 @@ Leaderboard Position: {} of {}</source>
     <message>
         <location filename="../cheatcodeeditordialog.ui" line="14"/>
         <source>Cheat Code Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Éditeur de code de triche</translation>
     </message>
     <message>
         <location filename="../cheatcodeeditordialog.ui" line="23"/>
         <source>Description:</source>
-        <translation type="unfinished"></translation>
+        <translation>Description :</translation>
     </message>
     <message>
         <location filename="../cheatcodeeditordialog.ui" line="33"/>
         <source>Group:</source>
-        <translation type="unfinished"></translation>
+        <translation>Groupe :</translation>
     </message>
     <message>
         <location filename="../cheatcodeeditordialog.ui" line="43"/>
         <source>Type:</source>
-        <translation type="unfinished"></translation>
+        <translation>Type :</translation>
     </message>
     <message>
         <location filename="../cheatcodeeditordialog.ui" line="53"/>
         <source>Activation:</source>
-        <translation type="unfinished"></translation>
+        <translation>Activation :</translation>
     </message>
     <message>
         <source>Save</source>
@@ -1439,20 +1652,20 @@ Leaderboard Position: {} of {}</source>
         <translation type="obsolete">Annuler</translation>
     </message>
     <message>
-        <location filename="../cheatcodeeditordialog.cpp" line="20"/>
-        <location filename="../cheatcodeeditordialog.cpp" line="26"/>
+        <location filename="../cheatcodeeditordialog.cpp" line="23"/>
+        <location filename="../cheatcodeeditordialog.cpp" line="29"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../cheatcodeeditordialog.cpp" line="20"/>
+        <location filename="../cheatcodeeditordialog.cpp" line="23"/>
         <source>Description cannot be empty.</source>
-        <translation type="unfinished"></translation>
+        <translation>La description ne peut pas être vide.</translation>
     </message>
     <message>
-        <location filename="../cheatcodeeditordialog.cpp" line="26"/>
+        <location filename="../cheatcodeeditordialog.cpp" line="29"/>
         <source>Instructions are invalid.</source>
-        <translation type="unfinished"></translation>
+        <translation>Les instructions sont invalides.</translation>
     </message>
 </context>
 <context>
@@ -1460,491 +1673,507 @@ Leaderboard Position: {} of {}</source>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="14"/>
         <source>Cheat Manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Gestionnaire de triche</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="24"/>
         <source>Cheat List</source>
-        <translation type="unfinished"></translation>
+        <translation>Liste de triche</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="32"/>
         <source>&amp;Add Group...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Ajouter groupe...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="39"/>
         <source>&amp;Add Code...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Ajouter code...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="46"/>
         <source>&amp;Edit Code...</source>
-        <translation type="unfinished"></translation>
+        <translation>Édit&amp;er code...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="56"/>
         <source>&amp;Delete Code</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Supprimer code</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="66"/>
-        <location filename="../cheatmanagerdialog.cpp" line="395"/>
-        <location filename="../cheatmanagerdialog.cpp" line="433"/>
-        <location filename="../cheatmanagerdialog.cpp" line="438"/>
+        <location filename="../cheatmanagerdialog.cpp" line="398"/>
+        <location filename="../cheatmanagerdialog.cpp" line="436"/>
+        <location filename="../cheatmanagerdialog.cpp" line="441"/>
         <source>Activate</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="73"/>
         <source>Import...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="83"/>
         <source>Export...</source>
-        <translation type="unfinished"></translation>
+        <translation>Exporter...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="90"/>
         <source>Clear</source>
-        <translation type="unfinished">Vider</translation>
+        <translation>Vider</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="97"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Réinitialiser</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="126"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="131"/>
         <location filename="../cheatmanagerdialog.ui" line="598"/>
         <source>Type</source>
-        <translation type="unfinished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="136"/>
         <source>Activation</source>
-        <translation type="unfinished"></translation>
+        <translation>Activation</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="141"/>
         <source>Instructions</source>
-        <translation type="unfinished"></translation>
+        <translation>Instructions</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="150"/>
         <source>Memory Scanner</source>
-        <translation type="unfinished"></translation>
+        <translation>Scanner de mémoire</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="185"/>
         <location filename="../cheatmanagerdialog.ui" line="593"/>
         <source>Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Adresse</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="190"/>
         <location filename="../cheatmanagerdialog.ui" line="603"/>
         <source>Value</source>
-        <translation type="unfinished">Valeur</translation>
+        <translation>Valeur</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="195"/>
         <source>Previous Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Valeur précédente</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="205"/>
         <source>Search Parameters</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres de recherche</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="211"/>
         <source>Value:</source>
-        <translation type="unfinished"></translation>
+        <translation>Valeur :</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="227"/>
         <source>Signed</source>
-        <translation type="unfinished"></translation>
+        <translation>Signé</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="232"/>
         <source>Unsigned</source>
-        <translation type="unfinished"></translation>
+        <translation>Non-signé</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="244"/>
         <source>Decimal</source>
-        <translation type="unfinished"></translation>
+        <translation>Décimal</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="249"/>
         <source>Hex</source>
-        <translation type="unfinished"></translation>
+        <translation>Hex</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="259"/>
         <source>Data Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Taille de donnée :</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="270"/>
         <source>Byte (1 byte)</source>
-        <translation type="unfinished"></translation>
+        <translation>Byte (1 byte)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="275"/>
         <source>Halfword (2 bytes)</source>
-        <translation type="unfinished"></translation>
+        <translation>Demi-mot (2 bytes)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="280"/>
         <source>Word (4 bytes)</source>
-        <translation type="unfinished"></translation>
+        <translation>Mot (4 bytes)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="288"/>
         <source>Operator:</source>
-        <translation type="unfinished"></translation>
+        <translation>Opérateur :</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
         <source>Equal to...</source>
-        <translation type="unfinished"></translation>
+        <translation>Équivaut à...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
         <source>Not Equal to...</source>
-        <translation type="unfinished"></translation>
+        <translation>N&apos;équivaut pas à...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
         <source>Greater Than...</source>
-        <translation type="unfinished"></translation>
+        <translation>Supérieur à...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
         <source>Greater or Equal...</source>
-        <translation type="unfinished"></translation>
+        <translation>Supérieur ou égal...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
         <source>Less Than...</source>
-        <translation type="unfinished"></translation>
+        <translation>Inférieur à...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
         <source>Less or Equal...</source>
-        <translation type="unfinished"></translation>
+        <translation>Inférieur ou égal...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
         <source>Increased By...</source>
-        <translation type="unfinished"></translation>
+        <translation>Augmenté par...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
         <source>Decreased By...</source>
-        <translation type="unfinished"></translation>
+        <translation>Diminué par...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
         <source>Changed By...</source>
-        <translation type="unfinished"></translation>
+        <translation>Changé par...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
         <source>Equal to Previous (Unchanged Value)</source>
-        <translation type="unfinished"></translation>
+        <translation>Équivaut au précédent (valeur inchangée)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
         <source>Not Equal to Previous (Changed Value)</source>
-        <translation type="unfinished"></translation>
+        <translation>Non-équivalent au précédent (valeur changée)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
         <source>Greater Than Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Supérieur au précédent</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
         <source>Greater or Equal to Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Supérieur ou égal au précédent</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
         <source>Less Than Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Inférieur au précédent</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
         <source>Less or Equal to Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Inférieur ou égal ou précédent</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
         <source>Any Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Toute valeur</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="379"/>
         <source>Start Address:</source>
-        <translation type="unfinished"></translation>
+        <translation>Adresse de début :</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="389"/>
         <source>End Address:</source>
-        <translation type="unfinished"></translation>
+        <translation>Adresse de fin :</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="399"/>
         <source>Preset Range:</source>
-        <translation type="unfinished"></translation>
+        <translation>Plage prédéfinie :</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="407"/>
         <source>RAM</source>
-        <translation type="unfinished"></translation>
+        <translation>RAM</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="412"/>
         <source>Scratchpad</source>
-        <translation type="unfinished"></translation>
+        <translation>Bloc-note</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="417"/>
         <source>BIOS</source>
-        <translation type="unfinished"></translation>
+        <translation>BIOS</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="430"/>
         <source>New Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouvelle recherche</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="440"/>
         <source>Search Again</source>
-        <translation type="unfinished"></translation>
+        <translation>Chercher à nouveau</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="450"/>
         <source>Clear Results</source>
-        <translation type="unfinished"></translation>
+        <translation>Nettoyer les résultats</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="462"/>
         <source>Add Selected Results To Watch List</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajouter les résultats sélectionnés à la liste de surveillance</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="498"/>
         <source>Number of Results (Display limited to first 5000) : </source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre de résultats (limite d&apos;affichage au premiers 5000) : </translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="538"/>
         <source>0</source>
-        <translation type="unfinished">100% {0?}</translation>
+        <translation>0</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="588"/>
         <source>Simple Cheat Code or Description</source>
-        <translation type="unfinished"></translation>
+        <translation>Code de triche simple ou description</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="608"/>
         <source>Freeze</source>
-        <translation type="unfinished"></translation>
+        <translation>Geler</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="628"/>
         <source>Remove Selected Entries from Watch List</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer les entrées sélectionnées de la liste de surveillance</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="618"/>
         <source>Add Manual Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajouter une adresse manuelle</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="641"/>
         <source>Load Watch</source>
-        <translation type="unfinished"></translation>
+        <translation>Charger une surveillance</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="654"/>
         <source>Save Watch</source>
-        <translation type="unfinished"></translation>
+        <translation>Sauvegarder une surveillance</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="22"/>
+        <location filename="../cheatmanagerdialog.cpp" line="25"/>
         <source>Byte</source>
-        <translation type="unfinished"></translation>
+        <translation>Byte</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="22"/>
+        <location filename="../cheatmanagerdialog.cpp" line="25"/>
         <source>Halfword</source>
-        <translation type="unfinished"></translation>
+        <translation>Demi-mot</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="23"/>
+        <location filename="../cheatmanagerdialog.cpp" line="26"/>
         <source>Word</source>
-        <translation type="unfinished"></translation>
+        <translation>Mot</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="23"/>
+        <location filename="../cheatmanagerdialog.cpp" line="26"/>
         <source>Signed Byte</source>
-        <translation type="unfinished"></translation>
+        <translation>Byte signé</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="24"/>
+        <location filename="../cheatmanagerdialog.cpp" line="27"/>
         <source>Signed Halfword</source>
-        <translation type="unfinished"></translation>
+        <translation>Demi-mot signé</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="24"/>
+        <location filename="../cheatmanagerdialog.cpp" line="27"/>
         <source>Signed Word</source>
-        <translation type="unfinished"></translation>
+        <translation>Mot signé</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="438"/>
+        <location filename="../cheatmanagerdialog.cpp" line="441"/>
         <source>Toggle</source>
-        <translation type="unfinished"></translation>
+        <translation>Basculer</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="522"/>
+        <location filename="../cheatmanagerdialog.cpp" line="525"/>
         <source>Add Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajouter groupe</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="522"/>
+        <location filename="../cheatmanagerdialog.cpp" line="525"/>
         <source>Group Name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom de groupe :</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="528"/>
-        <location filename="../cheatmanagerdialog.cpp" line="662"/>
-        <location filename="../cheatmanagerdialog.cpp" line="685"/>
-        <location filename="../cheatmanagerdialog.cpp" line="707"/>
+        <location filename="../cheatmanagerdialog.cpp" line="531"/>
+        <location filename="../cheatmanagerdialog.cpp" line="665"/>
+        <location filename="../cheatmanagerdialog.cpp" line="688"/>
+        <location filename="../cheatmanagerdialog.cpp" line="710"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="528"/>
+        <location filename="../cheatmanagerdialog.cpp" line="531"/>
         <source>This group name already exists.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce nom de groupe existe déjà.</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="619"/>
+        <location filename="../cheatmanagerdialog.cpp" line="622"/>
         <source>Delete Code</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer le code</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="620"/>
+        <location filename="../cheatmanagerdialog.cpp" line="623"/>
         <source>Are you sure you wish to delete the selected code? This action is not reversible.</source>
-        <translation type="unfinished"></translation>
+        <translation>Êtes-vous sûr de vouloir supprimer le code sélectionné ? Cette action est irréversible.</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="647"/>
+        <location filename="../cheatmanagerdialog.cpp" line="650"/>
         <source>From File...</source>
-        <translation type="unfinished">Depuis le Fichier...</translation>
+        <translation>Depuis le fichier...</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="648"/>
+        <location filename="../cheatmanagerdialog.cpp" line="651"/>
         <source>From Text...</source>
-        <translation type="unfinished"></translation>
+        <translation>Depuis le texte...</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="654"/>
+        <location filename="../cheatmanagerdialog.cpp" line="657"/>
         <source>PCSXR/Libretro Cheat Files (*.cht *.txt);;All Files (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fichiers de triche PCSXR/Libretro (*.cht *.txt);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="655"/>
-        <location filename="../cheatmanagerdialog.cpp" line="678"/>
+        <location filename="../cheatmanagerdialog.cpp" line="658"/>
+        <location filename="../cheatmanagerdialog.cpp" line="681"/>
         <source>Import Cheats</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer les codes de triche</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="662"/>
-        <location filename="../cheatmanagerdialog.cpp" line="685"/>
+        <location filename="../cheatmanagerdialog.cpp" line="665"/>
+        <location filename="../cheatmanagerdialog.cpp" line="688"/>
         <source>Failed to parse cheat file. The log may contain more information.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec d&apos;analyse du fichier de triche. La log peut contenir plus d&apos;informations.</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="678"/>
+        <location filename="../cheatmanagerdialog.cpp" line="681"/>
         <source>Cheat File Text:</source>
-        <translation type="unfinished"></translation>
+        <translation>Texte du fichier de triche :</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="701"/>
+        <location filename="../cheatmanagerdialog.cpp" line="704"/>
         <source>PCSXR Cheat Files (*.cht);;All Files (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fichiers de triche PCSXR/Libretro  (*.cht *.txt);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="702"/>
+        <location filename="../cheatmanagerdialog.cpp" line="705"/>
         <source>Export Cheats</source>
-        <translation type="unfinished"></translation>
+        <translation>Exporter les codes de triche</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="707"/>
+        <location filename="../cheatmanagerdialog.cpp" line="710"/>
         <source>Failed to save cheat file. The log may contain more information.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la sauvegarde du fichier de triche. La log peut contenir plus d&apos;informations.</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="712"/>
+        <location filename="../cheatmanagerdialog.cpp" line="715"/>
         <source>Confirm Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmation de nettoyage</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="713"/>
+        <location filename="../cheatmanagerdialog.cpp" line="716"/>
         <source>Are you sure you want to remove all cheats? This is not reversible.</source>
-        <translation type="unfinished"></translation>
+        <translation>Étes-vous sûr de vouloir supprimer tous les codes de triche ? Ceci est irréversible.</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="726"/>
+        <location filename="../cheatmanagerdialog.cpp" line="729"/>
         <source>Confirm Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmation de réinitialisation</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="727"/>
+        <location filename="../cheatmanagerdialog.cpp" line="730"/>
         <source>Are you sure you want to reset the cheat list? Any cheats not in the DuckStation database WILL BE LOST.</source>
-        <translation type="unfinished"></translation>
+        <translation>Étes-vous sûr de vouloir réinitialiser la liste de triche ? Tout code de triche absent de la base de données de DuckStation SERA PERDU.</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="756"/>
+        <location filename="../cheatmanagerdialog.cpp" line="759"/>
         <source>Enter manual address:</source>
-        <translation type="unfinished"></translation>
+        <translation>Entrer une adresse manuelle :</translation>
     </message>
     <message>
-        <location filename="../cheatmanagerdialog.cpp" line="765"/>
+        <location filename="../cheatmanagerdialog.cpp" line="768"/>
         <source>Select data size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionne la taille de donnée :</translation>
     </message>
 </context>
 <context>
     <name>Cheats</name>
     <message>
-        <location filename="../../core/cheats.cpp" line="2767"/>
+        <location filename="../../core/cheats.cpp" line="2770"/>
         <source>Gameshark</source>
-        <translation type="unfinished"></translation>
+        <translation>Gameshark</translation>
     </message>
     <message>
-        <location filename="../../core/cheats.cpp" line="2792"/>
+        <location filename="../../core/cheats.cpp" line="2795"/>
         <source>Manual</source>
-        <translation type="unfinished"></translation>
+        <translation>Manuel</translation>
     </message>
     <message>
-        <location filename="../../core/cheats.cpp" line="2792"/>
+        <location filename="../../core/cheats.cpp" line="2795"/>
         <source>Automatic (Frame End)</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatique (image de fin)</translation>
+    </message>
+</context>
+<context>
+    <name>ColorPickerButton</name>
+    <message>
+        <location filename="../colorpickerbutton.cpp" line="41"/>
+        <source>Select LED Color</source>
+        <translation>Sélectionner la couleur de LED</translation>
+    </message>
+</context>
+<context>
+    <name>CommonHost</name>
+    <message>
+        <location filename="../../frontend-common/cubeb_audio_stream.cpp" line="257"/>
+        <source>Default Output Device</source>
+        <translation>Périphérique de sortie par défaut</translation>
     </message>
 </context>
 <context>
@@ -1958,30 +2187,30 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">L&apos;état en cours sera sauvegardé.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3809"/>
+        <location filename="../../core/system.cpp" line="4039"/>
         <source>Invalid version %u (%s version %u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Version invalide %u (%s version %u)</translation>
     </message>
 </context>
 <context>
     <name>ConsoleRegion</name>
     <message>
-        <location filename="../../core/settings.cpp" line="691"/>
+        <location filename="../../core/settings.cpp" line="764"/>
         <source>Auto-Detect</source>
         <translation>Détection automatique</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="691"/>
+        <location filename="../../core/settings.cpp" line="764"/>
         <source>NTSC-J (Japan)</source>
         <translation>NTSC-J (Japon)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="692"/>
+        <location filename="../../core/settings.cpp" line="765"/>
         <source>NTSC-U/C (US, Canada)</source>
         <translation>NTSC-U/C (US, Canada)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="692"/>
+        <location filename="../../core/settings.cpp" line="765"/>
         <source>PAL (Europe, Australia)</source>
         <translation>PAL (Europe, Australie)</translation>
     </message>
@@ -2019,7 +2248,7 @@ Leaderboard Position: {} of {}</source>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="78"/>
-        <location filename="../consolesettingswidget.cpp" line="61"/>
+        <location filename="../consolesettingswidget.cpp" line="64"/>
         <source>Enable Clock Speed Control (Overclocking/Underclocking)</source>
         <translation>Activer le contrôle de la fréquence de l&apos;horloge du CPU (Overclocking/Underclocking)</translation>
     </message>
@@ -2039,7 +2268,7 @@ Leaderboard Position: {} of {}</source>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="285"/>
-        <location filename="../consolesettingswidget.cpp" line="91"/>
+        <location filename="../consolesettingswidget.cpp" line="94"/>
         <source>Enable Region Check</source>
         <translation>Activer la vérification de la région</translation>
     </message>
@@ -2051,23 +2280,23 @@ Leaderboard Position: {} of {}</source>
     <message>
         <location filename="../consolesettingswidget.ui" line="153"/>
         <source>Read Speedup:</source>
-        <translation>Accélérer la lecture:</translation>
+        <translation>Accélérer la lecture :</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="48"/>
-        <location filename="../consolesettingswidget.cpp" line="70"/>
+        <location filename="../consolesettingswidget.cpp" line="73"/>
         <source>Enable 8MB RAM (Dev Console)</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer la RAM 8MB (console de dév)</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="134"/>
-        <location filename="../consolesettingswidget.cpp" line="65"/>
+        <location filename="../consolesettingswidget.cpp" line="68"/>
         <source>Enable Recompiler ICache</source>
-        <translation type="unfinished">Activer le recompileur ICache</translation>
+        <translation>Activer le recompilateur ICache</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="161"/>
-        <location filename="../consolesettingswidget.cpp" line="80"/>
+        <location filename="../consolesettingswidget.cpp" line="83"/>
         <source>None (Double Speed)</source>
         <translation>Aucune (Vitesse 2x)</translation>
     </message>
@@ -2119,164 +2348,166 @@ Leaderboard Position: {} of {}</source>
     <message>
         <location filename="../consolesettingswidget.ui" line="214"/>
         <source>Seek Speedup:</source>
-        <translation type="unfinished"></translation>
+        <translation>Accélération de recherche :</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="225"/>
         <source>Infinite/Instantaneous</source>
-        <translation type="unfinished"></translation>
+        <translation>Infini/Instantané</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="230"/>
-        <location filename="../consolesettingswidget.cpp" line="84"/>
+        <location filename="../consolesettingswidget.cpp" line="87"/>
         <source>None (Normal Speed)</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucune (vitesse normale)</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="235"/>
         <source>2x</source>
-        <translation type="unfinished">2x</translation>
+        <translation>2x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="240"/>
         <source>3x</source>
-        <translation type="unfinished">100% {3x?}</translation>
+        <translation>3x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="245"/>
         <source>4x</source>
-        <translation type="unfinished">4x</translation>
+        <translation>4x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="250"/>
         <source>5x</source>
-        <translation type="unfinished">100% {5x?}</translation>
+        <translation>5x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="255"/>
         <source>6x</source>
-        <translation type="unfinished">100% {6x?}</translation>
+        <translation>6x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="260"/>
         <source>7x</source>
-        <translation type="unfinished">7x</translation>
+        <translation>7x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="265"/>
         <source>8x</source>
-        <translation type="unfinished">8x</translation>
+        <translation>8x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="270"/>
         <source>9x</source>
-        <translation type="unfinished">9x</translation>
+        <translation>9x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="275"/>
         <source>10x</source>
-        <translation type="unfinished">10x</translation>
+        <translation>10x</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="299"/>
-        <location filename="../consolesettingswidget.cpp" line="97"/>
+        <location filename="../consolesettingswidget.cpp" line="100"/>
         <source>Apply Image Patches</source>
-        <translation type="unfinished"></translation>
+        <translation>Appliquer les patchs d&apos;image</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="308"/>
         <source>Async Readahead:</source>
-        <translation type="unfinished"></translation>
+        <translation>Lecture anticipée asynchrone :</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="76"/>
-        <location filename="../consolesettingswidget.cpp" line="94"/>
+        <location filename="../consolesettingswidget.cpp" line="79"/>
+        <location filename="../consolesettingswidget.cpp" line="97"/>
         <source>Preload Image to RAM</source>
         <translation>Précharger l&apos;image disque dans la RAM</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="61"/>
-        <location filename="../consolesettingswidget.cpp" line="65"/>
-        <location filename="../consolesettingswidget.cpp" line="70"/>
-        <location filename="../consolesettingswidget.cpp" line="76"/>
-        <location filename="../consolesettingswidget.cpp" line="94"/>
+        <location filename="../consolesettingswidget.cpp" line="64"/>
+        <location filename="../consolesettingswidget.cpp" line="68"/>
+        <location filename="../consolesettingswidget.cpp" line="73"/>
+        <location filename="../consolesettingswidget.cpp" line="79"/>
         <location filename="../consolesettingswidget.cpp" line="97"/>
+        <location filename="../consolesettingswidget.cpp" line="100"/>
         <source>Unchecked</source>
         <translation>Décoché</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="30"/>
-        <source>Disabled (Synchronous)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../consolesettingswidget.cpp" line="33"/>
+        <source>Disabled (Synchronous)</source>
+        <translation>Désactivée (synchrone)</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="36"/>
         <source>%1 sectors (%2 KB / %3 ms)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="56"/>
-        <source>Region</source>
-        <translation type="unfinished">Région</translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="56"/>
-        <source>Auto-Detect</source>
-        <translation type="unfinished">Détection automatique</translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="57"/>
-        <source>Determines the emulated hardware type.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="58"/>
-        <source>Execution Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="58"/>
-        <source>Recompiler (Fastest)</source>
-        <translation type="unfinished">Recompileur &apos;(Le plus rapide)</translation>
+        <translation>%1 secteurs (%2 KB / %3 ms)</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.cpp" line="59"/>
-        <source>Determines how the emulated CPU executes instructions.</source>
-        <translation type="unfinished"></translation>
+        <source>Region</source>
+        <translation>Région</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="59"/>
+        <source>Auto-Detect</source>
+        <translation>Détection automatique</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="60"/>
+        <source>Determines the emulated hardware type.</source>
+        <translation>Détermine le type de matériel émulé.</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="61"/>
+        <source>Execution Mode</source>
+        <translation>Mode d&apos;exécution</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="61"/>
+        <source>Recompiler (Fastest)</source>
+        <translation>Recompilateur (le + rapide)</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.cpp" line="62"/>
+        <source>Determines how the emulated CPU executes instructions.</source>
+        <translation>Détermine comment le processeur émulé exécute les instructions.</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="65"/>
         <source>When this option is chosen, the clock speed set below will be used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="63"/>
-        <source>Overclocking Percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="63"/>
-        <source>100%</source>
-        <translation type="unfinished">100%</translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="64"/>
-        <source>Selects the percentage of the normal clock speed the emulated hardware will run at.</source>
-        <translation type="unfinished"></translation>
+        <translation>Quand cette option est choisie, la vitesse d&apos;horloge ci-dessous sera utilisée.</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.cpp" line="66"/>
+        <source>Overclocking Percentage</source>
+        <translation>Pourcentage d&apos;overclocking</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="66"/>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="67"/>
+        <source>Selects the percentage of the normal clock speed the emulated hardware will run at.</source>
+        <translatorcomment>Le pourcentage [...] auquel</translatorcomment>
+        <translation>Sélectionne le pourcentage de la vitesse normale d&apos;horloge auquel le matériel émulé tournera.</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="69"/>
         <source>Simulates stalls in the recompilers when the emulated CPU would have to fetch instructions into its cache. Makes games run closer to their console framerate, at a small cost to performance. Interpreter mode always simulates the instruction cache.</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Cf. https://fr.wikipedia.org/wiki/Bulle_(informatique)</translatorcomment>
+        <translation>Simule des bulles dans le recompilateur quand le processeur émulé a à récupérer les instructions vers son cache. Rapproche les jeux de leur taux d&apos;image console, au coût d&apos;un léger impact des performances. Le mode interpréteur simule toujours le cache d&apos;instruction.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="71"/>
+        <location filename="../consolesettingswidget.cpp" line="74"/>
         <source>Enables an additional 6MB of RAM to obtain a total of 2+6 = 8MB, usually present on dev consoles. Games have to use a larger heap size for this additional RAM to be usable. Titles which rely on memory mirrors may break, so it should only be used with compatible mods.</source>
-        <translation type="unfinished"></translation>
+        <translation>Active un ajout de 6MB de RAM pour obtenir un total de 2+6 = 8MB, habituellement présent sur les consoles de dév. Les jeux doivent utiliser un tas plus large pour que cette RAM additionnelle soit utilisable. Les titres qui s&apos;appuient sur les miroirs mémoire peuvent casser, cela ne devrait être seulement utilisé qu&apos;avec les mods compatibles.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="77"/>
-        <location filename="../consolesettingswidget.cpp" line="95"/>
+        <location filename="../consolesettingswidget.cpp" line="80"/>
+        <location filename="../consolesettingswidget.cpp" line="98"/>
         <source>Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some cases also eliminates stutter when games initiate audio track playback.</source>
         <translation>Chargement de l&apos;image du jeu dans la RAM. Utile pour les chemins réseau qui peuvent devenir peu fiables pendant le jeu. Dans certains cas, élimine également les saccades lorsque les jeux lancent la lecture de la piste audio.</translation>
     </message>
@@ -2289,52 +2520,53 @@ Leaderboard Position: {} of {}</source>
         <translation type="vanished">Aucune (Vitesse 2x)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="81"/>
+        <location filename="../consolesettingswidget.cpp" line="84"/>
         <source>Speeds up CD-ROM reads by the specified factor. Only applies to double-speed reads, and is ignored when audio is playing. May improve loading speeds in some games, at the cost of breaking others.</source>
         <translation>Accélère la lecture des CD-ROM selon le facteur spécifié. S&apos;applique uniquement aux lectures à double vitesse, et est ignoré lorsque le son est en cours de lecture. Peut améliorer la vitesse de chargement dans certains jeux, au prix de blocages dans d&apos;autres jeux.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="84"/>
+        <location filename="../consolesettingswidget.cpp" line="87"/>
         <source>CD-ROM Seek Speedup</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="85"/>
-        <source>Reduces the simulated time for the CD-ROM sled to move to different areas of the disc. Can improve loading times, but crash games which do not expect the CD-ROM to operate faster.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="87"/>
-        <source>Asynchronous Readahead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../consolesettingswidget.cpp" line="87"/>
-        <source>8 Sectors</source>
-        <translation type="unfinished"></translation>
+        <translation>Accélération de la recherche CD-ROM</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.cpp" line="88"/>
-        <source>Reduces hitches in emulation by reading/decompressing CD data asynchronously on a worker thread. Higher sector numbers can reduce spikes when streaming FMVs or audio on slower storage or when using compression formats such as CHD.</source>
-        <translation type="unfinished"></translation>
+        <source>Reduces the simulated time for the CD-ROM sled to move to different areas of the disc. Can improve loading times, but crash games which do not expect the CD-ROM to operate faster.</source>
+        <translation>Réduit le temps simulé pour la tête de lecture de CD-ROM pour se déplacer entre les différentes zones du disque. Peut améliorer les temps de chargement, mais plante les jeu qui ne s&apos;attendent pas à ce que le CD-ROM aille plus vite.</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="90"/>
+        <source>Asynchronous Readahead</source>
+        <translation>Lecture anticipée asynchrone</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="90"/>
+        <source>8 Sectors</source>
+        <translation>8 secteurs</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.cpp" line="91"/>
+        <source>Reduces hitches in emulation by reading/decompressing CD data asynchronously on a worker thread. Higher sector numbers can reduce spikes when streaming FMVs or audio on slower storage or when using compression formats such as CHD.</source>
+        <translatorcomment>Cf. https://fr.wikipedia.org/wiki/Thread_(informatique)</translatorcomment>
+        <translation>Réduit les accrocs de l&apos;émulation en lisant/décompressant les données CD de façon asynchrone sur le fil de travail. Un plus grand nombre de secteurs peut réduire les pics pendant la lecture de FMVs ou de l&apos;audio sur les stockages lents ou les formats de compression comme CHD.</translation>
+    </message>
+    <message>
+        <location filename="../consolesettingswidget.cpp" line="94"/>
         <source>Checked</source>
-        <translation type="unfinished">Coché</translation>
+        <translation>Coché</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="92"/>
+        <location filename="../consolesettingswidget.cpp" line="95"/>
         <source>Simulates the region check present in original, unmodified consoles.</source>
-        <translation type="unfinished"></translation>
+        <translation>Simule la vérification de région présente sur les consoles d&apos;origine, non-modifiées.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="98"/>
+        <location filename="../consolesettingswidget.cpp" line="101"/>
         <source>Automatically applies patches to disc images when they are present in the same directory. Currently only PPF patches are supported with this option.</source>
-        <translation type="unfinished"></translation>
+        <translation>Applique automatiquement les patchs aux images disque quand ils sont présents dans le même répertoire. Seuls les patchs PPF sont actuellement supportés avec cette option.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="131"/>
+        <location filename="../consolesettingswidget.cpp" line="134"/>
         <source>Enabling CPU overclocking will break games, cause bugs, reduce performance and can significantly increase system requirements.
 
 By enabling this option you are agreeing to not create any bug reports unless you have confirmed the bug also occurs with overclocking disabled.
@@ -2347,27 +2579,27 @@ En activant cette option, vous acceptez de ne créer aucun rapport de bogue à m
 Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="137"/>
+        <location filename="../consolesettingswidget.cpp" line="140"/>
         <source>Yes, I will confirm bugs without overclocking before reporting.</source>
         <translation>Oui, je confirmerai que les bogues sont sans overclocking avant de les signaler.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="138"/>
+        <location filename="../consolesettingswidget.cpp" line="141"/>
         <source>No, take me back to safety.</source>
         <translation>Non, je veux revenir en arrière.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="135"/>
+        <location filename="../consolesettingswidget.cpp" line="138"/>
         <source>CPU Overclocking Warning</source>
         <translation>Avertissement sur l&apos;overclocking du CPU</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="80"/>
+        <location filename="../consolesettingswidget.cpp" line="83"/>
         <source>CD-ROM Read Speedup</source>
-        <translation type="unfinished"></translation>
+        <translation>Accélération de lecture CD-ROM</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="179"/>
+        <location filename="../consolesettingswidget.cpp" line="183"/>
         <source>%1% (%2MHz)</source>
         <translation>%1% (%2MHz)</translation>
     </message>
@@ -2377,54 +2609,54 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllerbindingwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget.ui" line="32"/>
         <source>Controller Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Type de contrôleur</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget.ui" line="43"/>
         <source>Bindings</source>
-        <translation type="unfinished"></translation>
+        <translation>Mappage des boutons</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget.ui" line="63"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget.ui" line="83"/>
         <source>Macros</source>
-        <translation type="unfinished"></translation>
+        <translation>Macros</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget.ui" line="120"/>
-        <location filename="../controllerbindingwidgets.cpp" line="263"/>
+        <location filename="../controllerbindingwidgets.cpp" line="268"/>
         <source>Automatic Mapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Mappage automatique</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget.ui" line="134"/>
-        <location filename="../controllerbindingwidgets.cpp" line="213"/>
+        <location filename="../controllerbindingwidgets.cpp" line="217"/>
         <source>Clear Mapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Vider les mappages</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="203"/>
+        <location filename="../controllerbindingwidgets.cpp" line="207"/>
         <source>No devices available</source>
-        <translation type="unfinished"></translation>
+        <translation>Pas de périphérique disponible</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="214"/>
+        <location filename="../controllerbindingwidgets.cpp" line="218"/>
         <source>Are you sure you want to clear all mappings for this controller? This action cannot be undone.</source>
-        <translation type="unfinished"></translation>
+        <translation>Êtes-vous sûr de vouloir vider tous les mappages pour ce contrôleur ? Cette action ne peut être annulée.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="264"/>
-        <source>No generic bindings were generated for device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <location filename="../controllerbindingwidgets.cpp" line="269"/>
+        <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
+        <translation>Aucun mapage générique généré pour le périphérique &apos;%1&apos;. Le contrôleur/source peut ne pas supporter le mappage automatique.</translation>
     </message>
 </context>
 <context>
@@ -2432,19 +2664,19 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="59"/>
         <source>D-Pad</source>
-        <translation type="unfinished"></translation>
+        <translation>D-Pad</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="65"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="234"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="903"/>
         <source>Down</source>
-        <translation type="unfinished">Bas</translation>
+        <translation>Bas</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="95"/>
@@ -2475,118 +2707,122 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="1203"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="1243"/>
         <source>PushButton</source>
-        <translation type="unfinished"></translation>
+        <translation>PousserBouton</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="105"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="274"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="863"/>
         <source>Left</source>
-        <translation type="unfinished">Gauche</translation>
+        <translation>Gauche</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="145"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="314"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="983"/>
         <source>Up</source>
-        <translation type="unfinished">Haut</translation>
+        <translation>Haut</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="185"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="354"/>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="943"/>
         <source>Right</source>
-        <translation type="unfinished">Droite</translation>
+        <translation>Droite</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="228"/>
         <source>Left Analog</source>
-        <translation type="unfinished"></translation>
+        <translation>Stick analogique gauche</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="397"/>
         <source>Large Motor</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Par rapport à &quot;petit moteur&quot;</translatorcomment>
+        <translation>Gros moteur</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="454"/>
         <source>Select</source>
-        <translation type="unfinished">Sélectionner</translation>
+        <translatorcomment>Nom de la touche</translatorcomment>
+        <translation>Select</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="488"/>
         <source>L1</source>
-        <translation type="unfinished">L1</translation>
+        <translation>L1</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="522"/>
         <source>R1</source>
-        <translation type="unfinished">R1</translation>
+        <translation>R1</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="556"/>
         <source>R2</source>
-        <translation type="unfinished">R2</translation>
+        <translation>R2</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="590"/>
         <source>L2</source>
-        <translation type="unfinished">L2</translation>
+        <translation>L2</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="624"/>
         <source>Start</source>
-        <translation type="unfinished">Start</translation>
+        <translatorcomment>Nom de la touche</translatorcomment>
+        <translation>Start</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="688"/>
         <source>Face Buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>Boutons de face</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="694"/>
         <source>Cross</source>
-        <translation type="unfinished">Croix</translation>
+        <translation>Croix</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="734"/>
         <source>Square</source>
-        <translation type="unfinished">Carré</translation>
+        <translation>Carré</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="774"/>
         <source>Triangle</source>
-        <translation type="unfinished">Triangle</translation>
+        <translation>Triangle</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="814"/>
         <source>Circle</source>
-        <translation type="unfinished">Rond</translation>
+        <translation>Rond</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="857"/>
         <source>Right Analog</source>
-        <translation type="unfinished"></translation>
+        <translation>Stick analogique droit</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="1026"/>
         <source>Small Motor</source>
-        <translation type="unfinished"></translation>
+        <translation>Petit moteur</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="1151"/>
         <source>R3</source>
-        <translation type="unfinished">R3</translation>
+        <translation>R3</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="1191"/>
         <source>Analog</source>
-        <translation type="unfinished">Analogique</translation>
+        <translatorcomment>Nom du bouton</translatorcomment>
+        <translation>Analog</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_controller.ui" line="1213"/>
         <source>L3</source>
-        <translation type="unfinished">L3</translation>
+        <translation>L3</translation>
     </message>
 </context>
 <context>
@@ -2594,19 +2830,19 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="59"/>
         <source>D-Pad</source>
-        <translation type="unfinished"></translation>
+        <translation>D-Pad</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="65"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="234"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="863"/>
         <source>Down</source>
-        <translation type="unfinished">Bas</translation>
+        <translation>Bas</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="95"/>
@@ -2635,117 +2871,115 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="1128"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="1163"/>
         <source>PushButton</source>
-        <translation type="unfinished"></translation>
+        <translation>PousserBouton</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="105"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="274"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="823"/>
         <source>Left</source>
-        <translation type="unfinished">Gauche</translation>
+        <translation>Gauche</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="145"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="314"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="943"/>
         <source>Up</source>
-        <translation type="unfinished">Haut</translation>
+        <translation>Haut</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="185"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="354"/>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="903"/>
         <source>Right</source>
-        <translation type="unfinished">Droite</translation>
+        <translation>Droite</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="228"/>
         <source>Left Analog</source>
-        <translation type="unfinished"></translation>
+        <translation>Stick analogique gauche</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="414"/>
         <source>L2</source>
-        <translation type="unfinished">L2</translation>
+        <translation>L2</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="448"/>
         <source>L1</source>
-        <translation type="unfinished">L1</translation>
+        <translation>L1</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="482"/>
         <source>R2</source>
-        <translation type="unfinished">R2</translation>
+        <translation>R2</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="516"/>
         <source>Start</source>
-        <translation type="unfinished">Start</translation>
+        <translation>Start</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="550"/>
         <source>R1</source>
-        <translation type="unfinished">R1</translation>
+        <translation>R1</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="584"/>
         <source>Select</source>
-        <translation type="unfinished">Sélectionner</translation>
+        <translation>Select</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="648"/>
         <source>Face Buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>Boutons de face</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="654"/>
         <source>Cross</source>
-        <translation type="unfinished">Croix</translation>
+        <translation>Croix</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="694"/>
         <source>Square</source>
-        <translation type="unfinished">Carré</translation>
+        <translation>Carré</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="734"/>
         <source>Triangle</source>
-        <translation type="unfinished">Triangle</translation>
+        <translation>Triangle</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="774"/>
         <source>Circle</source>
-        <translation type="unfinished">Rond</translation>
+        <translation>Rond</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="817"/>
         <source>Right Analog</source>
-        <translation type="unfinished"></translation>
+        <translation>Stick analogique droit</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="1058"/>
         <source>R3</source>
-        <translation type="unfinished">R3</translation>
+        <translation>R3</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="1098"/>
         <source>L3</source>
-        <translation type="unfinished">L3</translation>
+        <translation>L3</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_analog_joystick.ui" line="1151"/>
         <source>Mode</source>
-        <translation type="unfinished">Mode</translation>
+        <translation>Mode</translation>
     </message>
 </context>
 <context>
     <name>ControllerBindingWidget_Base</name>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="738"/>
-        <location filename="../controllerbindingwidgets.cpp" line="754"/>
         <source>%1%</source>
-        <translation type="unfinished">%1%</translation>
+        <translation type="obsolete">%1%</translation>
     </message>
 </context>
 <context>
@@ -2753,12 +2987,12 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="46"/>
         <source>L1</source>
-        <translation type="unfinished">L1</translation>
+        <translation>L1</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="70"/>
@@ -2776,82 +3010,82 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="680"/>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="714"/>
         <source>PushButton</source>
-        <translation type="unfinished"></translation>
+        <translation>PousserBouton</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="80"/>
         <source>L2</source>
-        <translation type="unfinished">L2</translation>
+        <translation>L2</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="114"/>
         <source>R2</source>
-        <translation type="unfinished">R2</translation>
+        <translation>R2</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="148"/>
         <source>R1</source>
-        <translation type="unfinished">R1</translation>
+        <translation>R1</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="199"/>
         <source>Face Buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>Boutons de face</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="205"/>
         <source>Cross</source>
-        <translation type="unfinished">Croix</translation>
+        <translation>Croix</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="245"/>
         <source>Square</source>
-        <translation type="unfinished">Carré</translation>
+        <translation>Carré</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="285"/>
         <source>Triangle</source>
-        <translation type="unfinished">Triangle</translation>
+        <translation>Triangle</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="325"/>
         <source>Circle</source>
-        <translation type="unfinished">Rond</translation>
+        <translation>Rond</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="470"/>
         <source>D-Pad</source>
-        <translation type="unfinished"></translation>
+        <translation>D-Pad</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="476"/>
         <source>Down</source>
-        <translation type="unfinished">Bas</translation>
+        <translation>Bas</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="516"/>
         <source>Left</source>
-        <translation type="unfinished">Gauche</translation>
+        <translation>Gauche</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="556"/>
         <source>Up</source>
-        <translation type="unfinished">Haut</translation>
+        <translation>Haut</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="596"/>
         <source>Right</source>
-        <translation type="unfinished">Droite</translation>
+        <translation>Droite</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="656"/>
         <source>Select</source>
-        <translation type="unfinished">Sélectionner</translation>
+        <translation>Select</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_digital_controller.ui" line="690"/>
         <source>Start</source>
-        <translation type="unfinished">Start</translation>
+        <translation>Start</translation>
     </message>
 </context>
 <context>
@@ -2859,17 +3093,17 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllerbindingwidget_guncon.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_guncon.ui" line="59"/>
         <source>Side Buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>Boutons de côté</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_guncon.ui" line="65"/>
         <source>B</source>
-        <translation type="unfinished">B</translation>
+        <translation>B</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_guncon.ui" line="95"/>
@@ -2877,27 +3111,27 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
         <location filename="../controllerbindingwidget_guncon.ui" line="289"/>
         <location filename="../controllerbindingwidget_guncon.ui" line="329"/>
         <source>PushButton</source>
-        <translation type="unfinished"></translation>
+        <translation>PousserBouton</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_guncon.ui" line="105"/>
         <source>A</source>
-        <translation type="unfinished">A</translation>
+        <translation>A</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_guncon.ui" line="253"/>
         <source>Trigger</source>
-        <translation type="unfinished">Gâchette</translation>
+        <translation>Gâchette</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_guncon.ui" line="259"/>
         <source>Fire Offscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Feu hors-écran</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_guncon.ui" line="299"/>
         <source>Fire</source>
-        <translation type="unfinished"></translation>
+        <translation>Feu</translation>
     </message>
 </context>
 <context>
@@ -2905,28 +3139,28 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllerbindingwidget_mouse.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_mouse.ui" line="58"/>
         <source>Buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>Boutons</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_mouse.ui" line="64"/>
         <source>Left</source>
-        <translation type="unfinished">Gauche</translation>
+        <translation>Gauche</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_mouse.ui" line="94"/>
         <location filename="../controllerbindingwidget_mouse.ui" line="134"/>
         <source>PushButton</source>
-        <translation type="unfinished"></translation>
+        <translation>PousserBouton</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_mouse.ui" line="104"/>
         <source>Right</source>
-        <translation type="unfinished">Droite</translation>
+        <translation>Droite</translation>
     </message>
 </context>
 <context>
@@ -2934,17 +3168,17 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="26"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="59"/>
         <source>D-Pad</source>
-        <translation type="unfinished"></translation>
+        <translation>D-Pad</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="65"/>
         <source>Down</source>
-        <translation type="unfinished">Bas</translation>
+        <translation>Bas</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="95"/>
@@ -2961,97 +3195,97 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
         <location filename="../controllerbindingwidget_negcon.ui" line="641"/>
         <location filename="../controllerbindingwidget_negcon.ui" line="681"/>
         <source>PushButton</source>
-        <translation type="unfinished"></translation>
+        <translation>PousserBouton</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="105"/>
         <location filename="../controllerbindingwidget_negcon.ui" line="651"/>
         <source>Left</source>
-        <translation type="unfinished">Gauche</translation>
+        <translation>Gauche</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="145"/>
         <source>Up</source>
-        <translation type="unfinished">Haut</translation>
+        <translation>Haut</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="185"/>
         <location filename="../controllerbindingwidget_negcon.ui" line="611"/>
         <source>Right</source>
-        <translation type="unfinished">Droite</translation>
+        <translation>Droite</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="228"/>
         <source>Start</source>
-        <translation type="unfinished">Start</translation>
+        <translation>Start</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="279"/>
         <source>L</source>
-        <translation type="unfinished">L</translation>
+        <translation>L</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="313"/>
         <source>R</source>
-        <translation type="unfinished">R</translation>
+        <translation>R</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="364"/>
         <source>Face Buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>Boutons de face</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="370"/>
         <source>I</source>
-        <translation type="unfinished">I</translation>
+        <translation>I</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="410"/>
         <source>II</source>
-        <translation type="unfinished">II</translation>
+        <translation>II</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="450"/>
         <source>B</source>
-        <translation type="unfinished">B</translation>
+        <translation>B</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="490"/>
         <source>A</source>
-        <translation type="unfinished">A</translation>
+        <translation>A</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget_negcon.ui" line="605"/>
         <source>Steering/Twist</source>
-        <translation type="unfinished"></translation>
+        <translation>Direction/Torsion</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="843"/>
+        <location filename="../controllerbindingwidgets.cpp" line="866"/>
         <source>%1%</source>
-        <translation type="unfinished">%1%</translation>
+        <translation>%1%</translation>
     </message>
 </context>
 <context>
     <name>ControllerCustomSettingsWidget</name>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="497"/>
+        <location filename="../controllerbindingwidgets.cpp" line="504"/>
         <source>%1 Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres de %1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="506"/>
+        <location filename="../controllerbindingwidgets.cpp" line="513"/>
         <source>Restore Default Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Restaurer les paramètres par défaut</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="585"/>
+        <location filename="../controllerbindingwidgets.cpp" line="625"/>
         <source>Browse...</source>
-        <translation type="unfinished">Parcourir...</translation>
+        <translation>Parcourir...</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="588"/>
+        <location filename="../controllerbindingwidgets.cpp" line="628"/>
         <source>Select File</source>
-        <translation type="unfinished">Sélectionner un Fichier</translation>
+        <translation>Sélectionner un fichier</translation>
     </message>
 </context>
 <context>
@@ -3059,154 +3293,153 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllerglobalsettingswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="83"/>
+        <source>Controller Multitap</source>
+        <translation>Contrôleur multiprise</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="89"/>
+        <source>The multitap enables up to 8 controllers to be connected to the console. Each multitap provides 4 ports. Multitap is not supported by all games.</source>
+        <translation>La multiprise permet de brancher jusqu&apos;à 8 contrôleurs à la console. Chaque multiprise fournit 4 ports. La multiprise n&apos;est pas supportée pas tous les jeux.</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="99"/>
+        <source>Multitap Mode:</source>
+        <translation>Mode multiprise :</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="107"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="112"/>
+        <source>Enable on Port 1 Only</source>
+        <translation>Actif sur le port 1 uniquement</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="117"/>
+        <source>Enable on Port 2 Only</source>
+        <translation>Actif sur le port 2 uniquement</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="122"/>
+        <source>Enable on Ports 1 and 2</source>
+        <translation>Actif sur les ports 1 et 2</translation>
     </message>
     <message>
         <location filename="../controllerglobalsettingswidget.ui" line="32"/>
-        <source>Controller Multitap</source>
-        <translation type="unfinished"></translation>
+        <source>DInput Source</source>
+        <translation>Source DInput</translation>
     </message>
     <message>
         <location filename="../controllerglobalsettingswidget.ui" line="38"/>
-        <source>The multitap enables up to 8 controllers to be connected to the console. Each multitap provides 4 ports. Multitap is not supported by all games.</source>
-        <translation type="unfinished"></translation>
+        <source>The DInput source provides support for legacy controllers which do not support XInput. Accessing these controllers via SDL instead is recommended.</source>
+        <translation>La source DInput fournit un support pour les contrôleurs qui ne supportent pas XInput. Passer plutôt par SDL pour ces contrôleurs est recommandé.</translation>
     </message>
     <message>
         <location filename="../controllerglobalsettingswidget.ui" line="48"/>
-        <source>Multitap Mode:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="56"/>
-        <source>Disabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="61"/>
-        <source>Enable on Port 1 Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="66"/>
-        <source>Enable on Port 2 Only</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="71"/>
-        <source>Enable on Ports 1 and 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="82"/>
-        <source>DInput Source</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="88"/>
-        <source>The DInput source provides support for legacy controllers which do not support XInput. Accessing these controllers via SDL instead is recommended.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="98"/>
         <source>Enable DInput Input Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer la source d&apos;entrée DInput</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="108"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="133"/>
         <source>SDL Input Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Source d&apos;entrée SDL</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="114"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="139"/>
         <source>The SDL input source supports most controllers, and provides advanced functionality for DualShock 4 / DualSense pads in Bluetooth mode (Vibration / LED Control).</source>
-        <translation type="unfinished"></translation>
+        <translation>La source d&apos;entrée SDL supporte la plupart des contrôleurs, et fournit des fonctionnalités avancées pour DualShock 4 / manettes DualSense en mode Bluetooth (Vibration / contrôle LED).</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="124"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="149"/>
         <source>Enable SDL Input Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer la source d&apos;entrée SDL</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="131"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="158"/>
         <source>DualShock 4 / DualSense Enhanced Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode amélioré DualShock 4 / DualSense</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="141"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="58"/>
         <source>Detected Devices</source>
-        <translation type="unfinished"></translation>
+        <translation>Périphériques détectés</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="166"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="234"/>
         <source>Mouse/Pointer Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Souris/Source de pointeur</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="184"/>
-        <location filename="../controllerglobalsettingswidget.ui" line="260"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="296"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="351"/>
         <source>10</source>
-        <translation type="unfinished">100% {10?}</translation>
+        <translation>10</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="216"/>
-        <location filename="../controllerglobalsettingswidget.ui" line="267"/>
-        <source>Invert</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="274"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="240"/>
         <source>Using raw input improves precision when you bind controller sticks to the mouse pointer. Also enables multiple mice to be used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="284"/>
-        <source>Vertical Sensitivity:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="291"/>
-        <source>Horizontal Sensitivity:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="298"/>
-        <source>Enable Mouse Mapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser l&apos;entrée brute améliore la précision quand vous assignez les sticks du contrôleur au poiteur de souris. Autorise l&apos;usage de multiples souris.</translation>
     </message>
     <message>
         <location filename="../controllerglobalsettingswidget.ui" line="305"/>
+        <source>Vertical Sensitivity:</source>
+        <translation>Sensitivité verticale :</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="250"/>
+        <source>Horizontal Sensitivity:</source>
+        <translation>Sensitivité horizontale :</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="362"/>
+        <source>Enable Mouse Mapping</source>
+        <translation>Activer le mappage de la souris</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="369"/>
         <source>Use Raw Input</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser l&apos;entrée brute</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="315"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="182"/>
         <source>XInput Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Source XInput</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="321"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="165"/>
+        <source>Controller LED Settings</source>
+        <translation>Paramètres des LED de la manette</translation>
+    </message>
+    <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="188"/>
         <source>The XInput source provides support for XBox 360 / XBox One / XBox Series controllers, and third party controllers which implement the XInput protocol.</source>
-        <translation type="unfinished"></translation>
+        <translation>La source XInput fournit le support pour les manettes XBox 360 / XBox One / XBox Series, et les manettes tierces qui implémentent le protocole XInput.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="331"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="198"/>
         <source>Enable XInput Input Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer la source d&apos;entrée XInput</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="341"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="208"/>
         <source>Profile Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres de profil</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="347"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="214"/>
         <source>When this option is enabled, hotkeys can be set in this input profile, and will be used instead of the global hotkeys. By default, hotkeys are always shared between all profiles.</source>
-        <translation type="unfinished"></translation>
+        <translation>Quand cette option est active, des raccourcis peuvent être définis dans ce profil d&apos;entrée, et seront utilisés à la place des raccourcis globaux. Par défaut, les raccourcis sont toujours partagés entre tous les profils.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="357"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="224"/>
         <source>Use Per-Profile Hotkeys</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser des raccourcis par profil</translation>
     </message>
 </context>
 <context>
@@ -3225,90 +3458,121 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     </message>
 </context>
 <context>
+    <name>ControllerLEDSettingsDialog</name>
+    <message>
+        <location filename="../controllerledsettingsdialog.ui" line="14"/>
+        <source>Controller LED Settings</source>
+        <translation>Paramètres des LED du contrôleur</translation>
+    </message>
+    <message>
+        <location filename="../controllerledsettingsdialog.ui" line="20"/>
+        <source>SDL-0 LED</source>
+        <translation>SDL-0 LED</translation>
+    </message>
+    <message>
+        <location filename="../controllerledsettingsdialog.ui" line="32"/>
+        <source>SDL-1 LED</source>
+        <translation>SDL-1 LED</translation>
+    </message>
+    <message>
+        <location filename="../controllerledsettingsdialog.ui" line="44"/>
+        <source>SDL-2 LED</source>
+        <translation>SDL-2 LED</translation>
+    </message>
+    <message>
+        <location filename="../controllerledsettingsdialog.ui" line="56"/>
+        <source>SDL-3 LED</source>
+        <translation>SDL-3 LED</translation>
+    </message>
+</context>
+<context>
     <name>ControllerMacroEditWidget</name>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="32"/>
         <source>Binds/Buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>Mappages/Boutons</translation>
     </message>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="38"/>
         <source>Select the buttons which you want to trigger with this macro. All buttons are activated concurrently.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionnez les boutons que vous voulez déclencher avec cette macro. Tous les boutons sont activés en même temps.</translation>
     </message>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="54"/>
         <source>Trigger</source>
-        <translation type="unfinished">Gâchette</translation>
+        <translatorcomment>Différent du trigger de la manette</translatorcomment>
+        <translation>Déclencheur</translation>
     </message>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="60"/>
         <source>Select the trigger to activate this macro. This can be a single button, or combination of buttons (chord). Shift-click for multiple triggers.</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Chord ?</translatorcomment>
+        <translation>Sélectionnez le déclencheur qui active la macro. Cela peut être un simple bouton, ou une combinaison de boutons (chord). Shift-clic pour plusieurs déclencheurs.</translation>
     </message>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="73"/>
         <source>PushButton</source>
-        <translation type="unfinished"></translation>
+        <translation>PousserBouton</translation>
     </message>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="83"/>
         <source>Frequency</source>
-        <translation type="unfinished"></translation>
+        <translation>Fréquence</translation>
     </message>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="91"/>
         <source>Macro will toggle every N frames.</source>
-        <translation type="unfinished"></translation>
+        <translation>La macro basculera toutes les N images.</translation>
     </message>
     <message>
         <location filename="../controllermacroeditwidget.ui" line="98"/>
         <source>Set...</source>
-        <translation type="unfinished"></translation>
+        <translation>Définir...</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="399"/>
+        <location filename="../controllerbindingwidgets.cpp" line="406"/>
         <source>Not Configured</source>
-        <translation type="unfinished"></translation>
+        <translation>Non-configuré</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="405"/>
+        <location filename="../controllerbindingwidgets.cpp" line="412"/>
         <source>Set Frequency</source>
-        <translation type="unfinished"></translation>
+        <translation>Définir la fréquence</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="405"/>
+        <location filename="../controllerbindingwidgets.cpp" line="412"/>
         <source>Frequency: </source>
-        <translation type="unfinished"></translation>
+        <translation>Fréquence : </translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="434"/>
+        <location filename="../controllerbindingwidgets.cpp" line="441"/>
         <source>Macro will not repeat.</source>
-        <translation type="unfinished"></translation>
+        <translation>La macro ne se répètera pas.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="436"/>
+        <location filename="../controllerbindingwidgets.cpp" line="443"/>
         <source>Macro will toggle buttons every %1 frames.</source>
-        <translation type="unfinished"></translation>
+        <translation>La macro basculera les boutons toutes les %1 images.</translation>
     </message>
 </context>
 <context>
     <name>ControllerMacroWidget</name>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="298"/>
+        <location filename="../controllerbindingwidgets.cpp" line="304"/>
         <source>Controller Port %1 Macros</source>
-        <translation type="unfinished"></translation>
+        <translation>Macros du port contrôleur %1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="307"/>
+        <location filename="../controllerbindingwidgets.cpp" line="313"/>
         <source>Macro %1
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Macro %1
+%2</translation>
     </message>
 </context>
 <context>
@@ -3316,141 +3580,153 @@ Cet avertissement ne sera affiché qu&apos;une seule fois.</translation>
     <message>
         <location filename="../controllersettingsdialog.ui" line="23"/>
         <source>Controller Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres du contrôleur</translation>
     </message>
     <message>
         <location filename="../controllersettingsdialog.ui" line="71"/>
         <source>Profile:</source>
-        <translation type="unfinished"></translation>
+        <translation>Profil :</translation>
     </message>
     <message>
         <location filename="../controllersettingsdialog.ui" line="81"/>
         <source>New Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouveau profil</translation>
     </message>
     <message>
         <location filename="../controllersettingsdialog.ui" line="92"/>
         <source>Load Profile</source>
-        <translation type="unfinished">Charger un Profil</translation>
+        <translation>Charger profil</translation>
     </message>
     <message>
         <location filename="../controllersettingsdialog.ui" line="102"/>
         <source>Delete Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer profil</translation>
     </message>
     <message>
         <location filename="../controllersettingsdialog.ui" line="113"/>
-        <location filename="../controllersettingsdialog.cpp" line="186"/>
+        <location filename="../controllersettingsdialog.cpp" line="189"/>
         <source>Restore Defaults</source>
-        <translation type="unfinished"></translation>
+        <translation>Restaurer par défaut</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="90"/>
-        <location filename="../controllersettingsdialog.cpp" line="101"/>
+        <location filename="../controllersettingsdialog.cpp" line="93"/>
+        <location filename="../controllersettingsdialog.cpp" line="104"/>
         <source>Create Input Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Créer un profil d&apos;entrée</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="90"/>
+        <location filename="../controllersettingsdialog.cpp" line="93"/>
         <source>Enter the name for the new input profile:</source>
-        <translation type="unfinished"></translation>
+        <translation>Entrez le nom pour le nouveau profil d&apos;entrée :</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="97"/>
-        <location filename="../controllersettingsdialog.cpp" line="130"/>
-        <location filename="../controllersettingsdialog.cpp" line="174"/>
-        <location filename="../controllersettingsdialog.cpp" line="467"/>
+        <location filename="../controllersettingsdialog.cpp" line="100"/>
+        <location filename="../controllersettingsdialog.cpp" line="133"/>
+        <location filename="../controllersettingsdialog.cpp" line="177"/>
+        <location filename="../controllersettingsdialog.cpp" line="474"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="97"/>
+        <location filename="../controllersettingsdialog.cpp" line="100"/>
         <source>A profile with the name &apos;%1&apos; already exists.</source>
-        <translation type="unfinished"></translation>
+        <translation>Un profil du nom &apos;%1&apos; existe déjà.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="102"/>
+        <location filename="../controllersettingsdialog.cpp" line="105"/>
         <source>Do you want to copy all bindings from the currently-selected profile to the new profile? Selecting No will create a completely empty profile.</source>
-        <translation type="unfinished"></translation>
+        <translation>Voulez-vous copier tous les mappages depuis le profil sélectionné vers le nouveau profil ? Sélectionner Non créera un profil totalement vide.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="131"/>
+        <location filename="../controllersettingsdialog.cpp" line="134"/>
         <source>Failed to save the new profile to &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de sauvegarde du nouveau profil vers &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="141"/>
+        <location filename="../controllersettingsdialog.cpp" line="144"/>
         <source>Load Input Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Charger profil d&apos;entrée</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="142"/>
+        <location filename="../controllersettingsdialog.cpp" line="145"/>
         <source>Are you sure you want to load the input profile named &apos;%1&apos;?
 
 All current global bindings will be removed, and the profile bindings loaded.
 
 You cannot undo this action.</source>
-        <translation type="unfinished"></translation>
+        <translation>Êtes-vous sûr de vouloir charger le profil d&apos;entrée nommé &apos;%1&apos; ?
+
+Tous les mappages globaux en cours seront supprimés, et les mappages du profil par défaut chargés.
+
+Vous ne pourrez pas annuler cette action.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="163"/>
+        <location filename="../controllersettingsdialog.cpp" line="166"/>
         <source>Delete Input Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer profil d&apos;entrée</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="164"/>
+        <location filename="../controllersettingsdialog.cpp" line="167"/>
         <source>Are you sure you want to delete the input profile named &apos;%1&apos;?
 
 You cannot undo this action.</source>
-        <translation type="unfinished"></translation>
+        <translation>Êtes-vous sûr de vouloir supprimer le profil d&apos;entrée nommé &apos;%1&apos; ?
+
+Vous ne pourrez pas annuler cette action.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="174"/>
+        <location filename="../controllersettingsdialog.cpp" line="177"/>
         <source>Failed to delete &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de suppression de &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="187"/>
+        <location filename="../controllersettingsdialog.cpp" line="190"/>
         <source>Are you sure you want to restore the default controller configuration?
 
 All shared bindings and configuration will be lost, but your input profiles will remain.
 
 You cannot undo this action.</source>
-        <translation type="unfinished"></translation>
+        <translation>Êtes-vous sûr de vouloir restaurer la configuration par défaut du contrôleur ?
+
+Tous les mappages et configurations partagés seront perdus, mais les profils d&apos;entrée resteront.
+
+Vous ne pourrez pas annuler cette action.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="350"/>
+        <location filename="../controllersettingsdialog.cpp" line="357"/>
         <source>Global Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Paramètres globaux</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="392"/>
-        <location filename="../controllersettingsdialog.cpp" line="432"/>
+        <location filename="../controllersettingsdialog.cpp" line="399"/>
+        <location filename="../controllersettingsdialog.cpp" line="439"/>
         <source>Controller Port %1%2
 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>Port contrôleur %1%2
+%3</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="393"/>
-        <location filename="../controllersettingsdialog.cpp" line="433"/>
+        <location filename="../controllersettingsdialog.cpp" line="400"/>
+        <location filename="../controllersettingsdialog.cpp" line="440"/>
         <source>Controller Port %1
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Port contrôleur %1
+%2</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="403"/>
+        <location filename="../controllersettingsdialog.cpp" line="410"/>
         <source>Hotkeys</source>
-        <translation type="unfinished"></translation>
+        <translation>Raccourcis</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="445"/>
+        <location filename="../controllersettingsdialog.cpp" line="452"/>
         <source>Shared</source>
-        <translation type="unfinished"></translation>
+        <translation>Partagé</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="467"/>
+        <location filename="../controllersettingsdialog.cpp" line="474"/>
         <source>The input profile named &apos;%1&apos; cannot be found.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le profil d&apos;entrée nommé &apos;%1&apos; est introuvable.</translation>
     </message>
 </context>
 <context>
@@ -3539,159 +3815,219 @@ You cannot undo this action.</source>
 <context>
     <name>ControllerType</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1074"/>
+        <location filename="../../core/settings.cpp" line="1178"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../core/digital_controller.cpp" line="174"/>
-        <location filename="../../core/settings.cpp" line="1074"/>
+        <location filename="../../core/digital_controller.cpp" line="177"/>
+        <location filename="../../core/settings.cpp" line="1178"/>
         <source>Digital Controller</source>
         <translatorcomment>Sony Entertainment classe le contrôleur en &apos;classique&apos; en français.</translatorcomment>
         <translation>Contrôleur classique</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1075"/>
+        <location filename="../../core/settings.cpp" line="1179"/>
         <source>Analog Controller (DualShock)</source>
         <translation>Contrôleur analogique (DualShock)</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="341"/>
-        <location filename="../../core/settings.cpp" line="1075"/>
+        <location filename="../../core/analog_joystick.cpp" line="403"/>
+        <location filename="../../core/settings.cpp" line="1179"/>
         <source>Analog Joystick</source>
-        <translation type="unfinished"></translation>
+        <translation>Joystick analogique</translation>
     </message>
     <message>
         <source>Namco GunCon</source>
         <translation type="vanished">Namco GunCon</translation>
     </message>
     <message>
-        <location filename="../../core/playstation_mouse.cpp" line="195"/>
-        <location filename="../../core/settings.cpp" line="1076"/>
+        <location filename="../../core/playstation_mouse.cpp" line="198"/>
+        <location filename="../../core/settings.cpp" line="1180"/>
         <source>PlayStation Mouse</source>
         <translatorcomment>Marque déposée, on ne change pas avec la traduction</translatorcomment>
         <translation>PlayStation Mouse</translation>
     </message>
     <message>
-        <location filename="../../core/negcon.cpp" line="258"/>
-        <location filename="../../core/settings.cpp" line="1077"/>
+        <location filename="../../core/negcon.cpp" line="268"/>
+        <location filename="../../core/settings.cpp" line="1181"/>
         <source>NeGcon</source>
         <translation>NeGcon</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="809"/>
+        <location filename="../../core/analog_controller.cpp" line="873"/>
         <source>Analog Controller</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrôleur analogique</translation>
     </message>
     <message>
-        <location filename="../../core/guncon.cpp" line="230"/>
-        <location filename="../../core/settings.cpp" line="1076"/>
+        <location filename="../../core/guncon.cpp" line="234"/>
+        <location filename="../../core/settings.cpp" line="1180"/>
         <source>GunCon</source>
-        <translation type="unfinished"></translation>
+        <translation>GunCon</translation>
+    </message>
+    <message>
+        <location filename="../../core/controller.cpp" line="17"/>
+        <source>Not Connected</source>
+        <translation>Non-connecté</translation>
+    </message>
+</context>
+<context>
+    <name>CoverDownloadDialog</name>
+    <message>
+        <location filename="../coverdownloaddialog.ui" line="14"/>
+        <source>Download Covers</source>
+        <translation>Télécharger des jaquettes</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.ui" line="38"/>
+        <source>DuckStation can automatically download covers for games which do not currently have a cover set. We do not host any cover images, the user must provide their own source for images.</source>
+        <translation>DuckStation peut automatiquement télécharger des jaquettes pour les jeux qui n&apos;en ont pas actuellement définie. Nous n&apos;hébergeons aucune jaquette, l&apos;utilisateur doit fournir sa propre source d&apos;images.</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.ui" line="50"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In the box below, specify the URLs to download covers from, with one template URL per line. The following variables are available:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${title}:&lt;/span&gt; Title of the game.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${filetitle}:&lt;/span&gt; Name component of the game&apos;s filename.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${serial}:&lt;/span&gt; Serial of the game.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Example:&lt;/span&gt; https://www.example-not-a-real-domain.com/covers/${serial}.jpg&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translatorcomment>Attention à ne pas traduire les variables !</translatorcomment>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dans la boîte ci-dessous, spécifiez les URLs depuis lesquelles télécharger des jaquettes, avec une URL de modèle par ligne. Les variables suivantes sont disponibles :&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${title}:&lt;/span&gt; Titre du jeu.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${filetitle}:&lt;/span&gt; Nom composant le nom de fichier du jeu.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${serial}:&lt;/span&gt; Numéro de série du jeu.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Exemple :&lt;/span&gt; https://www.example-not-a-real-domain.com/covers/${serial}.jpg&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.ui" line="63"/>
+        <source>By default, the downloaded covers will be saved with the game&apos;s title. If this is not desired, you can check the &quot;Use Serial File Names&quot; box below. Using serials instead of game titles will prevent conflicts when multiple regions of the same game are used.</source>
+        <translation>Par défaut, les jaquettes téléchargées sont sauvegardées avec le titre du jeu. Si cela est indésirable, vous pouvez cocher la case ci-dessous &quot;Utiliser les noms de série fichier&quot;. Utiliser les noms de série plûtot que les titres de jeux préviendra les conflits quand plusieurs régions pour un même jeu seront utilisées.</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.ui" line="73"/>
+        <source>Use Serial File Names</source>
+        <translation>Utiliser les noms de série fichier</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.ui" line="80"/>
+        <source>Waiting to start...</source>
+        <translation>En attente du démarrage...</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.ui" line="95"/>
+        <location filename="../coverdownloaddialog.cpp" line="83"/>
+        <source>Start</source>
+        <translation>Démarrer</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.ui" line="105"/>
+        <source>Close</source>
+        <translation>Fermer</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.cpp" line="61"/>
+        <source>Download complete.</source>
+        <translation>Téléchargement fini.</translation>
+    </message>
+    <message>
+        <location filename="../coverdownloaddialog.cpp" line="83"/>
+        <source>Stop</source>
+        <translation>Stop</translation>
     </message>
 </context>
 <context>
     <name>DebuggerCodeModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="78"/>
-        <location filename="../debuggermodels.cpp" line="88"/>
-        <location filename="../debuggermodels.cpp" line="103"/>
+        <location filename="../debuggermodels.cpp" line="81"/>
+        <location filename="../debuggermodels.cpp" line="91"/>
+        <location filename="../debuggermodels.cpp" line="106"/>
         <source>&lt;invalid&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;invalid&gt;</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="171"/>
+        <location filename="../debuggermodels.cpp" line="174"/>
         <source>Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="173"/>
+        <location filename="../debuggermodels.cpp" line="176"/>
         <source>Bytes</source>
-        <translation type="unfinished"></translation>
+        <translation>Bytes</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="175"/>
+        <location filename="../debuggermodels.cpp" line="178"/>
         <source>Instruction</source>
-        <translation type="unfinished"></translation>
+        <translation>Instruction</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="177"/>
+        <location filename="../debuggermodels.cpp" line="180"/>
         <source>Comment</source>
-        <translation type="unfinished"></translation>
+        <translation>Commentaire</translation>
     </message>
 </context>
 <context>
     <name>DebuggerMessage</name>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1694"/>
+        <location filename="../../core/cpu_core.cpp" line="1823"/>
         <source>Added breakpoint at 0x%08X.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajouté un point d&apos;arrêt à 0x%08%X.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1721"/>
+        <location filename="../../core/cpu_core.cpp" line="1850"/>
         <source>Removed breakpoint at 0x%08X.</source>
-        <translation type="unfinished"></translation>
+        <translation>Enlevé le point d&apos;arrêt à 0x%08X.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1753"/>
+        <location filename="../../core/cpu_core.cpp" line="1882"/>
         <source>0x%08X is not a call instruction.</source>
-        <translation type="unfinished"></translation>
+        <translation>0x%08X n&apos;est pas une instruction d&apos;appel.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1764"/>
+        <location filename="../../core/cpu_core.cpp" line="1893"/>
         <source>Can&apos;t step over double branch at 0x%08X</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible de franchir la double-branche à 0x%08X</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1771"/>
+        <location filename="../../core/cpu_core.cpp" line="1900"/>
         <source>Stepping over to 0x%08X.</source>
-        <translation type="unfinished"></translation>
+        <translation>Franchissement vers 0x%08X.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1788"/>
+        <location filename="../../core/cpu_core.cpp" line="1917"/>
         <source>Instruction read failed at %08X while searching for function end.</source>
-        <translation type="unfinished"></translation>
+        <translation>La lecture d&apos;instruction a échoué à %08X pendant la recherche de la fin de fonction.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1795"/>
+        <location filename="../../core/cpu_core.cpp" line="1924"/>
         <source>Stepping out to 0x%08X.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sortie vers 0x%08X.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1802"/>
+        <location filename="../../core/cpu_core.cpp" line="1931"/>
         <source>No return instruction found after %u instructions for step-out at %08X.</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucune instruction de retour trouvée après les instructions %u pour sortir à %08X.</translation>
     </message>
 </context>
 <context>
     <name>DebuggerRegistersModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="352"/>
+        <location filename="../debuggermodels.cpp" line="355"/>
         <source>Register</source>
-        <translation type="unfinished"></translation>
+        <translation>Registre</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="354"/>
+        <location filename="../debuggermodels.cpp" line="357"/>
         <source>Value</source>
-        <translation type="unfinished">Valeur</translation>
+        <translation>Valeur</translation>
     </message>
 </context>
 <context>
     <name>DebuggerStackModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="403"/>
+        <location filename="../debuggermodels.cpp" line="406"/>
         <source>&lt;invalid&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;invalid&gt;</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="419"/>
+        <location filename="../debuggermodels.cpp" line="422"/>
         <source>Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="421"/>
+        <location filename="../debuggermodels.cpp" line="424"/>
         <source>Value</source>
-        <translation type="unfinished">Valeur</translation>
+        <translation>Valeur</translation>
     </message>
 </context>
 <context>
@@ -3699,103 +4035,104 @@ You cannot undo this action.</source>
     <message>
         <location filename="../debuggerwindow.ui" line="14"/>
         <source>CPU Debugger</source>
-        <translation type="unfinished"></translation>
+        <translation>Débogueur CPU</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="31"/>
         <source>&amp;Debug</source>
-        <translation type="unfinished">&amp;Débug</translation>
+        <translation>&amp;Débug</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="51"/>
         <location filename="../debuggerwindow.ui" line="245"/>
         <source>Breakpoints</source>
-        <translation type="unfinished"></translation>
+        <translation>Points d&apos;arrêt</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="63"/>
         <source>toolBar</source>
-        <translation type="unfinished">Barre d&apos;Outils</translation>
+        <translatorcomment>Vu la tête du texte source, préférence à laisser tel-quel</translatorcomment>
+        <translation>toolBar</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="93"/>
         <source>Disassembly</source>
-        <translation type="unfinished"></translation>
+        <translation>Désassembleur</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="115"/>
         <source>Registers</source>
-        <translation type="unfinished"></translation>
+        <translation>Registres</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="146"/>
         <source>Memory</source>
-        <translation type="unfinished"></translation>
+        <translation>Mémoire</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="168"/>
         <source>RAM</source>
-        <translation type="unfinished"></translation>
+        <translation>RAM</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="178"/>
         <source>Scratchpad</source>
-        <translation type="unfinished"></translation>
+        <translation>Bloc-notes</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="185"/>
         <source>EXP1</source>
-        <translation type="unfinished"></translation>
+        <translation>EXP1</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="192"/>
         <source>BIOS</source>
-        <translation type="unfinished"></translation>
+        <translation>BIOS</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="217"/>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation>Rechercher</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="265"/>
         <source>#</source>
-        <translation type="unfinished">#</translation>
+        <translation>#</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="270"/>
         <source>Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Adresse</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="275"/>
         <source>Hit Count</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre de résultats</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="285"/>
         <source>Stack</source>
-        <translation type="unfinished"></translation>
+        <translation>Pile</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="308"/>
         <source>Pause/Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>Pause/Continuer</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="311"/>
         <source>&amp;Pause/Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Pause/Continuer</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="314"/>
         <source>F5</source>
-        <translation type="unfinished"></translation>
+        <translation>F5</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="323"/>
         <source>Step Into</source>
-        <translation type="unfinished"></translation>
+        <translation>Pas-à-pas entrant</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="326"/>
@@ -3805,12 +4142,12 @@ You cannot undo this action.</source>
     <message>
         <location filename="../debuggerwindow.ui" line="329"/>
         <source>F11</source>
-        <translation type="unfinished"></translation>
+        <translation>F11</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="338"/>
         <source>Step Over</source>
-        <translation type="unfinished"></translation>
+        <translation>Pas-à-pas principal</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="341"/>
@@ -3820,22 +4157,23 @@ You cannot undo this action.</source>
     <message>
         <location filename="../debuggerwindow.ui" line="344"/>
         <source>F10</source>
-        <translation type="unfinished"></translation>
+        <translation>F10</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="353"/>
         <source>Toggle Breakpoint</source>
-        <translation type="unfinished"></translation>
+        <translation>Basculer le point d&apos;arrêt</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="356"/>
+        <location filename="../debuggerwindow.cpp" line="254"/>
         <source>Toggle &amp;Breakpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="359"/>
         <source>F9</source>
-        <translation type="unfinished"></translation>
+        <translation>F9</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="364"/>
@@ -3845,7 +4183,7 @@ You cannot undo this action.</source>
     <message>
         <location filename="../debuggerwindow.ui" line="373"/>
         <source>Step Out</source>
-        <translation type="unfinished"></translation>
+        <translation>Pas-à-pas sortant</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="376"/>
@@ -3855,27 +4193,28 @@ You cannot undo this action.</source>
     <message>
         <location filename="../debuggerwindow.ui" line="379"/>
         <source>Ctrl+F11</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F11</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="388"/>
         <source>Run To Cursor</source>
-        <translation type="unfinished"></translation>
+        <translation>Aller au curseur</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="391"/>
+        <location filename="../debuggerwindow.cpp" line="257"/>
         <source>&amp;Run To Cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="394"/>
         <source>Ctrl+F10</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F10</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="403"/>
         <source>Clear Breakpoints</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer les points d&apos;arrêt</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="406"/>
@@ -3885,12 +4224,12 @@ You cannot undo this action.</source>
     <message>
         <location filename="../debuggerwindow.ui" line="409"/>
         <source>Ctrl+Del</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Del</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="418"/>
         <source>Add Breakpoint</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajouter un point d&apos;arrêt</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="421"/>
@@ -3900,7 +4239,7 @@ You cannot undo this action.</source>
     <message>
         <location filename="../debuggerwindow.ui" line="424"/>
         <source>Ctrl+F9</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+F9</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="433"/>
@@ -3915,116 +4254,127 @@ You cannot undo this action.</source>
     <message>
         <location filename="../debuggerwindow.ui" line="439"/>
         <source>Ctrl+P</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+P</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="448"/>
         <source>Go To Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Aller à l&apos;adresse</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="451"/>
         <source>Go To &amp;Address</source>
-        <translation type="unfinished"></translation>
+        <translation>Aller à l&apos;&amp;adresse</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="454"/>
         <source>Ctrl+G</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+G</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="463"/>
         <source>&amp;Dump Address</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Décharger l&apos;adresse</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="466"/>
         <source>Ctrl+D</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+D</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="475"/>
         <source>Trace</source>
-        <translation type="unfinished">Traceur</translation>
+        <translation>Trace</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="478"/>
         <source>&amp;Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Trace</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.ui" line="481"/>
         <source>Ctrl+T</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="95"/>
+        <location filename="../debuggerwindow.cpp" line="98"/>
         <source>No address selected.</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucune adresse sélectionnée.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="111"/>
-        <location filename="../debuggerwindow.cpp" line="152"/>
+        <location filename="../debuggerwindow.cpp" line="114"/>
+        <location filename="../debuggerwindow.cpp" line="155"/>
         <source>Enter code address:</source>
-        <translation type="unfinished"></translation>
+        <translation>Entrer un code adresse :</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="121"/>
-        <location filename="../qtutils.cpp" line="738"/>
+        <location filename="../debuggerwindow.cpp" line="124"/>
+        <location filename="../qtutils.cpp" line="750"/>
         <source>Enter memory address:</source>
-        <translation type="unfinished"></translation>
+        <translation>Entrer une adresse mémoire :</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="134"/>
+        <location filename="../debuggerwindow.cpp" line="137"/>
         <source>Trace logging started to cpu_log.txt.
 This file can be several gigabytes, so be aware of SSD wear.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;enregistrement de la trace a débuté vers cpu_log.txt.
+Ce fichier peut faire plusieurs gigaoctets, alors attention à l&apos;usure SSD.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="140"/>
+        <location filename="../debuggerwindow.cpp" line="143"/>
         <source>Trace logging to cpu_log.txt stopped.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;enregistrement vers cpu_log.tx s&apos;est arrêté.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="158"/>
+        <location filename="../debuggerwindow.cpp" line="161"/>
         <source>A breakpoint already exists at this address.</source>
-        <translation type="unfinished"></translation>
+        <translation>Un point d&apos;arrêt existe déjà à cette adresse.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="206"/>
+        <location filename="../debuggerwindow.cpp" line="209"/>
         <source>Debugger</source>
-        <translation type="unfinished"></translation>
+        <translation>Débogueur</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="206"/>
+        <location filename="../debuggerwindow.cpp" line="209"/>
         <source>Failed to add step-out breakpoint, are you in a valid function?</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;ajout d&apos;un point d&apos;arrêt de pas-à-pas sortant, êtes-vous dans une fonction valide ?</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="285"/>
-        <location filename="../debuggerwindow.cpp" line="312"/>
+        <location filename="../debuggerwindow.cpp" line="266"/>
+        <source>View in &amp;Dump</source>
+        <translation>Voir dans la &amp;décharge</translation>
+    </message>
+    <message>
+        <location filename="../debuggerwindow.cpp" line="269"/>
+        <source>Follow Load/Store</source>
+        <translation>Suivre le chargement/enregistrement</translation>
+    </message>
+    <message>
+        <location filename="../debuggerwindow.cpp" line="321"/>
+        <location filename="../debuggerwindow.cpp" line="348"/>
         <source>Invalid search pattern. It should contain hex digits or question marks.</source>
-        <translation type="unfinished"></translation>
+        <translation>Motif de recherche invalide. Il devrait contenir des chiffres héxa ou des points d&apos;interrogation.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="324"/>
+        <location filename="../debuggerwindow.cpp" line="360"/>
         <source>Pattern not found.</source>
-        <translation type="unfinished"></translation>
+        <translation>Motif non-trouvé.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="340"/>
+        <location filename="../debuggerwindow.cpp" line="376"/>
         <source>Pattern found at 0x%1 (passed the end of memory).</source>
-        <translation type="unfinished"></translation>
+        <translation>Motif trouvé à l&apos;adresse 0x%1 (passé la fin de mémoire).</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="346"/>
+        <location filename="../debuggerwindow.cpp" line="382"/>
         <source>Pattern found at 0x%1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Motif trouvé à l&apos;adresse 0x%1.</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="755"/>
+        <location filename="../qtutils.cpp" line="767"/>
         <source>Invalid address. It should be in hex (0x12345678 or 12345678)</source>
-        <translation type="unfinished"></translation>
+        <translation>Adresse invalide. Elle devrait être en héxa (0x12345678 ou 12345678)</translation>
     </message>
 </context>
 <context>
@@ -4086,71 +4436,94 @@ This file can be several gigabytes, so be aware of SSD wear.</source>
         <translation type="vanished">R2</translation>
     </message>
     <message>
-        <location filename="../../core/digital_controller.cpp" line="169"/>
+        <location filename="../../core/digital_controller.cpp" line="172"/>
         <source>Force Pop&apos;n Controller Mode</source>
-        <translation>Forcer le Mode Contrôleur Pop&apos;n</translation>
+        <translation>Forcer le mode contrôleur Pop&apos;n</translation>
     </message>
     <message>
-        <location filename="../../core/digital_controller.cpp" line="170"/>
+        <location filename="../../core/digital_controller.cpp" line="173"/>
         <source>Forces the Digital Controller to act as a Pop&apos;n Controller.</source>
-        <translation type="unfinished"></translation>
+        <translation>Force le contrôleur digital à se comporter comme un contrôleur Pop&apos;n.</translation>
     </message>
 </context>
 <context>
     <name>DiscRegion</name>
     <message>
-        <location filename="../../core/settings.cpp" line="720"/>
+        <location filename="../../core/settings.cpp" line="793"/>
         <source>NTSC-J (Japan)</source>
         <translation>NTSC-J (Japon)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="720"/>
+        <location filename="../../core/settings.cpp" line="793"/>
         <source>NTSC-U/C (US, Canada)</source>
         <translation>NTSC-U/C (US, Canada)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="721"/>
+        <location filename="../../core/settings.cpp" line="794"/>
         <source>PAL (Europe, Australia)</source>
         <translation>PAL (Europe, Australie)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="721"/>
+        <location filename="../../core/settings.cpp" line="794"/>
         <source>Other</source>
         <translation>Autre</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="795"/>
+        <source>Non-PS1</source>
+        <translation>Non-PS1</translation>
+    </message>
+</context>
+<context>
+    <name>DisplayAlignment</name>
+    <message>
+        <location filename="../../core/settings.cpp" line="1098"/>
+        <source>Left / Top</source>
+        <translation>Gauche / Haut</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1098"/>
+        <source>Center</source>
+        <translation>Centre</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1099"/>
+        <source>Right / Bottom</source>
+        <translation>Droit / Bas</translation>
     </message>
 </context>
 <context>
     <name>DisplayAspectRatio</name>
     <message>
-        <location filename="../../core/settings.cpp" line="970"/>
+        <location filename="../../core/settings.cpp" line="1045"/>
         <source>Auto (Game Native)</source>
-        <translation type="unfinished"></translation>
+        <translation>Auto (natif)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="970"/>
+        <location filename="../../core/settings.cpp" line="1045"/>
         <source>Auto (Match Window)</source>
-        <translation type="unfinished"></translation>
+        <translation>Auto (dimensions fenêtre)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="971"/>
+        <location filename="../../core/settings.cpp" line="1046"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Personnalisé</translation>
     </message>
 </context>
 <context>
     <name>DisplayCropMode</name>
     <message>
-        <location filename="../../core/settings.cpp" line="942"/>
+        <location filename="../../core/settings.cpp" line="1017"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="942"/>
+        <location filename="../../core/settings.cpp" line="1017"/>
         <source>Only Overscan Area</source>
         <translation>Zone de surbalayage uniquement</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="943"/>
+        <location filename="../../core/settings.cpp" line="1018"/>
         <source>All Borders</source>
         <translation>Toutes les bordures</translation>
     </message>
@@ -4170,112 +4543,111 @@ This file can be several gigabytes, so be aware of SSD wear.</source>
     <message>
         <location filename="../displaysettingswidget.ui" line="38"/>
         <source>Renderer:</source>
-        <translation>Rendu:</translation>
+        <translation>Rendu :</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="48"/>
         <source>Adapter:</source>
-        <translation>Adaptateur:</translation>
+        <translation>Adaptateur :</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="58"/>
         <source>Fullscreen Mode:</source>
-        <translation>Mode Plein Ecran</translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.ui" line="70"/>
-        <location filename="../displaysettingswidget.cpp" line="129"/>
-        <source>Threaded Rendering</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode plein écran :</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="77"/>
-        <location filename="../displaysettingswidget.cpp" line="126"/>
-        <source>Threaded Presentation</source>
-        <translation type="unfinished"></translation>
+        <location filename="../displaysettingswidget.cpp" line="128"/>
+        <source>Threaded Rendering</source>
+        <translation>Rendu threadé</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="84"/>
-        <location filename="../displaysettingswidget.cpp" line="119"/>
+        <location filename="../displaysettingswidget.cpp" line="125"/>
+        <source>Threaded Presentation</source>
+        <translation>Présentation threadée</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.ui" line="253"/>
+        <source>Show GPU Usage</source>
+        <translation>Afficher l&apos;usage GPU</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.ui" line="260"/>
+        <source>Show Settings Overlay</source>
+        <translation>Afficher les paramètres d&apos;overlay</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.ui" line="70"/>
+        <location filename="../displaysettingswidget.cpp" line="122"/>
         <source>VSync</source>
         <translation>Synchro Verticale</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="91"/>
-        <location filename="../displaysettingswidget.cpp" line="133"/>
-        <source>Sync To Host Refresh Rate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.ui" line="98"/>
-        <location filename="../displaysettingswidget.cpp" line="122"/>
-        <source>Optimal Frame Pacing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.ui" line="110"/>
+        <location filename="../displaysettingswidget.ui" line="103"/>
         <source>Screen Display</source>
-        <translation>Affichage à l&apos;Ecran</translation>
+        <translation>Affichage à l&apos;écran</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="116"/>
+        <location filename="../displaysettingswidget.ui" line="109"/>
         <source>Aspect Ratio:</source>
-        <translation type="unfinished">Ratio d&apos;affichage :</translation>
+        <translation>Ratio d&apos;affichage :</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="138"/>
+        <location filename="../displaysettingswidget.ui" line="131"/>
         <source>:</source>
-        <translation type="unfinished"></translation>
+        <translation>:</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="157"/>
+        <location filename="../displaysettingswidget.ui" line="150"/>
         <source>Crop:</source>
-        <translation type="unfinished">Rognage:</translation>
+        <translation>Rognage :</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="167"/>
-        <source>Downsampling:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../displaysettingswidget.ui" line="179"/>
+        <location filename="../displaysettingswidget.cpp" line="115"/>
+        <source>Stretch To Fill</source>
+        <translation>Étirer pour remplir</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="186"/>
-        <location filename="../displaysettingswidget.cpp" line="112"/>
-        <source>Stretch To Fill</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.ui" line="193"/>
-        <location filename="../displaysettingswidget.cpp" line="102"/>
+        <location filename="../displaysettingswidget.cpp" line="105"/>
         <source>Linear Upscaling</source>
         <translation>Upscaling Linéaire</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="246"/>
+        <location filename="../displaysettingswidget.ui" line="218"/>
+        <location filename="../displaysettingswidget.cpp" line="142"/>
         <source>Show CPU Usage</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher l&apos;usage CPU</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="253"/>
-        <location filename="../displaysettingswidget.cpp" line="150"/>
+        <location filename="../displaysettingswidget.ui" line="239"/>
+        <location filename="../displaysettingswidget.cpp" line="147"/>
         <source>Show Controller Input</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher les entrées contrôleur</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="179"/>
-        <location filename="../displaysettingswidget.cpp" line="109"/>
+        <location filename="../displaysettingswidget.ui" line="172"/>
+        <location filename="../displaysettingswidget.cpp" line="112"/>
         <source>Integer Upscaling</source>
-        <translation>Upscaling Complet</translation>
+        <translation>Upscaling entier</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="200"/>
-        <location filename="../displaysettingswidget.cpp" line="114"/>
+        <location filename="../displaysettingswidget.ui" line="160"/>
+        <source>Position:</source>
+        <translation>Position :</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.ui" line="193"/>
+        <location filename="../displaysettingswidget.cpp" line="117"/>
         <source>Internal Resolution Screenshots</source>
-        <translation type="unfinished"></translation>
+        <translation>Résolution interne des captures d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="212"/>
+        <location filename="../displaysettingswidget.ui" line="205"/>
         <source>On-Screen Display</source>
-        <translation>Affichage à l&apos;Ecran</translation>
+        <translation>Affichage à l&apos;écran</translation>
     </message>
     <message>
         <source>Show Messages</source>
@@ -4283,13 +4655,13 @@ This file can be several gigabytes, so be aware of SSD wear.</source>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="232"/>
-        <location filename="../displaysettingswidget.cpp" line="142"/>
+        <location filename="../displaysettingswidget.cpp" line="134"/>
         <source>Show FPS</source>
-        <translation>Afficher les FPS</translation>
+        <translation>Afficher les IPS</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="225"/>
-        <location filename="../displaysettingswidget.cpp" line="145"/>
+        <location filename="../displaysettingswidget.ui" line="211"/>
+        <location filename="../displaysettingswidget.cpp" line="137"/>
         <source>Show Emulation Speed</source>
         <translation>Afficher la vitesse d&apos;émulation</translation>
     </message>
@@ -4298,171 +4670,155 @@ This file can be several gigabytes, so be aware of SSD wear.</source>
         <translation type="vanished">Afficher les VPS</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="239"/>
-        <location filename="../displaysettingswidget.cpp" line="147"/>
+        <location filename="../displaysettingswidget.ui" line="246"/>
+        <location filename="../displaysettingswidget.cpp" line="139"/>
         <source>Show Resolution</source>
-        <translation>Afficher la Résolution</translation>
+        <translation>Afficher la résolution</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="74"/>
+        <location filename="../displaysettingswidget.cpp" line="77"/>
         <source>Renderer</source>
         <translation>Rendu</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="76"/>
+        <location filename="../displaysettingswidget.cpp" line="79"/>
         <source>Chooses the backend to use for rendering the console/game visuals. &lt;br&gt;Depending on your system and hardware, Direct3D 11 and OpenGL hardware backends may be available. &lt;br&gt;The software renderer offers the best compatibility, but is the slowest and does not offer any enhancements.</source>
-        <translation type="unfinished">Choisit le moteur vidéo à utiliser pour le rendu des visuels de la console/du jeu. &lt;br&gt;Selon votre système et votre matériel, des moteurs  matériels Direct3D 11 et OpenGL peuvent être disponibles. &lt;br&gt;Le rendu logiciel offre la meilleure compatibilité, mais est le plus lent et n&apos;offre aucune amélioration possible.</translation>
+        <translation>Choisis le moteur vidéo à utiliser pour le rendu des visuels de la console/du jeu. &lt;br&gt;Selon votre système et votre matériel, des moteurs matériels Direct3D 11 et OpenGL peuvent être disponibles. &lt;br&gt;Le rendu logiciel offre la meilleure compatibilité, mais est le plus lent et n&apos;offre aucune amélioration possible.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="80"/>
+        <location filename="../displaysettingswidget.cpp" line="83"/>
         <source>Adapter</source>
         <translation>Adaptateur</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="80"/>
-        <location filename="../displaysettingswidget.cpp" line="232"/>
+        <location filename="../displaysettingswidget.cpp" line="83"/>
+        <location filename="../displaysettingswidget.cpp" line="227"/>
         <source>(Default)</source>
         <translation>(Défaut)</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="81"/>
+        <location filename="../displaysettingswidget.cpp" line="84"/>
         <source>If your system contains multiple GPUs or adapters, you can select which GPU you wish to use for the hardware renderers. &lt;br&gt;This option is only supported in Direct3D and Vulkan. OpenGL will always use the default device.</source>
         <translation>Si votre système contient plusieurs GPU ou adaptateurs, vous pouvez sélectionner le GPU que vous souhaitez utiliser pour les rendus matériels. Cette option n&apos;est prise en charge que dans Direct3D et Vulkan, OpenGL utilisera toujours le périphérique par défaut.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="84"/>
-        <source>Fullscreen Mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.cpp" line="85"/>
-        <source>Chooses the fullscreen resolution and frequency.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../displaysettingswidget.cpp" line="87"/>
+        <source>Fullscreen Mode</source>
+        <translation>Mode plein écran</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.cpp" line="88"/>
+        <source>Chooses the fullscreen resolution and frequency.</source>
+        <translation>Choisis la résolution plein écran et la fréquence.</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.cpp" line="90"/>
         <source>Aspect Ratio</source>
-        <translation type="unfinished">Ratio d&apos;affichage</translation>
+        <translation>Ratio d&apos;affichage</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.cpp" line="102"/>
+        <source>Position</source>
+        <translation>Position</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.cpp" line="104"/>
+        <source>Determines the position on the screen when black borders must be added.</source>
+        <translation>Détermine la position à l&apos;écran quand des bordures noires doivent être ajoutées.</translation>
     </message>
     <message>
         <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is 4:3 which matches a typical TV of the era.</source>
         <translation type="vanished">Modifie le format d&apos;image utilisé pour afficher la sortie de la console sur l&apos;écran. Le rapport par défaut est de 4:3, ce qui correspond à un téléviseur typique de l&apos;époque.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="89"/>
+        <location filename="../displaysettingswidget.cpp" line="92"/>
         <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is Auto (Game Native) which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era.</source>
-        <translation type="unfinished"></translation>
+        <translation>Change le ratio d&apos;affichage utilisé pour afficher la sortie console à l&apos;écran. Par défaut Auto(natif), qui ajuste automatiquement le ratio d&apos;affichage pour correspondre à la façon un jeu s&apos;affichait sur les TVs de cette période.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="92"/>
+        <location filename="../displaysettingswidget.cpp" line="95"/>
         <source>Crop Mode</source>
-        <translation type="unfinished">Mode Rognage</translation>
+        <translation>Mode rognage</translation>
     </message>
     <message>
         <source>Only Overscan Area</source>
         <translation type="vanished">Zone de Surbalayage uniquement</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="94"/>
+        <location filename="../displaysettingswidget.cpp" line="97"/>
         <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide. &lt;br&gt;Some games display content in the overscan area, or use it for screen effects. &lt;br&gt;May not display correctly with the &quot;All Borders&quot; setting. &quot;Only Overscan&quot; offers a good compromise between stability and hiding black borders.</source>
         <translation>Détermine la partie de la zone qui n&apos;est généralement pas visible sur un téléviseur grand public et qui doit être coupée/cachée. Certains jeux affichent le contenu dans la zone de surbalayage, ou l&apos;utilisent pour des effets d&apos;écran et peuvent ne pas s&apos;afficher correctement avec le paramètre &quot;Toutes les bordures&quot;. Seul le surbalayage offre un bon compromis entre la stabilité et le masquage des bordures noires.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="99"/>
-        <source>Downsampling</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.cpp" line="99"/>
-        <source>Disabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.cpp" line="100"/>
-        <source>Downsamples the rendered image prior to displaying it. Can improve overall image quality in mixed 2D/3D games, but should be disabled for pure 3D games. Only applies to the hardware renderers.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.cpp" line="102"/>
-        <location filename="../displaysettingswidget.cpp" line="119"/>
-        <location filename="../displaysettingswidget.cpp" line="126"/>
-        <location filename="../displaysettingswidget.cpp" line="129"/>
-        <location filename="../displaysettingswidget.cpp" line="139"/>
+        <location filename="../displaysettingswidget.cpp" line="105"/>
+        <location filename="../displaysettingswidget.cpp" line="122"/>
+        <location filename="../displaysettingswidget.cpp" line="125"/>
+        <location filename="../displaysettingswidget.cpp" line="128"/>
+        <location filename="../displaysettingswidget.cpp" line="131"/>
         <source>Checked</source>
         <translation>Coché</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="103"/>
+        <location filename="../displaysettingswidget.cpp" line="106"/>
         <source>Uses bilinear texture filtering when displaying the console&apos;s framebuffer to the screen. &lt;br&gt;Disabling filtering will producer a sharper, blockier/pixelated image. Enabling will smooth out the image. &lt;br&gt;The option will be less noticable the higher the resolution scale.</source>
         <translation>Utilise un filtrage de texture bilinéaire lors de l&apos;affichage du tampon image de la console à l&apos;écran. La désactivation du filtrage produira une image plus nette, plus bloquante et plus pixelisée. L&apos;activation du filtrage rendra l&apos;image plus lisse. L&apos;option sera moins notable plus la résolution sera élevée.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="109"/>
         <location filename="../displaysettingswidget.cpp" line="112"/>
-        <location filename="../displaysettingswidget.cpp" line="114"/>
-        <location filename="../displaysettingswidget.cpp" line="122"/>
-        <location filename="../displaysettingswidget.cpp" line="133"/>
+        <location filename="../displaysettingswidget.cpp" line="115"/>
+        <location filename="../displaysettingswidget.cpp" line="117"/>
+        <location filename="../displaysettingswidget.cpp" line="134"/>
+        <location filename="../displaysettingswidget.cpp" line="137"/>
+        <location filename="../displaysettingswidget.cpp" line="139"/>
         <location filename="../displaysettingswidget.cpp" line="142"/>
-        <location filename="../displaysettingswidget.cpp" line="145"/>
         <location filename="../displaysettingswidget.cpp" line="147"/>
-        <location filename="../displaysettingswidget.cpp" line="150"/>
-        <location filename="../displaysettingswidget.cpp" line="158"/>
+        <location filename="../displaysettingswidget.cpp" line="152"/>
         <source>Unchecked</source>
         <translation>Décoché</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="110"/>
+        <location filename="../displaysettingswidget.cpp" line="113"/>
         <source>Adds padding to the display area to ensure that the ratio between pixels on the host to pixels in the console is an integer number. &lt;br&gt;May result in a sharper image in some 2D games.</source>
         <translation>Ajoute du remplissage à la zone d&apos;affichage pour que le rapport entre les pixels sur l&apos;hôte et les pixels dans la console soit un nombre entier. Peut donner une image plus nette dans certains jeux en 2D.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="113"/>
+        <location filename="../displaysettingswidget.cpp" line="116"/>
         <source>Fills the window with the active display area, regardless of the aspect ratio.</source>
-        <translation type="unfinished"></translation>
+        <translation>Remplis la fenêtre avec la zone d&apos;affichage active, peu importe le ratio d&apos;affichage.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="115"/>
+        <location filename="../displaysettingswidget.cpp" line="118"/>
         <source>Saves screenshots at internal render resolution and without postprocessing. If this option is disabled, the screenshots will be taken at the window&apos;s resolution. Internal resolution screenshots can be very large at high rendering scales.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.cpp" line="120"/>
-        <source>Enable this option to match DuckStation&apos;s refresh rate with your current monitor or screen. VSync is automatically disabled when it is not possible (e.g. running at non-100% speed).</source>
-        <translation type="unfinished">Activer cette option pour faire correspondre le taux de rafraîchissement de DuckStation avec votre moniteur ou écran actuel. VSync est automatiquement désactivé lorsque ce n&apos;est pas possible (par exemple, si la vitesse n&apos;est pas de 100 %).</translation>
+        <translation>Sauvegarde les captures d&apos;écran à la résolution interne et sans postprocessing. Si cette option est désactivée, les captures d&apos;écran seront prises à la résolution de la fenêtre. Les captures d&apos;écran en résolution interne peuvent être très volumineuses avec les grandes échelles de rendu.</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.cpp" line="123"/>
-        <source>Enable this option will ensure every frame the console renders is displayed to the screen, for optimal frame pacing. If you are having difficulties maintaining full speed, or are getting audio glitches, try disabling this option.</source>
-        <translation type="unfinished"></translation>
+        <source>Enable this option to match DuckStation&apos;s refresh rate with your current monitor or screen. VSync is automatically disabled when it is not possible (e.g. running at non-100% speed).</source>
+        <translation>Activer cette option pour faire correspondre le taux de rafraîchissement de DuckStation avec votre moniteur ou écran actuel. La VSync est automatiquement désactivée lorsque ce n&apos;est pas possible (càd si la vitesse n&apos;est pas de 100%).</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="127"/>
+        <location filename="../displaysettingswidget.cpp" line="126"/>
         <source>Presents frames on a background thread when fast forwarding or vsync is disabled. This can measurably improve performance in the Vulkan renderer.</source>
-        <translation type="unfinished"></translation>
+        <translation>Présente les images via un thread d&apos;arrière-plan quand l&apos;avance rapide ou la vsync sont désactivées. Cela peut sensiblement améliorer les performances avec le rendu Vulkan.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="130"/>
+        <location filename="../displaysettingswidget.cpp" line="129"/>
         <source>Uses a second thread for drawing graphics. Currently only available for the software renderer, but can provide a significant speed improvement, and is safe to use.</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilise un second thread de dessin graphique. Actuellement seulement disponible pour le rendu logiciel, mais peut fournir une amélioration significative de la vitesse, et est sûr à utiliser.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="134"/>
-        <source>Adjusts the emulation speed so the console&apos;s refresh rate matches the host&apos;s refresh rate when both VSync and Audio Resampling settings are enabled. This results in the smoothest animations possible, at the cost of potentially increasing the emulation speed by less than 1%. Sync To Host Refresh Rate will not take effect if the console&apos;s refresh rate is too far from the host&apos;s refresh rate. Users with variable refresh rate displays should disable this option.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../displaysettingswidget.ui" line="218"/>
-        <location filename="../displaysettingswidget.cpp" line="139"/>
+        <location filename="../displaysettingswidget.ui" line="225"/>
+        <location filename="../displaysettingswidget.cpp" line="131"/>
         <source>Show OSD Messages</source>
         <translation>Afficher les Messages OSD</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="140"/>
+        <location filename="../displaysettingswidget.cpp" line="132"/>
         <source>Shows on-screen-display messages when events occur such as save states being created/loaded, screenshots being taken, etc.</source>
         <translation>Affiche des messages à l&apos;écran lorsque des événements se produisent, tels que la création/le chargement des sauvegardes d&apos;états, les captures d&apos;écran, etc.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="143"/>
+        <location filename="../displaysettingswidget.cpp" line="135"/>
         <source>Shows the internal frame rate of the game in the top-right corner of the display.</source>
         <translation>Affiche la fréquence d&apos;images interne du jeu dans le coin supérieur droit de l&apos;écran.</translation>
     </message>
@@ -4475,36 +4831,41 @@ This file can be several gigabytes, so be aware of SSD wear.</source>
         <translation type="vanished">Afficher la Vitesse</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="146"/>
+        <location filename="../displaysettingswidget.cpp" line="138"/>
         <source>Shows the current emulation speed of the system in the top-right corner of the display as a percentage.</source>
         <translation>Indique en pourcentage la vitesse d&apos;émulation actuelle du système dans le coin supérieur droit de l&apos;écran.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="148"/>
+        <location filename="../displaysettingswidget.cpp" line="140"/>
         <source>Shows the resolution of the game in the top-right corner of the display.</source>
-        <translation type="unfinished"></translation>
+        <translation>Affiche la résolution du jeu dans le coin supérieur-droit de l&apos;affichage.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="151"/>
+        <location filename="../displaysettingswidget.cpp" line="143"/>
+        <source>Shows the host&apos;s CPU usage based on threads in the top-right corner of the display. This does not display the emulated system CPU&apos;s usage. If a value close to 100% is being displayed, this means your host&apos;s CPU is likely the bottleneck. In this case, you should reduce enhancement-related settings such as overclocking.</source>
+        <translation>Affichage l&apos;usage du CPu de l&apos;hôte en se basant sur les threads dans le coin supérieur droit de l&apos;affichage. Cela n&apos;affiche pas l&apos;usage du CPU système émulé. Si une valeur est proche de 100% est affichée, cela signifie que le CPU de l&apos;hôte est probablement le goulôt d&apos;étranglement. Dans ce cas, vous devriez réduire les paramètres liés aux améliorations, comme l&apos;overclocking.</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.cpp" line="148"/>
         <source>Shows the current controller state of the system in the bottom-left corner of the display.</source>
-        <translation type="unfinished"></translation>
+        <translation>Affiche l&apos;état système du contrôleur courant dans le coin inférieur-gauche de l&apos;affichage.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="155"/>
-        <location filename="../displaysettingswidget.cpp" line="158"/>
+        <location filename="../displaysettingswidget.ui" line="91"/>
+        <location filename="../displaysettingswidget.cpp" line="152"/>
         <source>Use Blit Swap Chain</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser la chaîne d&apos;échange Blit</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="159"/>
+        <location filename="../displaysettingswidget.cpp" line="153"/>
         <source>Uses a blit presentation model instead of flipping when using the Direct3D 11 renderer. This usually results in slower performance, but may be required for some streaming applications, or to uncap framerates on some systems.</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilise le modèle de présentation blit plutôt que le retournement quand le rendu Direct3D 11 est utilisé. Cela résulte habituellement en des performances plus lentes, mais peut être requis pour certaines applications de streaming, ou pour déplafonner le taux d&apos;image sur certains systèmes.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="84"/>
-        <location filename="../displaysettingswidget.cpp" line="252"/>
+        <location filename="../displaysettingswidget.cpp" line="87"/>
+        <location filename="../displaysettingswidget.cpp" line="247"/>
         <source>Borderless Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Plein écran sans bordure</translation>
     </message>
 </context>
 <context>
@@ -4512,82 +4873,85 @@ This file can be several gigabytes, so be aware of SSD wear.</source>
     <message>
         <location filename="../emptygamelistwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../emptygamelistwidget.ui" line="33"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;No games in supported formats were found.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please add a directory with games to begin.&lt;/p&gt;&lt;p&gt;Game dumps in the following formats will be scanned and listed:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Aucun jeu dans les formats supportés n&apos;a été trouvé.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Veuillez ajouter un répertoire avec des jeux pour commencer.&lt;/p&gt;&lt;p&gt;Les jeux extraits dans les formats suivants seront scannés et listés :&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../emptygamelistwidget.ui" line="43"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../emptygamelistwidget.ui" line="68"/>
         <source>Add Game Directory...</source>
-        <translation type="unfinished">Ajouter un Répertoire de Jeu...</translation>
+        <translation>Ajouter un répertoire de jeu...</translation>
     </message>
     <message>
         <location filename="../emptygamelistwidget.ui" line="105"/>
         <source>Scan For New Games</source>
-        <translation type="unfinished"></translation>
+        <translation>Scanner pour des nouveaux jeux</translation>
     </message>
 </context>
 <context>
     <name>EmuThread</name>
     <message>
-        <location filename="../qthost.cpp" line="530"/>
+        <location filename="../qthost.cpp" line="536"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="530"/>
+        <location filename="../qthost.cpp" line="536"/>
         <source>No resume save state found.</source>
-        <translation type="unfinished">Aucun résumé sur la sauvegarde d&apos;état n&apos;a été trouvé.</translation>
+        <translation>Aucun sauvegarde d&apos;état de reprise n&apos;a été trouvée.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1288"/>
+        <location filename="../qthost.cpp" line="1306"/>
         <source>Game ID: %1
 Game Title: %2
 Achievements: %5 (%6)
 
 </source>
-        <translation type="unfinished"></translation>
+        <translation>ID du jeu : %1
+Titre du jeu : %2
+Succès : %5 (%6)
+</translation>
     </message>
     <message numerus="yes">
-        <location filename="../qthost.cpp" line="1294"/>
+        <location filename="../qthost.cpp" line="1312"/>
         <source>%n points</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n points</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1300"/>
+        <location filename="../qthost.cpp" line="1318"/>
         <source>Rich presence inactive or unsupported.</source>
-        <translation type="unfinished"></translation>
+        <translation>Riche presence inactive ou non-supportée.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1304"/>
+        <location filename="../qthost.cpp" line="1322"/>
         <source>Game not loaded or no RetroAchievements available.</source>
-        <translation type="unfinished"></translation>
+        <translation>Jeu non-chargé ou RetroAchievements indisponible.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1674"/>
+        <location filename="../qthost.cpp" line="1639"/>
         <source>%1x%2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1x%2</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1683"/>
+        <location filename="../qthost.cpp" line="1648"/>
         <source>Game: %1 FPS</source>
-        <translation type="unfinished"></translation>
+        <translation>Jeu : %1 IPS</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1693"/>
+        <location filename="../qthost.cpp" line="1658"/>
         <source>Video: %1 FPS (%2%)</source>
-        <translation type="unfinished"></translation>
+        <translation>Vidéo : %1 IPS (%2%)</translation>
     </message>
 </context>
 <context>
@@ -4595,222 +4959,247 @@ Achievements: %5 (%6)
     <message>
         <location filename="../emulationsettingswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="32"/>
         <source>Speed Control</source>
-        <translation type="unfinished">Contrôle de la Vitesse</translation>
+        <translation>Contrôle de la vitesse</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="38"/>
         <source>Emulation Speed:</source>
-        <translation type="unfinished">Vitesse de l’Emulation</translation>
+        <translation>Vitesse de l’émulation :</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="48"/>
         <source>Fast Forward Speed:</source>
-        <translation type="unfinished">Vitesse de l&apos;Avance Rapide</translation>
+        <translation>Vitesse de l&apos;avance rapide :</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="58"/>
         <source>Turbo Speed:</source>
-        <translation type="unfinished"></translation>
+        <translation>Vitesse turbo :</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="71"/>
-        <source>Rewind/Runahead</source>
-        <translation type="unfinished"></translation>
+        <location filename="../emulationsettingswidget.ui" line="70"/>
+        <location filename="../emulationsettingswidget.cpp" line="92"/>
+        <source>Sync To Host Refresh Rate</source>
+        <translation>Sync avec taux rafraîch. hôte</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="77"/>
+        <location filename="../emulationsettingswidget.cpp" line="98"/>
+        <source>Optimal Frame Pacing</source>
+        <translation>Rythme optimal d&apos;image</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.ui" line="89"/>
+        <source>Rewind/Runahead</source>
+        <translatorcomment>Laissé tel-quel</translatorcomment>
+        <translation>Rewind/Runahead</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.ui" line="95"/>
         <source>Enable Rewinding</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer le rewinding</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="84"/>
+        <location filename="../emulationsettingswidget.ui" line="102"/>
         <source>Rewind Save Frequency:</source>
-        <translation type="unfinished"></translation>
+        <translation>Fréquence de sauve :</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="91"/>
+        <location filename="../emulationsettingswidget.ui" line="109"/>
         <source> Seconds</source>
-        <translation type="unfinished"></translation>
+        <translation> secondes</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="104"/>
+        <location filename="../emulationsettingswidget.ui" line="122"/>
         <source>Rewind Buffer Size:</source>
-        <translation type="unfinished"></translation>
+        <translation>Taille du buffer :</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="111"/>
+        <location filename="../emulationsettingswidget.ui" line="129"/>
         <source> Frames</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.ui" line="124"/>
-        <source>Runahead:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.ui" line="132"/>
-        <location filename="../emulationsettingswidget.cpp" line="94"/>
-        <source>Disabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.ui" line="137"/>
-        <source>1 Frame</source>
-        <translation type="unfinished"></translation>
+        <translation> images</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="142"/>
+        <source>Runahead:</source>
+        <translation>Runahead :</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.ui" line="150"/>
+        <location filename="../emulationsettingswidget.cpp" line="110"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.ui" line="155"/>
+        <source>1 Frame</source>
+        <translation>1 image</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.ui" line="160"/>
         <source>2 Frames</source>
-        <translation type="unfinished"></translation>
+        <translation>2 images</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="147"/>
+        <location filename="../emulationsettingswidget.ui" line="165"/>
         <source>3 Frames</source>
-        <translation type="unfinished"></translation>
+        <translation>3 images</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="152"/>
+        <location filename="../emulationsettingswidget.ui" line="170"/>
         <source>4 Frames</source>
-        <translation type="unfinished"></translation>
+        <translation>4 images</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="157"/>
+        <location filename="../emulationsettingswidget.ui" line="175"/>
         <source>5 Frames</source>
-        <translation type="unfinished"></translation>
+        <translation>5 images</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="162"/>
+        <location filename="../emulationsettingswidget.ui" line="180"/>
         <source>6 Frames</source>
-        <translation type="unfinished"></translation>
+        <translation>6 images</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="167"/>
+        <location filename="../emulationsettingswidget.ui" line="185"/>
         <source>7 Frames</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.ui" line="172"/>
-        <source>8 Frames</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.ui" line="177"/>
-        <source>9 Frames</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.ui" line="182"/>
-        <source>10 Frames</source>
-        <translation type="unfinished"></translation>
+        <translation>7 images</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="190"/>
+        <source>8 Frames</source>
+        <translation>8 images</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.ui" line="195"/>
+        <source>9 Frames</source>
+        <translation>9 images</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.ui" line="200"/>
+        <source>10 Frames</source>
+        <translation>10 images</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.ui" line="208"/>
         <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="76"/>
-        <source>Emulation Speed</source>
-        <translation type="unfinished">Vitesse de l&apos;Emulation</translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="77"/>
-        <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached, and if not, the emulator will run as fast as it can manage.</source>
-        <translation type="unfinished">Définit la vitesse d&apos;émulation de la cible. Il n&apos;est pas garanti que cette vitesse sera atteinte, et si ce n&apos;est pas le cas, l&apos;émulateur fonctionnera aussi vite qu&apos;il le pourra.</translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="80"/>
-        <source>Fast Forward Speed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="80"/>
-        <location filename="../emulationsettingswidget.cpp" line="83"/>
-        <source>User Preference</source>
-        <translation type="unfinished"></translation>
+        <translation>TextLabel</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.cpp" line="81"/>
+        <source>Emulation Speed</source>
+        <translation>Vitesse de l&apos;émulation</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="82"/>
+        <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached, and if not, the emulator will run as fast as it can manage.</source>
+        <translation>Définis la vitesse d&apos;émulation de la cible. Il n&apos;est pas garanti que cette vitesse soit atteinte, et si ce n&apos;est pas le cas, l&apos;émulateur fonctionnera aussi vite qu&apos;il le pourra.</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="85"/>
+        <source>Fast Forward Speed</source>
+        <translation>Vitesse d&apos;avance rapide</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="85"/>
+        <location filename="../emulationsettingswidget.cpp" line="88"/>
+        <source>User Preference</source>
+        <translation>Préférence utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="86"/>
         <source>Sets the fast forward speed. This speed will be used when the fast forward hotkey is pressed/toggled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="83"/>
-        <source>Turbo Speed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="84"/>
-        <source>Sets the turbo speed. This speed will be used when the turbo hotkey is pressed/toggled. Turboing will take priority over fast forwarding if both hotkeys are pressed/toggled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="87"/>
-        <source>Rewinding</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="87"/>
-        <source>Unchecked</source>
-        <translation type="unfinished">Décoché</translation>
+        <translation>Définis la vitesse d&apos;avance rapide. Cette vitesse sera utilisée quand le raccourci d&apos;avance rapide sera pressé/basculé.</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.cpp" line="88"/>
+        <source>Turbo Speed</source>
+        <translation>Vitesse turbo</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="89"/>
+        <source>Sets the turbo speed. This speed will be used when the turbo hotkey is pressed/toggled. Turboing will take priority over fast forwarding if both hotkeys are pressed/toggled.</source>
+        <translation>Définis la vitesse turbo. Cette vitesse sera utilisée quand le raccourci turbo sera pressé/basculé. Le turbo sera prioritaire sur l&apos;avance rapide si les deux raccourcis sont pressés/basculés.</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="103"/>
+        <source>Rewinding</source>
+        <translation>Rewinding</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="92"/>
+        <location filename="../emulationsettingswidget.cpp" line="98"/>
+        <location filename="../emulationsettingswidget.cpp" line="103"/>
+        <source>Unchecked</source>
+        <translation>Décoché</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="93"/>
+        <source>Adjusts the emulation speed so the console&apos;s refresh rate matches the host&apos;s refresh rate when both VSync and Audio Resampling settings are enabled. This results in the smoothest animations possible, at the cost of potentially increasing the emulation speed by less than 1%. Sync To Host Refresh Rate will not take effect if the console&apos;s refresh rate is too far from the host&apos;s refresh rate. Users with variable refresh rate displays should disable this option.</source>
+        <translation>Ajuste la vitesse d&apos;émulation de façon à ce que le taux de rafraîchissement de la console corresponde à celui de l&apos;hôte quand les options de VSync et rééchantillonnage audio sont activées. Cela résulte en des animations possiblement plus lisses, au coût d&apos;une potentielle augmentation de la vitesse d&apos;émulation inférieure à 1%. Sync. avec le tx de rafraîch. de l&apos;hôte ne prendre effet que si le taux de rafraîchissement de la console est trop éloigné de celui de l&apos;hôte. Les utilisateurs avec un taux de rafraîchissement variable devraient désactiver cette option.</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="99"/>
+        <source>Enable this option will ensure every frame the console renders is displayed to the screen, for optimal frame pacing. If you are having difficulties maintaining full speed, or are getting audio glitches, try disabling this option.</source>
+        <translation>Activer cette option fera en sorte que chaque image que la console rend est affichée à l&apos;écran, pour un frame pacing optimal. Si vous avez des diffultés à maintenant la pleine vitesse, ou que vous avez des glitchs audio, essayez de désactiver cette option.</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="104"/>
         <source>&lt;b&gt;Enable Rewinding:&lt;/b&gt; Saves state periodically so you can rewind any mistakes while playing.&lt;br&gt; &lt;b&gt;Rewind Save Frequency:&lt;/b&gt; How often a rewind state will be created. Higher frequencies have greater system requirements.&lt;br&gt; &lt;b&gt;Rewind Buffer Size:&lt;/b&gt; How many saves will be kept for rewinding. Higher values have greater memory requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="94"/>
-        <source>Runahead</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="95"/>
-        <source>Simulates the system ahead of time and rolls back/replays to reduce input lag. Very high system requirements.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../emulationsettingswidget.cpp" line="108"/>
-        <source>Use Global Setting [Unlimited]</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;Activer le rewinding :&lt;/b&gt; Sauvegarde périodiquement l&apos;état de façon à pouvoir revenir sur ses erreurs en jeu.&lt;br&gt; &lt;b&gt;Fréquence de sauvegarde du rewind :&lt;/b&gt; Tous les combien un état sera crée. Les fréquences les plus élevées ont des prérequis systèmes plus grands.&lt;br&gt; &lt;b&gt;Taille du tampon du rewind :&lt;/b&gt; Combien de sauvegarde seront conservées pour le rewinding. Les valeurs plus élevées ont des prérequis mémoire plus grands.</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.cpp" line="110"/>
+        <source>Runahead</source>
+        <translation>Runahead</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="111"/>
+        <source>Simulates the system ahead of time and rolls back/replays to reduce input lag. Very high system requirements.</source>
+        <translation>Simule le système en avance sur le temps et revient en arrière/rejoue pour réduire l&apos;input lag. Très haute configuration système requise.</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="124"/>
+        <source>Use Global Setting [Unlimited]</source>
+        <translation>Utiliser le paramètre global [Illimité]</translation>
+    </message>
+    <message>
+        <location filename="../emulationsettingswidget.cpp" line="126"/>
         <source>Use Global Setting [%1%]</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser le paramètre global [%1%]</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="113"/>
+        <location filename="../emulationsettingswidget.cpp" line="129"/>
         <source>Unlimited</source>
-        <translation type="unfinished">Illimité</translation>
+        <translation>Illimité</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="119"/>
+        <location filename="../emulationsettingswidget.cpp" line="135"/>
         <source>%1% [%2 FPS (NTSC) / %3 FPS (PAL)]</source>
-        <translation type="unfinished"></translation>
+        <translation>%1% [%2 IPS (NTSC) / %3 IPS (PAL)]</translation>
     </message>
     <message numerus="yes">
-        <location filename="../emulationsettingswidget.cpp" line="180"/>
+        <location filename="../emulationsettingswidget.cpp" line="196"/>
         <source>Rewind for %n frame(s), lasting %1 second(s) will require up to %2MB of RAM and %3MB of VRAM.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Rewind pour %n image(s), durer %1 seconde(s) nécessitera jusqu&apos;à %2MB de RAM et %3MB de VRAM.</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="191"/>
+        <location filename="../emulationsettingswidget.cpp" line="207"/>
         <source>Rewind is disabled because runahead is enabled. Runahead will significantly increase system requirements.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le rewind est désactivé parce que le runahead est activé. Runahead augmentera significativement les prérequis système.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="197"/>
+        <location filename="../emulationsettingswidget.cpp" line="213"/>
         <source>Rewind is not enabled. Please note that enabling rewind may significantly increase system requirements.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le rewind est désactivé. Veuillez noter qu&apos;activer le rewind peut augmenter significativement les prérequis système.</translation>
     </message>
 </context>
 <context>
@@ -4837,13 +5226,13 @@ Achievements: %5 (%6)
     </message>
     <message>
         <location filename="../enhancementsettingswidget.ui" line="58"/>
-        <location filename="../enhancementsettingswidget.cpp" line="63"/>
+        <location filename="../enhancementsettingswidget.cpp" line="70"/>
         <source>True Color Rendering (24-bit, disables dithering)</source>
         <translation>Rendu en Vrai Couleur (24-bit, désactive le lissage)</translation>
     </message>
     <message>
         <location filename="../enhancementsettingswidget.ui" line="65"/>
-        <location filename="../enhancementsettingswidget.cpp" line="70"/>
+        <location filename="../enhancementsettingswidget.cpp" line="77"/>
         <source>Scaled Dithering (scale dither pattern to resolution)</source>
         <translation>Echelle du Lissage (modèle de lissage à l&apos;échelle pour la résolution)</translation>
     </message>
@@ -4855,194 +5244,235 @@ Achievements: %5 (%6)
     <message>
         <location filename="../enhancementsettingswidget.ui" line="79"/>
         <source>Software Renderer Readbacks (run in parallel for VRAM-&gt;CPU transfers)</source>
-        <translation type="unfinished"></translation>
+        <translation>Relectures du rendu logiciel (tourne en parallèle pour les transferts VRAM -&gt; CPU)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="89"/>
+        <location filename="../enhancementsettingswidget.ui" line="86"/>
+        <source>Downsampling:</source>
+        <translation>Sous-échantillonnage :</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.ui" line="99"/>
         <source>Display Enhancements</source>
-        <translation>Améliorations de l&apos;Affichage</translation>
+        <translation>Améliorations de l&apos;affichage</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="95"/>
-        <location filename="../enhancementsettingswidget.cpp" line="52"/>
+        <location filename="../enhancementsettingswidget.ui" line="105"/>
+        <location filename="../enhancementsettingswidget.cpp" line="59"/>
         <source>Disable Interlacing (force progressive render/scan)</source>
-        <translation>Désactiver l&apos;Entrelacement (Forcer le Rendu/Scan progressif)</translation>
+        <translation>Désactiver l&apos;entrelacement (force le rendu/scan progressif)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="102"/>
-        <location filename="../enhancementsettingswidget.cpp" line="73"/>
+        <location filename="../enhancementsettingswidget.ui" line="112"/>
+        <location filename="../enhancementsettingswidget.cpp" line="80"/>
         <source>Force NTSC Timings (60hz-on-PAL)</source>
-        <translation>Forcer les Timings NTSC (60hz-en-PAL)</translation>
+        <translation>Forcer les timings NTSC (60hz-en-PAL)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="109"/>
+        <location filename="../enhancementsettingswidget.ui" line="119"/>
         <source>Force 4:3 For 24-Bit Display (disable widescreen for FMVs)</source>
-        <translation>Forcer le 4:3 pour l&apos;Affichage en 24-Bit (désactive l&apos;écran large pour les FMVs)</translation>
-    </message>
-    <message>
-        <location filename="../enhancementsettingswidget.ui" line="116"/>
-        <source>Chroma Smoothing For 24-Bit Display (reduce FMV color blockyness)</source>
-        <translation type="unfinished"></translation>
+        <translation>Forcer le 4:3 pour l&apos;affichage en 24-Bit (désactive l&apos;écran large pour les FMVs)</translation>
     </message>
     <message>
         <location filename="../enhancementsettingswidget.ui" line="126"/>
+        <source>Chroma Smoothing For 24-Bit Display (reduce FMV color blockyness)</source>
+        <translation>Lissage chroma. pour l&apos;affichage 24-Bit (réduit l&apos;aspect bloc des coul. des FMV)</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.ui" line="136"/>
         <source>PGXP (Precision Geometry Transform Pipeline)</source>
         <translation>PGXP (Precision Geometry Transform Pipeline)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="132"/>
-        <location filename="../enhancementsettingswidget.cpp" line="101"/>
+        <location filename="../enhancementsettingswidget.ui" line="149"/>
+        <location filename="../enhancementsettingswidget.cpp" line="115"/>
+        <source>Perspective Correct Textures</source>
+        <translation>Textures en perspective correcte</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.ui" line="156"/>
+        <location filename="../enhancementsettingswidget.cpp" line="109"/>
         <source>Geometry Correction</source>
-        <translation>Correction de la Géométrie</translation>
+        <translation>Correction de la géométrie</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="139"/>
-        <location filename="../enhancementsettingswidget.cpp" line="104"/>
+        <location filename="../enhancementsettingswidget.ui" line="184"/>
+        <location filename="../enhancementsettingswidget.cpp" line="119"/>
+        <source>Perspective Correct Colors</source>
+        <translation>Couleurs en perspective correcte</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.ui" line="142"/>
+        <location filename="../enhancementsettingswidget.cpp" line="112"/>
         <source>Culling Correction</source>
-        <translation>Correction du Culling</translation>
+        <translation>Correction du culling</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="146"/>
-        <location filename="../enhancementsettingswidget.cpp" line="107"/>
         <source>Texture Correction</source>
-        <translation>Correction de la Texture</translation>
+        <translation type="vanished">Correction de la Texture</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="153"/>
-        <location filename="../enhancementsettingswidget.cpp" line="115"/>
+        <location filename="../enhancementsettingswidget.ui" line="177"/>
+        <location filename="../enhancementsettingswidget.cpp" line="127"/>
         <source>Preserve Projection Precision</source>
-        <translation type="unfinished"></translation>
+        <translation>Préserver la précision de la projection</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="160"/>
-        <location filename="../enhancementsettingswidget.cpp" line="111"/>
+        <location filename="../enhancementsettingswidget.ui" line="170"/>
+        <location filename="../enhancementsettingswidget.cpp" line="123"/>
         <source>Depth Buffer (Low Compatibility)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampon de profondeur (faible compat.)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="167"/>
-        <location filename="../enhancementsettingswidget.cpp" line="117"/>
+        <location filename="../enhancementsettingswidget.ui" line="163"/>
+        <location filename="../enhancementsettingswidget.cpp" line="129"/>
         <source>CPU Mode (Very Slow)</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode CPU (très lent)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="52"/>
-        <location filename="../enhancementsettingswidget.cpp" line="63"/>
-        <location filename="../enhancementsettingswidget.cpp" line="73"/>
+        <location filename="../enhancementsettingswidget.cpp" line="55"/>
+        <source>Downsampling</source>
+        <translation>Sous-échantillonnage</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="55"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="56"/>
+        <source>Downsamples the rendered image prior to displaying it. Can improve overall image quality in mixed 2D/3D games, but should be disabled for pure 3D games. Only applies to the hardware renderers.</source>
+        <translation>Sous-échantillonne l&apos;image rendu avant son affichage. Peut améliorer la qualité globale de l&apos;image dans les jeux mixtes 2D/3D, mais devrait être désactivé pour les jeux pur 3D. S&apos;applique uniquement aux rendus matériels.</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="59"/>
+        <location filename="../enhancementsettingswidget.cpp" line="70"/>
         <location filename="../enhancementsettingswidget.cpp" line="80"/>
-        <location filename="../enhancementsettingswidget.cpp" line="82"/>
-        <location filename="../enhancementsettingswidget.cpp" line="91"/>
-        <location filename="../enhancementsettingswidget.cpp" line="97"/>
-        <location filename="../enhancementsettingswidget.cpp" line="101"/>
-        <location filename="../enhancementsettingswidget.cpp" line="111"/>
-        <location filename="../enhancementsettingswidget.cpp" line="115"/>
-        <location filename="../enhancementsettingswidget.cpp" line="117"/>
+        <location filename="../enhancementsettingswidget.cpp" line="87"/>
+        <location filename="../enhancementsettingswidget.cpp" line="89"/>
+        <location filename="../enhancementsettingswidget.cpp" line="99"/>
+        <location filename="../enhancementsettingswidget.cpp" line="105"/>
+        <location filename="../enhancementsettingswidget.cpp" line="109"/>
+        <location filename="../enhancementsettingswidget.cpp" line="119"/>
+        <location filename="../enhancementsettingswidget.cpp" line="123"/>
+        <location filename="../enhancementsettingswidget.cpp" line="127"/>
+        <location filename="../enhancementsettingswidget.cpp" line="129"/>
         <source>Unchecked</source>
         <translation>Décoché</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="53"/>
+        <location filename="../enhancementsettingswidget.cpp" line="60"/>
         <source>Forces the rendering and display of frames to progressive mode. &lt;br&gt;This removes the &quot;combing&quot; effect seen in 480i games by rendering them in 480p. Usually safe to enable.&lt;br&gt; &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Force le rendu et l&apos;affichage des images en mode progressif. &lt;br&gt;Ceci supprime l&apos;effet &quot;combing&quot; vu dans les jeux en 480i en les passant en 480p. Généralement sans danger à activer.&quot;&lt;br&gt;b&gt;&lt;u&gt;Peut ne pas être compatible avec tous les jeux.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="58"/>
+        <location filename="../enhancementsettingswidget.cpp" line="65"/>
         <source>Resolution Scale</source>
         <translation>Echelle de la Résolution</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="59"/>
+        <location filename="../enhancementsettingswidget.cpp" line="66"/>
         <source>Setting this beyond 1x will enhance the resolution of rendered 3D polygons and lines. Only applies to the hardware backends. &lt;br&gt;This option is usually safe, with most games looking fine at higher resolutions. Higher resolutions require a more powerful GPU.</source>
         <translation>En paramétrant à plus de 1x, on améliore la résolution du rendu des polygones et des lignes 3D. S&apos;applique uniquement aux moteurs matériels. Cette option est généralement sans danger, la plupart des jeux ayant l&apos;air bien à des résolutions plus élevées. Les résolutions plus élevées nécessitent un GPU plus puissant.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="64"/>
+        <location filename="../enhancementsettingswidget.cpp" line="71"/>
         <source>Forces the precision of colours output to the console&apos;s framebuffer to use the full 8 bits of precision per channel. This produces nicer looking gradients at the cost of making some colours look slightly different. Disabling the option also enables dithering, which makes the transition between colours less sharp by applying a pattern around those pixels. Most games are compatible with this option, but there is a number which aren&apos;t and will have broken effects with it enabled. Only applies to the hardware renderers.</source>
         <translation>Force la précision de la sortie des couleurs vers le tampon image de la console pour utiliser les 8 bits complets de précision par canal. Cela permet d&apos;obtenir des dégradés plus beaux au prix d&apos;une apparence légèrement différente pour certaines couleurs. La désactivation de l&apos;option permet également d&apos;activer le lissage, qui rend la transition entre les couleurs moins nette en appliquant un motif autour de ces pixels. La plupart des jeux sont compatibles avec cette option, mais il y en a un certain nombre qui ne le seront pas et qui auront des effets non fonctionnels si elle est activée. Ne s&apos;applique qu&apos;aux moteurs de rendu matériels.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="70"/>
-        <location filename="../enhancementsettingswidget.cpp" line="104"/>
-        <location filename="../enhancementsettingswidget.cpp" line="107"/>
+        <location filename="../enhancementsettingswidget.cpp" line="77"/>
+        <location filename="../enhancementsettingswidget.cpp" line="112"/>
+        <location filename="../enhancementsettingswidget.cpp" line="115"/>
         <source>Checked</source>
         <translation>Coché</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="71"/>
+        <location filename="../enhancementsettingswidget.cpp" line="78"/>
         <source>Scales the dither pattern to the resolution scale of the emulated GPU. This makes the dither pattern much less obvious at higher resolutions. &lt;br&gt;Usually safe to enable, and only supported by the hardware renderers.</source>
         <translation>Met à l&apos;échelle du modèle de lissage à l&apos;échelle de résolution du GPU émulé. Cela rend le modèle du lissage beaucoup moins apparent à des résolutions plus élevées. &lt;br&gt;Activer cette option est en général sécurisé, et seulement pris en charge par les moteurs de rendu matériels.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="74"/>
+        <location filename="../enhancementsettingswidget.cpp" line="81"/>
         <source>Uses NTSC frame timings when the console is in PAL mode, forcing PAL games to run at 60hz. &lt;br&gt;For most games which have a speed tied to the framerate, this will result in the game running approximately 17% faster. &lt;br&gt;For variable frame rate games, it may not affect the speed.</source>
         <translation>Utilise la synchronisation des images NTSC lorsque la console est en mode PAL, ce qui oblige les jeux PAL à fonctionner à 60hz. &lt;br&gt;Pour la plupart des jeux dont la vitesse est liée à la fréquence d&apos;images, cela se traduira par un jeu fonctionnant environ 17% plus rapidement. &lt;br&gt;Pour les jeux à fréquence d&apos;images variable, cela peut ne pas affecter la vitesse.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="80"/>
+        <location filename="../enhancementsettingswidget.cpp" line="87"/>
         <source>Force 4:3 For 24-bit Display</source>
         <translation>Forcer en 4:3 pour l&apos;Affichage en 24-bit</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="81"/>
+        <location filename="../enhancementsettingswidget.cpp" line="88"/>
         <source>Switches back to 4:3 display aspect ratio when displaying 24-bit content, usually FMVs.</source>
         <translation>Revient au format d&apos;affichage 4:3 pour l&apos;affichage de contenu 24 bits, généralement des FMV.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="82"/>
+        <location filename="../enhancementsettingswidget.cpp" line="89"/>
         <source>Chroma Smoothing For 24-Bit Display</source>
-        <translation type="unfinished"></translation>
+        <translation>Lissage chroma. pour les affichages 24-Bit</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="83"/>
+        <location filename="../enhancementsettingswidget.cpp" line="90"/>
         <source>Smooths out blockyness between colour transitions in 24-bit content, usually FMVs. Only applies to the hardware renderers.</source>
-        <translation type="unfinished"></translation>
+        <translation>Lisse l&apos;aspect bloc entre les transitions de couleur pour les contenus 24-bit, habituellement les FMVs. S&apos;applique uniquement aux rendus matériels.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="86"/>
+        <location filename="../enhancementsettingswidget.cpp" line="93"/>
         <source>Texture Filtering</source>
-        <translation>Filtrage de Texture</translation>
+        <translation>Filtrage de texture</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="88"/>
-        <source>Smooths out the blockyness of magnified textures on 3D object by using filtering. &lt;br&gt;Will have a greater effect on higher resolution scales. Only applies to the hardware renderers.</source>
-        <translation type="unfinished"></translation>
+        <location filename="../enhancementsettingswidget.cpp" line="95"/>
+        <source>Smooths out the blockiness of magnified textures on 3D object by using filtering. &lt;br&gt;Will have a greater effect on higher resolution scales. Only applies to the hardware renderers. &lt;br&gt;The JINC2 and especially xBR filtering modes are very demanding, and may not be worth the speed penalty.</source>
+        <translation>Lisse l&apos;aspect bloc des textures magnifiées sur les objets 3D en utilisant du filtrage.&lt;br&gt;Aura un plus grand effet sur les grandes échelles de résolution. S&apos;applique uniquement aux rendus matériels.&lt;br&gt;Les modes de filtrage JINC2 et spécifiquement xBR sont très demandeurs, et peuvent ne pas valoir la peine pour la pénalité sur les performances.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="92"/>
+        <location filename="../enhancementsettingswidget.cpp" line="100"/>
         <source>Scales vertex positions in screen-space to a widescreen aspect ratio, essentially increasing the field of view from 4:3 to the chosen display aspect ratio in 3D games. &lt;br&gt;For 2D games, or games which use pre-rendered backgrounds, this enhancement will not work as expected. &lt;br&gt;&lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Mets à l&apos;échelle la position des vertices depuis l&apos;espace-écran vers un ratio d&apos;aspect écran large, essentiellement pour augmenter le champ de vision du 4:3 vers le ratio d&apos;aspect d&apos;affichage choisi pour les jeux 3D. &lt;br&gt;Pour les jeux 2D, ou les jeux qui ont des arrières-plans pré-rendus, cette amélioration ne fonctionne pas comme attendu. &lt;br&gt;&lt;b&gt;&lt;u&gt;Peut ne pas être compatible avec tous les jeux.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="97"/>
+        <location filename="../enhancementsettingswidget.cpp" line="105"/>
         <source>Use Software Renderer For Readbacks</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser le rendu logiciel pour les relectures</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="98"/>
+        <location filename="../enhancementsettingswidget.cpp" line="106"/>
         <source>Runs the software renderer in parallel for VRAM readbacks. On some systems, this may result in greater performance when using graphical enhancements with the hardware renderer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../enhancementsettingswidget.cpp" line="112"/>
-        <source>Attempts to reduce polygon Z-fighting by testing pixels against the depth values from PGXP. Low compatibility, but can work well in some games. Other games may need a threshold adjustment.</source>
-        <translation type="unfinished"></translation>
+        <translation>Fait tourner le rendu logiciel en parallèle pour les relectures de la VRAM. Sur certains systèmes, cela peut donner de meilleures performances quand des améliorations graphiques sont utilisées avec le rendu matériel.</translation>
     </message>
     <message>
         <location filename="../enhancementsettingswidget.cpp" line="116"/>
-        <source>Adds additional precision to PGXP data post-projection. May improve visuals in some games.</source>
-        <translation type="unfinished"></translation>
+        <source>Uses perspective-correct interpolation for texture coordinates, straightening out warped textures. Requires geometry correction enabled.</source>
+        <translation>Utilise l&apos;interpolation fidèle à la perspective pour les coordonnées des textures, redressant les textures déformées. Requiert que la correction de géométrie soit active.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="118"/>
+        <location filename="../enhancementsettingswidget.cpp" line="120"/>
+        <source>Uses perspective-correct interpolation for vertex colors, which can improve visuals in some games, but cause rendering errors in others. Requires geometry correction enabled.</source>
+        <translation>Utilise l&apos;interpolation fidèle à la perspective pour les couleurs des vertex, ce qui peut améliorer les visuels dans certains jeux, mais causer des erreurs de rendu dans d&apos;autres. Requiert que la correction de géométrie soit active.</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="124"/>
+        <source>Attempts to reduce polygon Z-fighting by testing pixels against the depth values from PGXP. Low compatibility, but can work well in some games. Other games may need a threshold adjustment.</source>
+        <translation>Essaye de réduire le Z-fighting polygonal en testant les pixels par rapport aux valeur de profondeur depuis PGXP. Faible compatibilité, mais peut marcher correctement dans certains jeux. Les autres jeux pourraient nécessiter un ajustement du seuil.</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="128"/>
+        <source>Adds additional precision to PGXP data post-projection. May improve visuals in some games.</source>
+        <translation>Ajoute une précision additionnelle à la post-projection des données PGXP. Peut améliorer les visuels dans certains jeux.</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="130"/>
         <source>Uses PGXP for all instructions, not just memory operations. Required for PGXP to correct wobble in some games, but has a very high performance cost.</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilise PGXP pour toutes les instructions, pas seulement les opérations mémoire. Nécessaire pour que PGXP corrige l&apos;oscillation dans certains jeux, mais à un coût sur les performances très élevé.</translation>
     </message>
     <message>
         <source>Smooths out the blockyness of magnified textures on 3D object by using bilinear filtering. &lt;br&gt;Will have a greater effect on higher resolution scales. Only applies to the hardware renderers.</source>
         <translation type="vanished">Lisse le blocage des textures agrandies sur l&apos;objet 3D en utilisant le filtrage bilinéaire. aura un effet plus important sur les échelles en haute résolution. S&apos;applique uniquement aux rendus matériels.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="91"/>
+        <location filename="../enhancementsettingswidget.cpp" line="99"/>
         <source>Widescreen Hack</source>
         <translation>Hack Ecran Large</translation>
     </message>
@@ -5051,19 +5481,18 @@ Achievements: %5 (%6)
         <translation type="vanished">Met à l&apos;échelle les positions des vertex dans l&apos;espace de l&apos;écran vers une proportion écran large, augmentant essentiellement le champ de vision de 4:3 à 16:9 dans les jeux 3D. &lt;br&gt;Pour les jeux 2D, ou les jeux qui utilisent des fonds pré-rendu, cette amélioration ne fonctionnera pas comme prévu. &lt;br&gt;&lt;b&gt;&lt;u&gt;Peut ne pas être compatible avec tous les jeux.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="102"/>
+        <location filename="../enhancementsettingswidget.cpp" line="110"/>
         <source>Reduces &quot;wobbly&quot; polygons and &quot;warping&quot; textures that are common in PS1 games. &lt;br&gt;Only works with the hardware renderers. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Réduits les polygones &quot;carrés&quot; et les textures &quot;distordues&quot; qui sont communes dans les jeux PS1. &lt;br&gt;Ne fonctionne qu&apos;avec les rendus matériels. &lt;b&gt;&lt;u&gt;Peut ne pas être compatible avec tous les jeux.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="105"/>
+        <location filename="../enhancementsettingswidget.cpp" line="113"/>
         <source>Increases the precision of polygon culling, reducing the number of holes in geometry. Requires geometry correction enabled.</source>
         <translation>Augmente la précision des polygones de culling en réduisant le nombre de trous dans la géométrie. Nécessite l&apos;activation de la correction de la géométrie.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="108"/>
         <source>Uses perspective-correct interpolation for texture coordinates and colors, straightening out warped textures. Requires geometry correction enabled.</source>
-        <translation>Utilise une interpolation en perspective correcte pour les coordonnées et les couleurs des textures, en redressant les textures déformées. Nécessite l&apos;activation de la correction de la géométrie.</translation>
+        <translation type="vanished">Utilise une interpolation en perspective correcte pour les coordonnées et les couleurs des textures, en redressant les textures déformées. Nécessite l&apos;activation de la correction de la géométrie.</translation>
     </message>
 </context>
 <context>
@@ -5071,12 +5500,12 @@ Achievements: %5 (%6)
     <message>
         <location filename="../foldersettingswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="32"/>
         <source>Cache Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Répertoire de cache</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="41"/>
@@ -5084,7 +5513,7 @@ Achievements: %5 (%6)
         <location filename="../foldersettingswidget.ui" line="121"/>
         <location filename="../foldersettingswidget.ui" line="161"/>
         <source>Browse...</source>
-        <translation type="unfinished">Parcourir...</translation>
+        <translation>Parcourir...</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="48"/>
@@ -5092,7 +5521,7 @@ Achievements: %5 (%6)
         <location filename="../foldersettingswidget.ui" line="128"/>
         <location filename="../foldersettingswidget.ui" line="168"/>
         <source>Open...</source>
-        <translation type="unfinished">Ouvrir...</translation>
+        <translation>Ouvrir...</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="55"/>
@@ -5100,86 +5529,86 @@ Achievements: %5 (%6)
         <location filename="../foldersettingswidget.ui" line="135"/>
         <location filename="../foldersettingswidget.ui" line="175"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Réinitialiser</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="62"/>
         <source>Used for storing shaders and game list data.</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilisé pour stocker les shaders et les données de la liste des jeux.</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="72"/>
         <source>Covers Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Répertoire des jaquettes</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="102"/>
         <source>Used for storing covers in the game grid/Big Picture UIs.</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser pour stocker les jaquettes de la grille des jeux/UIs Big Picture.</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="112"/>
         <source>Screenshots Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Répertoire des captures d&apos;écran</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="142"/>
         <source>Used for screenshots.</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilisé pour les captures d&apos;écran.</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="152"/>
         <source>Save States Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Répertoire des save states</translation>
     </message>
     <message>
         <location filename="../foldersettingswidget.ui" line="182"/>
         <source>Used for storing save states.</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilisé pour les save states.</translation>
     </message>
 </context>
 <context>
     <name>GPUDownsampleMode</name>
     <message>
-        <location filename="../../core/settings.cpp" line="913"/>
+        <location filename="../../core/settings.cpp" line="988"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactivé</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="913"/>
+        <location filename="../../core/settings.cpp" line="988"/>
         <source>Box (Downsample 3D/Smooth All)</source>
-        <translation type="unfinished"></translation>
+        <translation>Boîte (Sous-échantillonnage 3D/Tout lisser)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="914"/>
+        <location filename="../../core/settings.cpp" line="989"/>
         <source>Adaptive (Preserve 3D/Smooth 2D)</source>
-        <translation type="unfinished"></translation>
+        <translation>Adaptif (Préserver 3D/Lisser 2D)</translation>
     </message>
 </context>
 <context>
     <name>GPURenderer</name>
     <message>
-        <location filename="../../core/settings.cpp" line="821"/>
+        <location filename="../../core/settings.cpp" line="895"/>
         <source>Hardware (D3D11)</source>
         <translation>Matériel (D3D11)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="821"/>
+        <location filename="../../core/settings.cpp" line="895"/>
         <source>Hardware (D3D12)</source>
-        <translation type="unfinished">Matériel (D3D11) {3D?} {12)?}</translation>
+        <translation>Matériel (D3D12)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="824"/>
+        <location filename="../../core/settings.cpp" line="898"/>
         <source>Hardware (Vulkan)</source>
         <translation>Matériel (Vulkan)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="827"/>
+        <location filename="../../core/settings.cpp" line="901"/>
         <source>Hardware (OpenGL)</source>
         <translation>Matériel (OpenGL)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="829"/>
+        <location filename="../../core/settings.cpp" line="903"/>
         <source>Software</source>
         <translation>Logiciel</translation>
     </message>
@@ -5187,106 +5616,106 @@ Achievements: %5 (%6)
 <context>
     <name>GPUSettingsWidget</name>
     <message>
-        <location filename="../qtutils.cpp" line="684"/>
+        <location filename="../qtutils.cpp" line="696"/>
         <source>Automatic based on window size</source>
         <translation>Automatiquement basé sur la taille de la fenêtre</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="685"/>
+        <location filename="../qtutils.cpp" line="697"/>
         <source>1x</source>
         <translation>1x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="686"/>
+        <location filename="../qtutils.cpp" line="698"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="687"/>
+        <location filename="../qtutils.cpp" line="699"/>
         <source>3x (for 720p)</source>
         <translation>3x (pour le 720p)</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="688"/>
+        <location filename="../qtutils.cpp" line="700"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="689"/>
+        <location filename="../qtutils.cpp" line="701"/>
         <source>5x (for 1080p)</source>
         <translation>5x (pour le 1080p)</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="690"/>
+        <location filename="../qtutils.cpp" line="702"/>
         <source>6x (for 1440p)</source>
         <translation>6x (pour le 1440p)</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="691"/>
+        <location filename="../qtutils.cpp" line="703"/>
         <source>7x</source>
         <translation>7x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="692"/>
+        <location filename="../qtutils.cpp" line="704"/>
         <source>8x</source>
         <translation>8x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="693"/>
+        <location filename="../qtutils.cpp" line="705"/>
         <source>9x (for 4K)</source>
-        <translation type="unfinished">6x (pour le 1440p) {9x?} {4K?}</translation>
+        <translation>9x (pour le 4K)</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="726"/>
+        <location filename="../qtutils.cpp" line="738"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactivé</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="729"/>
+        <location filename="../qtutils.cpp" line="741"/>
         <source>%1x MSAA</source>
-        <translation type="unfinished"></translation>
+        <translation>%1x MSAA</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="732"/>
+        <location filename="../qtutils.cpp" line="744"/>
         <source>%1x SSAA</source>
-        <translation type="unfinished"></translation>
+        <translation>%1x SSAA</translation>
     </message>
     <message>
         <source>9x</source>
         <translation type="vanished">9x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="694"/>
+        <location filename="../qtutils.cpp" line="706"/>
         <source>10x</source>
         <translation>10x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="695"/>
+        <location filename="../qtutils.cpp" line="707"/>
         <source>11x</source>
         <translation>11x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="696"/>
+        <location filename="../qtutils.cpp" line="708"/>
         <source>12x</source>
         <translation>12x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="697"/>
+        <location filename="../qtutils.cpp" line="709"/>
         <source>13x</source>
         <translation>13x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="698"/>
+        <location filename="../qtutils.cpp" line="710"/>
         <source>14x</source>
         <translation>14x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="699"/>
+        <location filename="../qtutils.cpp" line="711"/>
         <source>15x</source>
         <translation>15x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="700"/>
+        <location filename="../qtutils.cpp" line="712"/>
         <source>16x</source>
         <translation>16x</translation>
     </message>
@@ -5294,93 +5723,151 @@ Achievements: %5 (%6)
 <context>
     <name>GPUTextureFilter</name>
     <message>
-        <location filename="../../core/settings.cpp" line="882"/>
+        <location filename="../../core/settings.cpp" line="956"/>
         <source>Nearest-Neighbor</source>
         <translation>Voisinage le plus proche</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="882"/>
+        <location filename="../../core/settings.cpp" line="956"/>
         <source>Bilinear</source>
         <translation>Bilinéaire</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="883"/>
+        <location filename="../../core/settings.cpp" line="957"/>
+        <source>JINC2 (Slow)</source>
+        <translation>JINC2 (lent)</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="958"/>
+        <source>JINC2 (Slow, No Edge Blending)</source>
+        <translation>JINC2 (lent, sans fusion des bords)</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="959"/>
+        <source>xBR (Very Slow)</source>
+        <translation>xBR (très lent)</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="960"/>
+        <source>xBR (Very Slow, No Edge Blending)</source>
+        <translation>xBR (très lent, sans fusion des bords)</translation>
+    </message>
+    <message>
         <source>JINC2</source>
-        <translation>JINC2</translation>
+        <translation type="vanished">JINC2</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="883"/>
+        <location filename="../../core/settings.cpp" line="957"/>
         <source>Bilinear (No Edge Blending)</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilinéaire (sans fusion des bords)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="884"/>
         <source>xBR</source>
-        <translation>xBR</translation>
-    </message>
-    <message>
-        <location filename="../../core/settings.cpp" line="884"/>
-        <source>JINC2 (No Edge Blending)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../core/settings.cpp" line="885"/>
-        <source>xBR (No Edge Blending)</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">xBR</translation>
     </message>
 </context>
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="71"/>
+        <location filename="../../frontend-common/game_list.cpp" line="105"/>
         <source>Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Disque</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="71"/>
+        <location filename="../../frontend-common/game_list.cpp" line="105"/>
         <source>PS-EXE</source>
-        <translation type="unfinished"></translation>
+        <translation>PS-EXE</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="71"/>
+        <location filename="../../frontend-common/game_list.cpp" line="105"/>
         <source>Playlist</source>
-        <translation type="unfinished"></translation>
+        <translation>Liste de lecture</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="72"/>
+        <location filename="../../frontend-common/game_list.cpp" line="106"/>
         <source>PSF</source>
-        <translation type="unfinished"></translation>
+        <translation>PSF</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="967"/>
+        <source>Never</source>
+        <translation>Jamais</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="984"/>
+        <source>Today</source>
+        <translation>Aujourd&apos;hui</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="989"/>
+        <source>Yesterday</source>
+        <translation>Hier</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="1012"/>
+        <source>{}h {}m</source>
+        <translation>{}h {}m</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="1014"/>
+        <source>{}h {}m {}s</source>
+        <translation>{}h {}m {}s</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="1016"/>
+        <source>{}m {}s</source>
+        <translation>{}m {}s</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="1018"/>
+        <source>{}s</source>
+        <translation>{}s</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="1020"/>
+        <source>None</source>
+        <translation>Aucun</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="1025"/>
+        <source>{} hours</source>
+        <translation>{} heures</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/game_list.cpp" line="1027"/>
+        <source>{} minutes</source>
+        <translation>{} minutes</translation>
     </message>
 </context>
 <context>
     <name>GameListCompatibilityRating</name>
     <message>
-        <location filename="../../core/game_database.cpp" line="203"/>
+        <location filename="../../core/game_database.cpp" line="202"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="204"/>
+        <location filename="../../core/game_database.cpp" line="203"/>
         <source>Doesn&apos;t Boot</source>
         <translation>Ne démarre pas</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="205"/>
+        <location filename="../../core/game_database.cpp" line="204"/>
         <source>Crashes In Intro</source>
         <translation>Plante sur l&apos;Intro</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="206"/>
+        <location filename="../../core/game_database.cpp" line="205"/>
         <source>Crashes In-Game</source>
         <translation>Plante dans le Jeu</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="207"/>
+        <location filename="../../core/game_database.cpp" line="206"/>
         <source>Graphical/Audio Issues</source>
         <translation>Problèmes Graphiques/Audio</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="208"/>
+        <location filename="../../core/game_database.cpp" line="207"/>
         <source>No Issues</source>
         <translation>Aucun Problème</translation>
     </message>
@@ -5388,62 +5875,76 @@ Achievements: %5 (%6)
 <context>
     <name>GameListModel</name>
     <message>
-        <location filename="../gamelistmodel.cpp" line="568"/>
+        <location filename="../gamelistmodel.cpp" line="605"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="569"/>
         <source>Code</source>
-        <translation>Code</translation>
+        <translation type="vanished">Code</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="570"/>
+        <location filename="../gamelistmodel.cpp" line="606"/>
+        <source>Serial</source>
+        <translation>Numéro de série</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="607"/>
         <source>Title</source>
         <translation>Titre</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="571"/>
+        <location filename="../gamelistmodel.cpp" line="608"/>
         <source>File Title</source>
         <translation>Titre du Fichier</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="572"/>
+        <location filename="../gamelistmodel.cpp" line="609"/>
         <source>Developer</source>
-        <translation type="unfinished">Développeur</translation>
+        <translation>Développeur</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="573"/>
+        <location filename="../gamelistmodel.cpp" line="610"/>
         <source>Publisher</source>
-        <translation type="unfinished"></translation>
+        <translation>Éditeur</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="574"/>
+        <location filename="../gamelistmodel.cpp" line="611"/>
         <source>Genre</source>
-        <translation type="unfinished"></translation>
+        <translation>Genre</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="575"/>
+        <location filename="../gamelistmodel.cpp" line="612"/>
         <source>Year</source>
-        <translation type="unfinished"></translation>
+        <translation>Année</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="576"/>
+        <location filename="../gamelistmodel.cpp" line="613"/>
         <source>Players</source>
-        <translation type="unfinished"></translation>
+        <translation>Joueurs</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="577"/>
+        <location filename="../gamelistmodel.cpp" line="614"/>
+        <source>Time Played</source>
+        <translation>Temps joué</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="615"/>
+        <source>Last Played</source>
+        <translation>Joué dernièrement</translation>
+    </message>
+    <message>
+        <location filename="../gamelistmodel.cpp" line="616"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="578"/>
+        <location filename="../gamelistmodel.cpp" line="617"/>
         <source>Region</source>
         <translation>Région</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="579"/>
+        <location filename="../gamelistmodel.cpp" line="618"/>
         <source>Compatibility</source>
         <translation>Comptabilité</translation>
     </message>
@@ -5451,12 +5952,12 @@ Achievements: %5 (%6)
 <context>
     <name>GameListSearchDirectoriesModel</name>
     <message>
-        <location filename="../gamelistsearchdirectoriesmodel.cpp" line="30"/>
+        <location filename="../gamelistsearchdirectoriesmodel.cpp" line="33"/>
         <source>Path</source>
         <translation>Chemin</translation>
     </message>
     <message>
-        <location filename="../gamelistsearchdirectoriesmodel.cpp" line="32"/>
+        <location filename="../gamelistsearchdirectoriesmodel.cpp" line="35"/>
         <source>Recursive</source>
         <translation>Récursif</translation>
     </message>
@@ -5475,7 +5976,7 @@ Achievements: %5 (%6)
     <message>
         <location filename="../gamelistsettingswidget.ui" line="34"/>
         <source>Search Directories (will be scanned for games)</source>
-        <translation type="unfinished"></translation>
+        <translation>Répertoires de recherche (seront scannés pour des jeux)</translation>
     </message>
     <message>
         <location filename="../gamelistsettingswidget.ui" line="60"/>
@@ -5486,24 +5987,24 @@ Achievements: %5 (%6)
     <message>
         <location filename="../gamelistsettingswidget.ui" line="76"/>
         <location filename="../gamelistsettingswidget.ui" line="135"/>
-        <location filename="../gamelistsettingswidget.cpp" line="101"/>
+        <location filename="../gamelistsettingswidget.cpp" line="105"/>
         <source>Remove</source>
-        <translation>Enlever</translation>
+        <translation type="unfinished">Enlever</translation>
     </message>
     <message>
         <location filename="../gamelistsettingswidget.ui" line="93"/>
         <source>Excluded Paths (will not be scanned)</source>
-        <translation type="unfinished"></translation>
+        <translation>Chemins à exclure (ne seront pas scannés)</translation>
     </message>
     <message>
         <location filename="../gamelistsettingswidget.ui" line="171"/>
         <source>Scan For New Games</source>
-        <translation type="unfinished"></translation>
+        <translation>Chercher les nouveaux jeux</translation>
     </message>
     <message>
         <location filename="../gamelistsettingswidget.ui" line="187"/>
         <source>Rescan All Games</source>
-        <translation type="unfinished"></translation>
+        <translation>Re-chercher tous les jeux</translation>
     </message>
     <message>
         <source>Scan New</source>
@@ -5518,22 +6019,22 @@ Achievements: %5 (%6)
         <translation type="vanished">Mise à Jour de la BDD Redump</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="103"/>
+        <location filename="../gamelistsettingswidget.cpp" line="107"/>
         <source>Open Directory...</source>
         <translation>Ouvrir le Répertoire...</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="111"/>
+        <location filename="../gamelistsettingswidget.cpp" line="115"/>
         <source>Select Search Directory</source>
         <translation>Sélectionner le Répertoire de Recherche</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="117"/>
+        <location filename="../gamelistsettingswidget.cpp" line="121"/>
         <source>Scan Recursively?</source>
         <translation>Scan récursif?</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="118"/>
+        <location filename="../gamelistsettingswidget.cpp" line="122"/>
         <source>Would you like to scan the directory &quot;%1&quot; recursively?
 
 Scanning recursively takes more time, but will identify files in subdirectories.</source>
@@ -5542,9 +6043,9 @@ Scanning recursively takes more time, but will identify files in subdirectories.
 L&apos;analyse récursive prend plus de temps, mais elle permet d&apos;identifier les fichiers dans les sous-répertoires.</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="147"/>
+        <location filename="../gamelistsettingswidget.cpp" line="151"/>
         <source>Select Path</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner un chemin</translation>
     </message>
     <message>
         <source>Download database from redump.org?</source>
@@ -5588,37 +6089,37 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
     <message>
         <location filename="../gamelistwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Formulaire</translation>
+        <translation>Formulaire</translation>
     </message>
     <message>
         <location filename="../gamelistwidget.ui" line="60"/>
         <source>Game List</source>
-        <translation type="unfinished"></translation>
+        <translation>Liste de jeux</translation>
     </message>
     <message>
         <location filename="../gamelistwidget.ui" line="83"/>
         <source>Game Grid</source>
-        <translation type="unfinished"></translation>
+        <translation>Grille de jeux</translation>
     </message>
     <message>
         <location filename="../gamelistwidget.ui" line="106"/>
         <source>Show Titles</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher les titres</translation>
     </message>
     <message>
         <location filename="../gamelistwidget.ui" line="169"/>
         <source>All Types</source>
-        <translation type="unfinished"></translation>
+        <translation>Tous les types</translation>
     </message>
     <message>
         <location filename="../gamelistwidget.ui" line="182"/>
         <source>All Regions</source>
-        <translation type="unfinished"></translation>
+        <translation>Toutes les régions</translation>
     </message>
     <message>
         <location filename="../gamelistwidget.ui" line="200"/>
         <source>Search...</source>
-        <translation type="unfinished"></translation>
+        <translation>Rechercher...</translation>
     </message>
 </context>
 <context>
@@ -5923,96 +6424,105 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
 <context>
     <name>GameSettingsTrait</name>
     <message>
-        <location filename="../../core/game_database.cpp" line="48"/>
+        <location filename="../../core/game_database.cpp" line="51"/>
         <source>Force Interpreter</source>
         <translation>Forcer l&apos;Interpréteur</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="49"/>
+        <location filename="../../core/game_database.cpp" line="52"/>
         <source>Force Software Renderer</source>
         <translation>Forcer le Rendu Logiciel</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="50"/>
+        <location filename="../../core/game_database.cpp" line="53"/>
         <source>Force Software Renderer For Readbacks</source>
-        <translation type="unfinished"></translation>
+        <translation>Forcer le rendu logiciel pour les relectures</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="51"/>
+        <location filename="../../core/game_database.cpp" line="54"/>
         <source>Force Interlacing</source>
         <translation>Forcer l&apos;Entrelacement</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="52"/>
+        <location filename="../../core/game_database.cpp" line="55"/>
         <source>Disable True Color</source>
         <translation>Désactiver la Vrai Couleur</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="53"/>
+        <location filename="../../core/game_database.cpp" line="56"/>
         <source>Disable Upscaling</source>
         <translation>Désactiver L&apos;Upscaling</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="54"/>
+        <location filename="../../core/game_database.cpp" line="57"/>
         <source>Disable Scaled Dithering</source>
         <translation>Désactiver l&apos;Echelle du Lissage</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="55"/>
+        <location filename="../../core/game_database.cpp" line="58"/>
         <source>Disallow Forcing NTSC Timings</source>
         <translation>Ne pas autoriser le forcage des Timings NTSC</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="56"/>
+        <location filename="../../core/game_database.cpp" line="59"/>
         <source>Disable Widescreen</source>
         <translation>Désactiver l&apos;Ecran Large</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="57"/>
+        <location filename="../../core/game_database.cpp" line="60"/>
         <source>Disable PGXP</source>
         <translation>Désactiver PGXP</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="58"/>
+        <location filename="../../core/game_database.cpp" line="61"/>
         <source>Disable PGXP Culling</source>
         <translation>Désactiver le Culling PGXP</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="59"/>
-        <source>Disable PGXP Texture Correction</source>
-        <translation>Désactiver la Correction de Texture PGXP</translation>
-    </message>
-    <message>
-        <location filename="../../core/game_database.cpp" line="60"/>
-        <source>Disable PGXP Depth Buffer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../core/game_database.cpp" line="61"/>
-        <source>Force PGXP Vertex Cache</source>
-        <translation>Forcer le Cache Vertex de PGXP</translation>
-    </message>
-    <message>
         <location filename="../../core/game_database.cpp" line="62"/>
-        <source>Force PGXP CPU Mode</source>
-        <translation>Forcer le Mode CPU PGXP</translation>
+        <source>Disable PGXP Perspective Correct Textures</source>
+        <translation>Désactiver les textures fidèles à la perspective PGXP</translation>
+    </message>
+    <message>
+        <location filename="../../core/game_database.cpp" line="63"/>
+        <source>Disable PGXP Perspective Correct Colors</source>
+        <translation>Désactiver les couleurs fidèles à la perspective PGXP</translation>
+    </message>
+    <message>
+        <source>Disable PGXP Texture Correction</source>
+        <translation type="vanished">Désactiver la Correction de Texture PGXP</translation>
+    </message>
+    <message>
+        <location filename="../../core/game_database.cpp" line="64"/>
+        <source>Disable PGXP Depth Buffer</source>
+        <translation>Désactiver le tampon de profondeur PGXP</translation>
     </message>
     <message>
         <location filename="../../core/game_database.cpp" line="65"/>
+        <source>Force PGXP Vertex Cache</source>
+        <translation>Forcer le cache vertex PGXP</translation>
+    </message>
+    <message>
+        <location filename="../../core/game_database.cpp" line="66"/>
+        <source>Force PGXP CPU Mode</source>
+        <translation>Forcer le mode CPU PGXP</translation>
+    </message>
+    <message>
+        <location filename="../../core/game_database.cpp" line="69"/>
         <source>Force Recompiler LUT Fastmem</source>
-        <translation type="unfinished"></translation>
+        <translation>Forcer le recompilateur LUT Fastmem</translation>
     </message>
     <message>
         <source>Force Digital Controller</source>
         <translation type="vanished">Forcer le Contrôleur Digital</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="63"/>
+        <location filename="../../core/game_database.cpp" line="67"/>
         <source>Force Recompiler Memory Exceptions</source>
         <translation>Forcer les Exceptions Mémoire du Recompileur</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="64"/>
+        <location filename="../../core/game_database.cpp" line="68"/>
         <source>Force Recompiler ICache</source>
         <translation>Forcer l&apos;ICache du Recompileur</translation>
     </message>
@@ -6022,195 +6532,196 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
     <message>
         <location filename="../gamesummarywidget.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished">Dialogue</translation>
+        <translation>Dialogue</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="57"/>
         <source>Image Path:</source>
-        <translation type="unfinished">Chemin de l&apos;Image:</translation>
+        <translation>Chemin de l&apos;image :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="71"/>
         <source>Serial:</source>
-        <translation type="unfinished"></translation>
+        <translation>Numéro de série :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="88"/>
         <source>#</source>
-        <translation type="unfinished">#</translation>
+        <translation>#</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="93"/>
         <source>Mode</source>
-        <translation type="unfinished">Mode</translation>
+        <translation>Mode</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="98"/>
         <source>Start</source>
-        <translation type="unfinished">Start</translation>
+        <translation>Début</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="103"/>
         <source>Length</source>
-        <translation type="unfinished">Longueur</translation>
+        <translation>Longueur</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="108"/>
         <source>Hash</source>
-        <translation type="unfinished">Hash</translation>
+        <translation>Hashage</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="113"/>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Statut</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="121"/>
         <source>Region:</source>
-        <translation type="unfinished"></translation>
+        <translation>Région :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="128"/>
         <source>Developer:</source>
-        <translation type="unfinished"></translation>
+        <translation>Développeur :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="135"/>
         <source>Controllers:</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrôlleurs :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="142"/>
         <source>Tracks:</source>
-        <translation type="unfinished">Pistes:</translation>
+        <translation>Pistes :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="163"/>
         <source>Release Info:</source>
-        <translation type="unfinished"></translation>
+        <translation>Info. d&apos;édition :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="170"/>
         <source>Input Profile:</source>
-        <translation type="unfinished"></translation>
+        <translation>Profile d&apos;entrée :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="184"/>
         <source>Genre:</source>
-        <translation type="unfinished"></translation>
+        <translation>Genre :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="222"/>
         <source>Compute Hashes...</source>
-        <translation type="unfinished"></translation>
+        <translation>Calcul des hachages...</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="238"/>
         <source>Type:</source>
-        <translation type="unfinished"></translation>
+        <translation>Type :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="245"/>
         <source>Title:</source>
-        <translation type="unfinished">Titre:</translation>
+        <translation>Titre :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="259"/>
         <source>Compatibility:</source>
-        <translation type="unfinished">Compatibilité:</translation>
+        <translation>Compatibilité :</translation>
     </message>
     <message>
         <location filename="../gamesummarywidget.ui" line="275"/>
         <source>Edit...</source>
-        <translation type="unfinished"></translation>
+        <translation>Éditer...</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="61"/>
-        <location filename="../gamesummarywidget.cpp" line="71"/>
-        <location filename="../gamesummarywidget.cpp" line="98"/>
-        <location filename="../gamesummarywidget.cpp" line="115"/>
-        <location filename="../gamesummarywidget.cpp" line="120"/>
-        <location filename="../gamesummarywidget.cpp" line="121"/>
-        <location filename="../gamesummarywidget.cpp" line="122"/>
+        <location filename="../gamesummarywidget.cpp" line="64"/>
+        <location filename="../gamesummarywidget.cpp" line="74"/>
+        <location filename="../gamesummarywidget.cpp" line="101"/>
+        <location filename="../gamesummarywidget.cpp" line="118"/>
         <location filename="../gamesummarywidget.cpp" line="123"/>
         <location filename="../gamesummarywidget.cpp" line="124"/>
+        <location filename="../gamesummarywidget.cpp" line="125"/>
+        <location filename="../gamesummarywidget.cpp" line="126"/>
+        <location filename="../gamesummarywidget.cpp" line="127"/>
         <source>Unknown</source>
-        <translation type="unfinished">Inconnu</translation>
+        <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="63"/>
+        <location filename="../gamesummarywidget.cpp" line="66"/>
         <source>%1 (Published by %2)</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 (édité par %2)</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="69"/>
+        <location filename="../gamesummarywidget.cpp" line="72"/>
         <source>Published by %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Édité par %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="76"/>
+        <location filename="../gamesummarywidget.cpp" line="79"/>
         <source>Released %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Sorti %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="82"/>
+        <location filename="../gamesummarywidget.cpp" line="85"/>
         <source>%1-%2 players</source>
-        <translation type="unfinished"></translation>
+        <translation>%1-%2 joueurs</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="84"/>
+        <location filename="../gamesummarywidget.cpp" line="87"/>
         <source>%1 players</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 joueurs</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="91"/>
+        <location filename="../gamesummarywidget.cpp" line="94"/>
         <source>%1-%2 memory card blocks</source>
-        <translation type="unfinished"></translation>
+        <translation>%1-%2 blocs de carte mémoire</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="93"/>
+        <location filename="../gamesummarywidget.cpp" line="96"/>
         <source>%1 memory card blocks</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 blocs de carte mémoire</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="134"/>
+        <location filename="../gamesummarywidget.cpp" line="137"/>
         <source>Use Global Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser les paramètres globaux</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="176"/>
+        <location filename="../gamesummarywidget.cpp" line="179"/>
         <source>Track %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Piste %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="184"/>
+        <location filename="../gamesummarywidget.cpp" line="187"/>
         <source>&lt;not computed&gt;</source>
-        <translation type="unfinished">&lt;aucun calcul&gt;</translation>
+        <translation>&lt;non-calculé&gt;</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="212"/>
+        <location filename="../gamesummarywidget.cpp" line="215"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="212"/>
+        <location filename="../gamesummarywidget.cpp" line="215"/>
         <source>Failed to open CD image for hashing.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;ouverture du CD pour hashage.</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="320"/>
+        <location filename="../gamesummarywidget.cpp" line="323"/>
         <source>Revision: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Révision : %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="320"/>
+        <location filename="../gamesummarywidget.cpp" line="323"/>
         <source>N/A</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Sans Objet</translatorcomment>
+        <translation>S/O</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="345"/>
+        <location filename="../gamesummarywidget.cpp" line="348"/>
         <source>Search on Redump.org</source>
-        <translation type="unfinished"></translation>
+        <translation>Rechercher sur Redump.org</translation>
     </message>
 </context>
 <context>
@@ -6223,13 +6734,13 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
     <message>
         <location filename="../generalsettingswidget.ui" line="32"/>
         <source>Behaviour</source>
-        <translation>Commportement</translation>
+        <translation>Comportement</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="45"/>
-        <location filename="../generalsettingswidget.cpp" line="50"/>
+        <location filename="../generalsettingswidget.cpp" line="53"/>
         <source>Confirm Power Off</source>
-        <translation>Confirmer l&apos;Arrêt</translation>
+        <translation>Confirmer l&apos;arrêt</translation>
     </message>
     <message>
         <source>Render To Main Window</source>
@@ -6237,83 +6748,84 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="94"/>
-        <location filename="../generalsettingswidget.cpp" line="67"/>
+        <location filename="../generalsettingswidget.cpp" line="70"/>
         <source>Pause On Start</source>
-        <translation>Pause au Démarrage</translation>
+        <translation>Pause au démarrage</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="59"/>
-        <location filename="../generalsettingswidget.cpp" line="69"/>
+        <location filename="../generalsettingswidget.cpp" line="72"/>
         <source>Pause On Focus Loss</source>
-        <translation>Pause sur la Perte de Focus</translation>
+        <translation>Pause sur la perte de focus</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="52"/>
         <source>Save State On Shutdown</source>
-        <translation type="unfinished"></translation>
+        <translation>Sauvegarder l&apos;état à l&apos;extinction</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="73"/>
         <source>Create Save State Backups</source>
-        <translation type="unfinished"></translation>
+        <translation>Créer des sauvegardes des save states</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="80"/>
-        <location filename="../generalsettingswidget.cpp" line="61"/>
+        <location filename="../generalsettingswidget.cpp" line="64"/>
         <source>Inhibit Screensaver</source>
-        <translation type="unfinished"></translation>
+        <translation>Empêcher l&apos;économiseur d&apos;écran</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="108"/>
         <source>Compress Save States</source>
-        <translation type="unfinished"></translation>
+        <translation>Compresser les save states</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="118"/>
         <source>Game Display</source>
-        <translation type="unfinished"></translation>
+        <translation>Affichage de jeu</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="124"/>
-        <location filename="../generalsettingswidget.cpp" line="56"/>
+        <location filename="../generalsettingswidget.cpp" line="59"/>
         <source>Start Fullscreen</source>
-        <translation>Démarrer en Plein Ecran</translation>
+        <translation>Démarrer en plein écran</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="53"/>
+        <location filename="../generalsettingswidget.cpp" line="56"/>
         <source>Save State On Exit</source>
-        <translation>Sauvegarder l&apos;Etat en Quittant</translation>
+        <translation>Sauvegarder l&apos;état en quittant</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="87"/>
-        <location filename="../generalsettingswidget.cpp" line="73"/>
+        <location filename="../generalsettingswidget.cpp" line="76"/>
         <source>Load Devices From Save States</source>
-        <translation>Charger les Périphériques depuis les Sauvegardes d&apos;Etats</translation>
+        <translation>Charger les périphériques depuis les save states</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="131"/>
         <source>Double-Click Toggles Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Double-clic bascule le plein écran</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="138"/>
-        <location filename="../generalsettingswidget.cpp" line="64"/>
+        <location filename="../generalsettingswidget.cpp" line="67"/>
         <source>Render To Separate Window</source>
-        <translation type="unfinished"></translation>
+        <translation>Rendre dans une fenêtre séparée</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="145"/>
         <source>Hide Main Window When Running</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Abrégé pour que ça rentre dans la fenêtre</translatorcomment>
+        <translation>Masq. fen. principale qd lancé</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="152"/>
         <source>Disable Window Resizing</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactiver redimens. fenêtre</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="159"/>
-        <location filename="../generalsettingswidget.cpp" line="58"/>
+        <location filename="../generalsettingswidget.cpp" line="61"/>
         <source>Hide Cursor In Fullscreen</source>
         <translation>Cacher le Curseur en Plein Ecran</translation>
     </message>
@@ -6332,32 +6844,32 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
     <message>
         <location filename="../generalsettingswidget.ui" line="169"/>
         <source>Automatic Updater</source>
-        <translation type="unfinished">Mise à jour automatique</translation>
+        <translation>Mise à jour automatique</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="175"/>
         <source>Update Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation>Canal de MAJ :</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="185"/>
         <source>Current Version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Version courante :</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="221"/>
         <source>Check for Updates...</source>
-        <translation type="unfinished"></translation>
+        <translation>Vérifier les MAJs...</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="66"/>
-        <location filename="../generalsettingswidget.cpp" line="78"/>
+        <location filename="../generalsettingswidget.cpp" line="81"/>
         <source>Apply Per-Game Settings</source>
         <translation>Appliquer les Paramètres par Jeu</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="38"/>
-        <location filename="../generalsettingswidget.cpp" line="81"/>
+        <location filename="../generalsettingswidget.cpp" line="84"/>
         <source>Automatically Load Cheats</source>
         <translation>Charger Auto les triches</translation>
     </message>
@@ -6386,90 +6898,89 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation type="vanished">Moteur du Contrôleur: </translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="50"/>
         <location filename="../generalsettingswidget.cpp" line="53"/>
-        <location filename="../generalsettingswidget.cpp" line="58"/>
+        <location filename="../generalsettingswidget.cpp" line="56"/>
         <location filename="../generalsettingswidget.cpp" line="61"/>
         <location filename="../generalsettingswidget.cpp" line="64"/>
-        <location filename="../generalsettingswidget.cpp" line="78"/>
-        <location filename="../generalsettingswidget.cpp" line="99"/>
+        <location filename="../generalsettingswidget.cpp" line="67"/>
+        <location filename="../generalsettingswidget.cpp" line="81"/>
+        <location filename="../generalsettingswidget.cpp" line="102"/>
         <source>Checked</source>
         <translation>Coché</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="51"/>
+        <location filename="../generalsettingswidget.cpp" line="54"/>
         <source>Determines whether a prompt will be displayed to confirm shutting down the emulator/game when the hotkey is pressed.</source>
-        <translation>Détermine si un invité de commande sera affiché pour confirmer l&apos;arrêt de l&apos;émulateur/jeu lorsque la touche de raccourci est enfoncée.
-</translation>
+        <translation>Détermine si un invite de commande sera affiché pour confirmer l&apos;arrêt de l&apos;émulateur/jeu lorsque la touche de raccourci est enfoncée.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="54"/>
+        <location filename="../generalsettingswidget.cpp" line="57"/>
         <source>Automatically saves the emulator state when powering down or exiting. You can then resume directly from where you left off next time.</source>
         <translation>Sauvegarde automatique de l&apos;état de l&apos;émulateur lors de la mise hors tension ou de la sortie. Vous pouvez ensuite reprendre directement là où vous vous êtes arrêté la prochaine fois.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="56"/>
-        <location filename="../generalsettingswidget.cpp" line="67"/>
-        <location filename="../generalsettingswidget.cpp" line="69"/>
-        <location filename="../generalsettingswidget.cpp" line="73"/>
-        <location filename="../generalsettingswidget.cpp" line="81"/>
-        <location filename="../generalsettingswidget.cpp" line="88"/>
+        <location filename="../generalsettingswidget.cpp" line="59"/>
+        <location filename="../generalsettingswidget.cpp" line="70"/>
+        <location filename="../generalsettingswidget.cpp" line="72"/>
+        <location filename="../generalsettingswidget.cpp" line="76"/>
+        <location filename="../generalsettingswidget.cpp" line="84"/>
+        <location filename="../generalsettingswidget.cpp" line="91"/>
         <source>Unchecked</source>
         <translation>Décoché</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="57"/>
+        <location filename="../generalsettingswidget.cpp" line="60"/>
         <source>Automatically switches to fullscreen mode when a game is started.</source>
         <translation>Bascule automatiquement vers le mode Plein Ecran quand un jeu est lancé.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="59"/>
-        <source>Hides the mouse pointer/cursor when the emulator is in fullscreen mode.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../generalsettingswidget.cpp" line="62"/>
-        <source>Prevents the screen saver from activating and the host from sleeping while emulation is running.</source>
-        <translation type="unfinished"></translation>
+        <source>Hides the mouse pointer/cursor when the emulator is in fullscreen mode.</source>
+        <translation>Masque le pointeur/curseur de souris quand l&apos;émulateur est en mode plein écran.</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.cpp" line="65"/>
+        <source>Prevents the screen saver from activating and the host from sleeping while emulation is running.</source>
+        <translation>Empêche l&apos;activation de l&apos;économiseur d&apos;écran et la mise en veille de l&apos;hôte quand l&apos;émulation tourne.</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="68"/>
         <source>Renders the display of the simulated console to the main window of the application, over the game list. If checked, the display will render in a separate window.</source>
-        <translation type="unfinished"></translation>
+        <translation>Rends l&apos;affichage de la console simulée vers la fenêtre principâle de l&apos;application, par-dessus la liste de jeux. Si coché, l&apos;affichage sera rendu dans une fenêtre séparée.</translation>
     </message>
     <message>
         <source>Renders the display of the simulated console to the main window of the application, over the game list. If unchecked, the display will render in a separate window.</source>
         <translation type="vanished">Rend l&apos;affichage de la console simulée vers la fenêtre principale de l&apos;application, au-dessus de la liste des jeux. Si cette option n&apos;est pas cochée, l&apos;affichage se fera dans une fenêtre séparée.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="68"/>
+        <location filename="../generalsettingswidget.cpp" line="71"/>
         <source>Pauses the emulator when a game is started.</source>
         <translation>Met l&apos;émulateur en pause lorsqu&apos;un jeu est lancé.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="70"/>
+        <location filename="../generalsettingswidget.cpp" line="73"/>
         <source>Pauses the emulator when you minimize the window or switch to another application, and unpauses when you switch back.</source>
-        <translation type="unfinished"></translation>
+        <translation>Mets en pause l&apos;émulateur quand vous minimisez la fenêtre ou basculez vers une autre application, et rétablit quand vous revenez.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="74"/>
+        <location filename="../generalsettingswidget.cpp" line="77"/>
         <source>When enabled, memory cards and controllers will be overwritten when save states are loaded. This can result in lost saves, and controller type mismatches. For deterministic save states, enable this option, otherwise leave disabled.</source>
         <translation>Lorsqu&apos;elles sont activées, les cartes mémoire et les contrôleurs seront écrasés lors du chargement des sauvegardes d&apos;états. Cela peut entraîner la perte des sauvegardes et la non-concordance des types de contrôleurs. Pour des sauvegardes déterminées, activez cette option, sinon désactivez la.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="79"/>
+        <location filename="../generalsettingswidget.cpp" line="82"/>
         <source>When enabled, per-game settings will be applied, and incompatible enhancements will be disabled. You should leave this option enabled except when testing enhancements with incompatible games.</source>
         <translation>Lorsque activé, des paramètres de jeu seront appliquées, et les améliorations incompatibles seront désactivées. Vous devriez laisser cette option active, excepté lors des tests des améliorations avec les jeux incompatibles.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="82"/>
+        <location filename="../generalsettingswidget.cpp" line="85"/>
         <source>Automatically loads and applies cheats on game start.</source>
-        <translation type="unfinished"></translation>
+        <translation>Charge et applique automatiquement les codes de triche au démarrage d&apos;un jeu.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="107"/>
+        <location filename="../generalsettingswidget.cpp" line="110"/>
         <source>%1 (%2)</source>
-        <translation type="unfinished">%1 (%2)</translation>
+        <translation>%1 (%2)</translation>
     </message>
     <message>
         <source>Throttles the emulation speed to the chosen speed above. If unchecked, the emulator will run as fast as possible, which may not be playable.</source>
@@ -6493,23 +7004,23 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="101"/>
-        <location filename="../generalsettingswidget.cpp" line="88"/>
+        <location filename="../generalsettingswidget.cpp" line="91"/>
         <source>Enable Discord Presence</source>
         <translation>Activer la Présence Discord</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="89"/>
+        <location filename="../generalsettingswidget.cpp" line="92"/>
         <source>Shows the game you are currently playing as part of your profile in Discord.</source>
         <translation>Affiche le jeu auquel vous jouez actuellement sur votre profil Discord.</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="199"/>
-        <location filename="../generalsettingswidget.cpp" line="99"/>
+        <location filename="../generalsettingswidget.cpp" line="102"/>
         <source>Enable Automatic Update Check</source>
         <translation>Activer Auto la Vérification de la MaJ Auto</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="100"/>
+        <location filename="../generalsettingswidget.cpp" line="103"/>
         <source>Automatically checks for updates to the program on startup. Updates can be deferred until later or skipped entirely.</source>
         <translation>Vérifie automatiquement les mises à jour du programme au démarrage. Les mises à jour peuvent être reportées à une date ultérieure ou entièrement ignorées.</translation>
     </message>
@@ -6525,45 +7036,45 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
 <context>
     <name>GunCon</name>
     <message>
-        <location filename="../../core/guncon.cpp" line="220"/>
-        <source>Crosshair Image Path</source>
-        <translation type="unfinished">Chemin de l&apos;Image du Viseur</translation>
-    </message>
-    <message>
-        <location filename="../../core/guncon.cpp" line="221"/>
-        <source>Path to an image to use as a crosshair/cursor.</source>
-        <translation type="unfinished">Chemin d&apos;accès à une image à utiliser comme viseur/curseur.</translation>
-    </message>
-    <message>
-        <location filename="../../core/guncon.cpp" line="222"/>
-        <source>Crosshair Image Scale</source>
-        <translation type="unfinished">Echelle de l&apos;Image du Viseur</translation>
-    </message>
-    <message>
         <location filename="../../core/guncon.cpp" line="223"/>
-        <source>Scale of crosshair image on screen.</source>
-        <translation type="unfinished">Échelle de l&apos;image du viseur à l&apos;écran.</translation>
+        <source>Crosshair Image Path</source>
+        <translation>Chemin de l&apos;image du viseur</translation>
     </message>
     <message>
         <location filename="../../core/guncon.cpp" line="224"/>
-        <source>X Scale</source>
-        <translation type="unfinished"></translation>
+        <source>Path to an image to use as a crosshair/cursor.</source>
+        <translation>Chemin d&apos;accès à une image à utiliser comme viseur/curseur.</translation>
     </message>
     <message>
         <location filename="../../core/guncon.cpp" line="225"/>
+        <source>Crosshair Image Scale</source>
+        <translation>Échelle de l&apos;image du viseur</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="226"/>
+        <source>Scale of crosshair image on screen.</source>
+        <translation>Échelle de l&apos;image du viseur à l&apos;écran.</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="228"/>
+        <source>X Scale</source>
+        <translation>Échelle X</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="229"/>
         <source>Scales X coordinates relative to the center of the screen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Mets à l&apos;échelle les coordonnées X par rapport au centre de l&apos;écran.</translation>
     </message>
 </context>
 <context>
     <name>HostInterface</name>
     <message>
-        <location filename="../../core/bios.cpp" line="310"/>
+        <location filename="../../core/bios.cpp" line="306"/>
         <source>Failed to load configured BIOS file &apos;%s&apos;</source>
         <translation>Impossible de charger le fichier BIOS configuré &apos;%s&apos;</translation>
     </message>
     <message>
-        <location filename="../../core/bios.cpp" line="371"/>
+        <location filename="../../core/bios.cpp" line="361"/>
         <source>No BIOS image found for %s region</source>
         <translation>Aucune image du BIOS n&apos;a été trouvé pour la région %s</translation>
     </message>
@@ -6571,470 +7082,470 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
 <context>
     <name>Hotkeys</name>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="639"/>
-        <location filename="../../frontend-common/common_host.cpp" line="646"/>
-        <location filename="../../frontend-common/common_host.cpp" line="653"/>
-        <location filename="../../frontend-common/common_host.cpp" line="659"/>
-        <location filename="../../frontend-common/common_host.cpp" line="665"/>
-        <location filename="../../frontend-common/common_host.cpp" line="672"/>
-        <location filename="../../frontend-common/common_host.cpp" line="678"/>
-        <location filename="../../frontend-common/common_host.cpp" line="684"/>
-        <location filename="../../frontend-common/common_host.cpp" line="691"/>
-        <location filename="../../frontend-common/common_host.cpp" line="698"/>
-        <location filename="../../frontend-common/common_host.cpp" line="711"/>
+        <location filename="../../frontend-common/common_host.cpp" line="676"/>
+        <location filename="../../frontend-common/common_host.cpp" line="683"/>
+        <location filename="../../frontend-common/common_host.cpp" line="690"/>
+        <location filename="../../frontend-common/common_host.cpp" line="696"/>
+        <location filename="../../frontend-common/common_host.cpp" line="702"/>
+        <location filename="../../frontend-common/common_host.cpp" line="709"/>
+        <location filename="../../frontend-common/common_host.cpp" line="715"/>
+        <location filename="../../frontend-common/common_host.cpp" line="721"/>
+        <location filename="../../frontend-common/common_host.cpp" line="728"/>
+        <location filename="../../frontend-common/common_host.cpp" line="735"/>
+        <location filename="../../frontend-common/common_host.cpp" line="748"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="646"/>
+        <location filename="../../frontend-common/common_host.cpp" line="683"/>
         <source>Fast Forward</source>
         <translation>Avance Rapide</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="653"/>
+        <location filename="../../frontend-common/common_host.cpp" line="690"/>
         <source>Toggle Fast Forward</source>
         <translation>Basculer sur l&apos;Avance Rapide</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="672"/>
+        <location filename="../../frontend-common/common_host.cpp" line="709"/>
         <source>Toggle Fullscreen</source>
         <translation>Basculer en Plein Ecran</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="678"/>
+        <location filename="../../frontend-common/common_host.cpp" line="715"/>
         <source>Toggle Pause</source>
         <translation>Basculer sur Pause</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="760"/>
+        <location filename="../../frontend-common/common_host.cpp" line="797"/>
         <source>Toggle Cheats</source>
-        <translation type="unfinished"></translation>
+        <translation>Basculer les codes de triche</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="684"/>
+        <location filename="../../frontend-common/common_host.cpp" line="721"/>
         <source>Power Off System</source>
         <translation>Eteindre le Système</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="725"/>
+        <location filename="../../frontend-common/common_host.cpp" line="762"/>
         <source>Reset System</source>
         <translation>Réinitialiser le Système</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="691"/>
+        <location filename="../../frontend-common/common_host.cpp" line="728"/>
         <source>Save Screenshot</source>
         <translation>Sauvegarder les Captures d&apos;Ecrans</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="747"/>
+        <location filename="../../frontend-common/common_host.cpp" line="784"/>
         <source>Frame Step</source>
         <translation>Pas de la Trame</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="837"/>
-        <location filename="../../frontend-common/common_host.cpp" line="843"/>
-        <location filename="../../frontend-common/common_host.cpp" line="869"/>
-        <location filename="../../frontend-common/common_host.cpp" line="875"/>
-        <location filename="../../frontend-common/common_host.cpp" line="881"/>
-        <location filename="../../frontend-common/common_host.cpp" line="887"/>
-        <location filename="../../frontend-common/common_host.cpp" line="893"/>
-        <location filename="../../frontend-common/common_host.cpp" line="904"/>
-        <location filename="../../frontend-common/common_host.cpp" line="910"/>
-        <location filename="../../frontend-common/common_host.cpp" line="931"/>
+        <location filename="../../frontend-common/common_host.cpp" line="874"/>
+        <location filename="../../frontend-common/common_host.cpp" line="880"/>
+        <location filename="../../frontend-common/common_host.cpp" line="906"/>
+        <location filename="../../frontend-common/common_host.cpp" line="912"/>
+        <location filename="../../frontend-common/common_host.cpp" line="918"/>
+        <location filename="../../frontend-common/common_host.cpp" line="924"/>
+        <location filename="../../frontend-common/common_host.cpp" line="930"/>
+        <location filename="../../frontend-common/common_host.cpp" line="941"/>
+        <location filename="../../frontend-common/common_host.cpp" line="947"/>
+        <location filename="../../frontend-common/common_host.cpp" line="968"/>
         <source>Graphics</source>
         <translation>Graphismes</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="838"/>
+        <location filename="../../frontend-common/common_host.cpp" line="875"/>
         <source>Toggle Software Rendering</source>
         <translation>Basculer sur le Rendu Logiciel</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="843"/>
+        <location filename="../../frontend-common/common_host.cpp" line="880"/>
         <source>Toggle PGXP</source>
         <translation>Basculer sur PGXP</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="911"/>
+        <location filename="../../frontend-common/common_host.cpp" line="948"/>
         <source>Toggle PGXP Depth Buffer</source>
-        <translation type="unfinished"></translation>
+        <translation>Basculer le  tampon de profondeur PGXP</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="870"/>
+        <location filename="../../frontend-common/common_host.cpp" line="907"/>
         <source>Increase Resolution Scale</source>
         <translation>Augmenter l&apos;Echelle de Résolution</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="639"/>
+        <location filename="../../frontend-common/common_host.cpp" line="676"/>
         <source>Open Pause Menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouvrir le menu de pause</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="659"/>
+        <location filename="../../frontend-common/common_host.cpp" line="696"/>
         <source>Turbo</source>
-        <translation type="unfinished"></translation>
+        <translation>Turbo</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="665"/>
+        <location filename="../../frontend-common/common_host.cpp" line="702"/>
         <source>Toggle Turbo</source>
-        <translation type="unfinished"></translation>
+        <translation>Basculer le turbo</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="698"/>
+        <location filename="../../frontend-common/common_host.cpp" line="735"/>
         <source>Open Achievement List</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouvrir la liste des succès</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="711"/>
+        <location filename="../../frontend-common/common_host.cpp" line="748"/>
         <source>Open Leaderboard List</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouvrir la liste du classement</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="725"/>
-        <location filename="../../frontend-common/common_host.cpp" line="730"/>
-        <location filename="../../frontend-common/common_host.cpp" line="740"/>
-        <location filename="../../frontend-common/common_host.cpp" line="747"/>
-        <location filename="../../frontend-common/common_host.cpp" line="753"/>
-        <location filename="../../frontend-common/common_host.cpp" line="760"/>
-        <location filename="../../frontend-common/common_host.cpp" line="766"/>
-        <location filename="../../frontend-common/common_host.cpp" line="773"/>
-        <location filename="../../frontend-common/common_host.cpp" line="801"/>
-        <location filename="../../frontend-common/common_host.cpp" line="813"/>
-        <location filename="../../frontend-common/common_host.cpp" line="825"/>
+        <location filename="../../frontend-common/common_host.cpp" line="762"/>
+        <location filename="../../frontend-common/common_host.cpp" line="767"/>
+        <location filename="../../frontend-common/common_host.cpp" line="777"/>
+        <location filename="../../frontend-common/common_host.cpp" line="784"/>
+        <location filename="../../frontend-common/common_host.cpp" line="790"/>
+        <location filename="../../frontend-common/common_host.cpp" line="797"/>
+        <location filename="../../frontend-common/common_host.cpp" line="803"/>
+        <location filename="../../frontend-common/common_host.cpp" line="810"/>
+        <location filename="../../frontend-common/common_host.cpp" line="838"/>
+        <location filename="../../frontend-common/common_host.cpp" line="850"/>
+        <location filename="../../frontend-common/common_host.cpp" line="862"/>
         <source>System</source>
-        <translation type="unfinished"></translation>
+        <translation>Système</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="730"/>
+        <location filename="../../frontend-common/common_host.cpp" line="767"/>
         <source>Change Disc</source>
-        <translation type="unfinished">Changer le Disque</translation>
+        <translation>Changer le disque</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="740"/>
+        <location filename="../../frontend-common/common_host.cpp" line="777"/>
         <source>Swap Memory Card Slots</source>
-        <translation type="unfinished"></translation>
+        <translation>Échanger les emplacements de carte mémoire</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="753"/>
+        <location filename="../../frontend-common/common_host.cpp" line="790"/>
         <source>Rewind</source>
-        <translation type="unfinished"></translation>
+        <translation>Rewind</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="766"/>
+        <location filename="../../frontend-common/common_host.cpp" line="803"/>
         <source>Toggle Patch Codes</source>
-        <translation type="unfinished"></translation>
+        <translation>Basculer les codes de patch</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="774"/>
+        <location filename="../../frontend-common/common_host.cpp" line="811"/>
         <source>Toggle Clock Speed Control (Overclocking)</source>
-        <translation type="unfinished"></translation>
+        <translation>Basculer le contrôle de vitesse de l&apos;horloge (overclocking)</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="802"/>
+        <location filename="../../frontend-common/common_host.cpp" line="839"/>
         <source>Increase Emulation Speed</source>
-        <translation type="unfinished"></translation>
+        <translation>Augmenter la vitesse d&apos;émulation</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="814"/>
+        <location filename="../../frontend-common/common_host.cpp" line="851"/>
         <source>Decrease Emulation Speed</source>
-        <translation type="unfinished"></translation>
+        <translation>Diminuer la vitesse d&apos;émulation</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="826"/>
+        <location filename="../../frontend-common/common_host.cpp" line="863"/>
         <source>Reset Emulation Speed</source>
-        <translation type="unfinished"></translation>
+        <translation>Réinitialiser la vitesse d&apos;émulation</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="876"/>
+        <location filename="../../frontend-common/common_host.cpp" line="913"/>
         <source>Decrease Resolution Scale</source>
-        <translation>Diminuer l&apos;Echelle de Résolution</translation>
+        <translation>Diminuer l&apos;échelle de résolution</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="882"/>
+        <location filename="../../frontend-common/common_host.cpp" line="919"/>
         <source>Toggle Post-Processing</source>
-        <translation>Basculer sur le Post Traitement</translation>
+        <translation>Basculer sur le post-traitement</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="888"/>
+        <location filename="../../frontend-common/common_host.cpp" line="925"/>
         <source>Reload Post Processing Shaders</source>
-        <translation>Recharger les Shaders du Post Traitement</translation>
-    </message>
-    <message>
-        <location filename="../../frontend-common/common_host.cpp" line="894"/>
-        <source>Reload Texture Replacements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../frontend-common/common_host.cpp" line="904"/>
-        <source>Toggle Widescreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Recharger les shaders du post-traitement</translation>
     </message>
     <message>
         <location filename="../../frontend-common/common_host.cpp" line="931"/>
-        <source>Toggle PGXP CPU Mode</source>
-        <translation type="unfinished"></translation>
+        <source>Reload Texture Replacements</source>
+        <translation>Recharger les remplacements de texture</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1020"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1025"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1030"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1035"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1041"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1048"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1054"/>
+        <location filename="../../frontend-common/common_host.cpp" line="941"/>
+        <source>Toggle Widescreen</source>
+        <translation>Basculer le plein écran</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/common_host.cpp" line="968"/>
+        <source>Toggle PGXP CPU Mode</source>
+        <translation>Basculer le mode CPU PGXP</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/common_host.cpp" line="1057"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1062"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1067"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1072"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1078"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1085"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1091"/>
         <source>Save States</source>
         <translation>Sauvegardes d&apos;Etats</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1021"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1058"/>
         <source>Load From Selected Slot</source>
         <translation>Charger depuis l&apos;Emplacement Sélectionné</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1026"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1063"/>
         <source>Save To Selected Slot</source>
         <translation>Sauvegarder vers l&apos;Emplacement Sélectionné</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1031"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1068"/>
         <source>Select Previous Save Slot</source>
         <translation>Choisir l&apos;Emplacement de Sauvegarde Précédent</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1036"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1073"/>
         <source>Select Next Save Slot</source>
         <translation>Choisir l&apos;Emplacement de Sauvegarde Suivant</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1041"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1078"/>
         <source>Undo Load State</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuler chargement état</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1060"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1097"/>
         <source>Load Game State 1</source>
         <translation>Charger l&apos;Etat du Jeu 1</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1062"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1099"/>
         <source>Load Game State 2</source>
         <translation>Charger l&apos;Etat du Jeu 2</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1064"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1101"/>
         <source>Load Game State 3</source>
         <translation>Charger l&apos;Etat du Jeu 3</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1066"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1103"/>
         <source>Load Game State 4</source>
         <translation>Charger l&apos;Etat du Jeu 4</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1068"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1105"/>
         <source>Load Game State 5</source>
         <translation>Charger l&apos;Etat du Jeu 5</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1070"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1107"/>
         <source>Load Game State 6</source>
         <translation>Charger l&apos;Etat du Jeu 6</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1072"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1109"/>
         <source>Load Game State 7</source>
         <translation>Charger l&apos;Etat du Jeu 7</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1074"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1111"/>
         <source>Load Game State 8</source>
         <translation>Charger l&apos;Etat du Jeu 8</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1076"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1113"/>
         <source>Load Game State 9</source>
         <translation>Charger l&apos;Etat du Jeu 9</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1078"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1115"/>
         <source>Load Game State 10</source>
         <translation>Charger l&apos;Etat du Jeu 10</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1061"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1098"/>
         <source>Save Game State 1</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 1</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1063"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1100"/>
         <source>Save Game State 2</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 2</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1065"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1102"/>
         <source>Save Game State 3</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 3</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1067"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1104"/>
         <source>Save Game State 4</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 4</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1069"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1106"/>
         <source>Save Game State 5</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 5</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1071"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1108"/>
         <source>Save Game State 6</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 6</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1073"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1110"/>
         <source>Save Game State 7</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 7</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1075"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1112"/>
         <source>Save Game State 8</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 8</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1077"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1114"/>
         <source>Save Game State 9</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 9</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1079"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1116"/>
         <source>Save Game State 10</source>
         <translation>Sauvegarder l&apos;Etat du Jeu 10</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1081"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1118"/>
         <source>Load Global State 1</source>
         <translation>Charger l&apos;Etat Complet 1</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1083"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1120"/>
         <source>Load Global State 2</source>
         <translation>Charger l&apos;Etat Complet 2</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1085"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1122"/>
         <source>Load Global State 3</source>
         <translation>Charger l&apos;Etat Complet 3</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1087"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1124"/>
         <source>Load Global State 4</source>
         <translation>Charger l&apos;Etat Complet 4</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1089"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1126"/>
         <source>Load Global State 5</source>
         <translation>Charger l&apos;Etat Complet 5</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1091"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1128"/>
         <source>Load Global State 6</source>
         <translation>Charger l&apos;Etat Complet 6</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1093"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1130"/>
         <source>Load Global State 7</source>
         <translation>Charger l&apos;Etat Complet 7</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1095"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1132"/>
         <source>Load Global State 8</source>
         <translation>Charger l&apos;Etat Complet 8</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1097"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1134"/>
         <source>Load Global State 9</source>
         <translation>Charger l&apos;Etat Complet 9</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1099"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1136"/>
         <source>Load Global State 10</source>
         <translation>Charger l&apos;Etat Complet 10</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1082"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1119"/>
         <source>Save Global State 1</source>
         <translation>Sauvegarder l&apos;Etat Complet 1</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1084"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1121"/>
         <source>Save Global State 2</source>
         <translation>Sauvegarder l&apos;Etat Complet 2</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1086"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1123"/>
         <source>Save Global State 3</source>
         <translation>Sauvegarder l&apos;Etat Complet 3</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1088"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1125"/>
         <source>Save Global State 4</source>
         <translation>Sauvegarder l&apos;Etat Complet 4</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1090"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1127"/>
         <source>Save Global State 5</source>
         <translation>Sauvegarder l&apos;Etat Complet 5</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1092"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1129"/>
         <source>Save Global State 6</source>
         <translation>Sauvegarder l&apos;Etat Complet 6</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1094"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1131"/>
         <source>Save Global State 7</source>
         <translation>Sauvegarder l&apos;Etat Complet 7</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1096"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1133"/>
         <source>Save Global State 8</source>
         <translation>Sauvegarder l&apos;Etat Complet 8</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1098"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1135"/>
         <source>Save Global State 9</source>
         <translation>Sauvegarder l&apos;Etat Complet 9</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1100"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1137"/>
         <source>Save Global State 10</source>
         <translation>Sauvegarder l&apos;Etat Complet 10</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="958"/>
-        <location filename="../../frontend-common/common_host.cpp" line="977"/>
-        <location filename="../../frontend-common/common_host.cpp" line="989"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1003"/>
+        <location filename="../../frontend-common/common_host.cpp" line="995"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1014"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1026"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1040"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="958"/>
+        <location filename="../../frontend-common/common_host.cpp" line="995"/>
         <source>Toggle Mute</source>
         <translation>Passer en Muet</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="977"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1014"/>
         <source>Toggle CD Audio Mute</source>
         <translation>Basculer le CD Audio en Muet</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="989"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1026"/>
         <source>Volume Up</source>
         <translation>Augmenter le Volume</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1003"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1040"/>
         <source>Volume Down</source>
         <translation>Diminuer le Volume</translation>
     </message>
@@ -7067,20 +7578,20 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation>Vider les Assignations</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.cpp" line="18"/>
+        <location filename="../inputbindingdialog.cpp" line="22"/>
         <source>Bindings for %1 %2</source>
         <translation>Assigne pour %1 %2</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.cpp" line="19"/>
+        <location filename="../inputbindingdialog.cpp" line="23"/>
         <source>Close</source>
-        <translation type="unfinished">Fermer</translation>
+        <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.cpp" line="127"/>
-        <location filename="../inputbindingdialog.cpp" line="142"/>
+        <location filename="../inputbindingdialog.cpp" line="131"/>
+        <location filename="../inputbindingdialog.cpp" line="147"/>
         <source>Push Button/Axis... [%1]</source>
-        <translation>Pressez le Bouton/Axe...</translation>
+        <translation>Pressez le bouton/axe... [%1]</translation>
     </message>
 </context>
 <context>
@@ -7090,16 +7601,16 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation type="vanished">Assigne %1</translation>
     </message>
     <message numerus="yes">
-        <location filename="../inputbindingwidgets.cpp" line="60"/>
+        <location filename="../inputbindingwidgets.cpp" line="65"/>
         <source>%n bindings</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n assignations</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="273"/>
-        <location filename="../inputbindingwidgets.cpp" line="288"/>
+        <location filename="../inputbindingwidgets.cpp" line="280"/>
+        <location filename="../inputbindingwidgets.cpp" line="296"/>
         <source>Push Button/Axis... [%1]</source>
         <translation>Pressez le Bouton/Axe... [%1]</translation>
     </message>
@@ -7107,40 +7618,40 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
 <context>
     <name>InputVibrationBindingWidget</name>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="412"/>
+        <location filename="../inputbindingwidgets.cpp" line="446"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="413"/>
+        <location filename="../inputbindingwidgets.cpp" line="447"/>
         <source>No devices with vibration motors were detected.</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucun périphérique avec des moteurs de vibration déctecté.</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="419"/>
+        <location filename="../inputbindingwidgets.cpp" line="453"/>
         <source>Select vibration motor for %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionnez le moteur de vibration pour %1.</translation>
     </message>
 </context>
 <context>
     <name>LogLevel</name>
     <message>
-        <location filename="../../core/settings.cpp" line="660"/>
+        <location filename="../../core/settings.cpp" line="733"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="660"/>
+        <location filename="../../core/settings.cpp" line="733"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="660"/>
+        <location filename="../../core/settings.cpp" line="733"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="661"/>
+        <location filename="../../core/settings.cpp" line="734"/>
         <source>Performance</source>
         <translation>Performance</translation>
     </message>
@@ -7149,32 +7660,32 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation type="vanished">Succès</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="661"/>
+        <location filename="../../core/settings.cpp" line="734"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="662"/>
+        <location filename="../../core/settings.cpp" line="735"/>
         <source>Developer</source>
         <translation>Développeur</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="662"/>
+        <location filename="../../core/settings.cpp" line="735"/>
         <source>Profile</source>
         <translation>Profil</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="662"/>
+        <location filename="../../core/settings.cpp" line="735"/>
         <source>Verbose</source>
-        <translation type="unfinished"></translation>
+        <translation>Verbeux</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="663"/>
+        <location filename="../../core/settings.cpp" line="736"/>
         <source>Debug</source>
         <translation>Débug</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="663"/>
+        <location filename="../../core/settings.cpp" line="736"/>
         <source>Trace</source>
         <translation>Traceur</translation>
     </message>
@@ -7193,8 +7704,8 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
     </message>
     <message>
         <location filename="../mainwindow.ui" line="39"/>
-        <location filename="../mainwindow.cpp" line="1072"/>
-        <location filename="../mainwindow.cpp" line="1308"/>
+        <location filename="../mainwindow.cpp" line="1197"/>
+        <location filename="../mainwindow.cpp" line="1436"/>
         <source>Change Disc</source>
         <translation>Changer le Disque</translation>
     </message>
@@ -7209,8 +7720,8 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
     </message>
     <message>
         <location filename="../mainwindow.ui" line="63"/>
-        <location filename="../mainwindow.cpp" line="663"/>
-        <location filename="../mainwindow.cpp" line="940"/>
+        <location filename="../mainwindow.cpp" line="788"/>
+        <location filename="../mainwindow.cpp" line="1065"/>
         <source>Load State</source>
         <translation>Charger un Etat</translation>
     </message>
@@ -7230,204 +7741,220 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation>Thème</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="113"/>
+        <location filename="../mainwindow.ui" line="114"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="146"/>
+        <location filename="../mainwindow.ui" line="149"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="159"/>
+        <location filename="../mainwindow.ui" line="162"/>
         <source>&amp;Debug</source>
         <translation>&amp;Débug</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="163"/>
+        <location filename="../mainwindow.ui" line="166"/>
         <source>Switch GPU Renderer</source>
         <translation>Changer le Rendu du GPU</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="168"/>
+        <location filename="../mainwindow.ui" line="171"/>
         <source>Switch CPU Emulation Mode</source>
         <translation>Changer le Mode d&apos;Emulation du CPU</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="173"/>
+        <location filename="../mainwindow.ui" line="176"/>
         <source>Switch Crop Mode</source>
         <translation>Changer le Mode de Coupe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="203"/>
+        <location filename="../mainwindow.ui" line="207"/>
         <source>&amp;View</source>
         <translation>&amp;Visualiser</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="207"/>
+        <location filename="../mainwindow.ui" line="211"/>
         <source>&amp;Window Size</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Taille de la fenêtre</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="229"/>
+        <location filename="../mainwindow.ui" line="232"/>
         <source>&amp;Tools</source>
         <translation>&amp;Outils</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="245"/>
+        <location filename="../mainwindow.ui" line="249"/>
         <source>toolBar</source>
         <translation>Barre d&apos;Outils</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="287"/>
+        <location filename="../mainwindow.ui" line="291"/>
         <source>Start &amp;File...</source>
-        <translation type="unfinished"></translation>
+        <translation>Démarrer le &amp;fichier...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="296"/>
+        <location filename="../mainwindow.ui" line="300"/>
         <source>Start &amp;Disc...</source>
         <translation>Lancer le &amp;Disque...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="305"/>
+        <location filename="../mainwindow.ui" line="309"/>
         <source>Start &amp;BIOS</source>
         <translation>Démarrer le &amp;BIOS</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="314"/>
+        <location filename="../mainwindow.ui" line="318"/>
         <source>&amp;Scan For New Games</source>
         <translation>&amp;Scanner les nouveaux Jeux</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="323"/>
+        <location filename="../mainwindow.ui" line="327"/>
         <source>&amp;Rescan All Games</source>
         <translation>&amp;Rescanner tous les Jeux</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="332"/>
+        <location filename="../mainwindow.ui" line="336"/>
         <source>Power &amp;Off</source>
         <translation>E&amp;teindre</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="341"/>
+        <location filename="../mainwindow.ui" line="345"/>
         <source>&amp;Reset</source>
         <translation>&amp;Réinitialiser</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="353"/>
+        <location filename="../mainwindow.ui" line="357"/>
         <source>&amp;Pause</source>
         <translation>&amp;Pause</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="362"/>
+        <location filename="../mainwindow.ui" line="366"/>
         <source>&amp;Load State</source>
         <translation>&amp;Charger un Etat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="371"/>
+        <location filename="../mainwindow.ui" line="375"/>
         <source>&amp;Save State</source>
         <translation>&amp;Sauvegarder un Etat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="380"/>
+        <location filename="../mainwindow.ui" line="384"/>
         <source>E&amp;xit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="389"/>
+        <location filename="../mainwindow.ui" line="393"/>
         <source>B&amp;IOS</source>
-        <translation type="unfinished"></translation>
+        <translation>B&amp;IOS</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="398"/>
+        <location filename="../mainwindow.ui" line="402"/>
         <source>C&amp;onsole</source>
-        <translation type="unfinished"></translation>
+        <translation>C&amp;onsole</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="407"/>
+        <location filename="../mainwindow.ui" line="411"/>
         <source>E&amp;mulation</source>
-        <translation type="unfinished"></translation>
+        <translation>É&amp;mulation</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="416"/>
+        <location filename="../mainwindow.ui" line="420"/>
         <source>&amp;Controllers</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Contrôleurs</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="425"/>
+        <location filename="../mainwindow.ui" line="429"/>
         <source>&amp;Hotkeys</source>
-        <translation type="unfinished"></translation>
+        <translation>Raccourcis</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="434"/>
+        <location filename="../mainwindow.ui" line="438"/>
         <source>&amp;Display</source>
-        <translation type="unfinished"></translation>
+        <translation>Affichage</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="443"/>
+        <location filename="../mainwindow.ui" line="447"/>
         <source>&amp;Enhancements</source>
-        <translation type="unfinished"></translation>
+        <translation>Améliorations</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="452"/>
+        <location filename="../mainwindow.ui" line="456"/>
         <source>&amp;Post-Processing</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Post-traitement</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="547"/>
+        <location filename="../mainwindow.ui" line="551"/>
         <source>Audio</source>
-        <translation type="unfinished">Audio</translation>
+        <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="556"/>
+        <location filename="../mainwindow.ui" line="560"/>
         <source>Achievements</source>
-        <translation type="unfinished"></translation>
+        <translation>Succès</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="565"/>
+        <location filename="../mainwindow.ui" line="569"/>
         <source>Folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Dossiers</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="574"/>
+        <location filename="../mainwindow.ui" line="578"/>
         <source>Game List</source>
-        <translation type="unfinished"></translation>
+        <translation>Liste de jeux</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="583"/>
+        <location filename="../mainwindow.ui" line="587"/>
         <source>General</source>
-        <translation type="unfinished">Général</translation>
+        <translation>Général</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="592"/>
+        <location filename="../mainwindow.ui" line="596"/>
         <source>Advanced</source>
-        <translation type="unfinished"></translation>
+        <translation>Avancé</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="727"/>
+        <location filename="../mainwindow.ui" line="614"/>
+        <location filename="../mainwindow.ui" line="626"/>
+        <source>&amp;Settings</source>
+        <translation>Paramètres</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="746"/>
         <source>Show CD-ROM State</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher état CD-ROM</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="777"/>
+        <location filename="../mainwindow.ui" line="796"/>
         <source>&amp;Memory Cards</source>
-        <translation type="unfinished"></translation>
+        <translation>Cartes &amp;mémoire</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="922"/>
+        <location filename="../mainwindow.ui" line="893"/>
+        <source>Enable GDB server</source>
+        <translation>Activer le serveur GDB</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="953"/>
         <source>Power Off &amp;Without Saving</source>
-        <translation type="unfinished"></translation>
+        <translation>Éteindre sans sauvegarder</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="931"/>
+        <location filename="../mainwindow.ui" line="962"/>
         <source>Start Big Picture Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Démarrer en mode Big Picture</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="940"/>
+        <location filename="../mainwindow.ui" line="971"/>
         <source>Big Picture</source>
-        <translation type="unfinished"></translation>
+        <translation>Big Picture</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.ui" line="976"/>
+        <source>Cover Downloader</source>
+        <translation>Téléchargeur de jaquette</translation>
     </message>
     <message>
         <source>B&amp;IOS Settings...</source>
@@ -7458,52 +7985,52 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation type="vanished">Paramètres du &amp;Post-Traitement...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="461"/>
+        <location filename="../mainwindow.ui" line="465"/>
         <source>Fullscreen</source>
         <translation>Plein Ecran</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="466"/>
+        <location filename="../mainwindow.ui" line="470"/>
         <source>Resolution Scale</source>
         <translation>Echelle de la Résolution</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="475"/>
+        <location filename="../mainwindow.ui" line="479"/>
         <source>&amp;GitHub Repository...</source>
         <translation>Dépôt &amp;GitHub...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="484"/>
+        <location filename="../mainwindow.ui" line="488"/>
         <source>&amp;Issue Tracker...</source>
         <translation>&amp;Suivi des Problèmes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="493"/>
+        <location filename="../mainwindow.ui" line="497"/>
         <source>&amp;Discord Server...</source>
         <translation>Serveur &amp;Discord...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="502"/>
+        <location filename="../mainwindow.ui" line="506"/>
         <source>Check for &amp;Updates...</source>
         <translation>Vérfication des &amp;Mises à Jour...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="511"/>
+        <location filename="../mainwindow.ui" line="515"/>
         <source>About &amp;Qt...</source>
         <translation>A Propos De &amp;Qt...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="520"/>
+        <location filename="../mainwindow.ui" line="524"/>
         <source>&amp;About DuckStation...</source>
         <translation>&amp;A Propos De DuckStation...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="529"/>
+        <location filename="../mainwindow.ui" line="533"/>
         <source>Change Disc...</source>
         <translation>Changement de Disque...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="538"/>
+        <location filename="../mainwindow.ui" line="542"/>
         <source>Cheats...</source>
         <translation>Triches...</translation>
     </message>
@@ -7524,97 +8051,96 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation type="vanished">Paramètres Avancés...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="601"/>
+        <location filename="../mainwindow.ui" line="605"/>
         <source>Add Game Directory...</source>
-        <translation>Ajouter un Répertoire de Jeu...</translation>
+        <translation>Ajouter un répertoire de jeu...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="610"/>
         <source>&amp;Settings...</source>
-        <translation>&amp;Paramètres...</translation>
+        <translation type="vanished">&amp;Paramètres...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="615"/>
+        <location filename="../mainwindow.ui" line="634"/>
         <source>From File...</source>
-        <translation>Depuis le Fichier...</translation>
+        <translation>Depuis le fichier...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="620"/>
+        <location filename="../mainwindow.ui" line="639"/>
         <source>From Device...</source>
-        <translation type="unfinished"></translation>
+        <translation>Depuis le périphérique...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="625"/>
+        <location filename="../mainwindow.ui" line="644"/>
         <source>From Game List...</source>
         <translation>Depuis la Liste de Jeu...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="630"/>
+        <location filename="../mainwindow.ui" line="649"/>
         <source>Remove Disc</source>
-        <translation>Enlever le Disque</translation>
+        <translation>Enlever le disque</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="635"/>
+        <location filename="../mainwindow.ui" line="654"/>
         <source>Resume State</source>
-        <translation>Résumer l&apos;Etat</translation>
+        <translation>Reprendre l&apos;état</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="640"/>
+        <location filename="../mainwindow.ui" line="659"/>
         <source>Global State</source>
-        <translation>Etat Complet</translation>
+        <translation>État complet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="648"/>
+        <location filename="../mainwindow.ui" line="667"/>
         <source>Show VRAM</source>
         <translation>Afficher la VRAM</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="656"/>
+        <location filename="../mainwindow.ui" line="675"/>
         <source>Dump CPU to VRAM Copies</source>
         <translation>Copier le CPU vers la VRAM</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="664"/>
+        <location filename="../mainwindow.ui" line="683"/>
         <source>Dump VRAM to CPU Copies</source>
         <translation>Copier la VRAM vers le CPU</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="672"/>
+        <location filename="../mainwindow.ui" line="691"/>
         <source>Disable All Enhancements</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactiver toutes les améliorations</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="680"/>
+        <location filename="../mainwindow.ui" line="699"/>
         <source>Disable Interlacing</source>
         <translation>Désactiver l&apos;Entrelacement</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="688"/>
+        <location filename="../mainwindow.ui" line="707"/>
         <source>Force NTSC Timings</source>
         <translation>Forcer les Timings NTSC</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="696"/>
+        <location filename="../mainwindow.ui" line="715"/>
         <source>Dump Audio</source>
         <translation>Copier l&apos;Audio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="701"/>
+        <location filename="../mainwindow.ui" line="720"/>
         <source>Dump RAM...</source>
         <translation>Copier la RAM...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="706"/>
+        <location filename="../mainwindow.ui" line="725"/>
         <source>Dump VRAM...</source>
-        <translation type="unfinished"></translation>
+        <translation>Copier la VRAM...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="711"/>
+        <location filename="../mainwindow.ui" line="730"/>
         <source>Dump SPU RAM...</source>
-        <translation type="unfinished"></translation>
+        <translation>Copier la RAM SPU...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="719"/>
+        <location filename="../mainwindow.ui" line="738"/>
         <source>Show GPU State</source>
         <translation>Afficher l&apos;Etat du GPU</translation>
     </message>
@@ -7623,27 +8149,27 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation type="vanished">Afficher l&apos;Etat du CD-ROM</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="735"/>
+        <location filename="../mainwindow.ui" line="754"/>
         <source>Show SPU State</source>
         <translation>Afficher l&apos;Etat du SPU</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="743"/>
+        <location filename="../mainwindow.ui" line="762"/>
         <source>Show Timers State</source>
         <translation>Afficher l&apos;Etat du Compteur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="751"/>
+        <location filename="../mainwindow.ui" line="770"/>
         <source>Show MDEC State</source>
         <translation>Afficher l&apos;Etat du MDEC</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="759"/>
+        <location filename="../mainwindow.ui" line="778"/>
         <source>Show DMA State</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher l&apos;état DMA</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="768"/>
+        <location filename="../mainwindow.ui" line="787"/>
         <source>&amp;Screenshot</source>
         <translation>&amp;Capture d&apos;Ecran</translation>
     </message>
@@ -7652,103 +8178,103 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation type="vanished">Paramètres de la Carte &amp;Mémoire...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="786"/>
-        <location filename="../mainwindow.cpp" line="660"/>
+        <location filename="../mainwindow.ui" line="805"/>
+        <location filename="../mainwindow.cpp" line="785"/>
         <source>Resume</source>
         <translation>Reprendre</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="789"/>
+        <location filename="../mainwindow.ui" line="808"/>
         <source>Resumes the last save state created.</source>
         <translation>Reprendre la dernière sauvegarde d&apos;état créée.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="800"/>
+        <location filename="../mainwindow.ui" line="819"/>
         <source>&amp;Toolbar</source>
         <translation>&amp;Barre d&apos;Outils</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="811"/>
+        <location filename="../mainwindow.ui" line="830"/>
         <source>Lock Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>Verrouiller la barre d&apos;outil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="822"/>
+        <location filename="../mainwindow.ui" line="841"/>
         <source>&amp;Status Bar</source>
         <translation>Barre  de &amp;Statut</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="831"/>
+        <location filename="../mainwindow.ui" line="850"/>
         <source>Game &amp;List</source>
         <translation>&amp;Liste de Jeu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="839"/>
+        <location filename="../mainwindow.ui" line="858"/>
         <source>System &amp;Display</source>
         <translation>&amp;Afficher le Système</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="847"/>
+        <location filename="../mainwindow.ui" line="870"/>
         <source>Game &amp;Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Propriétés de jeu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="852"/>
+        <location filename="../mainwindow.ui" line="875"/>
         <source>Memory &amp;Card Editor</source>
         <translation>Editeur de &amp;Carte Mémoire</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="857"/>
+        <location filename="../mainwindow.ui" line="880"/>
         <source>C&amp;heat Manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Gestionnaire de triche</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="862"/>
+        <location filename="../mainwindow.ui" line="885"/>
         <source>CPU D&amp;ebugger</source>
-        <translation type="unfinished"></translation>
+        <translation>Débogu&amp;eur CPU</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="871"/>
+        <location filename="../mainwindow.ui" line="902"/>
         <source>Game &amp;Grid</source>
         <translation>&amp;Grille de Jeu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="882"/>
+        <location filename="../mainwindow.ui" line="913"/>
         <source>Show Titles (Grid View)</source>
         <translation>Afficher les Titres (Vue Grille)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="887"/>
+        <location filename="../mainwindow.ui" line="918"/>
         <source>Zoom &amp;In (Grid View)</source>
         <translation>&amp;Zoomer (Vue Grille)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="890"/>
+        <location filename="../mainwindow.ui" line="921"/>
         <source>Ctrl++</source>
         <translation>Ctrl++</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="895"/>
+        <location filename="../mainwindow.ui" line="926"/>
         <source>Zoom &amp;Out (Grid View)</source>
         <translation>&amp;Dézoomer (Vue Grille)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="898"/>
+        <location filename="../mainwindow.ui" line="929"/>
         <source>Ctrl+-</source>
         <translation>Ctrl+-</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="903"/>
+        <location filename="../mainwindow.ui" line="934"/>
         <source>Refresh &amp;Covers (Grid View)</source>
         <translation>Rafraîchir les &amp;Couvertures (Vue Grille)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="908"/>
+        <location filename="../mainwindow.ui" line="939"/>
         <source>Open Memory Card Directory...</source>
         <translation>Ouvrir le Répertoire de la Carte Mémoire...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="913"/>
+        <location filename="../mainwindow.ui" line="944"/>
         <source>Open Data Directory...</source>
         <translation>Ouvrir le Répertoire de Données...</translation>
     </message>
@@ -7757,414 +8283,446 @@ Vous pourrez ainsi télécharger environ 4 mégaoctets via votre connexion Inter
         <translation type="vanished">Tous les Types de Fichiers (*.bin *.img *.cue *.chd *.exe *.psexe *.psf *.m3u);;Images Raw piste seule (*.bin *.img);;Cue Sheets (*.cue);;Images MAME CHD (*.chd);;Exécutables PlayStation (*.exe *.psexe);;Format de fichiers son portables (*.psf);;Listes de lecture (*.m3u)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="47"/>
+        <location filename="../mainwindow.cpp" line="57"/>
         <source>All File Types (*.bin *.img *.iso *.cue *.chd *.ecm *.mds *.pbp *.exe *.psexe *.ps-exe *.psf *.minipsf *.m3u);;Single-Track Raw Images (*.bin *.img *.iso);;Cue Sheets (*.cue);;MAME CHD Images (*.chd);;Error Code Modeler Images (*.ecm);;Media Descriptor Sidecar Images (*.mds);;PlayStation EBOOTs (*.pbp *.PBP);;PlayStation Executables (*.exe *.psexe *.ps-exe);;Portable Sound Format Files (*.psf *.minipsf);;Playlists (*.m3u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tous les types de fichier (*.bin *.img *.iso *.cue *.chd *.ecm *.mds *.pbp *.exe *.psexe *.ps-exe *.psf *.minipsf *.m3u);;Single-Track Raw Images (*.bin *.img *.iso);;Cue Sheets (*.cue);;MAME CHD Images (*.chd);;Error Code Modeler Images (*.ecm);;Media Descriptor Sidecar Images (*.mds);;PlayStation EBOOTs (*.pbp *.PBP);;PlayStation Executables (*.exe *.psexe *.ps-exe);;Portable Sound Format Files (*.psf *.minipsf);;Playlists (*.m3u)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="157"/>
-        <location filename="../mainwindow.cpp" line="167"/>
-        <location filename="../mainwindow.cpp" line="255"/>
-        <location filename="../mainwindow.cpp" line="960"/>
-        <location filename="../mainwindow.cpp" line="1222"/>
+        <location filename="../mainwindow.cpp" line="232"/>
+        <location filename="../mainwindow.cpp" line="241"/>
+        <location filename="../mainwindow.cpp" line="330"/>
+        <location filename="../mainwindow.cpp" line="1085"/>
+        <location filename="../mainwindow.cpp" line="1350"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="157"/>
+        <location filename="../mainwindow.cpp" line="232"/>
         <source>Failed to get window info from widget</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la récupération des infos fenêtre depuis le widget</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="167"/>
+        <location filename="../mainwindow.cpp" line="241"/>
         <source>Failed to create host display device context.</source>
         <translation>Impossible de créer un contexte de dispositif d&apos;affichage hôte.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="330"/>
         <source>Failed to get new window info from widget</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de récupération des infos de nouvelle fenêtre depuis le widget</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="508"/>
+        <location filename="../mainwindow.cpp" line="601"/>
         <source>Paused</source>
-        <translation type="unfinished"></translation>
+        <translation>En pause</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="595"/>
-        <location filename="../mainwindow.cpp" line="1057"/>
+        <location filename="../mainwindow.cpp" line="709"/>
+        <location filename="../mainwindow.cpp" line="1182"/>
         <source>Select Disc Image</source>
         <translation>Choisir une Image Disque</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="724"/>
         <source>Could not find any CD-ROM devices. Please ensure you have a CD-ROM drive connected and sufficient permissions to access it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible de trouver un périphérique CD-ROM. Veuillez vérifier que vous avez un lecteur CD-ROM connecté et les droits d&apos;accès.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="624"/>
+        <location filename="../mainwindow.cpp" line="738"/>
         <source>%1 (%2)</source>
-        <translation type="unfinished">%1 (%2)</translation>
+        <translation>%1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="628"/>
+        <location filename="../mainwindow.cpp" line="742"/>
         <source>Select disc drive:</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionnez un lecteur de disque :</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="683"/>
+        <location filename="../mainwindow.cpp" line="808"/>
         <source>Resume (%1)</source>
-        <translation type="unfinished">Reprendre (%1)</translation>
+        <translation>Reprendre (%1)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="690"/>
-        <location filename="../mainwindow.cpp" line="807"/>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="815"/>
+        <location filename="../mainwindow.cpp" line="932"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Game Save %1 (%2)</source>
-        <translation type="unfinished">Sauvegarde du Jeu %1 (%2)</translation>
+        <translation>Sauvegarde du jeu %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="699"/>
+        <location filename="../mainwindow.cpp" line="824"/>
         <source>Edit Memory Cards...</source>
-        <translation type="unfinished"></translation>
+        <translation>Éditer les cartes mémoire...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="872"/>
         <source>Delete Save States...</source>
-        <translation type="unfinished">Effacer les Sauvegardes d&apos;Etats...</translation>
+        <translation>Effacer les sauvegardes d&apos;état...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="753"/>
+        <location filename="../mainwindow.cpp" line="878"/>
         <source>Confirm Save State Deletion</source>
-        <translation type="unfinished">Confirmation la Suppression de la Sauvegarde d&apos;Etat</translation>
+        <translation>Confirmation de suppression de la sauvegarde d&apos;état</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="754"/>
+        <location filename="../mainwindow.cpp" line="879"/>
         <source>Are you sure you want to delete all save states for %1?
 
 The saves will not be recoverable.</source>
-        <translation type="unfinished">Êtes-vous sûr de vouloir supprimer tous les États sauf le %1 ?
+        <translation>Êtes-vous sûr de vouloir supprimer toutes les sauvegardes d&apos;état pour %1 ?
 
 Les sauvegardes ne seront pas récupérables.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="791"/>
+        <location filename="../mainwindow.cpp" line="916"/>
         <source>Load From File...</source>
-        <translation type="unfinished"></translation>
+        <translation>Charger depuis le fichier...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="793"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="918"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Select Save State File</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionnez un fichier de sauvegarde d&apos;état</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="793"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="918"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Save States (*.sav)</source>
-        <translation type="unfinished"></translation>
+        <translation>Sauvegardes d&apos;état (*.sav)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="799"/>
+        <location filename="../mainwindow.cpp" line="924"/>
         <source>Undo Load State</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuler chargement état</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="807"/>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="932"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Game Save %1 (Empty)</source>
-        <translation type="unfinished">Sauvegarde du Jeu %1 (Vide)</translation>
+        <translation>Sauvegarde du jeu %1 (vide)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="813"/>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="938"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Global Save %1 (%2)</source>
-        <translation type="unfinished">Sauvegarde Complète %1 (%2</translation>
+        <translation>Sauvegarde globale %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="813"/>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="938"/>
+        <location filename="../mainwindow.cpp" line="977"/>
         <source>Global Save %1 (Empty)</source>
-        <translation type="unfinished">Sauvegarde Complète %1 (Vide)</translation>
+        <translation>Sauvegarde globale %1 (vide)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="955"/>
         <source>Save To File...</source>
-        <translation type="unfinished"></translation>
+        <translation>Sauvegarder vers fichier...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="879"/>
+        <location filename="../mainwindow.cpp" line="1004"/>
         <source>&amp;Enabled Cheats</source>
-        <translation type="unfinished">&amp;Activation des triches</translation>
+        <translation>Activation des cod&amp;es de triche</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="1006"/>
         <source>&amp;Apply Cheats</source>
-        <translation type="unfinished">&amp;Appliquer les triches</translation>
+        <translation>&amp;Appliquer les codes de triche</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="935"/>
+        <location filename="../mainwindow.cpp" line="1060"/>
         <source>Load Resume State</source>
-        <translation type="unfinished"></translation>
+        <translation>Charger l&apos;état de reprise</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="936"/>
+        <location filename="../mainwindow.cpp" line="1061"/>
         <source>A resume save state was found for this game, saved at:
 
 %1.
 
 Do you want to load this state, or start from a fresh boot?</source>
-        <translation type="unfinished"></translation>
+        <translation>Une save state de reprise a été trouvée pour ce jeu, sauvegardée dans :
+
+%1.
+
+Voulez-vous charger cette save, ou démarrer normalement ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="941"/>
+        <location filename="../mainwindow.cpp" line="1066"/>
         <source>Fresh Boot</source>
-        <translation type="unfinished"></translation>
+        <translation>Démarrage normal</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="942"/>
+        <location filename="../mainwindow.cpp" line="1067"/>
         <source>Delete And Boot</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimer et démarrer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="1086"/>
         <source>Failed to delete save state file &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la suppression du fichier de save state &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1018"/>
+        <location filename="../mainwindow.cpp" line="1143"/>
         <source>Confirm Disc Change</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmation de changement de disque</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1019"/>
+        <location filename="../mainwindow.cpp" line="1144"/>
         <source>Do you want to swap discs or boot the new image (via system reset)?</source>
-        <translation type="unfinished"></translation>
+        <translation>Voulez-vous changer de disque; ou démarrer la nouvelle image (via une réinitialisation système) ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1021"/>
+        <location filename="../mainwindow.cpp" line="1146"/>
         <source>Swap Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Changer de disque</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1022"/>
+        <location filename="../mainwindow.cpp" line="1147"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Réinitialiser</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1023"/>
+        <location filename="../mainwindow.cpp" line="1148"/>
         <source>Cancel</source>
-        <translation type="unfinished">Annuler</translation>
+        <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1042"/>
+        <location filename="../mainwindow.cpp" line="1167"/>
         <source>Start Disc</source>
-        <translation type="unfinished"></translation>
+        <translation>Démarrer le disque</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1107"/>
-        <location filename="../mainwindow.cpp" line="2532"/>
+        <location filename="../mainwindow.cpp" line="1232"/>
+        <location filename="../mainwindow.cpp" line="2703"/>
         <source>Cheat Manager</source>
-        <translation type="unfinished"></translation>
+        <translation>Gestionnaire de codes de triche</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1222"/>
+        <location filename="../mainwindow.cpp" line="1350"/>
         <source>You must select a disc to change discs.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vous devez sélectionner un disque pour changer de disque.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1261"/>
+        <location filename="../mainwindow.cpp" line="1389"/>
         <source>Properties...</source>
         <translation>Propriétés...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1265"/>
+        <location filename="../mainwindow.cpp" line="1393"/>
         <source>Open Containing Directory...</source>
         <translation>Ouvrir le Répertoire Contenant...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1270"/>
+        <location filename="../mainwindow.cpp" line="1398"/>
         <source>Set Cover Image...</source>
         <translation>Sélectionner l&apos;Image de Couverture...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1280"/>
+        <location filename="../mainwindow.cpp" line="1408"/>
         <source>Default Boot</source>
         <translation>Démarrage par Défaut</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1283"/>
+        <location filename="../mainwindow.cpp" line="1411"/>
         <source>Fast Boot</source>
         <translation>Démarrage Rapide</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1289"/>
+        <location filename="../mainwindow.cpp" line="1417"/>
         <source>Full Boot</source>
         <translation>Démarrage Complet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1297"/>
+        <location filename="../mainwindow.cpp" line="1425"/>
         <source>Boot and Debug</source>
-        <translation type="unfinished"></translation>
+        <translation>Démarrer et déboguer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1318"/>
+        <location filename="../mainwindow.cpp" line="1445"/>
         <source>Exclude From List</source>
-        <translation type="unfinished"></translation>
+        <translation>Exclure de la liste</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1321"/>
+        <location filename="../mainwindow.cpp" line="1448"/>
+        <source>Reset Play Time</source>
+        <translation>Réinitialiser le temps de jeu</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1452"/>
         <source>Add Search Directory...</source>
         <translation>Ajout d&apos;un Répertoire de Recherche...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1329"/>
+        <location filename="../mainwindow.cpp" line="1460"/>
         <source>Select Cover Image</source>
         <translation>Choisir l&apos;Image de Couverture</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1330"/>
+        <location filename="../mainwindow.cpp" line="1461"/>
         <source>All Cover Image Types (*.jpg *.jpeg *.png)</source>
         <translation>Tous les Types d&apos;Images de Couverture (*.jpg *.jpeg *.png)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1336"/>
+        <location filename="../mainwindow.cpp" line="1467"/>
         <source>Cover Already Exists</source>
         <translation>La Couverture existe déjà</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1337"/>
+        <location filename="../mainwindow.cpp" line="1468"/>
         <source>A cover image for this game already exists, do you wish to replace it?</source>
         <translation>Une image de Couverture pour ce jeu existe déjà, souhaitez-vous la remplacer?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1351"/>
-        <location filename="../mainwindow.cpp" line="1357"/>
+        <location filename="../mainwindow.cpp" line="1482"/>
+        <location filename="../mainwindow.cpp" line="1488"/>
         <source>Copy Error</source>
         <translation>Copier l&apos;Erreur</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1351"/>
+        <location filename="../mainwindow.cpp" line="1482"/>
         <source>Failed to remove existing cover &apos;%1&apos;</source>
         <translation>N&apos;a pas réussi à supprimer la couverture existante &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1357"/>
+        <location filename="../mainwindow.cpp" line="1488"/>
         <source>Failed to copy &apos;%1&apos; to &apos;%2&apos;</source>
         <translation>N&apos;a pas réussi à copier &apos;%1&apos; to &apos;%2&apos;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1498"/>
+        <source>Confirm Reset</source>
+        <translation>Confirmation de réinitialisation</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1499"/>
+        <source>Are you sure you want to reset the play time for &apos;%1&apos;?
+
+This action cannot be undone.</source>
+        <translation>Êtes-vous sûr de vouloir réinitialiser le temps de jeu de &apos;%1&apos; ?
+
+Cette action ne peut pas être annulée.</translation>
     </message>
     <message>
         <source>Language changed. Please restart the application to apply.</source>
         <translation type="vanished">Langue changée. Veuillez relancer l&apos;application pour l&apos;appliquer.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1493"/>
+        <location filename="../mainwindow.cpp" line="1646"/>
         <source>%1x Scale</source>
-        <translation type="unfinished"></translation>
+        <translation>Échelle %1x</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1900"/>
-        <location filename="../mainwindow.cpp" line="1907"/>
-        <location filename="../mainwindow.cpp" line="1916"/>
+        <location filename="../mainwindow.cpp" line="2054"/>
+        <location filename="../mainwindow.cpp" line="2061"/>
+        <location filename="../mainwindow.cpp" line="2070"/>
         <source>Destination File</source>
         <translation>Fichier de Destination</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1900"/>
-        <location filename="../mainwindow.cpp" line="1916"/>
+        <location filename="../mainwindow.cpp" line="2054"/>
+        <location filename="../mainwindow.cpp" line="2070"/>
         <source>Binary Files (*.bin)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fichiers binaires (*.bin)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1908"/>
+        <location filename="../mainwindow.cpp" line="2062"/>
         <source>Binary Files (*.bin);;PNG Images (*.png)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fichiers binaires (*.bin);;Images PNG (*.png)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1932"/>
+        <location filename="../mainwindow.cpp" line="2086"/>
         <source>Default</source>
         <translation>Défaut</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1933"/>
+        <location filename="../mainwindow.cpp" line="2087"/>
         <source>Fusion</source>
         <translation>Fusion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1934"/>
+        <location filename="../mainwindow.cpp" line="2088"/>
         <source>Dark Fusion (Gray)</source>
         <translation>Fusion Sombre (Gris)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1935"/>
+        <location filename="../mainwindow.cpp" line="2089"/>
         <source>Dark Fusion (Blue)</source>
         <translation>Fusion Sombre (Bleu)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1936"/>
+        <location filename="../mainwindow.cpp" line="2090"/>
         <source>QDarkStyle</source>
         <translation>QDarkStyle</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2370"/>
+        <location filename="../mainwindow.cpp" line="2539"/>
         <source>Confirm Shutdown</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmation d&apos;arrêt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2373"/>
+        <location filename="../mainwindow.cpp" line="2540"/>
+        <source>Are you sure you want to shut down the virtual machine?</source>
+        <translation>Êtes-vous sûr de vouloir arrêter la machine vituelle ?</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2542"/>
         <source>Save State For Resume</source>
-        <translation type="unfinished"></translation>
+        <translation>Save state pour reprendre</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2454"/>
-        <location filename="../mainwindow.cpp" line="2459"/>
-        <location filename="../mainwindow.cpp" line="2479"/>
-        <location filename="../mainwindow.cpp" line="2488"/>
+        <location filename="../mainwindow.cpp" line="2618"/>
+        <location filename="../mainwindow.cpp" line="2623"/>
+        <location filename="../mainwindow.cpp" line="2643"/>
+        <location filename="../mainwindow.cpp" line="2652"/>
         <source>Memory Card Not Found</source>
-        <translation type="unfinished"></translation>
+        <translation>Carte mémoire introuvable</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2455"/>
+        <location filename="../mainwindow.cpp" line="2619"/>
         <source>Memory card &apos;%1&apos; does not exist. Do you want to create an empty memory card?</source>
-        <translation type="unfinished"></translation>
+        <translation>La carte mémoire &apos;%1&apos; n&apos;existe pas. Voulez-vous créer une carte mémoire vide ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2460"/>
+        <location filename="../mainwindow.cpp" line="2624"/>
         <source>Failed to create memory card &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de création de la carte mémoire &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2480"/>
-        <location filename="../mainwindow.cpp" line="2489"/>
+        <location filename="../mainwindow.cpp" line="2644"/>
+        <location filename="../mainwindow.cpp" line="2653"/>
         <source>Memory card &apos;%1&apos; could not be found. Try starting the game and saving to create it.</source>
-        <translation type="unfinished"></translation>
+        <translation>La carte mémoire &apos;%1&apos; n&apos;a pas pu être trouvée. Essayez de démarrer le jeu et de sauvegarder pour la créer.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2530"/>
+        <location filename="../mainwindow.cpp" line="2701"/>
         <source>Do not show again</source>
-        <translation type="unfinished"></translation>
+        <translation>Ne plus montrer à l&apos;avenir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2534"/>
+        <location filename="../mainwindow.cpp" line="2705"/>
         <source>Using cheats can have unpredictable effects on games, causing crashes, graphical glitches, and corrupted saves. By using the cheat manager, you agree that it is an unsupported configuration, and we will not provide you with any assistance when games break.
 
 Cheats persist through save states even after being disabled, please remember to reset/reboot the game after turning off any codes.
 
 Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser des codes de triche peut avoir des effets inprévisibles sur les jeux, causant crashs, glitches graphiques, et sauvegardes corrompues. En utiliser le gestionnaire de codes de triche, vous êtes d&apos;accord qu&apos;il s&apos;agit d&apos;une configuration non-supportée, et nous ne vous fournirons pas d&apos;assistance quand les jeux casseront.
+
+Les codes de triche persistent à travers les save states même après avoir été dédsactivés, veuillez vou rappeler de réinitialiser/redémarrer le jeu après désactivation de tout code de triche.
+
+Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2596"/>
+        <location filename="../mainwindow.cpp" line="2780"/>
         <source>Updater Error</source>
         <translation>Erreur de mise à jour</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2602"/>
+        <location filename="../mainwindow.cpp" line="2786"/>
         <source>&lt;p&gt;Sorry, you are trying to update a DuckStation version which is not an official GitHub release. To prevent incompatibilities, the auto-updater is only enabled on official builds.&lt;/p&gt;&lt;p&gt;To obtain an official build, please follow the instructions under &quot;Downloading and Running&quot; at the link below:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/&quot;&gt;https://github.com/stenzek/duckstation/&lt;/a&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Désolé, vous essayez de mettre à jour une version de DuckStation qui n&apos;est pas une version officielle Github. Pour éviter des incompatibilités, la mise à jour automatique n&apos;est activée que sur les builds officielles. &lt;/p&gt;&lt;p&gt;Pour obtenir une build officielle, veuillez suivre les instructions sous &quot;Téléchargement et Lancement&quot; au lien ci-dessous:&lt;/p&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/&quot;&gt;https://github.com/stenzek/duckstation/&lt;/a&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2608"/>
+        <location filename="../mainwindow.cpp" line="2792"/>
         <source>Automatic updating is not supported on the current platform.</source>
         <translation>La mise à jour automatique n&apos;est pas prise en charge sur la plateforme actuelle.</translation>
     </message>
@@ -8174,7 +8732,7 @@ Are you sure you want to continue?</source>
     <message>
         <location filename="../memorycardeditordialog.ui" line="14"/>
         <source>Memory Card Editor</source>
-        <translation>Edition de la Carte Mémoire</translation>
+        <translation>Éditeur de carte mémoire</translation>
     </message>
     <message>
         <location filename="../memorycardeditordialog.ui" line="44"/>
@@ -8186,7 +8744,7 @@ Are you sure you want to continue?</source>
         <location filename="../memorycardeditordialog.ui" line="49"/>
         <location filename="../memorycardeditordialog.ui" line="203"/>
         <source>File Name</source>
-        <translation>Nom du Fichier</translation>
+        <translation>Nom du fichier</translation>
     </message>
     <message>
         <location filename="../memorycardeditordialog.ui" line="54"/>
@@ -8198,7 +8756,7 @@ Are you sure you want to continue?</source>
         <location filename="../memorycardeditordialog.ui" line="64"/>
         <location filename="../memorycardeditordialog.ui" line="140"/>
         <source>Memory Card:</source>
-        <translation>Carte Mémoire:</translation>
+        <translation>Carte mémoire :</translation>
     </message>
     <message>
         <location filename="../memorycardeditordialog.ui" line="78"/>
@@ -8210,68 +8768,72 @@ Are you sure you want to continue?</source>
         <location filename="../memorycardeditordialog.ui" line="89"/>
         <location filename="../memorycardeditordialog.ui" line="161"/>
         <source>Open...</source>
-        <translation type="unfinished">Ouvrir...</translation>
+        <translation>Ouvrir...</translation>
     </message>
     <message>
         <source>0 blocks used</source>
         <translation type="vanished">0 blocs utilisés</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="114"/>
+        <location filename="../memorycardeditordialog.cpp" line="117"/>
         <source>Import File...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importer un fichier...</translation>
     </message>
     <message>
         <source>Import file...</source>
         <translation type="vanished">Importer le fichier...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="115"/>
+        <location filename="../memorycardeditordialog.cpp" line="118"/>
         <source>Import Card...</source>
         <translation>Importer la Carte...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="116"/>
+        <location filename="../memorycardeditordialog.cpp" line="119"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="24"/>
+        <location filename="../memorycardeditordialog.cpp" line="27"/>
         <source>Delete File</source>
         <translation>Effacer le Fichier</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="17"/>
+        <location filename="../memorycardeditordialog.cpp" line="15"/>
+        <source>All Memory Card Types (*.mcd *.mcr *.mc *.srm *.psm *.ps *.ddf *.mem *.vgs *.psx)</source>
+        <translation>Tous les types de carte mémoire (*.mcd *.mcr *.mc *.srm *.psm *.ps *.ddf *.mem *.vgs *.psx)</translation>
+    </message>
+    <message>
+        <location filename="../memorycardeditordialog.cpp" line="20"/>
         <source>Single Save Files (*.mcs);;All Files (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fichiers de sauvegarde unique (*.mcs);;Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="25"/>
+        <location filename="../memorycardeditordialog.cpp" line="28"/>
         <source>Undelete File</source>
-        <translation type="unfinished"></translation>
+        <translation>Restaurer le fichier</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="26"/>
+        <location filename="../memorycardeditordialog.cpp" line="29"/>
         <source>Export File</source>
         <translation>Exporter le Fichier</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="27"/>
+        <location filename="../memorycardeditordialog.cpp" line="30"/>
         <source>&lt;&lt;</source>
         <translation>&lt;&lt;</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="28"/>
+        <location filename="../memorycardeditordialog.cpp" line="31"/>
         <source>&gt;&gt;</source>
         <translation>&gt;&gt;</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="13"/>
         <source>All Memory Card Types (*.mcd *.mcr *.mc)</source>
-        <translation>Tous les Types de Carte Mémoire (*.mcd *.mcr *.mc)</translation>
+        <translation type="vanished">Tous les Types de Carte Mémoire (*.mcd *.mcr *.mc)</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="15"/>
+        <location filename="../memorycardeditordialog.cpp" line="18"/>
         <source>All Importable Memory Card Types (*.mcd *.mcr *.mc *.gme)</source>
         <translation>Tous les Types de Carte Mémoire Importable (*.mcd *.mcr *.mc *.gme)</translation>
     </message>
@@ -8280,45 +8842,45 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Parcourir...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="307"/>
-        <location filename="../memorycardeditordialog.cpp" line="333"/>
+        <location filename="../memorycardeditordialog.cpp" line="310"/>
+        <location filename="../memorycardeditordialog.cpp" line="336"/>
         <source>Select Memory Card</source>
         <translation>Choisir la Carte Mémoire</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="229"/>
-        <location filename="../memorycardeditordialog.cpp" line="339"/>
-        <location filename="../memorycardeditordialog.cpp" line="364"/>
-        <location filename="../memorycardeditordialog.cpp" line="403"/>
-        <location filename="../memorycardeditordialog.cpp" line="413"/>
-        <location filename="../memorycardeditordialog.cpp" line="423"/>
-        <location filename="../memorycardeditordialog.cpp" line="429"/>
-        <location filename="../memorycardeditordialog.cpp" line="448"/>
-        <location filename="../memorycardeditordialog.cpp" line="468"/>
-        <location filename="../memorycardeditordialog.cpp" line="496"/>
-        <location filename="../memorycardeditordialog.cpp" line="514"/>
-        <location filename="../memorycardeditordialog.cpp" line="560"/>
+        <location filename="../memorycardeditordialog.cpp" line="232"/>
+        <location filename="../memorycardeditordialog.cpp" line="342"/>
+        <location filename="../memorycardeditordialog.cpp" line="367"/>
+        <location filename="../memorycardeditordialog.cpp" line="406"/>
+        <location filename="../memorycardeditordialog.cpp" line="416"/>
+        <location filename="../memorycardeditordialog.cpp" line="426"/>
+        <location filename="../memorycardeditordialog.cpp" line="432"/>
+        <location filename="../memorycardeditordialog.cpp" line="451"/>
+        <location filename="../memorycardeditordialog.cpp" line="471"/>
+        <location filename="../memorycardeditordialog.cpp" line="499"/>
+        <location filename="../memorycardeditordialog.cpp" line="517"/>
+        <location filename="../memorycardeditordialog.cpp" line="563"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="45"/>
+        <location filename="../memorycardeditordialog.cpp" line="48"/>
         <source>New Card...</source>
-        <translation type="unfinished"></translation>
+        <translation>Nouvelle carte...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="46"/>
+        <location filename="../memorycardeditordialog.cpp" line="49"/>
         <source>Open Card...</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouvrir une carte...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="113"/>
+        <location filename="../memorycardeditordialog.cpp" line="116"/>
         <source>Format Card</source>
-        <translation type="unfinished"></translation>
+        <translation>Formater la carte</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="229"/>
-        <location filename="../memorycardeditordialog.cpp" line="339"/>
+        <location filename="../memorycardeditordialog.cpp" line="232"/>
+        <location filename="../memorycardeditordialog.cpp" line="342"/>
         <source>Failed to load memory card image.</source>
         <translation>Impossible de charger l&apos;image de la carte mémoire.</translation>
     </message>
@@ -8327,113 +8889,113 @@ Are you sure you want to continue?</source>
         <translation type="vanished">%1 blocs libre%2</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="273"/>
+        <location filename="../memorycardeditordialog.cpp" line="276"/>
         <source> (Deleted)</source>
-        <translation type="unfinished"></translation>
+        <translation> (supprimé)</translation>
     </message>
     <message numerus="yes">
-        <location filename="../memorycardeditordialog.cpp" line="293"/>
+        <location filename="../memorycardeditordialog.cpp" line="296"/>
         <source>%n block(s) free%1</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n bloc(s) libérés%1</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="365"/>
+        <location filename="../memorycardeditordialog.cpp" line="368"/>
         <source>Failed to write card to &apos;%1&apos;</source>
         <translation>N&apos;a pas écrit sur la carte à &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="379"/>
+        <location filename="../memorycardeditordialog.cpp" line="382"/>
         <source>Save memory card?</source>
         <translation>Sauvegarder la Carte Mémoire ?</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="380"/>
+        <location filename="../memorycardeditordialog.cpp" line="383"/>
         <source>Memory card &apos;%1&apos; is not saved, do you want to save before closing?</source>
         <translation>Carte mémoire &apos;%1&apos; non sauvegardée, voulez-vous l&apos;enregistrer avant la fermeture?</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="404"/>
+        <location filename="../memorycardeditordialog.cpp" line="407"/>
         <source>Destination memory card already contains a save file with the same name (%1) as the one you are attempting to copy. Please delete this file from the destination memory card before copying.</source>
-        <translation type="unfinished"></translation>
+        <translation>La carte mémoire de destination contient déjà un fichier de sauvegarde du même nom (%1) que celui que vous essayez de copier. Veuillez supprimer le fichier de carte mémoire de destination avant de copier.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="414"/>
+        <location filename="../memorycardeditordialog.cpp" line="417"/>
         <source>Insufficient blocks, this file needs %1 but only %2 are available.</source>
         <translation>Blocs insuffisants, ce fichier a besoin de %1 mais seuls %2 sont disponibles.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="423"/>
+        <location filename="../memorycardeditordialog.cpp" line="426"/>
         <source>Failed to read file %1</source>
         <translation>N&apos;a pas réussi à lire le fichier %1</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="429"/>
+        <location filename="../memorycardeditordialog.cpp" line="432"/>
         <source>Failed to write file %1</source>
         <translation>N&apos;a pas écrit le fichier %1</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="448"/>
+        <location filename="../memorycardeditordialog.cpp" line="451"/>
         <source>Failed to delete file %1</source>
         <translation>N&apos;a pas réussi à supprimer le fichier %1</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="469"/>
+        <location filename="../memorycardeditordialog.cpp" line="472"/>
         <source>Failed to undelete file %1. The file may have been partially overwritten by another save.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la restauration du fichier %1. The fichier a peut-être été partiellement écrasé par une autre sauvegarde.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="484"/>
+        <location filename="../memorycardeditordialog.cpp" line="487"/>
         <source>Select Single Savefile</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélection d&apos;un fichier de sauvegarde unique</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="497"/>
+        <location filename="../memorycardeditordialog.cpp" line="500"/>
         <source>Failed to export save file %1. Check the log for more details.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;export du fichier de sauvegarde %1. Vérifiez la log pour plus de détails.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="507"/>
+        <location filename="../memorycardeditordialog.cpp" line="510"/>
         <source>Select Import File</source>
         <translation>Sélectionnez le Fichier d&apos;Importation</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="514"/>
+        <location filename="../memorycardeditordialog.cpp" line="517"/>
         <source>Failed to import memory card. The log may contain more information.</source>
         <translation>Impossible d&apos;importer la carte mémoire. Le journal peut contenir plus d&apos;informations.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="531"/>
+        <location filename="../memorycardeditordialog.cpp" line="534"/>
         <source>Format memory card?</source>
-        <translation type="unfinished"></translation>
+        <translation>Formater la carte mémoire ?</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="532"/>
+        <location filename="../memorycardeditordialog.cpp" line="535"/>
         <source>Formatting the memory card will destroy all saves, and they will not be recoverable. The memory card which will be formatted is located at &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Formater la carte mémoire détruira toutes les sauvegardes, et elle ne seront pas récupérables. La carte mémoire qui va être formatée est située à &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="553"/>
+        <location filename="../memorycardeditordialog.cpp" line="556"/>
         <source>Select Import Save File</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélection de fichier de sauvegarde d&apos;import</translation>
     </message>
     <message>
-        <location filename="../memorycardeditordialog.cpp" line="561"/>
+        <location filename="../memorycardeditordialog.cpp" line="564"/>
         <source>Failed to import save. Check if there is enough room on the memory card or if an existing save with the same name already exists.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec d&apos;import de la sauvegarde. Vérifiez s&apos;il y a assez de place sur la carte mémoire, ou si une sauvegarde existante avec le même nom n&apos;existe pas déjà.</translation>
     </message>
 </context>
 <context>
     <name>MemoryCardSettingsWidget</name>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="16"/>
+        <location filename="../memorycardsettingswidget.cpp" line="19"/>
         <source>All Memory Card Types (*.mcd *.mcr *.mc)</source>
         <translation>Tous les Types de Carte Mémoire (*.mcd *.mcr *.mc)</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="38"/>
+        <location filename="../memorycardsettingswidget.cpp" line="41"/>
         <source>Shared Settings</source>
         <translation>Paramètres Partagés</translation>
     </message>
@@ -8442,7 +9004,7 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Utiliser une seule Carte pour la Liste de lecture</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="63"/>
+        <location filename="../memorycardsettingswidget.cpp" line="66"/>
         <source>Checked</source>
         <translation>Coché</translation>
     </message>
@@ -8459,70 +9021,70 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Ouvrir...</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="111"/>
+        <location filename="../memorycardsettingswidget.cpp" line="114"/>
         <source>Memory Card %1</source>
         <translation>Carte Mémoire %1</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="126"/>
+        <location filename="../memorycardsettingswidget.cpp" line="129"/>
         <source>Memory Card Type:</source>
         <translation>Type de Carte Mémoire:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="40"/>
-        <location filename="../memorycardsettingswidget.cpp" line="140"/>
+        <location filename="../memorycardsettingswidget.cpp" line="43"/>
+        <location filename="../memorycardsettingswidget.cpp" line="143"/>
         <source>Browse...</source>
         <translation>Parcourir...</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="41"/>
-        <location filename="../memorycardsettingswidget.cpp" line="145"/>
+        <location filename="../memorycardsettingswidget.cpp" line="44"/>
+        <location filename="../memorycardsettingswidget.cpp" line="148"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../memorycardsettingswidget.cpp" line="42"/>
-        <source>Open Directory...</source>
-        <translation type="unfinished">Ouvrir le Répertoire...</translation>
+        <translation>Réinitialiser</translation>
     </message>
     <message>
         <location filename="../memorycardsettingswidget.cpp" line="45"/>
+        <source>Open Directory...</source>
+        <translation>Ouvrir le répertoire...</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="48"/>
         <source>Memory Card Directory:</source>
-        <translation type="unfinished"></translation>
+        <translation>Répertoire de carte mémoire :</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="58"/>
-        <location filename="../memorycardsettingswidget.cpp" line="63"/>
+        <location filename="../memorycardsettingswidget.cpp" line="61"/>
+        <location filename="../memorycardsettingswidget.cpp" line="66"/>
         <source>Use Single Card For Sub-Images</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser une seule carte pour les sous-images</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="64"/>
+        <location filename="../memorycardsettingswidget.cpp" line="67"/>
         <source>When using a multi-disc format (m3u/pbp) and per-game (title) memory cards, a single memory card will be used for all discs. If unchecked, a separate card will be used for each disc.</source>
-        <translation type="unfinished"></translation>
+        <translation>En utilisant un format multi-disque (m3u/pbp) et des cartes mémoire par jeu (titre), une carte mémoire unique sera utilisée pour tous les disques. Si décoché, une carte séparée sera utilisé par disque.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="73"/>
+        <location filename="../memorycardsettingswidget.cpp" line="76"/>
         <source>If one of the &quot;separate card per game&quot; memory card types is chosen, these memory cards will be saved to the memory cards directory.</source>
-        <translation type="unfinished"></translation>
+        <translation>Si l&apos;un des types de carte mémoire &quot;carte séparée par jeu&quot; est choisi, ces cartes mémoire seront sauvegardées dans le répertoire des cartes mémoire.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="86"/>
+        <location filename="../memorycardsettingswidget.cpp" line="89"/>
         <source>The memory card editor enables you to move saves between cards, as well as import cards of other formats.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;éditeur de carte mémoire vous permet de déplacer les sauvegardes entres les cartes, ainsi que d&apos;importer des cartes dans d&apos;autres formats.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="91"/>
+        <location filename="../memorycardsettingswidget.cpp" line="94"/>
         <source>Memory Card Editor...</source>
-        <translation type="unfinished"></translation>
+        <translation>Éditeur de carte mémoire...</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="150"/>
+        <location filename="../memorycardsettingswidget.cpp" line="153"/>
         <source>Shared Memory Card Path:</source>
         <translation>Chemin de la Carte Mémoire Partagée:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="158"/>
+        <location filename="../memorycardsettingswidget.cpp" line="161"/>
         <source>Select path to memory card image</source>
         <translation>Choisir un chemin pour l&apos;image de la carte mémoire</translation>
     </message>
@@ -8530,57 +9092,65 @@ Are you sure you want to continue?</source>
 <context>
     <name>MemoryCardType</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1106"/>
+        <location filename="../../core/settings.cpp" line="1210"/>
         <source>No Memory Card</source>
         <translation>Aucune Carte Mémoire</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1106"/>
+        <location filename="../../core/settings.cpp" line="1210"/>
         <source>Shared Between All Games</source>
         <translation>Partagé entre tous les Jeux</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1107"/>
+        <location filename="../../core/settings.cpp" line="1211"/>
+        <source>Separate Card Per Game (Serial)</source>
+        <translation>Carte séparée par jeu (numéro de série)</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1212"/>
+        <source>Separate Card Per Game (Title)</source>
+        <translation>Carte séparée par jeu (titre)</translation>
+    </message>
+    <message>
         <source>Separate Card Per Game (Game Code)</source>
-        <translation>Séparation de Carte par Jeu (Code du Jeu)</translation>
+        <translation type="vanished">Séparation de Carte par Jeu (Code du Jeu)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1108"/>
         <source>Separate Card Per Game (Game Title)</source>
-        <translation>Séparation de Carte par Jeu (Titre du Jeu)</translation>
+        <translation type="vanished">Séparation de Carte par Jeu (Titre du Jeu)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1109"/>
+        <location filename="../../core/settings.cpp" line="1213"/>
         <source>Separate Card Per Game (File Title)</source>
-        <translation type="unfinished"></translation>
+        <translation>Carte séparée par jeu (titre de fichier)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1110"/>
+        <location filename="../../core/settings.cpp" line="1214"/>
         <source>Non-Persistent Card (Do Not Save)</source>
-        <translation type="unfinished"></translation>
+        <translation>Carte non-persistante (ne pas sauvegarder)</translation>
     </message>
 </context>
 <context>
     <name>MultitapMode</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1162"/>
+        <location filename="../../core/settings.cpp" line="1266"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactivé</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1162"/>
+        <location filename="../../core/settings.cpp" line="1266"/>
         <source>Enable on Port 1 Only</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer uniquement sur le port 1</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1163"/>
+        <location filename="../../core/settings.cpp" line="1267"/>
         <source>Enable on Port 2 Only</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer uniquement sur le port 2</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1163"/>
+        <location filename="../../core/settings.cpp" line="1267"/>
         <source>Enable on Ports 1 and 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer sur les ports 1 et 2</translation>
     </message>
 </context>
 <context>
@@ -8665,20 +9235,30 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Start</translation>
     </message>
     <message>
-        <location filename="../../core/negcon.cpp" line="253"/>
+        <location filename="../../core/negcon.cpp" line="258"/>
         <source>Steering Axis Deadzone</source>
-        <translation type="unfinished"></translation>
+        <translation>Zone morte de l&apos;axe de direction</translation>
     </message>
     <message>
-        <location filename="../../core/negcon.cpp" line="254"/>
+        <location filename="../../core/negcon.cpp" line="259"/>
         <source>Sets deadzone size for steering axis.</source>
-        <translation type="unfinished"></translation>
+        <translation>Définis la taille de la zone mort de l&apos;axe de direction.</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="261"/>
+        <source>Steering Axis Sensitivity</source>
+        <translation>Sensitivité de l&apos;axe de direction</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="262"/>
+        <source>Sets the steering axis scaling factor.</source>
+        <translation>Définis le facteur d&apos;échelle de l&apos;axe de direction.</translation>
     </message>
 </context>
 <context>
     <name>OSDMessage</name>
     <message>
-        <location filename="../../core/system.cpp" line="890"/>
+        <location filename="../../core/system.cpp" line="992"/>
         <source>System reset.</source>
         <translation>Réinitialisation du Système.</translation>
     </message>
@@ -8687,12 +9267,12 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Chargement d&apos;Etat depuis la &apos;%s&apos;...</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="953"/>
+        <location filename="../../core/system.cpp" line="1051"/>
         <source>Loading state from &apos;%s&apos; failed. Resetting.</source>
         <translation>Le chargement d&apos;Etat depuis la &apos;%s&apos; a échoué. Réinitialisation.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="994"/>
+        <location filename="../../core/system.cpp" line="1092"/>
         <source>Saving state to &apos;%s&apos; failed.</source>
         <translation>La sauvegarde vers &apos;%s&apos; a échoué.</translation>
     </message>
@@ -8701,31 +9281,41 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Etat Sauvegardé vers la &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="605"/>
+        <location filename="../../core/settings.cpp" line="651"/>
         <source>PGXP is incompatible with the software renderer, disabling PGXP.</source>
         <translation>PGXP est incompatible avec le logiciel de rendu, ce qui désactive PGXP.</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="623"/>
+        <location filename="../../core/settings.cpp" line="671"/>
         <source>Rewind is not supported on 32-bit ARM for Android.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le rewind n&apos;est pas supporté en 32-bit ARM sous Android.</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="678"/>
+        <source>Runahead is not supported on 32-bit ARM for Android.</source>
+        <translation>Le runahead n&apos;est pas supporté en 32-bit ARM sous Android.</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="686"/>
+        <source>Rewind is disabled because runahead is enabled.</source>
+        <translation>Le rewind est désactivé car le runahead est activé.</translation>
     </message>
     <message>
         <source>PGXP CPU mode is incompatible with the recompiler, using Cached Interpreter instead.</source>
         <translation type="vanished">Le mode PGXP CPU est incompatible avec le recompileur, qui utilise plutôt l&apos;Interpréteur en Cache.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3036"/>
+        <location filename="../../core/system.cpp" line="3263"/>
         <source>Switching to %s%s GPU renderer.</source>
         <translation>Passage à %s%s vers le rendu GPU.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3058"/>
+        <location filename="../../core/system.cpp" line="3287"/>
         <source>Switching to %s audio backend.</source>
         <translation>Passage à %s%s vers le moteur Audio.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3080"/>
+        <location filename="../../core/system.cpp" line="3309"/>
         <source>Switching to %s CPU execution mode.</source>
         <translation>Passage à %s%s vers le Mode d&apos;Execution du CPU.</translation>
     </message>
@@ -8746,105 +9336,105 @@ Are you sure you want to continue?</source>
         <translation type="vanished">CPU ICache désactivé, ce qui permet de vider tous les blocs.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3152"/>
+        <location filename="../../core/system.cpp" line="3387"/>
         <source>PGXP enabled, recompiling all blocks.</source>
         <translation>PGXP activé, ce qui permet de recompiler tous les blocs.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3153"/>
+        <location filename="../../core/system.cpp" line="3388"/>
         <source>PGXP disabled, recompiling all blocks.</source>
         <translation>PGXP désactivé, ce qui permet de recompiler tous les blocs.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3600"/>
+        <location filename="../../core/system.cpp" line="3832"/>
         <source>Failed to save undo load state.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/system.cpp" line="3907"/>
+        <location filename="../../core/system.cpp" line="4137"/>
         <source>%n cheats are enabled. This may result in instability.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n codes de triche sont activés. Cela peut résulter en de l&apos;instabilité.</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/system.cpp" line="3971"/>
+        <location filename="../../core/system.cpp" line="4201"/>
         <source>Saved %n cheats to &apos;%s&apos;.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Sauvegardé %n codes de triche vers &apos;%s&apos;.</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3987"/>
+        <location filename="../../core/system.cpp" line="4217"/>
         <source>Deleted cheat list &apos;%s&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Supprimé la liste de codes de triche &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4122"/>
+        <location filename="../../core/system.cpp" line="4352"/>
         <source>Widescreen hack is now enabled, and aspect ratio is set to %s.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le hack écran large est maintenant activé, et le ratio d&apos;aspect est défini sur %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4130"/>
+        <location filename="../../core/system.cpp" line="4360"/>
         <source>Widescreen hack is now disabled, and aspect ratio is set to %s.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le hack d&apos;écran large est maintenant désactivé, et le ratio d&apos;aspect est défini sur %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4146"/>
+        <location filename="../../core/system.cpp" line="4376"/>
         <source>Switching to %s renderer...</source>
-        <translation type="unfinished"></translation>
+        <translation>Bascule vers le rendu %s...</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="71"/>
+        <location filename="../../core/pad.cpp" line="196"/>
         <source>Save state contains controller type %s in port %u, but %s is used. Switching.</source>
-        <translation type="unfinished"></translation>
+        <translation>La save state contient le type de contrôleur %s dans le port %u, mais %s est utilisé. Bascule.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="79"/>
+        <location filename="../../core/pad.cpp" line="204"/>
         <source>Ignoring mismatched controller type %s in port %u.</source>
-        <translation type="unfinished"></translation>
+        <translation>Type de contrôleur %s dans le port %u incompatible, ignoré.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="175"/>
+        <location filename="../../core/pad.cpp" line="298"/>
         <source>Memory card %u from save state does match current card data. Simulating replugging.</source>
         <translation>Le %u de la carte mémoire de la sauvegarde d&apos;état correspond aux données actuelles de la carte. Simulation du rechargement.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="193"/>
+        <location filename="../../core/pad.cpp" line="316"/>
         <source>Memory card %u present in save state but not in system. Ignoring card.</source>
         <translation>La Carte Mémoire %u présente dans la Sauvegarde d&apos;Etat mais pas dans le système. La Carte est ignorée.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="214"/>
+        <location filename="../../core/pad.cpp" line="337"/>
         <source>Memory card %u present in system but not in save state. Replugging card.</source>
-        <translation type="unfinished"></translation>
+        <translation>La carte mémoire %u est présente dans le système mais pas dans le save state. Rebranchement de la carte.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="134"/>
+        <location filename="../../core/pad.cpp" line="259"/>
         <source>Memory card %u present in save state but not in system. Creating temporary card.</source>
         <translation>La Carte mémoire %u présente dans la Sauvegarde d&apos;Etat mais pas dans le système. Création d&apos;une carte temporaire.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="206"/>
+        <location filename="../../core/pad.cpp" line="329"/>
         <source>Memory card %u present in system but not in save state. Removing card.</source>
         <translation>La Carte mémoire %u présente dans le système mais pas la Sauvegarde d&apos;Etat. Suppression de la carte.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1320"/>
+        <location filename="../../core/system.cpp" line="1454"/>
         <source>CPU clock speed is set to %u%% (%u / %u). This may result in instability.</source>
         <translation>La vitesse de l&apos;horloge du CPU est réglée sur %u%% (%u / %u). Cela peut entraîner une instabilité.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1599"/>
+        <location filename="../../core/system.cpp" line="1770"/>
         <source>WARNING: CPU overclock (%u%%) was different in save state (%u%%).</source>
         <translation>ATTENTION : l&apos;overclock du CPU (%u%%) était différent dans la Sauvegarde d&apos;Etat (%u%%).</translation>
     </message>
     <message>
-        <location filename="../../core/gpu.cpp" line="50"/>
-        <location filename="../../core/system.cpp" line="3213"/>
-        <location filename="../../core/system.cpp" line="4074"/>
+        <location filename="../../core/gpu.cpp" line="54"/>
+        <location filename="../../core/system.cpp" line="3447"/>
+        <location filename="../../core/system.cpp" line="4304"/>
         <source>Failed to load post processing shader chain.</source>
         <translation>N&apos;a pas réussi à charger la chaîne de shaders Post-Traitement.</translation>
     </message>
@@ -8857,105 +9447,105 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Limiteur de Vitesse Désactivé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="854"/>
+        <location filename="../../frontend-common/common_host.cpp" line="891"/>
         <source>PGXP is now enabled.</source>
         <translation>PGXP est maintenant Activé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="855"/>
+        <location filename="../../frontend-common/common_host.cpp" line="892"/>
         <source>PGXP is now disabled.</source>
         <translation>PGXP est maintenant Désactivé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="925"/>
+        <location filename="../../frontend-common/common_host.cpp" line="962"/>
         <source>PGXP Depth Buffer is now enabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le tampon de profondeur PGXP est maintenant activé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="926"/>
+        <location filename="../../frontend-common/common_host.cpp" line="963"/>
         <source>PGXP Depth Buffer is now disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le tampon de profondeur PGXP est maintenant désactivé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="898"/>
+        <location filename="../../frontend-common/common_host.cpp" line="935"/>
         <source>Texture replacements reloaded.</source>
-        <translation type="unfinished"></translation>
+        <translation>Remplacements de texture rechargés.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="603"/>
+        <location filename="../../frontend-common/common_host.cpp" line="640"/>
         <source>Cannot load state for game without serial.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible de charger l&apos;état poiur le jeu sans numéro de série.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="613"/>
+        <location filename="../../frontend-common/common_host.cpp" line="650"/>
         <source>No save state found in slot {}.</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucune save state trouvée dans l&apos;emplacement {}.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="627"/>
+        <location filename="../../frontend-common/common_host.cpp" line="664"/>
         <source>Cannot save state for game without serial.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible de save state pour le jeu sans numéro de série.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="705"/>
+        <location filename="../../frontend-common/common_host.cpp" line="742"/>
         <source>Achievements are disabled or unavailable for  game.</source>
-        <translation type="unfinished"></translation>
+        <translation>Les succès sont désactivés ou indisponibles pour le jeu.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="718"/>
+        <location filename="../../frontend-common/common_host.cpp" line="755"/>
         <source>Leaderboards are disabled or unavailable for  game.</source>
-        <translation type="unfinished"></translation>
+        <translation>Les classements sont désactivés ou indisponibles pour le jeu.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="788"/>
+        <location filename="../../frontend-common/common_host.cpp" line="825"/>
         <source>CPU clock speed control enabled (%u%% / %.3f MHz).</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrôle de la vitesse de l&apos;horloge CPU activé (%u%% / %.3f MHz).</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="795"/>
-        <source>CPU clock speed control disabled (%.3f MHz).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../frontend-common/common_host.cpp" line="808"/>
-        <location filename="../../frontend-common/common_host.cpp" line="820"/>
         <location filename="../../frontend-common/common_host.cpp" line="832"/>
+        <source>CPU clock speed control disabled (%.3f MHz).</source>
+        <translation>Contrôle de la vitesse de l&apos;horloge CPU désactivé (%.3f MHz).</translation>
+    </message>
+    <message>
+        <location filename="../../frontend-common/common_host.cpp" line="845"/>
+        <location filename="../../frontend-common/common_host.cpp" line="857"/>
+        <location filename="../../frontend-common/common_host.cpp" line="869"/>
         <source>Emulation speed set to %u%%.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vitesse d&apos;émulation définie à %u%%.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="945"/>
+        <location filename="../../frontend-common/common_host.cpp" line="982"/>
         <source>PGXP CPU mode is now enabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le mode CPU PGXP est maintenant activé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="946"/>
+        <location filename="../../frontend-common/common_host.cpp" line="983"/>
         <source>PGXP CPU mode is now disabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le mode CPU PGXP est maintenant désactivé.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="967"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1004"/>
         <source>Volume: Muted</source>
-        <translation>Volume : Muet</translation>
+        <translation>Volume : muet</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="972"/>
-        <location filename="../../frontend-common/common_host.cpp" line="999"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1015"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1009"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1036"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1052"/>
         <source>Volume: {}%</source>
-        <translation type="unfinished"></translation>
+        <translation>Volume : {}%</translation>
     </message>
     <message>
         <source>Volume: %d%%</source>
         <translation type="vanished">Volume : %d%%</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="984"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1021"/>
         <source>CD Audio Muted.</source>
-        <translation>CD Audio Muet</translation>
+        <translation>CD Audio muet.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="985"/>
+        <location filename="../../frontend-common/common_host.cpp" line="1022"/>
         <source>CD Audio Unmuted.</source>
         <translation>CD Audio audible.</translation>
     </message>
@@ -8964,32 +9554,32 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Profil d&apos;entrée chargé à partir de &apos;%s&apos;</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3661"/>
+        <location filename="../../core/system.cpp" line="3893"/>
         <source>Started dumping audio to &apos;%s&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Début décharge audio vers &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3666"/>
+        <location filename="../../core/system.cpp" line="3898"/>
         <source>Failed to start dumping audio to &apos;%s&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec du démarrage de la décharge audio vers &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3677"/>
+        <location filename="../../core/system.cpp" line="3909"/>
         <source>Stopped dumping audio.</source>
-        <translation type="unfinished"></translation>
+        <translation>Arrêt décharge audio.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3707"/>
+        <location filename="../../core/system.cpp" line="3939"/>
         <source>Screenshot file &apos;%s&apos; already exists.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le fichier de capture d&apos;écran &apos;%s&apos; existe déjà.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3719"/>
+        <location filename="../../core/system.cpp" line="3949"/>
         <source>Failed to save screenshot to &apos;%s&apos;</source>
         <translation>Impossible d&apos;enregistrer la capture d&apos;écran dans &apos;%s&apos;</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3724"/>
+        <location filename="../../core/system.cpp" line="3954"/>
         <source>Screenshot saved to &apos;%s&apos;.</source>
         <translation>Capture d&apos;Ecran Sauvegardée sur &apos;%s&apos;.</translation>
     </message>
@@ -9002,7 +9592,7 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Utilisation du profil d&apos;entrée &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3900"/>
+        <location filename="../../core/system.cpp" line="4130"/>
         <source>Failed to load cheats from &apos;%s&apos;.</source>
         <translation>N&apos;a pas réussi à charger les triches de &apos;%s&apos;.</translation>
     </message>
@@ -9015,237 +9605,258 @@ Are you sure you want to continue?</source>
         <translation type="vanished">Triches sauvegardées %u vers &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4030"/>
+        <location filename="../../core/system.cpp" line="4260"/>
         <source>Cheat &apos;%s&apos; enabled.</source>
         <translation>Triches &apos;%s&apos; activées.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4035"/>
+        <location filename="../../core/system.cpp" line="4265"/>
         <source>Cheat &apos;%s&apos; disabled.</source>
         <translation>Triches &apos;%s&apos; désactivées.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3954"/>
+        <location filename="../../core/system.cpp" line="4184"/>
         <source>Failed to save cheat list to &apos;%s&apos;</source>
         <translation>Échec de la sauvegarde de la liste des triches dans &apos;%s&apos;</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="943"/>
+        <location filename="../../core/system.cpp" line="1041"/>
         <source>Loading state from &apos;{}&apos;...</source>
-        <translation type="unfinished"></translation>
+        <translation>Chargement de l&apos;état depuis &apos;{}&apos;...</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="993"/>
+        <location filename="../../core/system.cpp" line="1091"/>
         <source>Save State</source>
-        <translation type="unfinished">Sauvegarder un Etat</translation>
+        <translation>Sauvegarde de l&apos;état</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1001"/>
+        <location filename="../../core/system.cpp" line="1099"/>
         <source>State saved to &apos;{}&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>État sauvegardé vers &apos;{}&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1327"/>
+        <location filename="../../core/system.cpp" line="1461"/>
         <source>CD-ROM read speedup set to %ux (effective speed %ux). This may result in instability.</source>
-        <translation type="unfinished"></translation>
+        <translation>Accélération de la vitesse de lecture CD-ROM définie à %ux (vitesse effective %ux). Cela peut causer de l&apos;instabilité.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1336"/>
+        <location filename="../../core/system.cpp" line="1470"/>
         <source>CD-ROM seek speedup set to instant. This may result in instability.</source>
-        <translation type="unfinished"></translation>
+        <translation>Accélération de la recherche CD-ROM définie sur instantanée. Cela peut causer de l&apos;instabilité.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1343"/>
+        <location filename="../../core/system.cpp" line="1477"/>
         <source>CD-ROM seek speedup set to %ux. This may result in instability.</source>
-        <translation type="unfinished"></translation>
+        <translation>Accélération de la recherche CD-ROM définie sur %ux. Cela peut causer de l&apos;instabilité.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1512"/>
+        <location filename="../../core/system.cpp" line="1663"/>
         <source>Failed to initialize %s renderer, falling back to software renderer.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;initialisation du rendu %s, bascule vers le rendu logiciel.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1753"/>
+        <location filename="../../core/system.cpp" line="1697"/>
+        <source>This save state was created with a different BIOS version or patch options. This may cause stability issues.</source>
+        <translation>Cette save state a été créée avec une version différente du BIOS ou des options de patch. Cela peut causer de l&apos;instabilité.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="1952"/>
         <source>Failed to open CD image from save state &apos;%s&apos;: %s. Using existing image &apos;%s&apos;, this may result in instability.</source>
-        <translation type="unfinished"></translation>
+        <translation>Éched de l&apos;ouverture de l&apos;image CD à partir de la save state &apos;%s&apos; : %s. Utilisation de l&apos;image existante &apos;%s&apos;, cela peut causer de l&apos;instabilité.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2304"/>
+        <location filename="../../core/system.cpp" line="2522"/>
         <source>Rewinding is not enabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le rewinding n&apos;est pas activé.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2346"/>
+        <location filename="../../core/system.cpp" line="2564"/>
         <source>No cheats are loaded.</source>
-        <translation type="unfinished"></translation>
+        <translation>Aucun code de triche chargé.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/system.cpp" line="2354"/>
+        <location filename="../../core/system.cpp" line="2572"/>
         <source>%n cheats are now active.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n codes de triches sont maintenant actifs.</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/system.cpp" line="2355"/>
+        <location filename="../../core/system.cpp" line="2573"/>
         <source>%n cheats are now inactive.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n codes de triche sont maintenant inactifs.</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2701"/>
+        <location filename="../../core/system.cpp" line="2919"/>
         <source>Swapped memory card ports. Both ports have a memory card.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ports de carte mémoire échangés. Les deux ports ont une carte mémoire.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2706"/>
+        <location filename="../../core/system.cpp" line="2924"/>
         <source>Swapped memory card ports. Port 2 has a memory card, Port 1 is empty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ports de carte mémoire échangés. Le port 2 a une carte mémoire, le port 1 est vide.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2712"/>
+        <location filename="../../core/system.cpp" line="2930"/>
         <source>Swapped memory card ports. Port 1 has a memory card, Port 2 is empty.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ports de carte mémoire échangés. Le port 1 a une carte mémoire, le port 2 est vide.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2718"/>
+        <location filename="../../core/system.cpp" line="2936"/>
         <source>Swapped memory card ports. Neither port has a memory card.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ports de carte mémoire échangés. Aucun des deux ports n&apos;a de carte mémoire.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2803"/>
+        <location filename="../../core/system.cpp" line="3021"/>
         <source>Failed to open disc image &apos;%s&apos;: %s.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;ouverture de l&apos;image disque &apos;%s&apos; : %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2815"/>
+        <location filename="../../core/system.cpp" line="3034"/>
         <source>Inserted disc &apos;%s&apos; (%s).</source>
-        <translation type="unfinished"></translation>
+        <translation>Disque &apos;%s&apos; inséré (%s).</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2989"/>
+        <location filename="../../core/system.cpp" line="3213"/>
         <source>Failed to switch to subimage %u in &apos;%s&apos;: %s.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la bascule vers la sous-image %u dans &apos;%s&apos; : %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2995"/>
+        <location filename="../../core/system.cpp" line="3221"/>
         <source>Switched to sub-image %s (%u) in &apos;%s&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Basculé vers la sous-image %s (%u) dans &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3093"/>
+        <location filename="../../core/system.cpp" line="3322"/>
         <source>Recompiler options changed, flushing all blocks.</source>
-        <translation type="unfinished"></translation>
+        <translation>Les options du recompilateur ont changé, vidage de tous les blocs.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4052"/>
+        <location filename="../../core/system.cpp" line="4282"/>
         <source>Applied cheat &apos;%s&apos;.</source>
         <translation>Application de la triche &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4057"/>
+        <location filename="../../core/system.cpp" line="4287"/>
         <source>Cheat &apos;%s&apos; is already enabled.</source>
         <translation>La triche &apos;%s&apos;. est déjà activée.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4071"/>
+        <location filename="../../core/system.cpp" line="4301"/>
         <source>Post-processing is now enabled.</source>
         <translation>Le Post-Traitement est maintenant activé.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4080"/>
+        <location filename="../../core/system.cpp" line="4310"/>
         <source>Post-processing is now disabled.</source>
         <translation>Le Post-Traitement est maintenant désactivé.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4091"/>
+        <location filename="../../core/system.cpp" line="4321"/>
         <source>Failed to load post-processing shader chain.</source>
         <translation>N&apos;a pas réussi à charger la chaîne de shaders de Post-Traitement.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4093"/>
+        <location filename="../../core/system.cpp" line="4323"/>
         <source>Post-processing shaders reloaded.</source>
         <translation>Les shaders de post-traitement ont été rechargés.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="244"/>
+        <location filename="../../core/game_database.cpp" line="243"/>
         <source>CPU interpreter forced by game settings.</source>
         <translation>L&apos;Interpréteur CPU a été forcé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="256"/>
+        <location filename="../../core/game_database.cpp" line="255"/>
         <source>Software renderer forced by game settings.</source>
         <translation>Le rendu Logiciel a été forcé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="268"/>
+        <location filename="../../core/game_database.cpp" line="267"/>
+        <source>Using software renderer for readbacks based on game settings.</source>
+        <translation>Utilisation du rendu logiciel pour les relectures en se basant sur les paramètres de jeu.</translation>
+    </message>
+    <message>
+        <location filename="../../core/game_database.cpp" line="279"/>
         <source>Interlacing forced by game settings.</source>
         <translation>L&apos;Entrelacement a été forcé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="280"/>
+        <location filename="../../core/game_database.cpp" line="291"/>
         <source>True color disabled by game settings.</source>
         <translation>Les Vraies Couleurs a été désactivées par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="292"/>
+        <location filename="../../core/game_database.cpp" line="303"/>
         <source>Upscaling disabled by game settings.</source>
         <translation>L&apos;Upscaling a été désactivé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="304"/>
+        <location filename="../../core/game_database.cpp" line="315"/>
         <source>Scaled dithering disabled by game settings.</source>
         <translation>L&apos;Echelle du Lissage a été désactivée par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="317"/>
+        <location filename="../../core/game_database.cpp" line="328"/>
         <source>Widescreen disabled by game settings.</source>
         <translation>L&apos;Ecran Large a été désactivé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="331"/>
+        <location filename="../../core/game_database.cpp" line="342"/>
         <source>Forcing NTSC Timings disallowed by game settings.</source>
         <translation>Le Forcage des Timings NTSC a été interdit par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="343"/>
+        <location filename="../../core/game_database.cpp" line="354"/>
         <source>PGXP geometry correction disabled by game settings.</source>
         <translation>La Correction de la Géométrie PGXP a été désactivée par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="354"/>
+        <location filename="../../core/game_database.cpp" line="365"/>
         <source>PGXP culling disabled by game settings.</source>
         <translation>Le Culling PGXP a été désactivé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="367"/>
-        <source>PGXP texture correction disabled by game settings.</source>
-        <translation>La Correction des Textures PGXP a été désactivée par les paramètres du jeu.</translation>
+        <location filename="../../core/game_database.cpp" line="378"/>
+        <source>PGXP perspective corrected textures disabled by game settings.</source>
+        <translation>Textures fidèles à la perspective PGXP désactivées par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="378"/>
+        <location filename="../../core/game_database.cpp" line="392"/>
+        <source>PGXP perspective corrected colors disabled by game settings.</source>
+        <translation>Couleurs fidèles à la perspective PGXP désactivées par les paramètres du jeu.</translation>
+    </message>
+    <message>
+        <source>PGXP texture correction disabled by game settings.</source>
+        <translation type="vanished">La Correction des Textures PGXP a été désactivée par les paramètres du jeu.</translation>
+    </message>
+    <message>
+        <location filename="../../core/game_database.cpp" line="404"/>
         <source>PGXP vertex cache forced by game settings.</source>
         <translation>Le Cache Vertex PGXP a été forcé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="390"/>
+        <location filename="../../core/game_database.cpp" line="416"/>
         <source>PGXP CPU mode forced by game settings.</source>
         <translation>Le Mode CPU PGXP a été forcé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="402"/>
+        <location filename="../../core/game_database.cpp" line="428"/>
         <source>PGXP Depth Buffer disabled by game settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>Tampon de profondeur PGXP désactivé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="466"/>
+        <location filename="../../core/game_database.cpp" line="492"/>
         <source>Controller in port %u (%s) is not supported for %s.
 Supported controllers: %s
 Please configure a supported controller from the list above.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le contrôleur du port %u (%s) n&apos;est pas supproté pour %s.
+Contrôleurs supportés : %s
+Veuillez configurer un contrôleur appartenant à la liste ci-dessus.</translation>
     </message>
     <message>
         <source>Controller %u changed to digital by game settings.</source>
@@ -9260,94 +9871,94 @@ Please configure a supported controller from the list above.</source>
         <translation type="vanished">Le recompilateur ICache a été forcé par les paramètres du jeu.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="356"/>
+        <location filename="../mainwindow.cpp" line="437"/>
         <source>Acquired exclusive fullscreen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Obtenu le plein écran exclusif.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="360"/>
+        <location filename="../mainwindow.cpp" line="441"/>
         <source>Failed to acquire exclusive fullscreen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échéc de l&apos;obtention du plein écran exclusif.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="619"/>
+        <location filename="../qthost.cpp" line="625"/>
         <source>Lost exclusive fullscreen.</source>
-        <translation type="unfinished"></translation>
+        <translation>Plein écran exclusif perdu.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="52"/>
+        <location filename="../../core/analog_controller.cpp" line="60"/>
         <source>Analog mode forcing is disabled by game settings. Controller will start in digital mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le forçage du mode analogue est désactivé par les paramètre du jeu. Le contrôleur va démarrer en mode digital.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="71"/>
+        <location filename="../../core/gpu_hw.cpp" line="80"/>
         <source>%ux MSAA is not supported, using %ux instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>MSAA %ux n&apos;est pas supporté, utilisation de %ux à la place.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="76"/>
+        <location filename="../../core/gpu_hw.cpp" line="85"/>
         <source>SSAA is not supported, using MSAA instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>SSAA n&apos;est pas supporté, utilisation de MSAA à la place.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="81"/>
+        <location filename="../../core/gpu_hw.cpp" line="90"/>
         <source>Texture filter &apos;%s&apos; is not supported with the current renderer.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le filtre de texture &apos;%s&apos; n&apos;est pas supporté avec le rendu courant.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="89"/>
+        <location filename="../../core/gpu_hw.cpp" line="98"/>
         <source>Adaptive downsampling is not supported with the current renderer, using box filter instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le sous-échantillonnage adaptif n&apos;est pas supporté avec le rendu courant, utilisation du filtre boîte à la place.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="157"/>
+        <location filename="../../core/gpu_hw.cpp" line="170"/>
         <source>Resolution scale set to %ux (display %ux%u, VRAM %ux%u)</source>
-        <translation type="unfinished"></translation>
+        <translation>Échelle de résolution définie sur %ux (affichage %ux %u, VRAM %ux %u)</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="167"/>
+        <location filename="../../core/gpu_hw.cpp" line="180"/>
         <source>Multisample anti-aliasing set to %ux (SSAA).</source>
-        <translation type="unfinished"></translation>
+        <translation>Anticrénelage multi-échantillonné défini sur %ux (SSAA).</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="173"/>
+        <location filename="../../core/gpu_hw.cpp" line="186"/>
         <source>Multisample anti-aliasing set to %ux.</source>
-        <translation type="unfinished"></translation>
+        <translation>Anticrénelage multi-échantillonné défini sur %ux.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="236"/>
+        <location filename="../../core/gpu_hw.cpp" line="250"/>
         <source>Resolution scale %ux not supported for adaptive smoothing, using %ux.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;échelle de résolution %ux n&apos;est pas supportée pour le lissage adaptif, utilisation de %ux.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw_opengl.cpp" line="58"/>
-        <source>OpenGL renderer unavailable, your driver or hardware is not recent enough. OpenGL 3.1 or OpenGL ES 3.0 is required.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../core/cdrom.cpp" line="414"/>
+        <location filename="../../core/cdrom.cpp" line="783"/>
         <source>CD image preloading not available for multi-disc image &apos;%s&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Le pré-chargement d&apos;image CD n&apos;est pas disponible pour l&apos;image multi-disque &apos;%s&apos;</translation>
     </message>
     <message>
-        <location filename="../../core/cdrom.cpp" line="422"/>
+        <location filename="../../core/cdrom.cpp" line="791"/>
         <source>Precaching CD image failed, it may be unreliable.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la mise en pré-cache de l&apos;image CD, cela peut être non-fiable.</translation>
     </message>
     <message>
-        <location filename="../../core/memory_card.cpp" line="279"/>
+        <location filename="../../core/memory_card.cpp" line="282"/>
         <source>Memory card at &apos;%s&apos; could not be read, formatting.</source>
-        <translation type="unfinished"></translation>
+        <translation>La carte mémoire à &apos;%s&apos; ne peut être lue, formatage.</translation>
     </message>
     <message>
-        <location filename="../../core/memory_card.cpp" line="324"/>
+        <location filename="../../core/memory_card.cpp" line="327"/>
         <source>Failed to save memory card to &apos;{}&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la sauvegarde de la carte mémoire vers &apos;{}&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/memory_card.cpp" line="336"/>
+        <location filename="../../core/memory_card.cpp" line="339"/>
         <source>Saved memory card to &apos;{}&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sauvegardé la carte mémoire vers &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/gpu_hw_opengl.cpp" line="1323"/>
+        <source>OpenGL renderer unavailable, your driver or hardware is not recent enough. OpenGL 3.1 or OpenGL ES 3.1 is required.</source>
+        <translation>Le rendu OpenGL est indisponible, votre pilote ou matériel n&apos;est pas assez récent, OpenGL 3.1 ou OpenGL ES 3.1 est requis.</translation>
     </message>
 </context>
 <context>
@@ -9361,14 +9972,14 @@ Please configure a supported controller from the list above.</source>
         <translation type="vanished">Droite</translation>
     </message>
     <message>
-        <location filename="../../core/playstation_mouse.cpp" line="189"/>
+        <location filename="../../core/playstation_mouse.cpp" line="192"/>
         <source>Relative Mouse Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode souris relative</translation>
     </message>
     <message>
-        <location filename="../../core/playstation_mouse.cpp" line="190"/>
+        <location filename="../../core/playstation_mouse.cpp" line="193"/>
         <source>Locks the mouse cursor to the window, use for FPS games.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verrouille le curseur de la souris à la fenêtre, utile pour les jeux FPS.</translation>
     </message>
 </context>
 <context>
@@ -9409,27 +10020,27 @@ Please configure a supported controller from the list above.</source>
         <translation>Options...</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="115"/>
+        <location filename="../postprocessingchainconfigwidget.cpp" line="118"/>
         <source>No Shaders Available</source>
         <translation>Aucuns Shaders de disponible</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="127"/>
+        <location filename="../postprocessingchainconfigwidget.cpp" line="130"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="127"/>
+        <location filename="../postprocessingchainconfigwidget.cpp" line="130"/>
         <source>Failed to add shader. The log may contain more information.</source>
         <translation>N&apos;a pas réussi à ajouter de shader. Le journal peut contenir plus d&apos;informations.</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="159"/>
+        <location filename="../postprocessingchainconfigwidget.cpp" line="162"/>
         <source>Question</source>
         <translation>Question</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="159"/>
+        <location filename="../postprocessingchainconfigwidget.cpp" line="162"/>
         <source>Are you sure you want to clear all shader stages?</source>
         <translation>Etes-vous sûr de vouloir vider toutes les étapes de shader?</translation>
     </message>
@@ -9465,14 +10076,14 @@ Please configure a supported controller from the list above.</source>
         <translation>Chaîne de Post-Traitement</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="24"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="27"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="24"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="27"/>
         <source>The current post-processing chain is invalid, it has been reset.</source>
-        <translation type="unfinished"></translation>
+        <translation>La chaîne de post-traitement courante est invalide, elle a été réinitialisée.</translation>
     </message>
     <message>
         <source>The current post-processing chain is invalid, it has been reset. Any changes made will overwrite the existing config.</source>
@@ -9482,7 +10093,7 @@ Please configure a supported controller from the list above.</source>
 <context>
     <name>PostProcessingShaderConfigDialog</name>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="149"/>
+        <location filename="../postprocessingshaderconfigwidget.cpp" line="152"/>
         <source>%1 Shader Options</source>
         <translation>Options du Shader %1</translation>
     </message>
@@ -9494,27 +10105,27 @@ Please configure a supported controller from the list above.</source>
 <context>
     <name>PostProcessingShaderConfigWidget</name>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="54"/>
+        <location filename="../postprocessingshaderconfigwidget.cpp" line="57"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="54"/>
+        <location filename="../postprocessingshaderconfigwidget.cpp" line="57"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="54"/>
+        <location filename="../postprocessingshaderconfigwidget.cpp" line="57"/>
         <source>Blue</source>
         <translation>Bleu</translation>
     </message>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="54"/>
+        <location filename="../postprocessingshaderconfigwidget.cpp" line="57"/>
         <source>Alpha</source>
         <translation>Alpha</translation>
     </message>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="55"/>
+        <location filename="../postprocessingshaderconfigwidget.cpp" line="58"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
@@ -9534,12 +10145,12 @@ Please configure a supported controller from the list above.</source>
         <translation type="vanished">L&apos;interface hôte n&apos;a pas été initialisée. Impossible de continuer.</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="672"/>
+        <location filename="../qtutils.cpp" line="684"/>
         <source>Failed to open URL</source>
         <translation>Impossible d&apos;ouvrir l&apos;URL</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="673"/>
+        <location filename="../qtutils.cpp" line="685"/>
         <source>Failed to open URL.
 
 The URL was: %1</source>
@@ -9549,33 +10160,51 @@ L&apos;URL était : %1</translation>
     </message>
 </context>
 <context>
+    <name>QtAsyncProgressThread</name>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="184"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="189"/>
+        <source>Question</source>
+        <translation>Question</translation>
+    </message>
+    <message>
+        <location filename="../qtprogresscallback.cpp" line="195"/>
+        <source>Information</source>
+        <translation>Information</translation>
+    </message>
+</context>
+<context>
     <name>QtHost</name>
     <message>
-        <location filename="../qthost.cpp" line="2092"/>
-        <location filename="../qthost.cpp" line="2118"/>
-        <location filename="../qthost.cpp" line="2134"/>
+        <location filename="../qthost.cpp" line="2074"/>
+        <location filename="../qthost.cpp" line="2100"/>
+        <location filename="../qthost.cpp" line="2116"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2093"/>
+        <location filename="../qthost.cpp" line="2075"/>
         <source>File &apos;%1&apos; does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le fichier &apos;%1&apos; n&apos;existe pas.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2119"/>
+        <location filename="../qthost.cpp" line="2101"/>
         <source>The specified save state does not exist.</source>
-        <translation type="unfinished"></translation>
+        <translation>La save state spécifiée n&apos;existe pas.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2135"/>
+        <location filename="../qthost.cpp" line="2117"/>
         <source>Cannot use no-gui mode, because no boot filename was specified.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible d&apos;utiliser le mode sans-gui, parce qu&apos;aucun nom de fichier de démarrage n&apos;a été spécifié.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2136"/>
+        <location filename="../qthost.cpp" line="2118"/>
         <source>Cannot use batch mode, because no boot filename was specified.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible d&apos;utiliser le mode batch, parce qu&apos;aucun nom de fichier de démarrage n&apos;a été spécifié.</translation>
     </message>
 </context>
 <context>
@@ -9654,94 +10283,117 @@ Les sauvegardes ne seront pas récupérables.</translation>
     </message>
 </context>
 <context>
-    <name>QtProgressCallback</name>
+    <name>QtModalProgressCallback</name>
     <message>
-        <location filename="../qtprogresscallback.cpp" line="10"/>
+        <location filename="../qtprogresscallback.cpp" line="14"/>
         <source>DuckStation</source>
         <translation>DuckStation</translation>
     </message>
     <message>
-        <location filename="../qtprogresscallback.cpp" line="31"/>
+        <location filename="../qtprogresscallback.cpp" line="35"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../qtprogresscallback.cpp" line="90"/>
+        <location filename="../qtprogresscallback.cpp" line="94"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../qtprogresscallback.cpp" line="95"/>
+        <location filename="../qtprogresscallback.cpp" line="99"/>
         <source>Question</source>
         <translation>Question</translation>
     </message>
     <message>
-        <location filename="../qtprogresscallback.cpp" line="101"/>
+        <location filename="../qtprogresscallback.cpp" line="105"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
 </context>
 <context>
+    <name>QtProgressCallback</name>
+    <message>
+        <source>DuckStation</source>
+        <translation type="vanished">DuckStation</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="vanished">Annuler</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="vanished">Erreur</translation>
+    </message>
+    <message>
+        <source>Question</source>
+        <translation type="vanished">Question</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation type="vanished">Information</translation>
+    </message>
+</context>
+<context>
     <name>SaveStateSelectorUI</name>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="477"/>
+        <location filename="../../frontend-common/imgui_overlays.cpp" line="681"/>
         <source>Load</source>
-        <translation type="unfinished"></translation>
+        <translation>Charger</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="479"/>
+        <location filename="../../frontend-common/imgui_overlays.cpp" line="683"/>
         <source>Save</source>
-        <translation type="unfinished">Sauvegarder</translation>
+        <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="481"/>
+        <location filename="../../frontend-common/imgui_overlays.cpp" line="685"/>
         <source>Select Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner précédent</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="483"/>
+        <location filename="../../frontend-common/imgui_overlays.cpp" line="687"/>
         <source>Select Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner suivant</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="540"/>
+        <location filename="../../frontend-common/imgui_overlays.cpp" line="744"/>
         <source>No Save State</source>
-        <translation type="unfinished"></translation>
+        <translation>Pas de save state</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="613"/>
+        <location filename="../../frontend-common/imgui_overlays.cpp" line="817"/>
         <source>Global Slot %d</source>
-        <translation type="unfinished"></translation>
+        <translation>Emplacement global %d</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="617"/>
+        <location filename="../../frontend-common/imgui_overlays.cpp" line="821"/>
         <source>Game Slot %d</source>
-        <translation type="unfinished"></translation>
+        <translation>Emplacement de jeu %d</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="621"/>
+        <location filename="../../frontend-common/imgui_overlays.cpp" line="825"/>
         <source>%s Slot %d</source>
-        <translation type="unfinished"></translation>
+        <translation>%s Emplacement %d</translation>
     </message>
 </context>
 <context>
     <name>SettingWidgetBinder</name>
     <message>
-        <location filename="../settingwidgetbinder.h" line="319"/>
-        <location filename="../settingwidgetbinder.h" line="449"/>
+        <location filename="../settingwidgetbinder.h" line="322"/>
+        <location filename="../settingwidgetbinder.h" line="452"/>
         <source>Default: </source>
-        <translation type="unfinished"></translation>
+        <translation>Défaut :</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="418"/>
-        <location filename="../settingwidgetbinder.h" line="548"/>
+        <location filename="../settingwidgetbinder.h" line="421"/>
+        <location filename="../settingwidgetbinder.h" line="551"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Réinitialiser</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1065"/>
+        <location filename="../settingwidgetbinder.h" line="1077"/>
         <source>Select folder for %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner le dossier pour %1</translation>
     </message>
 </context>
 <context>
@@ -9804,12 +10456,12 @@ Les sauvegardes ne seront pas récupérables.</translation>
         <translation type="vanished">Fermer</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="66"/>
+        <location filename="../settingsdialog.cpp" line="69"/>
         <source>&lt;strong&gt;General Settings&lt;/strong&gt;&lt;hr&gt;These options control how the emulator looks and behaves.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Paramètres Généraux&lt;/strong&gt;&lt;hr&gt;Ces options contrôlent l&apos;apparence et le comportement de l&apos;émulateur.&lt;br&gt;&lt;br&gt;&lt;hr&gt;Passer la souris sur une option pour obtenir des informations supplémentaires.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="85"/>
+        <location filename="../settingsdialog.cpp" line="88"/>
         <source>&lt;strong&gt;Console Settings&lt;/strong&gt;&lt;hr&gt;These options determine the configuration of the simulated console.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Paramètres de la Console&lt;/strong&gt;&lt;hr&gt;Ces options déterminent la configuration de la console simulée.&lt;br&gt;&lt;br&gt;Passer la souris sur une option pour obtenir des informations supplémentaires.</translation>
     </message>
@@ -9826,222 +10478,227 @@ Les sauvegardes ne seront pas récupérables.</translation>
         <translation type="vanished">&lt;strong&gt;Paramètres des Contrôleurs&lt;/strong&gt;&lt;hr&gt;Cette page vous permet de choisir le type de contrôleur que vous souhaitez simuler pour la console, et de redéfinir les touches ou les boutons du contrôleur de jeu hôte selon votre choix. En cliquant sur une assignation, un compte à rebours sera lancé, auquel cas vous devrez appuyer sur la touche ou l&apos;axe de la manette que vous souhaitez assigner. (Pour la vibration, appuyez sur n&apos;importe quel bouton/axe de la manette à laquelle vous souhaitez envoyer la vibration). Si vous n&apos;appuyez sur aucun bouton et que le compte à rebours s&apos;écoule, l&apos;assignation ne sera pas modifiée. Pour effacer une assignation, cliquez sur le bouton droit de la souris. Pour assigner plusieurs boutons, maintenez la touche Maj enfoncée et cliquez sur le bouton.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="47"/>
+        <location filename="../settingsdialog.cpp" line="50"/>
         <source>Summary</source>
-        <translation type="unfinished"></translation>
+        <translation>Sommaire</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="49"/>
+        <location filename="../settingsdialog.cpp" line="52"/>
         <source>&lt;strong&gt;Summary&lt;/strong&gt;&lt;hr&gt;This page shows information about the selected game, and allows you to validate your disc was dumped correctly.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Sommaire&lt;/strong&gt;&lt;hr&gt;Cette page montre les informations à propos du jeu sélectionné, et vous permet de valider que votre disque a été correctement extrait.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="64"/>
+        <location filename="../settingsdialog.cpp" line="67"/>
         <source>General</source>
-        <translation type="unfinished">Général</translation>
+        <translation>Général</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="72"/>
+        <location filename="../settingsdialog.cpp" line="75"/>
         <source>Game List</source>
-        <translation type="unfinished"></translation>
+        <translation>Liste de jeux</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="74"/>
+        <location filename="../settingsdialog.cpp" line="77"/>
         <source>&lt;strong&gt;Game List Settings&lt;/strong&gt;&lt;hr&gt;The list above shows the directories which will be searched by DuckStation to populate the game list. Search directories can be added, removed, and switched to recursive/non-recursive.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Paramètres de la liste de jeux&lt;/strong&gt;&lt;hr&gt;La liste ci-dessus montre les répertoires scannés par DuckStation pour peupler la liste de jeux. Les répertoires de recherche peuvent être ajoutés, supprimés ou basculés en récursif/non-récursif.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="79"/>
+        <location filename="../settingsdialog.cpp" line="82"/>
         <source>BIOS</source>
-        <translation type="unfinished"></translation>
+        <translation>BIOS</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="81"/>
+        <location filename="../settingsdialog.cpp" line="84"/>
         <source>&lt;strong&gt;BIOS Settings&lt;/strong&gt;&lt;hr&gt;These options control which BIOS is used and how it will be patched.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Paramètres de BIOS&lt;/strong&gt;&lt;hr&gt;Ces options contrôles quel BIOS est utilisé et comment il sera patché.&lt;br&gt;&lt;br&gt;Survolez une option à la souris pour de plus amples informations.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="83"/>
+        <location filename="../settingsdialog.cpp" line="86"/>
         <source>Console</source>
-        <translation type="unfinished">Console</translation>
+        <translation>Console</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="87"/>
+        <location filename="../settingsdialog.cpp" line="90"/>
         <source>Emulation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog.cpp" line="89"/>
-        <source>&lt;strong&gt;Emulation Settings&lt;/strong&gt;&lt;hr&gt;These options determine the speed and runahead behavior of the system.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
-        <translation type="unfinished"></translation>
+        <translation>Émulation</translation>
     </message>
     <message>
         <location filename="../settingsdialog.cpp" line="92"/>
-        <source>Memory Cards</source>
-        <translation type="unfinished"></translation>
+        <source>&lt;strong&gt;Emulation Settings&lt;/strong&gt;&lt;hr&gt;These options determine the speed and runahead behavior of the system.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
+        <translation>&lt;strong&gt;Paramètres d&apos;émulation&lt;/strong&gt;&lt;hr&gt;Ces options déterminent la vitesse et le comportement runahead du système.&lt;br&gt;&lt;br&gt;Survolez une option à la souris pour de plus amples informations.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="94"/>
+        <location filename="../settingsdialog.cpp" line="95"/>
+        <source>Memory Cards</source>
+        <translation>Cartes mémoire</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="97"/>
         <source>&lt;strong&gt;Memory Card Settings&lt;/strong&gt;&lt;hr&gt;This page lets you control what mode the memory card emulation will function in, and where the images for these cards will be stored on disk.</source>
         <translation>&lt;strong&gt;Paramètres de Carte Mémoire&lt;/strong&gt;&lt;hr&gt;Cette page vous permet de contrôler dans quel mode l&apos;émulation de carte mémoire fonctionnera, et où les images de ces cartes seront stockées sur le disque.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="97"/>
+        <location filename="../settingsdialog.cpp" line="100"/>
         <source>Display</source>
-        <translation type="unfinished"></translation>
+        <translation>Affichage</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="99"/>
+        <location filename="../settingsdialog.cpp" line="102"/>
         <source>&lt;strong&gt;Display Settings&lt;/strong&gt;&lt;hr&gt;These options control the how the frames generated by the console are displayed on the screen.</source>
         <translation>&lt;strong&gt;Paramètres d&apos;Affichage&lt;/strong&gt;&lt;hr&gt;Ces options contrôlent la façon dont les images générées par la console sont affichées sur l&apos;écran.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="102"/>
+        <location filename="../settingsdialog.cpp" line="105"/>
         <source>Enhancements</source>
-        <translation type="unfinished"></translation>
+        <translation>Améliorations</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="104"/>
+        <location filename="../settingsdialog.cpp" line="107"/>
         <source>&lt;strong&gt;Enhancement Settings&lt;/strong&gt;&lt;hr&gt;These options control enhancements which can improve visuals compared to the original console. Mouse over each option for additional information.</source>
         <translation>&lt;strong&gt;Enhancement Settings&lt;/strong&gt;&lt;hr&gt;Ces options contrôlent les améliorations qui peuvent améliorer les visuels par rapport à la console d&apos;origine. Passez la souris sur une option pour obtenir des informations supplémentaires.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="110"/>
+        <location filename="../settingsdialog.cpp" line="113"/>
         <source>Post-Processing</source>
-        <translation type="unfinished"></translation>
+        <translation>Post-traitement</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="111"/>
+        <location filename="../settingsdialog.cpp" line="114"/>
         <source>&lt;strong&gt;Post-Processing Settings&lt;/strong&gt;&lt;hr&gt;Post processing allows you to alter the appearance of the image displayed on the screen with various filters. Shaders will be executed in sequence.</source>
         <translation>&lt;strong&gt;Paramètres Post-traitement&lt;/strong&gt;&lt;hr&gt;Le Post-Traitement permet de modifier l&apos;apparence de l&apos;image affichée à l&apos;écran à l&apos;aide de différents filtres. Les shaders seront exécutés dans la séquence.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="115"/>
+        <location filename="../settingsdialog.cpp" line="118"/>
         <source>Audio</source>
-        <translation type="unfinished">Audio</translation>
+        <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="117"/>
+        <location filename="../settingsdialog.cpp" line="120"/>
         <source>&lt;strong&gt;Audio Settings&lt;/strong&gt;&lt;hr&gt;These options control the audio output of the console. Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Paramètres Audio&lt;/strong&gt;&lt;hr&gt;Ces options contrôlent la sortie audio de la console. Passez la souris sur une option pour obtenir des informations supplémentaires.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="120"/>
+        <location filename="../settingsdialog.cpp" line="123"/>
         <source>Achievements</source>
-        <translation type="unfinished"></translation>
+        <translation>Succès</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="122"/>
+        <location filename="../settingsdialog.cpp" line="125"/>
         <source>&lt;strong&gt;Achievement Settings&lt;/strong&gt;&lt;hr&gt;These options control RetroAchievements. Mouse over an option for additional information.</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;strong&gt;Paramètres des succès&lt;/strong&gt;&lt;hr&gt;Ces options contrôlent RetroAchievements. Survolez une option à la souris pour de plus amples informations.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="142"/>
+        <location filename="../settingsdialog.cpp" line="145"/>
         <source>This DuckStation build was not compiled with RetroAchievements support.</source>
-        <translation type="unfinished"></translation>
+        <translation>Cette build DuckStation n&apos;a pas été compilée avec le support de RetroAchievements.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="152"/>
+        <location filename="../settingsdialog.cpp" line="155"/>
         <source>Folders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../settingsdialog.cpp" line="154"/>
-        <source>&lt;strong&gt;Folder Settings&lt;/strong&gt;&lt;hr&gt;These options control where DuckStation will save runtime data files.</source>
-        <translation type="unfinished"></translation>
+        <translation>Dossiers</translation>
     </message>
     <message>
         <location filename="../settingsdialog.cpp" line="157"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
+        <source>&lt;strong&gt;Folder Settings&lt;/strong&gt;&lt;hr&gt;These options control where DuckStation will save runtime data files.</source>
+        <translation>&lt;strong&gt;Paramètres de dossier&lt;/strong&gt;&lt;hr&gt;Ces options contrôlent où DuckStation sauvegardera ses fichiers de données lors de son exécution.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="159"/>
+        <location filename="../settingsdialog.cpp" line="160"/>
+        <source>Advanced</source>
+        <translation>Avancé</translation>
+    </message>
+    <message>
+        <location filename="../settingsdialog.cpp" line="162"/>
         <source>&lt;strong&gt;Advanced Settings&lt;/strong&gt;&lt;hr&gt;These options control logging and internal behavior of the emulator. Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Paramètres Avancés&lt;/strong&gt;&lt;hr&gt;Ces options contrôlent l&apos;enregistrement et le comportement interne de l&apos;émulateur. Passer la souris sur une option pour obtenir des informations supplémentaires.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="216"/>
+        <location filename="../settingsdialog.cpp" line="219"/>
         <source>Confirm Restore Defaults</source>
-        <translation type="unfinished"></translation>
+        <translation>Confirmation de restauration des paramètres par défaut</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="217"/>
+        <location filename="../settingsdialog.cpp" line="220"/>
         <source>Are you sure you want to restore the default settings? Any preferences will be lost.</source>
-        <translation type="unfinished"></translation>
+        <translation>Êtes-vous sûr de vouloir restaurer les paramètres par défaut ? Toute préférence sera perdue.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="233"/>
+        <location filename="../settingsdialog.cpp" line="236"/>
         <source>Recommended Value</source>
         <translation>Valeur Recommandée</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="497"/>
+        <location filename="../settingsdialog.cpp" line="505"/>
         <source>%1 [%2]</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 [%2]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="121"/>
+        <location filename="../settingwidgetbinder.h" line="124"/>
         <source>Use Global Setting [Enabled]</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser le paramétrage global [Activé]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="122"/>
+        <location filename="../settingwidgetbinder.h" line="125"/>
         <source>Use Global Setting [Disabled]</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser le paramétrage global [Désactivé]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="130"/>
-        <location filename="../settingwidgetbinder.h" line="146"/>
+        <location filename="../settingwidgetbinder.h" line="133"/>
+        <location filename="../settingwidgetbinder.h" line="149"/>
         <source>Use Global Setting [%1]</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser le paramétrage global [%1]</translation>
     </message>
 </context>
 <context>
     <name>System</name>
     <message>
-        <location filename="../../core/system.cpp" line="1139"/>
+        <location filename="../../core/system.cpp" line="1813"/>
         <source>Failed to load %s BIOS.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échech du chargement du BIOS %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1210"/>
-        <location filename="../../core/system.cpp" line="2922"/>
+        <location filename="../../core/system.cpp" line="1332"/>
+        <location filename="../../core/system.cpp" line="3146"/>
         <source>Error</source>
-        <translation type="unfinished">Erreur</translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1211"/>
+        <location filename="../../core/system.cpp" line="1333"/>
         <source>Failed to load save state file &apos;{}&apos; for booting.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec du chargemement du fichier de save state &apos;{}&apos; pour démarrer.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1712"/>
+        <location filename="../../core/system.cpp" line="1820"/>
+        <source>Incorrect BIOS image size</source>
+        <translation>Taille de l&apos;image BIOS incorrecte</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="1911"/>
         <source>Save state is incompatible: minimum version is %u but state is version %u.</source>
         <translation>La Sauvegarde d&apos;Etat est incompatible : la version minimale est %u mais l&apos;état est la version %u.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1721"/>
+        <location filename="../../core/system.cpp" line="1920"/>
         <source>Save state is incompatible: maximum version is %u but state is version %u.</source>
-        <translation type="unfinished"></translation>
+        <translation>La save state est incompatible : la version maximale est %u, mais la version de la state est %u.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1762"/>
+        <location filename="../../core/system.cpp" line="1961"/>
         <source>Failed to open CD image &apos;%s&apos; used by save state: %s.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de l&apos;ouverture de l&apos;image CD &apos;%s&apos; utilisée par la save state %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1781"/>
+        <location filename="../../core/system.cpp" line="1980"/>
         <source>Failed to switch to subimage %u in CD image &apos;%s&apos; used by save state: %s.</source>
-        <translation type="unfinished"></translation>
+        <translation>Échec de la bascule vers la sous-image %u dans l&apos;image CD &apos;%s&apos; utilisée par la save state %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2628"/>
+        <location filename="../../core/system.cpp" line="2846"/>
         <source>Per-game memory card cannot be used for slot %u as the running game has no path. Using shared card instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>La carte mémoire par-jeu ne peut être utilisée pour l&apos;emplacement %u car le jeu en cours n&apos;a pas de chemin. Utilisation de la carte partagée à la place.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2911"/>
+        <location filename="../../core/system.cpp" line="3135"/>
         <source>You are attempting to run a libcrypt protected game without an SBI file:
 
 %s: %s
@@ -10051,10 +10708,18 @@ The game will likely not run properly.
 Please check the README for instructions on how to add an SBI file.
 
 Do you wish to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Vous essayez de lancer le jeu protégé par libcrypt sans fichier SBI :
+
+%s : %s
+
+Le jeu va probablement mal tourner.
+
+Veuillez lire le README pour les instructions à propos de comment ajouter un fichier SBI.
+
+Voulez-vous continuer ?</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2924"/>
+        <location filename="../../core/system.cpp" line="3148"/>
         <source>You are attempting to run a libcrypt protected game without an SBI file:
 
 %s: %s
@@ -10062,19 +10727,25 @@ Do you wish to continue?</source>
 Your dump is incomplete, you must add the SBI file to run this game. 
 
 The name of the SBI file must match the name of the disc image.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vous essayez de lancer le jeu protégé par libcrypt sans fichier SBI :
+
+%s : %s
+
+Votre vidage est incomplet, vous devez ajouter un fichier SBI pour faire tourner le jeu.
+
+Le nom du fichier SBI doit correspondre au nom de l&apos;image disque.</translation>
     </message>
     <message>
         <source>Failed to open CD image from save state: &apos;%s&apos;.</source>
         <translation type="vanished">Impossible d&apos;ouvrir l&apos;image CD à partir de l&apos;état de sauvegarde : &apos;%s&apos;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2591"/>
+        <location filename="../../core/system.cpp" line="2809"/>
         <source>Per-game memory card cannot be used for slot %u as the running game has no code. Using shared card instead.</source>
         <translation>La carte mémoire par jeu ne peut pas être utilisée pour l&apos;emplacement %u car le jeu en cours n&apos;a pas de code. Utilisez plutôt une carte partagée.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2608"/>
+        <location filename="../../core/system.cpp" line="2826"/>
         <source>Per-game memory card cannot be used for slot %u as the running game has no title. Using shared card instead.</source>
         <translation>La carte mémoire par jeu ne peut pas être utilisée pour l&apos;emplacement %u car le jeu en cours n&apos;a pas de titre. Utilisez plutôt une carte partagée.</translation>
     </message>
@@ -10083,7 +10754,7 @@ The name of the SBI file must match the name of the disc image.</source>
         <translation type="vanished">Le chemin de la carte mémoire pour l&apos;emplacement %u est manquant, utilise celui par défaut.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2820"/>
+        <location filename="../../core/system.cpp" line="3039"/>
         <source>Game changed, reloading memory cards.</source>
         <translation>Le Jeu a été changé, rechargement des cartes mémoires.</translation>
     </message>


### PR DESCRIPTION
applied a fix to the spectator send buffer to prevent form ggpo from crashing when a spectator leaves, which allows us to continue the session without having to reset.