### PR TITLE
Fix `HostReg` enum cast outside valid range

### DIFF
--- a/src/core/cpu_recompiler_types.h
+++ b/src/core/cpu_recompiler_types.h
@@ -71,7 +71,7 @@ using CodeEmitter = Xbyak::CodeGenerator;
 using LabelType = Xbyak::Label;
 enum : u32
 {
-  HostReg_Count = 16
+  HostReg_Count = 15
 };
 constexpr HostReg HostReg_Invalid = static_cast<HostReg>(HostReg_Count);
 constexpr RegSize HostPointerSize = RegSize_64;

--- a/src/core/cpu_recompiler_types.h
+++ b/src/core/cpu_recompiler_types.h
@@ -66,12 +66,12 @@ enum class Condition : u8
 
 #if defined(CPU_X64)
 
-using HostReg = Xbyak::Operand::Code;
+using HostReg = unsigned;
 using CodeEmitter = Xbyak::CodeGenerator;
 using LabelType = Xbyak::Label;
 enum : u32
 {
-  HostReg_Count = 15
+  HostReg_Count = 16
 };
 constexpr HostReg HostReg_Invalid = static_cast<HostReg>(HostReg_Count);
 constexpr RegSize HostPointerSize = RegSize_64;


### PR DESCRIPTION
LLVM 16 errors by reporting that the valid range of `HostReg` is between 0 and 15.

I don't have enough knowledge if this is the best fix. ~Using a different type accepting the `16` value may be another option~. I changed to an unsigned type.

Here is the full error:
```
/duckstation/src/core/cpu_recompiler_types.h:76:37: error: integer value 16 is outside the valid range of values [0, 15] for this enumeration type [-Wenum-constexpr-conversion]
constexpr HostReg HostReg_Invalid = static_cast<HostReg>(HostReg_Count);
                                    ^
```