### PR TITLE
Updated Spanish (Latin America) translation

### DIFF
--- a/src/duckstation-qt/qttranslations.cpp
+++ b/src/duckstation-qt/qttranslations.cpp
@@ -199,7 +199,7 @@ std::vector<std::pair<QString, QString>> QtHost::GetAvailableLanguageList()
 {
   return {{QStringLiteral("English"), QStringLiteral("en")},
           {QStringLiteral("Deutsch"), QStringLiteral("de")},
-          {QStringLiteral("Español de Hispanoamérica"), QStringLiteral("es")},
+          {QStringLiteral("Español de Latinoamérica"), QStringLiteral("es")},
           {QStringLiteral("Español de España"), QStringLiteral("es-ES")},
           {QStringLiteral("Français"), QStringLiteral("fr")},
           {QStringLiteral("עברית"), QStringLiteral("he")},

--- a/src/duckstation-qt/translations/duckstation-qt_es.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_es.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="es_ES">
+<TS version="2.1" language="es_419">
 <context>
     <name>AboutDialog</name>
     <message>
@@ -14,27 +14,27 @@
         <translation>DuckStation</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="18"/>
+        <location filename="../aboutdialog.cpp" line="19"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="34"/>
+        <location filename="../aboutdialog.cpp" line="35"/>
         <source>DuckStation is a free and open-source simulator/emulator of the Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt; console, focusing on playability, speed, and long-term maintainability.</source>
         <translation>DuckStation es un emulador/simulador gratuito y de código abierto de la consola Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt;, enfocándose en jugabilidad, velocidad y mantenimiento a largo plazo.</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="37"/>
+        <location filename="../aboutdialog.cpp" line="38"/>
         <source>Authors</source>
         <translation>Autores</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="38"/>
+        <location filename="../aboutdialog.cpp" line="39"/>
         <source>Icon by</source>
         <translation>Icono por</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="39"/>
+        <location filename="../aboutdialog.cpp" line="40"/>
         <source>License</source>
         <translation>Licencia</translation>
     </message>
@@ -54,9 +54,13 @@
         <translation>Iniciar sesión en RetroAchievements</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.ui" line="69"/>
         <source>Please enter user name and password for retroachievements.org below. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
-        <translation>Ingresa tu nombre de usuario y contraseña de retroachievements.org. DuckStation no guardará tu contraseña; en su lugar se generará y se utilizará un token de acceso.</translation>
+        <translation type="vanished">Ingresa tu nombre de usuario y contraseña de retroachievements.org. DuckStation no guardará tu contraseña; en su lugar se generará y se utilizará un token de acceso.</translation>
+    </message>
+    <message>
+        <location filename="../achievementlogindialog.ui" line="69"/>
+        <source>Please enter your user name and password for retroachievements.org below. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
+        <translation>Ingresa tu nombre de usuario y contraseña de retroachievements.org. DuckStation no guardará tu contraseña; en su lugar se generará y utilizará un token de acceso.</translation>
     </message>
     <message>
         <location filename="../achievementlogindialog.ui" line="94"/>
@@ -74,27 +78,42 @@
         <translation>Listo...</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="14"/>
+        <location filename="../achievementlogindialog.cpp" line="22"/>
+        <source>&lt;strong&gt;Your RetroAchievements login token is no longer valid.&lt;/strong&gt; You must re-enter your credentials for achievements to be tracked. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
+        <translation>&lt;strong&gt;Tu token de acceso de RetroAchievements ya no es válido.&lt;/strong&gt; Debes ingresar nuevamente tus credenciales para el seguimiento de logros. DuckStation no guardará tu contraseña; en su lugar se generará y utilizará un token de acceso.</translation>
+    </message>
+    <message>
+        <location filename="../achievementlogindialog.cpp" line="27"/>
         <source>&amp;Login</source>
         <translation>&amp;Iniciar sesión</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="27"/>
+        <location filename="../achievementlogindialog.cpp" line="40"/>
         <source>Logging in...</source>
         <translation>Iniciando sesión...</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="45"/>
+        <location filename="../achievementlogindialog.cpp" line="71"/>
         <source>Login Error</source>
         <translation>Error al iniciar sesión</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="46"/>
-        <source>Login failed. Please check your username and password, and try again.</source>
-        <translation>Fallo al iniciar sesión. Comprueba el nombre de usuario y contraseña e intenta de nuevo.</translation>
+        <location filename="../achievementlogindialog.cpp" line="72"/>
+        <source>Login failed.
+Error: %1
+
+Please check your username and password, and try again.</source>
+        <translation>Fallo al iniciar sesión.
+Error: %1
+
+Comprueba el nombre de usuario y contraseña e intenta de nuevo.</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="47"/>
+        <source>Login failed. Please check your username and password, and try again.</source>
+        <translation type="vanished">Fallo al iniciar sesión. Comprueba el nombre de usuario y contraseña e intenta de nuevo.</translation>
+    </message>
+    <message>
+        <location filename="../achievementlogindialog.cpp" line="73"/>
         <source>Login failed.</source>
         <translation>Fallo al iniciar sesión.</translation>
     </message>
@@ -107,188 +126,251 @@
         <translation>Form</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="32"/>
         <source>Global Settings</source>
-        <translation>Configuración global</translation>
+        <translation type="vanished">Configuración global</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="38"/>
-        <location filename="../achievementsettingswidget.cpp" line="45"/>
         <source>Enable Rich Presence</source>
-        <translation>Habilitar Rich Presence</translation>
+        <translation type="vanished">Habilitar Rich Presence</translation>
+    </message>
+    <message>
+        <source>Enable Leaderboards</source>
+        <translation type="vanished">Habilitar tabla de posiciones</translation>
     </message>
     <message>
         <location filename="../achievementsettingswidget.ui" line="45"/>
-        <location filename="../achievementsettingswidget.cpp" line="61"/>
-        <source>Enable Leaderboards</source>
-        <translation>Habilitar tabla de posiciones</translation>
-    </message>
-    <message>
-        <location filename="../achievementsettingswidget.ui" line="52"/>
-        <location filename="../achievementsettingswidget.cpp" line="35"/>
+        <location filename="../achievementsettingswidget.cpp" line="46"/>
         <source>Enable Achievements</source>
         <translation>Habilitar logros</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="59"/>
-        <location filename="../achievementsettingswidget.cpp" line="51"/>
+        <location filename="../achievementsettingswidget.ui" line="66"/>
+        <location filename="../achievementsettingswidget.cpp" line="48"/>
         <source>Enable Hardcore Mode</source>
         <translation>Habilitar modo Hardcore</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="66"/>
-        <location filename="../achievementsettingswidget.cpp" line="65"/>
         <source>Show Challenge Indicators</source>
-        <translation>Mostrar indicadores de desafíos</translation>
+        <translation type="vanished">Mostrar indicadores de desafíos</translation>
     </message>
     <message>
         <location filename="../achievementsettingswidget.ui" line="73"/>
-        <location filename="../achievementsettingswidget.cpp" line="48"/>
+        <location filename="../achievementsettingswidget.cpp" line="72"/>
         <source>Use First Disc From Playlist</source>
         <translation>Utilizar el primer disco de la lista</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="80"/>
-        <location filename="../achievementsettingswidget.cpp" line="37"/>
         <source>Enable Test Mode</source>
-        <translation>Habilitar modo de prueba</translation>
+        <translation type="vanished">Habilitar modo de prueba</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="87"/>
-        <location filename="../achievementsettingswidget.cpp" line="41"/>
+        <location filename="../achievementsettingswidget.ui" line="52"/>
+        <location filename="../achievementsettingswidget.cpp" line="68"/>
         <source>Test Unofficial Achievements</source>
         <translation>Probar logros no oficiales</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="94"/>
-        <location filename="../achievementsettingswidget.cpp" line="58"/>
+        <location filename="../achievementsettingswidget.ui" line="181"/>
+        <location filename="../achievementsettingswidget.cpp" line="57"/>
         <source>Enable Sound Effects</source>
         <translation>Habilitar efectos de sonido</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="101"/>
-        <location filename="../achievementsettingswidget.cpp" line="55"/>
         <source>Show Notifications</source>
-        <translation>Mostrar notificaciones</translation>
+        <translation type="vanished">Mostrar notificaciones</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="111"/>
+        <location filename="../achievementsettingswidget.ui" line="198"/>
         <source>Account</source>
         <translation>Cuenta</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="126"/>
-        <location filename="../achievementsettingswidget.cpp" line="158"/>
+        <location filename="../achievementsettingswidget.ui" line="224"/>
+        <location filename="../achievementsettingswidget.cpp" line="192"/>
         <source>Login...</source>
         <translation>Iniciar sesión...</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="133"/>
+        <location filename="../achievementsettingswidget.ui" line="217"/>
         <source>View Profile...</source>
         <translation>Ver perfil...</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="151"/>
+        <location filename="../achievementsettingswidget.ui" line="32"/>
+        <source>Settings</source>
+        <translation>Configuración</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="38"/>
+        <location filename="../achievementsettingswidget.cpp" line="64"/>
+        <source>Enable Spectator Mode</source>
+        <translation>Habilitar modo espectador</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="59"/>
+        <location filename="../achievementsettingswidget.cpp" line="62"/>
+        <source>Enable Encore Mode</source>
+        <translation>Habilitar modo Encore</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="83"/>
+        <source>Notifications</source>
+        <translation>Notificaciones</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="119"/>
+        <location filename="../achievementsettingswidget.ui" line="165"/>
+        <source>5 seconds</source>
+        <translation>5 segundos</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="128"/>
+        <location filename="../achievementsettingswidget.cpp" line="51"/>
+        <source>Show Achievement Notifications</source>
+        <translation>Mostrar notificaciones de logros</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="174"/>
+        <location filename="../achievementsettingswidget.cpp" line="54"/>
+        <source>Show Leaderboard Notifications</source>
+        <translation>Mostrar notificaciones de tabla de posiciones</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="188"/>
+        <location filename="../achievementsettingswidget.cpp" line="60"/>
+        <source>Enable In-Game Overlays</source>
+        <translation>Superposiciones dentro del juego</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="204"/>
+        <source>Username:
+Login token generated at:</source>
+        <translation>Nombre de usuario:
+Token de acceso generado en:</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.ui" line="242"/>
         <source>Game Info</source>
         <translation>Información del juego</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="167"/>
+        <location filename="../achievementsettingswidget.ui" line="258"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;DuckStation uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;https://retroachievements.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;retroachievements.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;To view the achievement list in-game, press the hotkey for &lt;span style=&quot; font-weight:600;&quot;&gt;Open Pause Menu&lt;/span&gt; and select &lt;span style=&quot; font-weight:600;&quot;&gt;Achievements&lt;/span&gt; from the menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;DuckStation usa RetroAchievements como base de datos de logros y hacer seguimiento del progreso. Para utilizar el sistema de logros, primero debes registrar una cuenta en &lt;a href=&quot;https://retroachievements.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;retroachievements.org&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;Para ver la lista de logros dentro del juego, presiona el atajo para &lt;span style=&quot; font-weight:600;&quot;&gt;Abrir menu rápido&lt;/span&gt; y selecciona &lt;span style=&quot; font-weight:600;&quot;&gt;Logros&lt;/span&gt; desde el menú.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="35"/>
-        <location filename="../achievementsettingswidget.cpp" line="37"/>
-        <location filename="../achievementsettingswidget.cpp" line="41"/>
-        <location filename="../achievementsettingswidget.cpp" line="45"/>
+        <location filename="../achievementsettingswidget.cpp" line="46"/>
         <location filename="../achievementsettingswidget.cpp" line="48"/>
-        <location filename="../achievementsettingswidget.cpp" line="51"/>
+        <location filename="../achievementsettingswidget.cpp" line="62"/>
+        <location filename="../achievementsettingswidget.cpp" line="64"/>
+        <location filename="../achievementsettingswidget.cpp" line="68"/>
+        <location filename="../achievementsettingswidget.cpp" line="72"/>
         <source>Unchecked</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="36"/>
+        <location filename="../achievementsettingswidget.cpp" line="47"/>
         <source>When enabled and logged in, DuckStation will scan for achievements on startup.</source>
         <translation>Cuando esté habilitado y se haya iniciado sesión, DuckStation buscará logros al iniciarse.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="38"/>
+        <location filename="../achievementsettingswidget.cpp" line="52"/>
+        <source>Displays popup messages on events such as achievement unlocks and game completion.</source>
+        <translation>Muestra mensajes emergentes durante eventos como desbloqueo de logros y finalización de un juego.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="55"/>
+        <source>Displays popup messages when starting, submitting, or failing a leaderboard challenge.</source>
+        <translation>Muestra mensajes emergentes al iniciar, enviar o fallar un desafío de tabla de posiciones.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="63"/>
+        <source>When enabled, each session will behave as if no achievements have been unlocked.</source>
+        <translation>Cuando esté habilitado, cada sesión se tratará como si no se hubiese desbloqueado ningún logro.</translation>
+    </message>
+    <message>
+        <location filename="../achievementsettingswidget.cpp" line="65"/>
         <source>When enabled, DuckStation will assume all achievements are locked and not send any unlock notifications to the server.</source>
         <translation>Cuando esté habilitado, DuckStation asumirá que todos los logros están bloqueados, y no enviará ninguna notificación de desbloqueo al servidor.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="42"/>
+        <location filename="../achievementsettingswidget.cpp" line="69"/>
         <source>When enabled, DuckStation will list achievements from unofficial sets. Please note that these achievements are not tracked by RetroAchievements, so they unlock every time.</source>
         <translation>Cuando esté habilitado, DuckStation listará logros no oficiales. Ten en cuenta que RetroAchievements no rastreará estos logros, por lo que se desbloquearán cada vez que se consigan.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="46"/>
         <source>When enabled, rich presence information will be collected and sent to the server where supported.</source>
-        <translation>Cuando esté habilitado, se recopilará y enviará información de Rich Presence a un servidor compatible.</translation>
+        <translation type="vanished">Cuando esté habilitado, se recopilará y enviará información de Rich Presence a un servidor compatible.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="49"/>
+        <location filename="../achievementsettingswidget.cpp" line="73"/>
         <source>When enabled, the first disc in a playlist will be used for achievements, regardless of which disc is active.</source>
         <translation>Cuando esté habilitado, se utilizará el primer disco de una lista para los logros, independientemente de que disco esté activo.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="52"/>
+        <location filename="../achievementsettingswidget.cpp" line="49"/>
         <source>&quot;Challenge&quot; mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions.</source>
-        <translation>Modo &quot;desafío&quot; para los logros, incluyendo el seguimiento de tablas de posiciones. Deshabilita los estados guardados, trucos y funciones de ralentización.</translation>
+        <translation>Modo &quot;desafío&quot; para los logros, incluyendo el seguimiento de tabla de posiciones. Deshabilita los estados guardados, trucos y funciones de ralentización.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="55"/>
-        <location filename="../achievementsettingswidget.cpp" line="58"/>
-        <location filename="../achievementsettingswidget.cpp" line="61"/>
-        <location filename="../achievementsettingswidget.cpp" line="65"/>
+        <location filename="../achievementsettingswidget.cpp" line="51"/>
+        <location filename="../achievementsettingswidget.cpp" line="54"/>
+        <location filename="../achievementsettingswidget.cpp" line="57"/>
+        <location filename="../achievementsettingswidget.cpp" line="60"/>
         <source>Checked</source>
         <translation>Habilitado</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="56"/>
         <source>Displays popup messages on events such as achievement unlocks and leaderboard submissions.</source>
-        <translation>Muestra mensajes emergentes durante eventos como desbloqueo de logros y envíos a la tabla de posiciones.</translation>
+        <translation type="vanished">Muestra mensajes emergentes durante eventos como desbloqueo de logros y envíos a la tabla de posiciones.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="59"/>
+        <location filename="../achievementsettingswidget.cpp" line="58"/>
         <source>Plays sound effects for events such as achievement unlocks and leaderboard submissions.</source>
         <translation>Reproduce efectos de sonido durante eventos como desbloqueo de logros y envíos a la tabla de posiciones.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="62"/>
         <source>Enables tracking and submission of leaderboards in supported games. If leaderboards are disabled, you will still be able to view the leaderboard and scores, but no scores will be uploaded.</source>
-        <translation>Habilita el seguimiento y envíos a tablas de posiciones en juegos compatibles. Si las tablas de posiciones están deshabilitadas, podrás ver las tablas y puntuaciones, pero no enviar las tuyas.</translation>
+        <translation type="vanished">Habilita el seguimiento y envíos a tablas de posiciones en juegos compatibles. Si las tablas de posiciones están deshabilitadas, podrás ver las tablas y puntuaciones, pero no enviar las tuyas.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="66"/>
+        <location filename="../achievementsettingswidget.cpp" line="61"/>
         <source>Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active.</source>
         <translation>Muestra iconos en la esquina inferior derecha de la pantalla cuando un logro &quot;desafío&quot; esté activo.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="130"/>
+        <location filename="../achievementsettingswidget.cpp" line="150"/>
         <source>Reset System</source>
         <translation>Reiniciar sistema</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="131"/>
+        <location filename="../achievementsettingswidget.cpp" line="151"/>
         <source>Hardcore mode will not be enabled until the system is reset. Do you want to reset the system now?</source>
         <translation>El modo Hardcore no será habilitado hasta que se reinicie el sistema. ¿Quieres reiniciar el sistema ahora?</translation>
     </message>
+    <message numerus="yes">
+        <location filename="../achievementsettingswidget.cpp" line="164"/>
+        <location filename="../achievementsettingswidget.cpp" line="171"/>
+        <source>%n seconds</source>
+        <translation>
+            <numerusform>%n segundo</numerusform>
+            <numerusform>%n segundos</numerusform>
+        </translation>
+    </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="150"/>
+        <location filename="../achievementsettingswidget.cpp" line="184"/>
         <source>Username: %1
 Login token generated on %2.</source>
         <translation>Nombre de usuario: %1
 Token de inicio de sesión generado en %2.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="153"/>
+        <location filename="../achievementsettingswidget.cpp" line="187"/>
         <source>Logout</source>
         <translation>Cerrar sesión</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="157"/>
+        <location filename="../achievementsettingswidget.cpp" line="191"/>
         <source>Not Logged In.</source>
         <translation>Sesión no iniciada.</translation>
     </message>
@@ -296,91 +378,316 @@ Token de inicio de sesión generado en %2.</translation>
 <context>
     <name>Achievements</name>
     <message>
-        <location filename="../../core/system.cpp" line="1000"/>
+        <location filename="../../core/system.cpp" line="1124"/>
         <source>Loading state</source>
         <translation>Cargando estado</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1221"/>
+        <location filename="../../core/system.cpp" line="1342"/>
         <source>Resuming state</source>
         <translation>Resumiendo estado</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1988"/>
         <source>Hardcore mode disabled by state switch.</source>
-        <translation>El cambio de estados guardados deshabilitó el modo Hardcore.</translation>
+        <translation type="vanished">El cambio de estados guardados deshabilitó el modo Hardcore.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="505"/>
+        <location filename="../../core/achievements.cpp" line="1006"/>
         <source>Hardcore mode will be enabled on system reset.</source>
         <translation>El modo Hardcore será habilitado al reiniciar el sistema.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="534"/>
+        <location filename="../../core/achievements.cpp" line="1033"/>
+        <source>{} (Unofficial)</source>
+        <translation>{} (no oficial)</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1055"/>
+        <source>Mastered {}</source>
+        <translation>Dominado {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1056"/>
+        <source>{} achievements, {} points</source>
+        <translation>{} logros, {} puntos</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1071"/>
+        <source>Leaderboard attempt started.</source>
+        <translation>Intento de entrar en tabla de posiciones iniciado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1086"/>
+        <source>Leaderboard attempt failed.</source>
+        <translation>Intento de entrar en tabla de posiciones fallido.</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1101"/>
+        <source>Your Time: {}{}</source>
+        <translation>Tu tiempo: {}{}</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1102"/>
+        <source>Your Score: {}{}</source>
+        <translation>Tu puntuación: {}{}</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1103"/>
+        <source>Your Value: {}{}</source>
+        <translation>Tu valor: {}{}</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1112"/>
+        <source> (Submitting)</source>
+        <translation> (enviando)</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1131"/>
+        <source>Your Time: {} (Best: {})</source>
+        <translation>Tu tiempo: {}{} (Mejor: {})</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1132"/>
+        <source>Your Score: {} (Best: {})</source>
+        <translation>Tu puntuación: {}{} (Mejor: {})</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1133"/>
+        <source>Your Value: {} (Best: {})</source>
+        <translation>Tu valor: {}{} (Mejor: {})</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1138"/>
+        <source>{}
+Leaderboard Position: {} of {}</source>
+        <translation>{}
+Posición en tabla: {} de {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1271"/>
+        <source>Server error in {}:
+{}</source>
+        <translation>Error del servidor en {}:
+{}</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1285"/>
+        <source>Achievements Disconnected</source>
+        <translation>Logros desconectados</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1286"/>
+        <source>An unlock request could not be completed. We will keep retrying to submit this request.</source>
+        <translation>No se pudo completar una solicitud de desbloqueo. Se seguirá reenviando la solicitud.</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1298"/>
+        <source>Achievements Reconnected</source>
+        <translation>Logros reconectados</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1299"/>
+        <source>All pending unlock requests have completed.</source>
+        <translation>Se han completado todas las solicitudes de desbloqueo.</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1710"/>
+        <source>Score: {} ({} softcore)
+Unread messages: {}</source>
+        <translation>Puntuación: {} ({} en modo normal)
+Mensajes sin leer: {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1757"/>
         <source>Confirm Hardcore Mode</source>
         <translation>Confirma el modo Hardcore</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="535"/>
+        <location filename="../../core/achievements.cpp" line="1758"/>
         <source>{0} cannot be performed while hardcore mode is active. Do you want to disable hardcore mode? {0} will be cancelled if you select No.</source>
         <translation>No se puede utilizar la función de {0} mientras el modo Hardcore esté habilitado. ¿Quieres deshabilitar el modo Hardcore? La función {0} será cancelada si seleccionas no.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="586"/>
+        <location filename="../../core/achievements.cpp" line="1962"/>
+        <source>Active Challenge Achievements</source>
+        <translation>Logros de desafío activos</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2090"/>
+        <source> (Hardcore Mode)</source>
+        <translation> (modo Hardcore)</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2102"/>
+        <source>You have unlocked all achievements and earned {} points!</source>
+        <translation>Desbloqueaste todos los logros y conseguiste {} puntos!</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2108"/>
+        <source>You have unlocked {} of {} achievements, earning {} of {} possible points.</source>
+        <translation>Desbloqueaste {} de {} logros, consiguiendo {} de {} puntos posibles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2149"/>
+        <source>Unknown</source>
+        <translation>Desconocido</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2149"/>
+        <source>Locked</source>
+        <translation>Bloqueado</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2150"/>
+        <source>Unlocked</source>
+        <translation>Desbloqueado</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2150"/>
+        <source>Unsupported</source>
+        <translation>No admitido</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2151"/>
+        <source>Unofficial</source>
+        <translation>No oficial</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2151"/>
+        <source>Recently Unlocked</source>
+        <translation>Desbloqueado recientemente</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2152"/>
+        <source>Active Challenges</source>
+        <translation>Desafíos activos</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2152"/>
+        <source>Almost There</source>
+        <translation>Falta poco</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2243"/>
+        <source>{} points</source>
+        <translation>{} puntos</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2243"/>
+        <source>{} point</source>
+        <translation>{} punto</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2246"/>
+        <source>XXX points</source>
+        <translation>XXX puntos</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2279"/>
+        <source>Unlocked: {}</source>
+        <translation>Desbloqueado: {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2622"/>
+        <location filename="../../core/achievements.cpp" line="2631"/>
+        <source>Loading...</source>
+        <translation>Cargando...</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2792"/>
+        <location filename="../../core/achievements.cpp" line="2812"/>
+        <source>Leaderboard download failed</source>
+        <translation>Fallo al descargar tabla de posiciones</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1379"/>
         <source>Hardcore mode is now enabled.</source>
         <translation>El modo Hardcore está habilitado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="587"/>
+        <location filename="../../core/achievements.cpp" line="983"/>
+        <source>You have unlocked {} of {} achievements, and earned {} of {} points.</source>
+        <translation>Desbloqueaste {} de {} logros, y conseguiste {} de {} puntos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="1380"/>
         <source>Hardcore mode is now disabled.</source>
         <translation>El modo Hardcore está deshabilitado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="1002"/>
+        <location filename="../../core/achievements.cpp" line="976"/>
         <source>{} (Hardcore Mode)</source>
         <translation>{} (modo Hardcore)</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="1010"/>
         <source>You have earned {} of {} achievements, and {} of {} points.</source>
-        <translation>Conseguiste {} de {} logros, y {} de {} puntos.</translation>
+        <translation type="vanished">Conseguiste {} de {} logros, y {} de {} puntos.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="1016"/>
+        <location filename="../../core/achievements.cpp" line="989"/>
         <source>This game has no achievements.</source>
         <translation>No hay logros para este juego.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/achievements.cpp" line="1772"/>
         <source>Your Score: {} (Best: {})
 Leaderboard Position: {} of {}</source>
-        <translation>Tu puntuación: {} (mejor: {})
+        <translation type="vanished">Tu puntuación: {} (mejor: {})
 Posición en la tabla: {} de {}</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="6953"/>
+        <location filename="../../core/achievements.cpp" line="2451"/>
         <source>This game has {} leaderboards.</source>
         <translation>Este juego tiene {} tablas de puntuaciones.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="6971"/>
+        <location filename="../../core/achievements.cpp" line="2468"/>
         <source>Submitting scores is disabled because hardcore mode is off. Leaderboards are read-only.</source>
         <translation>No se enviarán puntuaciones porque el modo Hardcore está deshabilitado. Las tablas de posiciones serán de solo lectura.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="7006"/>
+        <location filename="../../core/achievements.cpp" line="2489"/>
+        <source>Show Best</source>
+        <translation>Mostrar mejores</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2489"/>
+        <source>Show Nearby</source>
+        <translation>Mostrar cercanos</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2517"/>
+        <source>Rank</source>
+        <translation>Rango</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2522"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2527"/>
         <source>Time</source>
         <translation>Tiempo</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="7007"/>
+        <location filename="../../core/achievements.cpp" line="2528"/>
         <source>Score</source>
         <translation>Puntuación</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/fullscreen_ui.cpp" line="7063"/>
+        <location filename="../../core/achievements.cpp" line="2529"/>
+        <source>Value</source>
+        <translation>Valor</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2542"/>
+        <source>Date Submitted</source>
+        <translation>Fecha de envío</translation>
+    </message>
+    <message>
+        <location filename="../../core/achievements.cpp" line="2603"/>
         <source>Downloading leaderboard data, please wait...</source>
-        <translation>Descargando información de tablas de posiciones, espera...</translation>
+        <translation>Descargando información de tabla de posiciones, espera...</translation>
     </message>
 </context>
 <context>
@@ -549,147 +856,157 @@ Posición en la tabla: {} de {}</translation>
         <translation>Suavizado de bordes de muestreo múltiple (MSAA)</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="284"/>
+        <location filename="../advancedsettingswidget.cpp" line="282"/>
+        <source>Wireframe Mode</source>
+        <translation>Ver mallas de polígonos</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="289"/>
         <source>Display Active Start Offset</source>
         <translation>Desplazamiento del inicio de imagen activa</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="286"/>
+        <location filename="../advancedsettingswidget.cpp" line="291"/>
         <source>Display Active End Offset</source>
         <translation>Desplazamiento del fin de imagen activa</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="288"/>
+        <location filename="../advancedsettingswidget.cpp" line="293"/>
         <source>Display Line Start Offset</source>
         <translation>Desplazamiento de la primera línea de imagen</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="290"/>
+        <location filename="../advancedsettingswidget.cpp" line="295"/>
         <source>Display Line End Offset</source>
         <translation>Desplazamiento de la última línea de imagen</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="294"/>
+        <location filename="../advancedsettingswidget.cpp" line="299"/>
         <source>PGXP Vertex Cache</source>
         <translation>Caché de vértices (PGXP)</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="295"/>
+        <location filename="../advancedsettingswidget.cpp" line="300"/>
         <source>PGXP Geometry Tolerance</source>
         <translation>Tolerancia geométrica (PGXP)</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="297"/>
+        <location filename="../advancedsettingswidget.cpp" line="302"/>
         <source>PGXP Depth Clear Threshold</source>
         <translation>Umbral de limpieza de profundidad (PGXP)</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="300"/>
+        <location filename="../advancedsettingswidget.cpp" line="305"/>
         <source>Enable Recompiler Memory Exceptions</source>
         <translation>Habilitar excepciones de memoria del recompilador</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="302"/>
+        <location filename="../advancedsettingswidget.cpp" line="307"/>
         <source>Enable Recompiler Block Linking</source>
         <translation>Habilitar vinculación de bloques del recompilador</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="304"/>
+        <location filename="../advancedsettingswidget.cpp" line="309"/>
         <source>Enable Recompiler Fast Memory Access</source>
         <translation>Habilitar memoria de acceso rápido del recompilador</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="309"/>
+        <location filename="../advancedsettingswidget.cpp" line="314"/>
         <source>Use Old MDEC Routines</source>
         <translation>Utilizar rutinas MDEC antiguas</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="311"/>
+        <location filename="../advancedsettingswidget.cpp" line="316"/>
         <source>Enable VRAM Write Texture Replacement</source>
         <translation>Habilitar reemplazo de textura de escritura de VRAM</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="313"/>
+        <location filename="../advancedsettingswidget.cpp" line="318"/>
         <source>Preload Texture Replacements</source>
         <translation>Precargar reemplazos de textura</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="315"/>
+        <location filename="../advancedsettingswidget.cpp" line="320"/>
         <source>Dump Replaceable VRAM Writes</source>
         <translation>Volcar escrituras de VRAM reemplazables</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="317"/>
+        <location filename="../advancedsettingswidget.cpp" line="322"/>
         <source>Set Dumped VRAM Write Alpha Channel</source>
         <translation>Establecer el canal alfa de la escritura de VRAM volcada</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="319"/>
+        <location filename="../advancedsettingswidget.cpp" line="324"/>
         <source>Minimum Dumped VRAM Write Width</source>
         <translation>Anchura mínima del volcado de escritura de VRAM</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="322"/>
+        <location filename="../advancedsettingswidget.cpp" line="327"/>
         <source>Minimum Dumped VRAM Write Height</source>
         <translation>Altura mínima del volcado de escritura de VRAM</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="326"/>
+        <location filename="../advancedsettingswidget.cpp" line="331"/>
         <source>DMA Max Slice Ticks</source>
         <translation>Duración máxima de los cortes de la DMA</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="328"/>
+        <location filename="../advancedsettingswidget.cpp" line="333"/>
         <source>DMA Halt Ticks</source>
         <translation>Duración de las paradas de la DMA</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="330"/>
+        <location filename="../advancedsettingswidget.cpp" line="335"/>
         <source>GPU FIFO Size</source>
         <translation>Tamaño del FIFO de la GPU</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="332"/>
+        <location filename="../advancedsettingswidget.cpp" line="337"/>
         <source>GPU Max Run-Ahead</source>
         <translation>Procesamiento anticipado máximo de la GPU</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="334"/>
+        <location filename="../advancedsettingswidget.cpp" line="339"/>
         <source>Use Debug Host GPU Device</source>
         <translation>Utilizar dispositivo gráfico de depuración</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="337"/>
+        <location filename="../advancedsettingswidget.cpp" line="341"/>
+        <source>Disable Shader Cache</source>
+        <translation>Deshabilitar caché de sombreadores</translation>
+    </message>
+    <message>
+        <location filename="../advancedsettingswidget.cpp" line="344"/>
         <source>Stretch Display Vertically</source>
         <translation>Estirar imagen verticalmente</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="340"/>
+        <location filename="../advancedsettingswidget.cpp" line="347"/>
         <source>Increase Timer Resolution</source>
         <translation>Incrementar la resolución del temporizador</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="343"/>
+        <location filename="../advancedsettingswidget.cpp" line="350"/>
         <source>Allow Booting Without SBI File</source>
         <translation>Permitir iniciar sin un archivo SBI</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="346"/>
+        <location filename="../advancedsettingswidget.cpp" line="353"/>
         <source>Create Save State Backups</source>
         <translation>Crear copias de seguridad de los estados guardados</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="349"/>
+        <location filename="../advancedsettingswidget.cpp" line="356"/>
         <source>Enable PCDrv</source>
         <translation>Habilitar PCDrv</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="350"/>
+        <location filename="../advancedsettingswidget.cpp" line="357"/>
         <source>Enable PCDrv Writes</source>
         <translation>Habilitar escrituras de PCDrv</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="351"/>
+        <location filename="../advancedsettingswidget.cpp" line="358"/>
         <source>PCDrv Root Directory</source>
         <translation>Directorio raíz de PCDrv</translation>
     </message>
@@ -697,124 +1014,249 @@ Posición en la tabla: {} de {}</translation>
 <context>
     <name>AnalogController</name>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="112"/>
-        <location filename="../../core/analog_controller.cpp" line="299"/>
+        <location filename="../../core/analog_controller.cpp" line="117"/>
+        <location filename="../../core/analog_controller.cpp" line="303"/>
         <source>Controller {} switched to analog mode.</source>
         <translation>Control {} cambiado a modo analógico.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="113"/>
-        <location filename="../../core/analog_controller.cpp" line="300"/>
+        <location filename="../../core/analog_controller.cpp" line="118"/>
+        <location filename="../../core/analog_controller.cpp" line="304"/>
         <source>Controller {} switched to digital mode.</source>
         <translation>Control {} cambiado a modo digital.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="315"/>
+        <location filename="../../core/analog_controller.cpp" line="318"/>
         <source>Controller {} is locked to analog mode by the game.</source>
         <translation>Control {} bloqueado en modo analógico por el juego.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="316"/>
+        <location filename="../../core/analog_controller.cpp" line="319"/>
         <source>Controller {} is locked to digital mode by the game.</source>
         <translation>Control {} bloqueado en modo digital por el juego.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="831"/>
+        <location filename="../../core/analog_controller.cpp" line="803"/>
+        <source>D-Pad Up</source>
+        <translation>Botón de dirección hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="804"/>
+        <source>D-Pad Right</source>
+        <translation>Botón de dirección hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="805"/>
+        <source>D-Pad Down</source>
+        <translation>Botón de dirección hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="806"/>
+        <source>D-Pad Left</source>
+        <translation>Botón de dirección hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="807"/>
+        <source>Triangle</source>
+        <translation>Triángulo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="808"/>
+        <source>Circle</source>
+        <translation>Círculo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="809"/>
+        <source>Cross</source>
+        <translation>Cruz</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="810"/>
+        <source>Square</source>
+        <translation>Cuadrado</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="811"/>
+        <source>Select</source>
+        <translation>Select</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="812"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="813"/>
+        <source>Analog Toggle</source>
+        <translation>Alternar analógico</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="814"/>
+        <source>L1</source>
+        <translation>L1</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="815"/>
+        <source>R1</source>
+        <translation>R1</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="816"/>
+        <source>L2</source>
+        <translation>L2</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="817"/>
+        <source>R2</source>
+        <translation>R2</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="818"/>
+        <source>L3</source>
+        <translation>L3</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="819"/>
+        <source>R3</source>
+        <translation>R3</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="821"/>
+        <source>Left Stick Left</source>
+        <translation>Palanca izquierda hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="822"/>
+        <source>Left Stick Right</source>
+        <translation>Palanca izquierda hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="823"/>
+        <source>Left Stick Down</source>
+        <translation>Palanca izquierda hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="824"/>
+        <source>Left Stick Up</source>
+        <translation>Palanca izquierda hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="825"/>
+        <source>Right Stick Left</source>
+        <translation>Palanca derecha hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="826"/>
+        <source>Right Stick Right</source>
+        <translation>Palanca derecha hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="827"/>
+        <source>Right Stick Down</source>
+        <translation>Palanca derecha hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="828"/>
+        <source>Right Stick Up</source>
+        <translation>Palanca derecha hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_controller.cpp" line="835"/>
         <source>Not Inverted</source>
         <translation>No invertir</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="832"/>
+        <location filename="../../core/analog_controller.cpp" line="836"/>
         <source>Invert Left/Right</source>
         <translation>Invertir izquierda/derecha</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="833"/>
+        <location filename="../../core/analog_controller.cpp" line="837"/>
         <source>Invert Up/Down</source>
         <translation>Invertir arriba/abajo</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="834"/>
+        <location filename="../../core/analog_controller.cpp" line="838"/>
         <source>Invert Left/Right + Up/Down</source>
         <translation>Invertir izquierda/derecha + arriba/abajo</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="837"/>
+        <location filename="../../core/analog_controller.cpp" line="841"/>
         <source>Force Analog Mode on Reset</source>
         <translation>Forzar el modo analógico al reiniciar</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="838"/>
+        <location filename="../../core/analog_controller.cpp" line="842"/>
         <source>Forces the controller to analog mode when the console is reset/powered on.</source>
         <translation>Fuerza el control a modo analógico cuando la consola se inicia/reinicia.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="841"/>
+        <location filename="../../core/analog_controller.cpp" line="845"/>
         <source>Use Analog Sticks for D-Pad in Digital Mode</source>
         <translation>Utilizar las palancas analógicas como cruceta en el modo digital</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="842"/>
+        <location filename="../../core/analog_controller.cpp" line="846"/>
         <source>Allows you to use the analog sticks to control the d-pad in digital mode, as well as the buttons.</source>
         <translation>Permite utilizar las palancas analógicas para controlar la cruceta y los botones en modo digital.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="845"/>
+        <location filename="../../core/analog_controller.cpp" line="849"/>
         <source>Analog Deadzone</source>
         <translation>Zona muerta de las palancas analógicas</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="846"/>
+        <location filename="../../core/analog_controller.cpp" line="850"/>
         <source>Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.</source>
         <translation>Establece la zona muerta de las palancas analógicas, es decir, el rango de movimiento de la palanca que será ignorado.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="849"/>
+        <location filename="../../core/analog_controller.cpp" line="853"/>
         <source>Analog Sensitivity</source>
         <translation>Sensibilidad analógica</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="850"/>
+        <location filename="../../core/analog_controller.cpp" line="854"/>
         <source>Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent controllers, e.g. DualShock 4, Xbox One Controller.</source>
         <translation>Establece el factor de escalado para los ejes de las palancas analógicas. Se recomienda un valor entre 130% y 140% cuando se usen controles modernos, como DualShock 4 o el control de Xbox One.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="855"/>
+        <location filename="../../core/analog_controller.cpp" line="859"/>
         <source>Button/Trigger Deadzone</source>
         <translation>Zona muerta de botón/gatillo</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="856"/>
+        <location filename="../../core/analog_controller.cpp" line="860"/>
         <source>Sets the deadzone for activating buttons/triggers, i.e. the fraction of the trigger which will be ignored.</source>
         <translation>Establece la zona muerta para activar botones/gatillos, es decir, la distancia de pulsación que será ignorada.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="859"/>
+        <location filename="../../core/analog_controller.cpp" line="863"/>
         <source>Vibration Bias</source>
         <translation>Fuerza de vibración</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="860"/>
+        <location filename="../../core/analog_controller.cpp" line="864"/>
         <source>Sets the rumble bias value. If rumble in some games is too weak or not functioning, try increasing this value.</source>
         <translation>Indica la medida de la vibración. Si la vibración en algunos juegos es débil o no funciona, intenta incrementar este valor.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="863"/>
+        <location filename="../../core/analog_controller.cpp" line="867"/>
         <source>Invert Left Stick</source>
         <translation>Invertir palanca izquierda</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="864"/>
+        <location filename="../../core/analog_controller.cpp" line="868"/>
         <source>Inverts the direction of the left analog stick.</source>
         <translation>Invierte la dirección de la palanca analógica izquierda.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="866"/>
+        <location filename="../../core/analog_controller.cpp" line="870"/>
         <source>Invert Right Stick</source>
         <translation>Invertir palanca derecha</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="867"/>
+        <location filename="../../core/analog_controller.cpp" line="871"/>
         <source>Inverts the direction of the right analog stick.</source>
         <translation>Invierte la dirección de la palanca analógica derecha.</translation>
     </message>
@@ -822,74 +1264,199 @@ Posición en la tabla: {} de {}</translation>
 <context>
     <name>AnalogJoystick</name>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="62"/>
-        <location filename="../../core/analog_joystick.cpp" line="238"/>
+        <location filename="../../core/analog_joystick.cpp" line="67"/>
+        <location filename="../../core/analog_joystick.cpp" line="242"/>
         <source>Controller %u switched to analog mode.</source>
         <translation>Control %u cambiado a modo analógico.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="63"/>
-        <location filename="../../core/analog_joystick.cpp" line="239"/>
+        <location filename="../../core/analog_joystick.cpp" line="68"/>
+        <location filename="../../core/analog_joystick.cpp" line="243"/>
         <source>Controller %u switched to digital mode.</source>
         <translation>Control %u cambiado a modo digital.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="377"/>
+        <location filename="../../core/analog_joystick.cpp" line="351"/>
+        <source>D-Pad Up</source>
+        <translation>Botón de dirección hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="352"/>
+        <source>D-Pad Right</source>
+        <translation>Botón de dirección hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="353"/>
+        <source>D-Pad Down</source>
+        <translation>Botón de dirección hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="354"/>
+        <source>D-Pad Left</source>
+        <translation>Botón de dirección hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="355"/>
+        <source>Triangle</source>
+        <translation>Triángulo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="356"/>
+        <source>Circle</source>
+        <translation>Círculo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="357"/>
+        <source>Cross</source>
+        <translation>Cruz</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="358"/>
+        <source>Square</source>
+        <translation>Cuadrado</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="359"/>
+        <source>Select</source>
+        <translation>Select</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="360"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="361"/>
+        <source>Mode Toggle</source>
+        <translation>Alternar modo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="362"/>
+        <source>L1</source>
+        <translation>L1</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="363"/>
+        <source>R1</source>
+        <translation>R1</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="364"/>
+        <source>L2</source>
+        <translation>L2</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="365"/>
+        <source>R2</source>
+        <translation>R2</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="366"/>
+        <source>L3</source>
+        <translation>L3</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="367"/>
+        <source>R3</source>
+        <translation>R3</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="369"/>
+        <source>Left Stick Left</source>
+        <translation>Palanca izquierda hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="370"/>
+        <source>Left Stick Right</source>
+        <translation>Palanca izquierda hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="371"/>
+        <source>Left Stick Down</source>
+        <translation>Palanca izquierda hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="372"/>
+        <source>Left Stick Up</source>
+        <translation>Palanca izquierda hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="373"/>
+        <source>Right Stick Left</source>
+        <translation>Palanca derecha hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="374"/>
+        <source>Right Stick Right</source>
+        <translation>Palanca derecha hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="375"/>
+        <source>Right Stick Down</source>
+        <translation>Palanca derecha hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="376"/>
+        <source>Right Stick Up</source>
+        <translation>Palanca derecha hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/analog_joystick.cpp" line="383"/>
         <source>Not Inverted</source>
         <translation>No invertir</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="378"/>
+        <location filename="../../core/analog_joystick.cpp" line="384"/>
         <source>Invert Left/Right</source>
         <translation>Invertir izquierda/derecha</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="379"/>
+        <location filename="../../core/analog_joystick.cpp" line="385"/>
         <source>Invert Up/Down</source>
         <translation>Invertir arriba/abajo</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="380"/>
+        <location filename="../../core/analog_joystick.cpp" line="386"/>
         <source>Invert Left/Right + Up/Down</source>
         <translation>Invertir izquierda/derecha + arriba/abajo</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="383"/>
+        <location filename="../../core/analog_joystick.cpp" line="389"/>
         <source>Analog Deadzone</source>
         <translation>Zona muerta de las palancas analógicas</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="384"/>
+        <location filename="../../core/analog_joystick.cpp" line="390"/>
         <source>Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.</source>
         <translation>Establece la zona muerta de las palancas analógicas, es decir, el rango de movimiento de la palanca que será ignorado.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="387"/>
+        <location filename="../../core/analog_joystick.cpp" line="393"/>
         <source>Analog Sensitivity</source>
         <translation>Sensibilidad analógica</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="388"/>
+        <location filename="../../core/analog_joystick.cpp" line="394"/>
         <source>Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent controllers, e.g. DualShock 4, Xbox One Controller.</source>
         <translation>Establece el factor de escalado para los ejes de las palancas analógicas. Se recomienda un valor entre 130% y 140% cuando se usen controles modernos, como DualShock 4 o el control de Xbox One.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="393"/>
+        <location filename="../../core/analog_joystick.cpp" line="399"/>
         <source>Invert Left Stick</source>
         <translation>Invertir palanca izquierda</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="394"/>
+        <location filename="../../core/analog_joystick.cpp" line="400"/>
         <source>Inverts the direction of the left analog stick.</source>
         <translation>Invierte la dirección de la palanca analógica izquierda.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="396"/>
+        <location filename="../../core/analog_joystick.cpp" line="402"/>
         <source>Invert Right Stick</source>
         <translation>Invertir palanca derecha</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="397"/>
+        <location filename="../../core/analog_joystick.cpp" line="403"/>
         <source>Inverts the direction of the right analog stick.</source>
         <translation>Invierte la dirección de la palanca analógica derecha.</translation>
     </message>
@@ -897,17 +1464,17 @@ Posición en la tabla: {} de {}</translation>
 <context>
     <name>AudioBackend</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1137"/>
+        <location filename="../../core/settings.cpp" line="1245"/>
         <source>Null (No Output)</source>
         <translation>Nulo (sin salida)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1139"/>
+        <location filename="../../core/settings.cpp" line="1247"/>
         <source>Cubeb</source>
         <translation>Cubeb</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1142"/>
+        <location filename="../../core/settings.cpp" line="1250"/>
         <source>XAudio2</source>
         <translation>XAudio2</translation>
     </message>
@@ -971,7 +1538,7 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../audiosettingswidget.ui" line="136"/>
-        <location filename="../audiosettingswidget.cpp" line="76"/>
+        <location filename="../audiosettingswidget.cpp" line="75"/>
         <source>Start Dumping On Boot</source>
         <translation>Comenzar volcado de audio al iniciar</translation>
     </message>
@@ -1008,122 +1575,145 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../audiosettingswidget.ui" line="281"/>
-        <location filename="../audiosettingswidget.cpp" line="82"/>
+        <location filename="../audiosettingswidget.cpp" line="81"/>
         <source>Mute All Sound</source>
         <translation>Silenciar todo</translation>
     </message>
     <message>
         <location filename="../audiosettingswidget.ui" line="288"/>
-        <location filename="../audiosettingswidget.cpp" line="84"/>
+        <location filename="../audiosettingswidget.cpp" line="83"/>
         <source>Mute CD Audio</source>
         <translation>Silenciar audio de CD</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="65"/>
+        <location filename="../audiosettingswidget.cpp" line="64"/>
         <source>Audio Backend</source>
         <translation>Motor de audio</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="66"/>
+        <location filename="../audiosettingswidget.cpp" line="65"/>
         <source>The audio backend determines how frames produced by the emulator are submitted to the host. Cubeb provides the lowest latency, if you encounter issues, try the SDL backend. The null backend disables all host audio output.</source>
         <translation>El motor de audio determina como se envían los fotogramas producidos por el emulador al sistema. Cubeb ofrece la menor latencia, pero en caso de tener problemas, prueba con el motor SDL. El motor nulo deshabilita la salida de audio.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="70"/>
+        <location filename="../audiosettingswidget.cpp" line="69"/>
         <source>Output Latency</source>
         <translation>Latencia de salida</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="71"/>
+        <location filename="../audiosettingswidget.cpp" line="69"/>
+        <source>50 ms</source>
+        <translation>50 ms</translation>
+    </message>
+    <message>
+        <location filename="../audiosettingswidget.cpp" line="70"/>
         <source>The buffer size determines the size of the chunks of audio which will be pulled by the host. Smaller values reduce the output latency, but may cause hitches if the emulation speed is inconsistent. Note that the Cubeb backend uses smaller chunks regardless of this value, so using a low value here may not significantly change latency.</source>
         <translation>El tamaño del búfer determina el tamaño de los fragmentos de audio que serán recibidos por el sistema. Valores más pequeños reducirán la latencia de salida, pero puede causar parones si la velocidad de la emulación no es consistente. Ten en cuenta que el motor Cubeb utiliza fragmentos más pequeños a pesar este valor, por lo tanto, utilizar valores más pequeños en este caso podría no cambiar mucho la latencia.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="76"/>
-        <location filename="../audiosettingswidget.cpp" line="82"/>
-        <location filename="../audiosettingswidget.cpp" line="84"/>
+        <location filename="../audiosettingswidget.cpp" line="75"/>
+        <location filename="../audiosettingswidget.cpp" line="81"/>
+        <location filename="../audiosettingswidget.cpp" line="83"/>
         <source>Unchecked</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="77"/>
+        <location filename="../audiosettingswidget.cpp" line="76"/>
         <source>Start dumping audio to file as soon as the emulator is started. Mainly useful as a debug option.</source>
         <translation>Comenzar a volcar audio en archivos tan pronto se inicie el emulador. Útil para fines de depuración.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="78"/>
+        <location filename="../audiosettingswidget.cpp" line="77"/>
         <source>Output Volume</source>
         <translation>Volumen de salida</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="79"/>
+        <location filename="../audiosettingswidget.cpp" line="78"/>
         <source>Controls the volume of the audio played on the host.</source>
         <translation>Controla el volúmen de reproducción de audio en el sistema.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="80"/>
+        <location filename="../audiosettingswidget.cpp" line="79"/>
         <source>Fast Forward Volume</source>
         <translation>Volumen durante avance rápido</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="81"/>
+        <location filename="../audiosettingswidget.cpp" line="80"/>
         <source>Controls the volume of the audio played on the host when fast forwarding.</source>
         <translation>Controla el volúmen de reproducción de audio durante el avance rápido en el sistema.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="83"/>
+        <location filename="../audiosettingswidget.cpp" line="82"/>
         <source>Prevents the emulator from producing any audible sound.</source>
         <translation>Impide que el emulador produzca cualquier sonido.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="85"/>
+        <location filename="../audiosettingswidget.cpp" line="84"/>
         <source>Forcibly mutes both CD-DA and XA audio from the CD-ROM. Can be used to disable background music in some games.</source>
         <translation>Silecia a la fuerza el audio CD-DA y XA del CD-ROM. Puede utilizarse para deshabilitar la música de fondo en algunos juegos.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="88"/>
+        <location filename="../audiosettingswidget.cpp" line="87"/>
         <source>Stretch Mode</source>
         <translation>Modo de estiramiento</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="88"/>
+        <location filename="../audiosettingswidget.cpp" line="87"/>
         <source>Time Stretching</source>
         <translation>Estiramiento temporal</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="89"/>
+        <location filename="../audiosettingswidget.cpp" line="88"/>
         <source>When running outside of 100% speed, adjusts the tempo on audio instead of dropping frames. Produces much nicer fast forward/slowdown audio at a small cost to performance.</source>
         <translation>Cuando la velocidad de ejecución sea distinta al 100%, se ajustará el tempo del audio en lugar de eliminar fotogramas. Produce un audio mucho más agradable durante el avance rápido/ralentizaciones a un pequeño costo de rendimiento.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="119"/>
-        <location filename="../audiosettingswidget.cpp" line="137"/>
+        <location filename="../audiosettingswidget.cpp" line="118"/>
+        <location filename="../audiosettingswidget.cpp" line="136"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="159"/>
+        <location filename="../audiosettingswidget.cpp" line="158"/>
         <source>Maximum Latency: %1 frames / %2 ms (%3ms buffer + %5ms output)</source>
         <translation>Latencia máxima: %1 fotogramas / %2 ms (búfer de %3ms + %5ms de salida)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="167"/>
+        <location filename="../audiosettingswidget.cpp" line="166"/>
         <source>Maximum Latency: %1 frames / %2 ms</source>
         <translation>Latencia máxima: %1 fotogramas / %2 ms</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="172"/>
         <location filename="../audiosettingswidget.cpp" line="173"/>
-        <location filename="../audiosettingswidget.cpp" line="174"/>
         <source>%1%</source>
         <translation>%1%</translation>
+    </message>
+</context>
+<context>
+    <name>AudioStream</name>
+    <message>
+        <location filename="../../util/audio_stream.cpp" line="58"/>
+        <source>None</source>
+        <translation>Ninguno</translation>
+    </message>
+    <message>
+        <location filename="../../util/audio_stream.cpp" line="59"/>
+        <source>Resampling</source>
+        <translation>Remuestreo</translation>
+    </message>
+    <message>
+        <location filename="../../util/audio_stream.cpp" line="60"/>
+        <source>Time Stretching</source>
+        <translation>Estiramiento temporal</translation>
     </message>
 </context>
 <context>
     <name>AutoUpdaterDialog</name>
     <message>
         <location filename="../autoupdaterdialog.ui" line="17"/>
-        <location filename="../autoupdaterdialog.cpp" line="187"/>
-        <location filename="../autoupdaterdialog.cpp" line="373"/>
+        <location filename="../autoupdaterdialog.cpp" line="199"/>
+        <location filename="../autoupdaterdialog.cpp" line="379"/>
         <source>Automatic Updater</source>
         <translation>Actualizador automático</translation>
     </message>
@@ -1158,57 +1748,57 @@ Posición en la tabla: {} de {}</translation>
         <translation>Recordar más tarde</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="111"/>
+        <location filename="../autoupdaterdialog.cpp" line="129"/>
         <source>Updater Error</source>
         <translation>Error de actualización</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="188"/>
+        <location filename="../autoupdaterdialog.cpp" line="200"/>
         <source>No updates are currently available. Please try again later.</source>
         <translation>No hay actualizaciones disponibles. Intenta más tarde.</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="240"/>
+        <location filename="../autoupdaterdialog.cpp" line="252"/>
         <source>Current Version: %1 (%2)</source>
         <translation>Versión actual: %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="242"/>
+        <location filename="../autoupdaterdialog.cpp" line="254"/>
         <source>New Version: %1 (%2)</source>
         <translation>Nueva versión: %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="243"/>
+        <location filename="../autoupdaterdialog.cpp" line="255"/>
         <source>Loading...</source>
         <translation>Cargando...</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="299"/>
+        <location filename="../autoupdaterdialog.cpp" line="308"/>
         <source>&lt;h2&gt;Changes:&lt;/h2&gt;</source>
         <translation>&lt;h2&gt;Cambios:&lt;/h2&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="332"/>
+        <location filename="../autoupdaterdialog.cpp" line="341"/>
         <source>&lt;h2&gt;Save State Warning&lt;/h2&gt;&lt;p&gt;Installing this update will make your save states &lt;b&gt;incompatible&lt;/b&gt;. Please ensure you have saved your games to memory card before installing this update or you will lose progress.&lt;/p&gt;</source>
         <translation>&lt;h2&gt;Alerta sobre estados guardados&lt;/h2&gt;&lt;p&gt;Instalar esta actualización hará que tus estados guardados &lt;b&gt;dejen de ser compatibles&lt;/b&gt;. Asegúrate de haber guardado tus partidas en una tarjeta de memoria antes de instalar la actualización o perderás tu progreso.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="340"/>
+        <location filename="../autoupdaterdialog.cpp" line="349"/>
         <source>&lt;h2&gt;Settings Warning&lt;/h2&gt;&lt;p&gt;Installing this update will reset your program configuration. Please note that you will have to reconfigure your settings after this update.&lt;/p&gt;</source>
         <translation>&lt;h2&gt;Alerta sobre configuración&lt;/h2&gt;&lt;p&gt;Instalar esta actualización reiniciará tu configuración. Ten en cuenta que deberás ajustar tu configuración nuevamente después de instalar la actualización.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="344"/>
+        <location filename="../autoupdaterdialog.cpp" line="353"/>
         <source>&lt;h4&gt;Installing this update will download %1 MB through your internet connection.&lt;/h4&gt;</source>
         <translation>&lt;h4&gt;Instalar esta actualización descargará %1 MB a través de tu conexión de internet.&lt;/h4&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="372"/>
+        <location filename="../autoupdaterdialog.cpp" line="378"/>
         <source>Downloading %1...</source>
         <translation>Descargando %1...</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="372"/>
+        <location filename="../autoupdaterdialog.cpp" line="378"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1272,44 +1862,52 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../biossettingswidget.ui" line="162"/>
-        <location filename="../biossettingswidget.cpp" line="22"/>
+        <location filename="../biossettingswidget.cpp" line="25"/>
         <source>Fast Boot</source>
         <translation>Inicio rápido</translation>
     </message>
     <message>
         <location filename="../biossettingswidget.ui" line="169"/>
-        <location filename="../biossettingswidget.cpp" line="26"/>
-        <source>Enable TTY Output</source>
-        <translation>Habilitar salida por terminal</translation>
+        <location filename="../biossettingswidget.cpp" line="28"/>
+        <source>Enable TTY Logging</source>
+        <translation>Habilitar registro por terminal</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="22"/>
-        <location filename="../biossettingswidget.cpp" line="26"/>
+        <source>Enable TTY Output</source>
+        <translation type="vanished">Habilitar salida por terminal</translation>
+    </message>
+    <message>
+        <location filename="../biossettingswidget.cpp" line="25"/>
+        <location filename="../biossettingswidget.cpp" line="28"/>
         <source>Unchecked</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="23"/>
+        <location filename="../biossettingswidget.cpp" line="26"/>
         <source>Patches the BIOS to skip the console&apos;s boot animation. Does not work with all games, but usually safe to enable.</source>
         <translation>Parchea el BIOS para saltar la animación de inicio de la consola. No funciona con todos los juegos, pero es generalmente seguro de activar.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="27"/>
         <source>Patches the BIOS to log calls to printf(). Only use when debugging, can break games.</source>
-        <translation>Parchea el BIOS para registrar mensajes en la consola. Utilizar solamente para depuración, puede no funcionar con algunos juegos.</translation>
+        <translation type="vanished">Parchea el BIOS para registrar mensajes en la consola. Utilizar solamente para depuración, puede no funcionar con algunos juegos.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="94"/>
+        <location filename="../biossettingswidget.cpp" line="29"/>
+        <source>Logs BIOS calls to printf(). Not all games contain debugging messages.</source>
+        <translation>Registra mensajes de BIOS a printf(). No todos los juegos contienen mensajes de depuración.</translation>
+    </message>
+    <message>
+        <location filename="../biossettingswidget.cpp" line="105"/>
         <source>Use Global Setting</source>
         <translation>Utilizar configuración global</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="96"/>
+        <location filename="../biossettingswidget.cpp" line="107"/>
         <source>Auto-Detect</source>
         <translation>Detectar automáticamente</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="114"/>
+        <location filename="../biossettingswidget.cpp" line="125"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
@@ -1317,17 +1915,17 @@ Posición en la tabla: {} de {}</translation>
 <context>
     <name>CPUExecutionMode</name>
     <message>
-        <location filename="../../core/settings.cpp" line="822"/>
+        <location filename="../../core/settings.cpp" line="839"/>
         <source>Interpreter (Slowest)</source>
         <translation>Intérprete (el más lento)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="823"/>
+        <location filename="../../core/settings.cpp" line="840"/>
         <source>Cached Interpreter (Faster)</source>
         <translation>Intérprete en caché (más rápido)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="824"/>
+        <location filename="../../core/settings.cpp" line="841"/>
         <source>Recompiler (Fastest)</source>
         <translation>Recompilador (el más rápido)</translation>
     </message>
@@ -1335,17 +1933,17 @@ Posición en la tabla: {} de {}</translation>
 <context>
     <name>CPUFastmemMode</name>
     <message>
-        <location filename="../../core/settings.cpp" line="853"/>
+        <location filename="../../core/settings.cpp" line="869"/>
         <source>Disabled (Slowest)</source>
         <translation>Deshabilitado (el más lento)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="854"/>
+        <location filename="../../core/settings.cpp" line="870"/>
         <source>MMap (Hardware, Fastest, 64-Bit Only)</source>
         <translation>MMap (por hardware, el más rápido, solo para x64)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="855"/>
+        <location filename="../../core/settings.cpp" line="871"/>
         <source>LUT (Faster)</source>
         <translation>LUT (más rápido)</translation>
     </message>
@@ -1897,7 +2495,7 @@ Posición en la tabla: {} de {}</translation>
 <context>
     <name>CommonHost</name>
     <message>
-        <location filename="../../frontend-common/cubeb_audio_stream.cpp" line="257"/>
+        <location filename="../../util/cubeb_audio_stream.cpp" line="261"/>
         <source>Default Output Device</source>
         <translation>Dispositivo de salida predeterminado</translation>
     </message>
@@ -1905,30 +2503,29 @@ Posición en la tabla: {} de {}</translation>
 <context>
     <name>CommonHostInterface</name>
     <message>
-        <location filename="../../core/system.cpp" line="4006"/>
         <source>Invalid version %u (%s version %u)</source>
-        <translation>Versión %u inválida (%s versión %u)</translation>
+        <translation type="vanished">Versión %u inválida (%s versión %u)</translation>
     </message>
 </context>
 <context>
     <name>ConsoleRegion</name>
     <message>
-        <location filename="../../core/settings.cpp" line="764"/>
+        <location filename="../../core/settings.cpp" line="780"/>
         <source>Auto-Detect</source>
         <translation>Detectar automáticamente</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="764"/>
+        <location filename="../../core/settings.cpp" line="780"/>
         <source>NTSC-J (Japan)</source>
         <translation>NTSC-J (Japón)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="765"/>
+        <location filename="../../core/settings.cpp" line="781"/>
         <source>NTSC-U/C (US, Canada)</source>
         <translation>NTSC-U/C (Estados Unidos, Canadá)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="765"/>
+        <location filename="../../core/settings.cpp" line="781"/>
         <source>PAL (Europe, Australia)</source>
         <translation>PAL (Europa, Australia)</translation>
     </message>
@@ -1952,7 +2549,7 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="48"/>
-        <location filename="../consolesettingswidget.cpp" line="73"/>
+        <location filename="../consolesettingswidget.cpp" line="70"/>
         <source>Enable 8MB RAM (Dev Console)</source>
         <translation>Habilitar 8MB de RAM (consola de desarrollo)</translation>
     </message>
@@ -1968,7 +2565,7 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="78"/>
-        <location filename="../consolesettingswidget.cpp" line="64"/>
+        <location filename="../consolesettingswidget.cpp" line="61"/>
         <source>Enable Clock Speed Control (Overclocking/Underclocking)</source>
         <translation>Habilitar control de velocidad de reloj (overclocking/underclocking)</translation>
     </message>
@@ -1979,7 +2576,7 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="134"/>
-        <location filename="../consolesettingswidget.cpp" line="68"/>
+        <location filename="../consolesettingswidget.cpp" line="65"/>
         <source>Enable Recompiler ICache</source>
         <translation>Habilitar ICache del recompilador</translation>
     </message>
@@ -1995,7 +2592,7 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="161"/>
-        <location filename="../consolesettingswidget.cpp" line="83"/>
+        <location filename="../consolesettingswidget.cpp" line="80"/>
         <source>None (Double Speed)</source>
         <translation>Ninguna (velocidad doble)</translation>
     </message>
@@ -2056,7 +2653,7 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="230"/>
-        <location filename="../consolesettingswidget.cpp" line="87"/>
+        <location filename="../consolesettingswidget.cpp" line="84"/>
         <source>None (Normal Speed)</source>
         <translation>Ninguna (velocidad normal)</translation>
     </message>
@@ -2107,7 +2704,7 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="285"/>
-        <location filename="../consolesettingswidget.cpp" line="94"/>
+        <location filename="../consolesettingswidget.cpp" line="91"/>
         <source>Enable Region Check</source>
         <translation>Habilitar chequeo regional</translation>
     </message>
@@ -2118,7 +2715,7 @@ Posición en la tabla: {} de {}</translation>
     </message>
     <message>
         <location filename="../consolesettingswidget.ui" line="299"/>
-        <location filename="../consolesettingswidget.cpp" line="100"/>
+        <location filename="../consolesettingswidget.cpp" line="97"/>
         <source>Apply Image Patches</source>
         <translation>Aplicar parches de imagen</translation>
     </message>
@@ -2128,177 +2725,177 @@ Posición en la tabla: {} de {}</translation>
         <translation>Lectura asincrónica:</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="33"/>
+        <location filename="../consolesettingswidget.cpp" line="30"/>
         <source>Disabled (Synchronous)</source>
         <translation>Deshabilitado (sincrónico)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="36"/>
+        <location filename="../consolesettingswidget.cpp" line="33"/>
         <source>%1 sectors (%2 KB / %3 ms)</source>
         <translation>%1 sectores (%2 KB / %3 ms)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="59"/>
+        <location filename="../consolesettingswidget.cpp" line="56"/>
         <source>Region</source>
         <translation>Región</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="59"/>
+        <location filename="../consolesettingswidget.cpp" line="56"/>
         <source>Auto-Detect</source>
         <translation>Detectar automáticamente</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="60"/>
+        <location filename="../consolesettingswidget.cpp" line="57"/>
         <source>Determines the emulated hardware type.</source>
         <translation>Determina el tipo de hardware emulado.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="61"/>
+        <location filename="../consolesettingswidget.cpp" line="58"/>
         <source>Execution Mode</source>
         <translation>Modo de ejecución</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="61"/>
+        <location filename="../consolesettingswidget.cpp" line="58"/>
         <source>Recompiler (Fastest)</source>
         <translation>Recompilador (el más rápido)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="62"/>
+        <location filename="../consolesettingswidget.cpp" line="59"/>
         <source>Determines how the emulated CPU executes instructions.</source>
         <translation>Determina cómo la CPU emulada ejecuta instrucciones.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="64"/>
-        <location filename="../consolesettingswidget.cpp" line="68"/>
-        <location filename="../consolesettingswidget.cpp" line="73"/>
-        <location filename="../consolesettingswidget.cpp" line="79"/>
+        <location filename="../consolesettingswidget.cpp" line="61"/>
+        <location filename="../consolesettingswidget.cpp" line="65"/>
+        <location filename="../consolesettingswidget.cpp" line="70"/>
+        <location filename="../consolesettingswidget.cpp" line="76"/>
+        <location filename="../consolesettingswidget.cpp" line="94"/>
         <location filename="../consolesettingswidget.cpp" line="97"/>
-        <location filename="../consolesettingswidget.cpp" line="100"/>
         <source>Unchecked</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="65"/>
+        <location filename="../consolesettingswidget.cpp" line="62"/>
         <source>When this option is chosen, the clock speed set below will be used.</source>
         <translation>Cuando se habilite esta opción, se utilizará la velocidad de reloj seleccionada.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="66"/>
+        <location filename="../consolesettingswidget.cpp" line="63"/>
         <source>Overclocking Percentage</source>
         <translation>Porcentaje de overclocking</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="66"/>
+        <location filename="../consolesettingswidget.cpp" line="63"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="67"/>
+        <location filename="../consolesettingswidget.cpp" line="64"/>
         <source>Selects the percentage of the normal clock speed the emulated hardware will run at.</source>
         <translation>Selecciona el porcentaje de velocidad de reloj normal en el cual se ejecutará el hardware emulado.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="69"/>
+        <location filename="../consolesettingswidget.cpp" line="66"/>
         <source>Simulates stalls in the recompilers when the emulated CPU would have to fetch instructions into its cache. Makes games run closer to their console framerate, at a small cost to performance. Interpreter mode always simulates the instruction cache.</source>
         <translation>Simula paradas en los recompiladores cuando la CPU emulada necesite buscar instrucciones en su caché. Hace que los juegos tengan una fluidez más fiel a la consola, a un pequeño costo de rendimiento. El modo intérprete siempre simula el caché de instrucciones.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="74"/>
+        <location filename="../consolesettingswidget.cpp" line="71"/>
         <source>Enables an additional 6MB of RAM to obtain a total of 2+6 = 8MB, usually present on dev consoles. Games have to use a larger heap size for this additional RAM to be usable. Titles which rely on memory mirrors may break, so it should only be used with compatible mods.</source>
-        <translation>Habilita 6MB de RAM adicionales para obtener un total de 8MB (2MB+6MB), generalmente presente en consolas de desarrollo. Los juegos deben permitir el uso de un tamaño extendido de memoria para que esta RAM adicional sea utilizable. Juegos que dependan de duplicados de memoria podrían romperse, por lo que solo debe utilizarse con modificaciones compatibles.</translation>
+        <translation>Habilita 6MB de RAM adicionales para obtener un total de 8MB (2MB+6MB), generalmente presente en consolas de desarrollo. Los juegos deben permitir el uso de un tamaño extendido de memoria para que esta RAM adicional sea utilizable. Juegos que dependan de duplicados de memoria podrían producir fallos, por lo que solo debe utilizarse con modificaciones compatibles.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="79"/>
-        <location filename="../consolesettingswidget.cpp" line="97"/>
+        <location filename="../consolesettingswidget.cpp" line="76"/>
+        <location filename="../consolesettingswidget.cpp" line="94"/>
         <source>Preload Image to RAM</source>
         <translation>Precargar imagen a RAM</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="80"/>
-        <location filename="../consolesettingswidget.cpp" line="98"/>
+        <location filename="../consolesettingswidget.cpp" line="77"/>
+        <location filename="../consolesettingswidget.cpp" line="95"/>
         <source>Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some cases also eliminates stutter when games initiate audio track playback.</source>
         <translation>Carga la imagen del juego en la memoria RAM. Útil para cuando se usan directorios a través de una red. En algunas ocasiones puede eliminar las pausas que se generan cuando el juego inicia la reproducción de una pista de audio.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="83"/>
+        <location filename="../consolesettingswidget.cpp" line="80"/>
         <source>CD-ROM Read Speedup</source>
         <translation>Aceleración de lectura de CD-ROM</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="84"/>
+        <location filename="../consolesettingswidget.cpp" line="81"/>
         <source>Speeds up CD-ROM reads by the specified factor. Only applies to double-speed reads, and is ignored when audio is playing. May improve loading speeds in some games, at the cost of breaking others.</source>
-        <translation>Acelera la lectura del CD-ROM por el valor especificado. Solo se aplica a lecturas de doble velocidad, y se ignora cuando se esté reproduciendo audio. Puede mejorar los tiempos de carga en algunos juegos, mientras que puede romper otros.</translation>
+        <translation>Acelera las lecturas del CD-ROM por el valor especificado. Solo se aplica a lecturas de doble velocidad, y se ignora cuando se esté reproduciendo audio. Puede mejorar los tiempos de carga en algunos juegos, mientras que puede producir fallos en otros.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="87"/>
+        <location filename="../consolesettingswidget.cpp" line="84"/>
         <source>CD-ROM Seek Speedup</source>
         <translation>Aceleración de búsqueda de CD-ROM</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="88"/>
+        <location filename="../consolesettingswidget.cpp" line="85"/>
         <source>Reduces the simulated time for the CD-ROM sled to move to different areas of the disc. Can improve loading times, but crash games which do not expect the CD-ROM to operate faster.</source>
-        <translation>Reduce el tiempo simulado para que el motor del CD-ROM se mueva a distintas partes del disco. Puede mejorar los tiempos de carga, pero también puede romper juegos que no esperen que el CD-ROM funcione más rápido de lo normal.</translation>
+        <translation>Reduce el tiempo simulado para que el motor del CD-ROM se mueva a distintas partes del disco. Puede mejorar los tiempos de carga, pero también puede producir fallas en juegos que no esperen que el CD-ROM funcione más rápido de lo normal.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="90"/>
+        <location filename="../consolesettingswidget.cpp" line="87"/>
         <source>Asynchronous Readahead</source>
         <translation>Lectura asincrónica</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="90"/>
+        <location filename="../consolesettingswidget.cpp" line="87"/>
         <source>8 Sectors</source>
         <translation>8 sectores</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="91"/>
+        <location filename="../consolesettingswidget.cpp" line="88"/>
         <source>Reduces hitches in emulation by reading/decompressing CD data asynchronously on a worker thread. Higher sector numbers can reduce spikes when streaming FMVs or audio on slower storage or when using compression formats such as CHD.</source>
         <translation>Reduce tirones durante la emulación al leer/descomprimir datos del CD de forma asincrónica en un hilo separado. Números de sectores más altos pueden reducir saltos/picos durante la reproducción de FMVs o audio en dispositivos de almacenamiento lentos, o cuando se usan formatos de compresión como CHD.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="94"/>
+        <location filename="../consolesettingswidget.cpp" line="91"/>
         <source>Checked</source>
         <translation>Habilitado</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="95"/>
+        <location filename="../consolesettingswidget.cpp" line="92"/>
         <source>Simulates the region check present in original, unmodified consoles.</source>
         <translation>Simula el chequeo regional presente en consolas originales sin modificar.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="101"/>
+        <location filename="../consolesettingswidget.cpp" line="98"/>
         <source>Automatically applies patches to disc images when they are present in the same directory. Currently only PPF patches are supported with this option.</source>
         <translation>Aplica parches a las imagenes de disco automáticamente si ambos están presentes en el mismo directorio. Actualmente solo los parches PPF son compatibles con esta opción.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="134"/>
+        <location filename="../consolesettingswidget.cpp" line="131"/>
         <source>Enabling CPU overclocking will break games, cause bugs, reduce performance and can significantly increase system requirements.
 
 By enabling this option you are agreeing to not create any bug reports unless you have confirmed the bug also occurs with overclocking disabled.
 
 This warning will only be shown once.</source>
-        <translation>Habilitar el overclocking de CPU puede romper juegos, causar defectos, reducir el rendimiento e incrementar significativamente los requerimientos del sistema.
+        <translation>Habilitar el overclocking de CPU puede producir fallos, causar defectos, reducir el rendimiento e incrementar significativamente los requerimientos del sistema.
 
-Al habilitar esta opción estás de acuerdo a no crear reportes de problemas a menos que hayas confirmado que estos también ocurren sin el overclocking activado.
+Al habilitar esta opción estás de acuerdo a no crear reportes de problemas a menos que hayas confirmado que estos también ocurren con el overclocking deshabilitado.
 
 Esta alerta solo se mostrará una vez.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="138"/>
+        <location filename="../consolesettingswidget.cpp" line="135"/>
         <source>CPU Overclocking Warning</source>
         <translation>Alerta de overclocking de CPU</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="140"/>
+        <location filename="../consolesettingswidget.cpp" line="137"/>
         <source>Yes, I will confirm bugs without overclocking before reporting.</source>
         <translation>Sí, voy a confirmar los problemas sin overclocking antes de reportarlos.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="141"/>
+        <location filename="../consolesettingswidget.cpp" line="138"/>
         <source>No, take me back to safety.</source>
         <translation>No, volver a una configuración segura.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="183"/>
+        <location filename="../consolesettingswidget.cpp" line="180"/>
         <source>%1% (%2MHz)</source>
         <translation>%1% (%2MHz)</translation>
     </message>
@@ -2332,28 +2929,28 @@ Esta alerta solo se mostrará una vez.</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget.ui" line="120"/>
-        <location filename="../controllerbindingwidgets.cpp" line="268"/>
+        <location filename="../controllerbindingwidgets.cpp" line="272"/>
         <source>Automatic Mapping</source>
         <translation>Asignación automática</translation>
     </message>
     <message>
         <location filename="../controllerbindingwidget.ui" line="134"/>
-        <location filename="../controllerbindingwidgets.cpp" line="217"/>
+        <location filename="../controllerbindingwidgets.cpp" line="221"/>
         <source>Clear Mapping</source>
         <translation>Limpiar asignaciones</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="207"/>
+        <location filename="../controllerbindingwidgets.cpp" line="211"/>
         <source>No devices available</source>
         <translation>No hay dispositivos disponibles</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="218"/>
+        <location filename="../controllerbindingwidgets.cpp" line="222"/>
         <source>Are you sure you want to clear all mappings for this controller? This action cannot be undone.</source>
         <translation>¿Seguro que quieres borrar todas las asignaciones para este control? Esta acción no se puede revertir.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="269"/>
+        <location filename="../controllerbindingwidgets.cpp" line="273"/>
         <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
         <translation>No se pudieron generar asignaciones para el dispositivo &quot;%1&quot;. El control/dispositivo de origen podría ser incompatible con las asignaciones automáticas.</translation>
     </message>
@@ -2784,40 +3381,80 @@ Esta alerta solo se mostrará una vez.</translation>
         <translation>Form</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="59"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="134"/>
         <source>Side Buttons</source>
         <translation>Botones laterales</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="65"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="140"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="95"/>
-        <location filename="../controllerbindingwidget_guncon.ui" line="135"/>
-        <location filename="../controllerbindingwidget_guncon.ui" line="289"/>
-        <location filename="../controllerbindingwidget_guncon.ui" line="329"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="223"/>
+        <source>Relative Aiming</source>
+        <extracomment>Try to use Sony&apos;s official terminology for this. A good place to start would be in the console or the DualShock 2&apos;s manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.</extracomment>
+        <translation>Puntería relativa</translation>
+    </message>
+    <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="229"/>
+        <source>Down</source>
+        <translation>Abajo</translation>
+    </message>
+    <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="269"/>
+        <source>Left</source>
+        <translation>Izquierda</translation>
+    </message>
+    <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="309"/>
+        <source>Up</source>
+        <translation>Arriba</translation>
+    </message>
+    <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="349"/>
+        <source>Right</source>
+        <translation>Derecha</translation>
+    </message>
+    <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="473"/>
+        <source>Pointer Setup</source>
+        <translation>Configuración del cursor</translation>
+    </message>
+    <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="479"/>
+        <source>&lt;p&gt;By default, GunCon will use the mouse pointer. To use the mouse, you &lt;strong&gt;do not&lt;/strong&gt; need to configure any bindings apart from the trigger and buttons.&lt;/p&gt;
+
+&lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;strong&gt;left unbound&lt;/strong&gt;.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;GunCon utilizará el cursor del mouse por defecto. Para utilizarlo &lt;strong&gt;no es necesario&lt;/strong&gt; configurar asignaciones además del gatillo y los botones.&lt;/p&gt;
+
+&lt;p&gt;Si quieres utilizar un control, o pistola que simule un control en lugar de un mouse, entonces deberás asignarlo en puntería relativa. De lo contrario, debe dejarse &lt;strong&gt;sin asignar&lt;/strong&gt;.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="68"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="108"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="170"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="210"/>
         <source>PushButton</source>
         <translation>PushButton</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="105"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="180"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="253"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="32"/>
         <source>Trigger</source>
         <translation>Gatillo</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="259"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="38"/>
         <source>Fire Offscreen</source>
         <translation>Disparo fuera de pantalla</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="299"/>
+        <location filename="../controllerbindingwidget_guncon.ui" line="78"/>
         <source>Fire</source>
         <translation>Disparo</translation>
     </message>
@@ -2948,7 +3585,7 @@ Esta alerta solo se mostrará una vez.</translation>
         <translation>Dirección/Giro</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="866"/>
+        <location filename="../controllerbindingwidgets.cpp" line="878"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
@@ -2956,22 +3593,22 @@ Esta alerta solo se mostrará una vez.</translation>
 <context>
     <name>ControllerCustomSettingsWidget</name>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="504"/>
+        <location filename="../controllerbindingwidgets.cpp" line="507"/>
         <source>%1 Settings</source>
         <translation>Configuración de %1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="513"/>
+        <location filename="../controllerbindingwidgets.cpp" line="516"/>
         <source>Restore Default Settings</source>
         <translation>Restablecer valores predeterminados</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="625"/>
+        <location filename="../controllerbindingwidgets.cpp" line="629"/>
         <source>Browse...</source>
         <translation>Buscar...</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="628"/>
+        <location filename="../controllerbindingwidgets.cpp" line="632"/>
         <source>Select File</source>
         <translation>Seleccionar archivo</translation>
     </message>
@@ -3206,27 +3843,27 @@ Esta alerta solo se mostrará una vez.</translation>
         <translation>Establecer...</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="406"/>
+        <location filename="../controllerbindingwidgets.cpp" line="409"/>
         <source>Not Configured</source>
         <translation>Sin configurar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="412"/>
+        <location filename="../controllerbindingwidgets.cpp" line="415"/>
         <source>Set Frequency</source>
         <translation>Establecer frecuencia</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="412"/>
+        <location filename="../controllerbindingwidgets.cpp" line="415"/>
         <source>Frequency: </source>
         <translation>Frecuencia: </translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="441"/>
+        <location filename="../controllerbindingwidgets.cpp" line="444"/>
         <source>Macro will not repeat.</source>
         <translation>El macro no se repetirá.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="443"/>
+        <location filename="../controllerbindingwidgets.cpp" line="446"/>
         <source>Macro will toggle buttons every %1 frames.</source>
         <translation>El macro alternará botones cada %1 fotogramas.</translation>
     </message>
@@ -3234,12 +3871,12 @@ Esta alerta solo se mostrará una vez.</translation>
 <context>
     <name>ControllerMacroWidget</name>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="304"/>
+        <location filename="../controllerbindingwidgets.cpp" line="308"/>
         <source>Controller Port %1 Macros</source>
         <translation>Macros del puerto de control %1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="313"/>
+        <location filename="../controllerbindingwidgets.cpp" line="317"/>
         <source>Macro %1
 %2</source>
         <translation>Macro %1
@@ -3275,51 +3912,51 @@ Esta alerta solo se mostrará una vez.</translation>
     </message>
     <message>
         <location filename="../controllersettingsdialog.ui" line="113"/>
-        <location filename="../controllersettingsdialog.cpp" line="189"/>
+        <location filename="../controllersettingsdialog.cpp" line="192"/>
         <source>Restore Defaults</source>
         <translation>Restablecer valores predeterminados</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="93"/>
-        <location filename="../controllersettingsdialog.cpp" line="104"/>
+        <location filename="../controllersettingsdialog.cpp" line="96"/>
+        <location filename="../controllersettingsdialog.cpp" line="107"/>
         <source>Create Input Profile</source>
         <translation>Crear perfil de entrada</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="93"/>
+        <location filename="../controllersettingsdialog.cpp" line="96"/>
         <source>Enter the name for the new input profile:</source>
         <translation>Ingresa el nombre para el nuevo perfil de entrada:</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="100"/>
-        <location filename="../controllersettingsdialog.cpp" line="133"/>
-        <location filename="../controllersettingsdialog.cpp" line="177"/>
-        <location filename="../controllersettingsdialog.cpp" line="474"/>
+        <location filename="../controllersettingsdialog.cpp" line="103"/>
+        <location filename="../controllersettingsdialog.cpp" line="136"/>
+        <location filename="../controllersettingsdialog.cpp" line="180"/>
+        <location filename="../controllersettingsdialog.cpp" line="477"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="100"/>
+        <location filename="../controllersettingsdialog.cpp" line="103"/>
         <source>A profile with the name &apos;%1&apos; already exists.</source>
         <translation>Ya existe un perfil con el nombre &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="105"/>
+        <location filename="../controllersettingsdialog.cpp" line="108"/>
         <source>Do you want to copy all bindings from the currently-selected profile to the new profile? Selecting No will create a completely empty profile.</source>
         <translation>¿Quieres copiar todas las asignaciones del perfil actual al nuevo? Seleccionando no creará un perfil vacío.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="134"/>
+        <location filename="../controllersettingsdialog.cpp" line="137"/>
         <source>Failed to save the new profile to &apos;%1&apos;.</source>
         <translation>Fallo al guardar el nuevo perfil &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="144"/>
+        <location filename="../controllersettingsdialog.cpp" line="147"/>
         <source>Load Input Profile</source>
         <translation>Cargar perfil de entrada</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="145"/>
+        <location filename="../controllersettingsdialog.cpp" line="148"/>
         <source>Are you sure you want to load the input profile named &apos;%1&apos;?
 
 All current global bindings will be removed, and the profile bindings loaded.
@@ -3332,12 +3969,12 @@ Todas las asignaciones globales actuales serán reemplazadas por las del perfil 
 Esta acción no se puede revertir.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="166"/>
+        <location filename="../controllersettingsdialog.cpp" line="169"/>
         <source>Delete Input Profile</source>
         <translation>Eliminar perfil de entrada</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="167"/>
+        <location filename="../controllersettingsdialog.cpp" line="170"/>
         <source>Are you sure you want to delete the input profile named &apos;%1&apos;?
 
 You cannot undo this action.</source>
@@ -3346,12 +3983,12 @@ You cannot undo this action.</source>
 Esta acción no se puede revertir.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="177"/>
+        <location filename="../controllersettingsdialog.cpp" line="180"/>
         <source>Failed to delete &apos;%1&apos;.</source>
         <translation>Fallo al eliminar &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="190"/>
+        <location filename="../controllersettingsdialog.cpp" line="193"/>
         <source>Are you sure you want to restore the default controller configuration?
 
 All shared bindings and configuration will be lost, but your input profiles will remain.
@@ -3364,38 +4001,38 @@ Se perderán todas las asignaciones y configuraciones compartidas, excepto tus p
 Esta acción no se puede revertir.</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="357"/>
+        <location filename="../controllersettingsdialog.cpp" line="360"/>
         <source>Global Settings</source>
         <translation>Configuración global</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="399"/>
-        <location filename="../controllersettingsdialog.cpp" line="439"/>
+        <location filename="../controllersettingsdialog.cpp" line="402"/>
+        <location filename="../controllersettingsdialog.cpp" line="442"/>
         <source>Controller Port %1%2
 %3</source>
         <translation>Puerto de control %1%2
 %3</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="400"/>
-        <location filename="../controllersettingsdialog.cpp" line="440"/>
+        <location filename="../controllersettingsdialog.cpp" line="403"/>
+        <location filename="../controllersettingsdialog.cpp" line="443"/>
         <source>Controller Port %1
 %2</source>
         <translation>Puerto de control %1
 %2</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="410"/>
+        <location filename="../controllersettingsdialog.cpp" line="413"/>
         <source>Hotkeys</source>
         <translation>Atajos</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="452"/>
+        <location filename="../controllersettingsdialog.cpp" line="455"/>
         <source>Shared</source>
         <translation>Compartido</translation>
     </message>
     <message>
-        <location filename="../controllersettingsdialog.cpp" line="474"/>
+        <location filename="../controllersettingsdialog.cpp" line="477"/>
         <source>The input profile named &apos;%1&apos; cannot be found.</source>
         <translation>No se puede encontrar el perfil de entrada &quot;%1&quot;.</translation>
     </message>
@@ -3403,13 +4040,13 @@ Esta acción no se puede revertir.</translation>
 <context>
     <name>ControllerType</name>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="873"/>
+        <location filename="../../core/analog_controller.cpp" line="877"/>
         <source>Analog Controller</source>
         <translation>Control analógico</translation>
     </message>
     <message>
-        <location filename="../../core/analog_joystick.cpp" line="403"/>
-        <location filename="../../core/settings.cpp" line="1178"/>
+        <location filename="../../core/analog_joystick.cpp" line="409"/>
+        <location filename="../../core/settings.cpp" line="1288"/>
         <source>Analog Joystick</source>
         <translation>Joystick analógico</translation>
     </message>
@@ -3419,36 +4056,36 @@ Esta acción no se puede revertir.</translation>
         <translation>Sin conectar</translation>
     </message>
     <message>
-        <location filename="../../core/digital_controller.cpp" line="177"/>
-        <location filename="../../core/settings.cpp" line="1177"/>
+        <location filename="../../core/digital_controller.cpp" line="182"/>
+        <location filename="../../core/settings.cpp" line="1286"/>
         <source>Digital Controller</source>
         <translation>Control digital</translation>
     </message>
     <message>
-        <location filename="../../core/guncon.cpp" line="234"/>
-        <location filename="../../core/settings.cpp" line="1179"/>
+        <location filename="../../core/guncon.cpp" line="304"/>
+        <location filename="../../core/settings.cpp" line="1289"/>
         <source>GunCon</source>
         <translation>GunCon</translation>
     </message>
     <message>
-        <location filename="../../core/negcon.cpp" line="268"/>
-        <location filename="../../core/settings.cpp" line="1180"/>
+        <location filename="../../core/negcon.cpp" line="273"/>
+        <location filename="../../core/settings.cpp" line="1291"/>
         <source>NeGcon</source>
         <translation>NeGcon</translation>
     </message>
     <message>
-        <location filename="../../core/playstation_mouse.cpp" line="198"/>
-        <location filename="../../core/settings.cpp" line="1179"/>
+        <location filename="../../core/playstation_mouse.cpp" line="220"/>
+        <location filename="../../core/settings.cpp" line="1290"/>
         <source>PlayStation Mouse</source>
         <translation>PlayStation Mouse</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1177"/>
+        <location filename="../../core/settings.cpp" line="1285"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1178"/>
+        <location filename="../../core/settings.cpp" line="1287"/>
         <source>Analog Controller (DualShock)</source>
         <translation>Control analógico (DualShock)</translation>
     </message>
@@ -3487,7 +4124,7 @@ Esta acción no se puede revertir.</translation>
     </message>
     <message>
         <location filename="../coverdownloaddialog.ui" line="95"/>
-        <location filename="../coverdownloaddialog.cpp" line="83"/>
+        <location filename="../coverdownloaddialog.cpp" line="85"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
@@ -3497,12 +4134,12 @@ Esta acción no se puede revertir.</translation>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../coverdownloaddialog.cpp" line="61"/>
+        <location filename="../coverdownloaddialog.cpp" line="63"/>
         <source>Download complete.</source>
         <translation>Descarga finalizada.</translation>
     </message>
     <message>
-        <location filename="../coverdownloaddialog.cpp" line="83"/>
+        <location filename="../coverdownloaddialog.cpp" line="85"/>
         <source>Stop</source>
         <translation>Detener</translation>
     </message>
@@ -3510,29 +4147,29 @@ Esta acción no se puede revertir.</translation>
 <context>
     <name>DebuggerCodeModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="81"/>
-        <location filename="../debuggermodels.cpp" line="91"/>
-        <location filename="../debuggermodels.cpp" line="106"/>
+        <location filename="../debuggermodels.cpp" line="87"/>
+        <location filename="../debuggermodels.cpp" line="97"/>
+        <location filename="../debuggermodels.cpp" line="112"/>
         <source>&lt;invalid&gt;</source>
         <translation>&lt;inválido&gt;</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="174"/>
+        <location filename="../debuggermodels.cpp" line="180"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="176"/>
+        <location filename="../debuggermodels.cpp" line="182"/>
         <source>Bytes</source>
         <translation>Bytes</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="178"/>
+        <location filename="../debuggermodels.cpp" line="184"/>
         <source>Instruction</source>
         <translation>Instrucción</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="180"/>
+        <location filename="../debuggermodels.cpp" line="186"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
@@ -3540,42 +4177,42 @@ Esta acción no se puede revertir.</translation>
 <context>
     <name>DebuggerMessage</name>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1823"/>
+        <location filename="../../core/cpu_core.cpp" line="1947"/>
         <source>Added breakpoint at 0x%08X.</source>
         <translation>Punto de interrupcción añadido en 0x%08X.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1850"/>
+        <location filename="../../core/cpu_core.cpp" line="1973"/>
         <source>Removed breakpoint at 0x%08X.</source>
         <translation>Punto de interrupcción en 0x%08X eliminado.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1882"/>
+        <location filename="../../core/cpu_core.cpp" line="2004"/>
         <source>0x%08X is not a call instruction.</source>
         <translation>0x%08X no es una instrucción de llamada.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1893"/>
+        <location filename="../../core/cpu_core.cpp" line="2013"/>
         <source>Can&apos;t step over double branch at 0x%08X</source>
         <translation>No se puede saltar la ramificación doble en 0x%08X</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1900"/>
+        <location filename="../../core/cpu_core.cpp" line="2021"/>
         <source>Stepping over to 0x%08X.</source>
         <translation>Saltando a 0x%08X.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1917"/>
+        <location filename="../../core/cpu_core.cpp" line="2038"/>
         <source>Instruction read failed at %08X while searching for function end.</source>
         <translation>Fallo de lectura de instrucción en %08X mientras se buscaba el final de la función.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1924"/>
+        <location filename="../../core/cpu_core.cpp" line="2044"/>
         <source>Stepping out to 0x%08X.</source>
         <translation>Regresando a 0x%08X.</translation>
     </message>
     <message>
-        <location filename="../../core/cpu_core.cpp" line="1931"/>
+        <location filename="../../core/cpu_core.cpp" line="2051"/>
         <source>No return instruction found after %u instructions for step-out at %08X.</source>
         <translation>No se encontró una instrucción de retorno después de %u instrucciones para regresar en %08X.</translation>
     </message>
@@ -3583,12 +4220,12 @@ Esta acción no se puede revertir.</translation>
 <context>
     <name>DebuggerRegistersModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="355"/>
+        <location filename="../debuggermodels.cpp" line="365"/>
         <source>Register</source>
         <translation>Registro</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="357"/>
+        <location filename="../debuggermodels.cpp" line="367"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
@@ -3596,17 +4233,17 @@ Esta acción no se puede revertir.</translation>
 <context>
     <name>DebuggerStackModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="406"/>
+        <location filename="../debuggermodels.cpp" line="420"/>
         <source>&lt;invalid&gt;</source>
         <translation>&lt;inválido&gt;</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="422"/>
+        <location filename="../debuggermodels.cpp" line="436"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="424"/>
+        <location filename="../debuggermodels.cpp" line="438"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
@@ -3889,7 +4526,7 @@ Esta acción no se puede revertir.</translation>
     </message>
     <message>
         <location filename="../debuggerwindow.cpp" line="124"/>
-        <location filename="../qtutils.cpp" line="750"/>
+        <location filename="../qtutils.cpp" line="752"/>
         <source>Enter memory address:</source>
         <translation>Ingresa la dirección de memoria:</translation>
     </message>
@@ -3952,7 +4589,7 @@ Este archivo puede alcanzar varios gigabytes en tamaño, así que ten cuidado co
         <translation>Patrón encontrado en 0x%1.</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="767"/>
+        <location filename="../qtutils.cpp" line="769"/>
         <source>Invalid address. It should be in hex (0x12345678 or 12345678)</source>
         <translation>Dirección inválida. Debe estar en formato hexadecimal (0x12345678 o 12345678)</translation>
     </message>
@@ -3960,12 +4597,82 @@ Este archivo puede alcanzar varios gigabytes en tamaño, así que ten cuidado co
 <context>
     <name>DigitalController</name>
     <message>
-        <location filename="../../core/digital_controller.cpp" line="172"/>
+        <location filename="../../core/digital_controller.cpp" line="155"/>
+        <source>D-Pad Up</source>
+        <translation>Botón de dirección hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="156"/>
+        <source>D-Pad Right</source>
+        <translation>Botón de dirección hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="157"/>
+        <source>D-Pad Down</source>
+        <translation>Botón de dirección hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="158"/>
+        <source>D-Pad Left</source>
+        <translation>Botón de dirección hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="159"/>
+        <source>Triangle</source>
+        <translation>Triángulo</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="160"/>
+        <source>Circle</source>
+        <translation>Círculo</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="161"/>
+        <source>Cross</source>
+        <translation>Cruz</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="162"/>
+        <source>Square</source>
+        <translation>Cuadrado</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="163"/>
+        <source>Select</source>
+        <translation>Select</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="164"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="165"/>
+        <source>L1</source>
+        <translation>L1</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="166"/>
+        <source>R1</source>
+        <translation>R1</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="167"/>
+        <source>L2</source>
+        <translation>L2</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="168"/>
+        <source>R2</source>
+        <translation>R2</translation>
+    </message>
+    <message>
+        <location filename="../../core/digital_controller.cpp" line="176"/>
         <source>Force Pop&apos;n Controller Mode</source>
         <translation>Forzar modo para el control de Pop&apos;n</translation>
     </message>
     <message>
-        <location filename="../../core/digital_controller.cpp" line="173"/>
+        <location filename="../../core/digital_controller.cpp" line="177"/>
         <source>Forces the Digital Controller to act as a Pop&apos;n Controller.</source>
         <translation>Fuerza el control digital para funcionar como un control de Pop&apos;n.</translation>
     </message>
@@ -3973,40 +4680,45 @@ Este archivo puede alcanzar varios gigabytes en tamaño, así que ten cuidado co
 <context>
     <name>DiscRegion</name>
     <message>
-        <location filename="../../core/settings.cpp" line="793"/>
+        <location filename="../../core/settings.cpp" line="809"/>
         <source>NTSC-J (Japan)</source>
         <translation>NTSC-J (Japón)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="793"/>
+        <location filename="../../core/settings.cpp" line="809"/>
         <source>NTSC-U/C (US, Canada)</source>
         <translation>NTSC-U/C (Estados Unidos, Canadá)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="794"/>
+        <location filename="../../core/settings.cpp" line="810"/>
         <source>PAL (Europe, Australia)</source>
         <translation>PAL (Europa, Australia)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="794"/>
+        <location filename="../../core/settings.cpp" line="810"/>
         <source>Other</source>
         <translation>Otro</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="811"/>
+        <source>Non-PS1</source>
+        <translation>Ajena a PS1</translation>
     </message>
 </context>
 <context>
     <name>DisplayAlignment</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1097"/>
+        <location filename="../../core/settings.cpp" line="1168"/>
         <source>Left / Top</source>
         <translation>Superior izquierda</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1097"/>
+        <location filename="../../core/settings.cpp" line="1168"/>
         <source>Center</source>
         <translation>Centro</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1098"/>
+        <location filename="../../core/settings.cpp" line="1169"/>
         <source>Right / Bottom</source>
         <translation>Inferior derecha</translation>
     </message>
@@ -4014,17 +4726,21 @@ Este archivo puede alcanzar varios gigabytes en tamaño, así que ten cuidado co
 <context>
     <name>DisplayAspectRatio</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1044"/>
+        <location filename="../../core/settings.cpp" line="1106"/>
         <source>Auto (Game Native)</source>
         <translation>Automática (nativa del juego)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1044"/>
-        <source>Auto (Match Window)</source>
-        <translation>Automática (tamaño de ventana)</translation>
+        <location filename="../../core/settings.cpp" line="1107"/>
+        <source>Stretch To Fill</source>
+        <translation>Estirar imagen</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1045"/>
+        <source>Auto (Match Window)</source>
+        <translation type="vanished">Automática (tamaño de ventana)</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1108"/>
         <source>Custom</source>
         <translation>Personalizada</translation>
     </message>
@@ -4032,19 +4748,42 @@ Este archivo puede alcanzar varios gigabytes en tamaño, así que ten cuidado co
 <context>
     <name>DisplayCropMode</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1016"/>
+        <location filename="../../core/settings.cpp" line="1078"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1016"/>
+        <location filename="../../core/settings.cpp" line="1078"/>
         <source>Only Overscan Area</source>
         <translation>Solo area de sobreescaneo</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1017"/>
+        <location filename="../../core/settings.cpp" line="1079"/>
         <source>All Borders</source>
         <translation>Todos los bordes</translation>
+    </message>
+</context>
+<context>
+    <name>DisplayScalingMode</name>
+    <message>
+        <location filename="../../core/settings.cpp" line="1202"/>
+        <source>Nearest-Neighbor</source>
+        <translation>Punto más cercano</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1203"/>
+        <source>Bilinear (Smooth)</source>
+        <translation>Bilinear (suavizado)</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1204"/>
+        <source>Nearest-Neighbor (Integer)</source>
+        <translation>Punto más cercano (entero)</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1205"/>
+        <source>Bilinear (Sharp)</source>
+        <translation>Bilinear (nítido)</translation>
     </message>
 </context>
 <context>
@@ -4076,25 +4815,25 @@ Este archivo puede alcanzar varios gigabytes en tamaño, así que ten cuidado co
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="70"/>
-        <location filename="../displaysettingswidget.cpp" line="122"/>
+        <location filename="../displaysettingswidget.cpp" line="108"/>
         <source>VSync</source>
         <translation>Sincronización vertical</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="77"/>
-        <location filename="../displaysettingswidget.cpp" line="128"/>
+        <location filename="../displaysettingswidget.cpp" line="114"/>
         <source>Threaded Rendering</source>
         <translation>Hilo de renderizado</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="84"/>
-        <location filename="../displaysettingswidget.cpp" line="125"/>
+        <location filename="../displaysettingswidget.cpp" line="111"/>
         <source>Threaded Presentation</source>
         <translation>Hilo de presentación</translation>
     </message>
     <message>
         <location filename="../displaysettingswidget.ui" line="91"/>
-        <location filename="../displaysettingswidget.cpp" line="152"/>
+        <location filename="../displaysettingswidget.cpp" line="138"/>
         <source>Use Blit Swap Chain</source>
         <translation>Utilizar cadena de intercambio de blits</translation>
     </message>
@@ -4124,241 +4863,249 @@ Este archivo puede alcanzar varios gigabytes en tamaño, así que ten cuidado co
         <translation>Posición:</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="172"/>
-        <location filename="../displaysettingswidget.cpp" line="112"/>
         <source>Integer Upscaling</source>
-        <translation>Escalado entero</translation>
+        <translation type="vanished">Escalado entero</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="179"/>
-        <location filename="../displaysettingswidget.cpp" line="115"/>
         <source>Stretch To Fill</source>
-        <translation>Estirar imagen</translation>
+        <translation type="vanished">Estirar imagen</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="186"/>
-        <location filename="../displaysettingswidget.cpp" line="105"/>
         <source>Linear Upscaling</source>
-        <translation>Escalado lineal</translation>
+        <translation type="vanished">Escalado lineal</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="193"/>
-        <location filename="../displaysettingswidget.cpp" line="117"/>
+        <location filename="../displaysettingswidget.ui" line="172"/>
+        <location filename="../displaysettingswidget.cpp" line="103"/>
         <source>Internal Resolution Screenshots</source>
         <translation>Capturas de pantalla a resolución interna</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="205"/>
+        <location filename="../displaysettingswidget.ui" line="181"/>
+        <source>Scaling:</source>
+        <translation>Escala:</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.ui" line="194"/>
         <source>On-Screen Display</source>
         <translation>Mensajes en pantalla</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="211"/>
-        <location filename="../displaysettingswidget.cpp" line="137"/>
+        <location filename="../displaysettingswidget.ui" line="200"/>
+        <location filename="../displaysettingswidget.cpp" line="123"/>
         <source>Show Emulation Speed</source>
         <translation>Mostrar velocidad de emulación</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="218"/>
-        <location filename="../displaysettingswidget.cpp" line="142"/>
+        <location filename="../displaysettingswidget.ui" line="207"/>
+        <location filename="../displaysettingswidget.cpp" line="128"/>
         <source>Show CPU Usage</source>
         <translation>Mostrar uso de la CPU</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="225"/>
-        <location filename="../displaysettingswidget.cpp" line="131"/>
+        <location filename="../displaysettingswidget.ui" line="214"/>
+        <location filename="../displaysettingswidget.cpp" line="117"/>
         <source>Show OSD Messages</source>
         <translation>Mostrar mensajes en pantalla</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="232"/>
-        <location filename="../displaysettingswidget.cpp" line="134"/>
+        <location filename="../displaysettingswidget.ui" line="221"/>
+        <location filename="../displaysettingswidget.cpp" line="120"/>
         <source>Show FPS</source>
         <translation>Mostrar FPS</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="239"/>
-        <location filename="../displaysettingswidget.cpp" line="147"/>
+        <location filename="../displaysettingswidget.ui" line="228"/>
+        <location filename="../displaysettingswidget.cpp" line="133"/>
         <source>Show Controller Input</source>
         <translation>Mostrar entrada del control</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="246"/>
-        <location filename="../displaysettingswidget.cpp" line="139"/>
+        <location filename="../displaysettingswidget.ui" line="235"/>
+        <location filename="../displaysettingswidget.cpp" line="125"/>
         <source>Show Resolution</source>
         <translation>Mostrar resolución</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="253"/>
+        <location filename="../displaysettingswidget.ui" line="242"/>
         <source>Show GPU Usage</source>
         <translation>Mostrar uso de la GPU</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.ui" line="260"/>
+        <location filename="../displaysettingswidget.ui" line="249"/>
         <source>Show Settings Overlay</source>
         <translation>Mostrar configuración en pantalla</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="77"/>
+        <location filename="../displaysettingswidget.cpp" line="73"/>
         <source>Renderer</source>
         <translation>Renderizador</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="79"/>
+        <location filename="../displaysettingswidget.cpp" line="74"/>
         <source>Chooses the backend to use for rendering the console/game visuals. &lt;br&gt;Depending on your system and hardware, Direct3D 11 and OpenGL hardware backends may be available. &lt;br&gt;The software renderer offers the best compatibility, but is the slowest and does not offer any enhancements.</source>
         <translation>Elige el motor para renderizar los gráficos de la consola/juegos.&lt;br&gt;Los motores Direct3D 11 y OpenGL estarán disponibles dependiendo de tu hardware y sistema.&lt;br&gt;El renderizador por software ofrece la mejor compatibilidad, pero es el más lento y no permite seleccionar ninguna mejora.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="83"/>
+        <location filename="../displaysettingswidget.cpp" line="78"/>
         <source>Adapter</source>
         <translation>Adaptador</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="83"/>
-        <location filename="../displaysettingswidget.cpp" line="227"/>
+        <location filename="../displaysettingswidget.cpp" line="78"/>
+        <location filename="../displaysettingswidget.cpp" line="223"/>
         <source>(Default)</source>
         <translation>(Predeterminado)</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="84"/>
+        <location filename="../displaysettingswidget.cpp" line="79"/>
         <source>If your system contains multiple GPUs or adapters, you can select which GPU you wish to use for the hardware renderers. &lt;br&gt;This option is only supported in Direct3D and Vulkan. OpenGL will always use the default device.</source>
         <translation>Si tu sistema tiene múltiples GPUs o adaptadores, puedes elegir cual quieres utilizar para los renderizadores.&lt;br&gt;Esta opción solo está disponible en Direct3D y Vulkan, OpenGL siempre utiliza el dispositivo por defecto.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="87"/>
+        <location filename="../displaysettingswidget.cpp" line="82"/>
         <source>Fullscreen Mode</source>
         <translation>Modo de pantalla completa</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="87"/>
-        <location filename="../displaysettingswidget.cpp" line="247"/>
+        <location filename="../displaysettingswidget.cpp" line="82"/>
+        <location filename="../displaysettingswidget.cpp" line="243"/>
         <source>Borderless Fullscreen</source>
         <translation>Pantalla completa sin bordes</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="88"/>
+        <location filename="../displaysettingswidget.cpp" line="83"/>
         <source>Chooses the fullscreen resolution and frequency.</source>
         <translation>Selecciona la resolución y frecuencia para el modo de pantalla completa.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="90"/>
+        <location filename="../displaysettingswidget.cpp" line="85"/>
         <source>Aspect Ratio</source>
         <translation>Relación de aspecto</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="92"/>
+        <location filename="../displaysettingswidget.cpp" line="87"/>
         <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is Auto (Game Native) which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era.</source>
         <translation>Cambia la relación de aspecto utilizada para mostrar la imagen de salida de la consola en la pantalla. La opción por defecto es &quot;Automática (nativa del juego)&quot;, que ajusta automáticamente la relación de aspecto para que coincida con la forma en que se mostraría un juego en un televisor típico de la época.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="95"/>
+        <location filename="../displaysettingswidget.cpp" line="90"/>
         <source>Crop Mode</source>
         <translation>Modo de recorte</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="97"/>
+        <location filename="../displaysettingswidget.cpp" line="92"/>
         <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide. &lt;br&gt;Some games display content in the overscan area, or use it for screen effects. &lt;br&gt;May not display correctly with the &quot;All Borders&quot; setting. &quot;Only Overscan&quot; offers a good compromise between stability and hiding black borders.</source>
         <translation>Determina cuanto del área generalmente no visible en un televisor recortar/ocultar.&lt;br&gt;Algunos juegos muestran contenido en el área de sobreescaneo, o la usan para algunos efectos.&lt;br&gt;&quot;Todos los bordes&quot; puede mostrar la imagen incorrectamente. &quot;Solo area de sobreescaneo&quot; ofrece un buen balance entre estabilidad y reducción de bordes.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="102"/>
+        <location filename="../displaysettingswidget.cpp" line="97"/>
         <source>Position</source>
         <translation>Posición</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="104"/>
+        <location filename="../displaysettingswidget.cpp" line="99"/>
         <source>Determines the position on the screen when black borders must be added.</source>
         <translation>Determina la posición de la pantalla cuando se añadan bordes negros.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="105"/>
-        <location filename="../displaysettingswidget.cpp" line="122"/>
-        <location filename="../displaysettingswidget.cpp" line="125"/>
-        <location filename="../displaysettingswidget.cpp" line="128"/>
-        <location filename="../displaysettingswidget.cpp" line="131"/>
+        <location filename="../displaysettingswidget.cpp" line="101"/>
+        <source>Scaling</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.cpp" line="101"/>
+        <source>Bilinear (Smooth)</source>
+        <translation>Bilinear (suavizado)</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.cpp" line="102"/>
+        <source>Determines how the emulated console&apos;s output is upscaled or downscaled to your monitor&apos;s resolution.</source>
+        <translation>Determina cómo se escalará la salida de la consola emulada a la resolución de tu monitor.</translation>
+    </message>
+    <message>
+        <location filename="../displaysettingswidget.cpp" line="108"/>
+        <location filename="../displaysettingswidget.cpp" line="111"/>
+        <location filename="../displaysettingswidget.cpp" line="114"/>
+        <location filename="../displaysettingswidget.cpp" line="117"/>
         <source>Checked</source>
         <translation>Habilitado</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="106"/>
         <source>Uses bilinear texture filtering when displaying the console&apos;s framebuffer to the screen. &lt;br&gt;Disabling filtering will producer a sharper, blockier/pixelated image. Enabling will smooth out the image. &lt;br&gt;The option will be less noticable the higher the resolution scale.</source>
-        <translation>Utiliza el filtrado de texturas bilineal cuando se muestra el búfer de fotograma en la pantalla.&lt;br&gt;Deshabilitar el filtrado va a producir una imagen más nítida y pixelada/cuadriculada. Activarlo va a suavizar la imagen.&lt;br&gt;Este efecto será menos notable mientras mayor sea la escala de resolución.</translation>
+        <translation type="vanished">Utiliza el filtrado de texturas bilineal cuando se muestra el búfer de fotograma en la pantalla.&lt;br&gt;Deshabilitar el filtrado va a producir una imagen más nítida y pixelada/cuadriculada. Activarlo va a suavizar la imagen.&lt;br&gt;Este efecto será menos notable mientras mayor sea la escala de resolución.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="112"/>
-        <location filename="../displaysettingswidget.cpp" line="115"/>
-        <location filename="../displaysettingswidget.cpp" line="117"/>
-        <location filename="../displaysettingswidget.cpp" line="134"/>
-        <location filename="../displaysettingswidget.cpp" line="137"/>
-        <location filename="../displaysettingswidget.cpp" line="139"/>
-        <location filename="../displaysettingswidget.cpp" line="142"/>
-        <location filename="../displaysettingswidget.cpp" line="147"/>
-        <location filename="../displaysettingswidget.cpp" line="152"/>
+        <location filename="../displaysettingswidget.cpp" line="103"/>
+        <location filename="../displaysettingswidget.cpp" line="120"/>
+        <location filename="../displaysettingswidget.cpp" line="123"/>
+        <location filename="../displaysettingswidget.cpp" line="125"/>
+        <location filename="../displaysettingswidget.cpp" line="128"/>
+        <location filename="../displaysettingswidget.cpp" line="133"/>
+        <location filename="../displaysettingswidget.cpp" line="138"/>
         <source>Unchecked</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="113"/>
         <source>Adds padding to the display area to ensure that the ratio between pixels on the host to pixels in the console is an integer number. &lt;br&gt;May result in a sharper image in some 2D games.</source>
-        <translation>Añade relleno en la pantalla para asegurarse que la relación entre los pixeles de la consola y del sistema es un número entero.&lt;br&gt;Puede producir una imagen más nítida en algunos juegos 2D.</translation>
+        <translation type="vanished">Añade relleno en la pantalla para asegurarse que la relación entre los pixeles de la consola y del sistema es un número entero.&lt;br&gt;Puede producir una imagen más nítida en algunos juegos 2D.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="116"/>
         <source>Fills the window with the active display area, regardless of the aspect ratio.</source>
-        <translation>Rellena la ventana con el área de visualización activa, sin importar la relación de aspecto.</translation>
+        <translation type="vanished">Rellena la ventana con el área de visualización activa, sin importar la relación de aspecto.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="118"/>
+        <location filename="../displaysettingswidget.cpp" line="104"/>
         <source>Saves screenshots at internal render resolution and without postprocessing. If this option is disabled, the screenshots will be taken at the window&apos;s resolution. Internal resolution screenshots can be very large at high rendering scales.</source>
         <translation>Guarda capturas de pantalla en la resolución interna de renderizado, sin postprocesamiento. Si esta opción está deshabilitada, las capturas se tomarán en la resolución de la ventana. Las capturas en resolución interna pueden alcanzar grandes tamaños a escalas de renderizado altas.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="123"/>
+        <location filename="../displaysettingswidget.cpp" line="109"/>
         <source>Enable this option to match DuckStation&apos;s refresh rate with your current monitor or screen. VSync is automatically disabled when it is not possible (e.g. running at non-100% speed).</source>
         <translation>Habilita esta opción para coincidir la tasa de refresco de DuckStation con la de tu pantalla. La sincronización vertical se deshabilita automáticamente cuando no sea posible (por ejemplo, no llegar al 100% de la velocidad).</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="126"/>
+        <location filename="../displaysettingswidget.cpp" line="112"/>
         <source>Presents frames on a background thread when fast forwarding or vsync is disabled. This can measurably improve performance in the Vulkan renderer.</source>
         <translation>Presenta los fotogramas en un hilo en segundo plano durante el avance rápido o si la sincronización vertical está deshabilitada. Esto puede mejorar considerablemente el rendimiento del renderizador de Vulkan.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="129"/>
+        <location filename="../displaysettingswidget.cpp" line="115"/>
         <source>Uses a second thread for drawing graphics. Currently only available for the software renderer, but can provide a significant speed improvement, and is safe to use.</source>
         <translation>Utiliza un segundo hilo para dibujar los gráficos. Actualmente solo está disponible para el renderizador por software, pero puede aumentar significativamente la velocidad, y es seguro de activar.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="132"/>
+        <location filename="../displaysettingswidget.cpp" line="118"/>
         <source>Shows on-screen-display messages when events occur such as save states being created/loaded, screenshots being taken, etc.</source>
         <translation>Muestra mensajes en pantalla cuando ocurren eventos como crear o cargar estados guardados, tomar capturas de pantalla, etc.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="135"/>
+        <location filename="../displaysettingswidget.cpp" line="121"/>
         <source>Shows the internal frame rate of the game in the top-right corner of the display.</source>
         <translation>Muestra la velocidad de fotogramas interna del juego en la esquina superior derecha de la pantalla.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="138"/>
+        <location filename="../displaysettingswidget.cpp" line="124"/>
         <source>Shows the current emulation speed of the system in the top-right corner of the display as a percentage.</source>
         <translation>Muestra el porcentaje de velocidad de emulación actual del sistema en la esquina superior derecha de la pantalla.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="140"/>
+        <location filename="../displaysettingswidget.cpp" line="126"/>
         <source>Shows the resolution of the game in the top-right corner of the display.</source>
         <translation>Muestra la resolución del juego en la esquina superior derecha de la pantalla.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="143"/>
+        <location filename="../displaysettingswidget.cpp" line="129"/>
         <source>Shows the host&apos;s CPU usage based on threads in the top-right corner of the display. This does not display the emulated system CPU&apos;s usage. If a value close to 100% is being displayed, this means your host&apos;s CPU is likely the bottleneck. In this case, you should reduce enhancement-related settings such as overclocking.</source>
         <translation>Muestra el uso de la CPU del sistema detallado por hilos en la esquina superior derecha de la pantalla. Esto no muestra el uso de la CPU de la consola. Si se muestra un valor cercano al 100%, es probable que tu CPU sea el cuello de botella. De ser así, deberías reducir la configuración relacionada a mejoras, como overclocking.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="148"/>
+        <location filename="../displaysettingswidget.cpp" line="134"/>
         <source>Shows the current controller state of the system in the bottom-left corner of the display.</source>
         <translation>Muestra el estado actual del control del sistema en la esquina inferior izquierda de la pantalla.</translation>
     </message>
     <message>
-        <location filename="../displaysettingswidget.cpp" line="153"/>
+        <location filename="../displaysettingswidget.cpp" line="139"/>
         <source>Uses a blit presentation model instead of flipping when using the Direct3D 11 renderer. This usually results in slower performance, but may be required for some streaming applications, or to uncap framerates on some systems.</source>
         <translation>Utiliza un modelo de presentación blit en lugar de voltear cuando se usa el renderizador de Direct3D 11. Esto generalmente resulta en menor rendimiento, pero puede ser necesario para algunas aplicaciones de transmisión, o para eliminar el límite de fotogramas en algunos sistemas.</translation>
     </message>
@@ -4394,58 +5141,63 @@ Este archivo puede alcanzar varios gigabytes en tamaño, así que ten cuidado co
 <context>
     <name>EmuThread</name>
     <message>
-        <location filename="../qthost.cpp" line="536"/>
+        <location filename="../qthost.cpp" line="562"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="536"/>
+        <location filename="../qthost.cpp" line="562"/>
         <source>No resume save state found.</source>
         <translation>No se encontraron estados guardados para resumir.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1306"/>
         <source>Game ID: %1
 Game Title: %2
 Achievements: %5 (%6)
 
 </source>
-        <translation>ID: %1
+        <translation type="vanished">ID: %1
 Título: %2
 Logros: %5 (%6)
 
 </translation>
     </message>
     <message numerus="yes">
-        <location filename="../qthost.cpp" line="1312"/>
         <source>%n points</source>
-        <translation>
+        <translation type="vanished">
             <numerusform>%n punto</numerusform>
             <numerusform>%n puntos</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1318"/>
+        <location filename="../qthost.cpp" line="1229"/>
+        <source>Game: %1 (%2)
+</source>
+        <translation>Juego: %1 (%2)
+</translation>
+    </message>
+    <message>
+        <location filename="../qthost.cpp" line="1237"/>
         <source>Rich presence inactive or unsupported.</source>
         <translation>Rich Presence está inactiva o es incompatible.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1322"/>
+        <location filename="../qthost.cpp" line="1241"/>
         <source>Game not loaded or no RetroAchievements available.</source>
         <translation>Juego no cargado o RetroAchievements no está disponible.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1639"/>
+        <location filename="../qthost.cpp" line="1511"/>
         <source>%1x%2</source>
         <translation>%1x%2</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1648"/>
+        <location filename="../qthost.cpp" line="1520"/>
         <source>Game: %1 FPS</source>
         <translation>Juego: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1658"/>
+        <location filename="../qthost.cpp" line="1530"/>
         <source>Video: %1 FPS (%2%)</source>
         <translation>Video: %1 FPS (%2%)</translation>
     </message>
@@ -4479,13 +5231,13 @@ Logros: %5 (%6)
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="70"/>
-        <location filename="../emulationsettingswidget.cpp" line="92"/>
+        <location filename="../emulationsettingswidget.cpp" line="91"/>
         <source>Sync To Host Refresh Rate</source>
         <translation>Sincronizar al refresco de pantalla</translation>
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="77"/>
-        <location filename="../emulationsettingswidget.cpp" line="98"/>
+        <location filename="../emulationsettingswidget.cpp" line="97"/>
         <source>Optimal Frame Pacing</source>
         <translation>Ritmo de fotogramas óptimo</translation>
     </message>
@@ -4526,7 +5278,7 @@ Logros: %5 (%6)
     </message>
     <message>
         <location filename="../emulationsettingswidget.ui" line="150"/>
-        <location filename="../emulationsettingswidget.cpp" line="110"/>
+        <location filename="../emulationsettingswidget.cpp" line="109"/>
         <source>Disabled</source>
         <translation>Deshabilitado</translation>
     </message>
@@ -4586,100 +5338,100 @@ Logros: %5 (%6)
         <translation>TextLabel</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="81"/>
+        <location filename="../emulationsettingswidget.cpp" line="80"/>
         <source>Emulation Speed</source>
         <translation>Velocidad de emulación</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="82"/>
+        <location filename="../emulationsettingswidget.cpp" line="81"/>
         <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached, and if not, the emulator will run as fast as it can manage.</source>
         <translation>Establece la velocidad de emulación de destino. No se asegura que esa velocidad se vaya a alcanzar, y de no hacerlo, el emulador funcionará lo más rápido que pueda.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="85"/>
+        <location filename="../emulationsettingswidget.cpp" line="84"/>
         <source>Fast Forward Speed</source>
         <translation>Velocidad de avance rápido</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="85"/>
-        <location filename="../emulationsettingswidget.cpp" line="88"/>
+        <location filename="../emulationsettingswidget.cpp" line="84"/>
+        <location filename="../emulationsettingswidget.cpp" line="87"/>
         <source>User Preference</source>
         <translation>Preferencia de usuario</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="86"/>
+        <location filename="../emulationsettingswidget.cpp" line="85"/>
         <source>Sets the fast forward speed. This speed will be used when the fast forward hotkey is pressed/toggled.</source>
         <translation>Determina la velocidad del avance rápido. Se utilizará cuando se presione/active la tecla de avance rápido.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="88"/>
+        <location filename="../emulationsettingswidget.cpp" line="87"/>
         <source>Turbo Speed</source>
         <translation>Velocidad turbo</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="89"/>
+        <location filename="../emulationsettingswidget.cpp" line="88"/>
         <source>Sets the turbo speed. This speed will be used when the turbo hotkey is pressed/toggled. Turboing will take priority over fast forwarding if both hotkeys are pressed/toggled.</source>
         <translation>Determina la velocidad del modo turbo. Se utilizará cuando se presione/active la tecla de turbo. Esta opción tendrá prioridad por sobre el avance rápido si el atajo de ambas se presionan/activan al mismo tiempo.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="92"/>
-        <location filename="../emulationsettingswidget.cpp" line="98"/>
-        <location filename="../emulationsettingswidget.cpp" line="103"/>
+        <location filename="../emulationsettingswidget.cpp" line="91"/>
+        <location filename="../emulationsettingswidget.cpp" line="97"/>
+        <location filename="../emulationsettingswidget.cpp" line="102"/>
         <source>Unchecked</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="93"/>
+        <location filename="../emulationsettingswidget.cpp" line="92"/>
         <source>Adjusts the emulation speed so the console&apos;s refresh rate matches the host&apos;s refresh rate when both VSync and Audio Resampling settings are enabled. This results in the smoothest animations possible, at the cost of potentially increasing the emulation speed by less than 1%. Sync To Host Refresh Rate will not take effect if the console&apos;s refresh rate is too far from the host&apos;s refresh rate. Users with variable refresh rate displays should disable this option.</source>
         <translation>Ajusta la velocidad de emulación para que la tasa de refresco de la consola coincida con la pantalla de tu sistema cuando la sincronización vertical y el remuestreo de audio estén habilitados. Produce que las animaciones sean lo más fluídas posibles, a costa de aumentar potencialmente la velocidad de emulación en menos del 1%. Esta opción no tendrá efecto si la tasa de refresco de la consola es muy diferente a de la de tu sistema. Usuarios con tasas de refresco variables deberían deshabilitar esta opción.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="99"/>
+        <location filename="../emulationsettingswidget.cpp" line="98"/>
         <source>Enable this option will ensure every frame the console renders is displayed to the screen, for optimal frame pacing. If you are having difficulties maintaining full speed, or are getting audio glitches, try disabling this option.</source>
         <translation>Habilitar esta opción asegurará que cada fotograma que renderiza la consola se mostrará en la pantalla, para un ritmo de fotogramas óptimo. Si tienes dificultades para mantener máxima velocidad, o problemas de audio, intenta deshabilitar esta opción.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="103"/>
+        <location filename="../emulationsettingswidget.cpp" line="102"/>
         <source>Rewinding</source>
         <translation>Rebobinado</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="104"/>
+        <location filename="../emulationsettingswidget.cpp" line="103"/>
         <source>&lt;b&gt;Enable Rewinding:&lt;/b&gt; Saves state periodically so you can rewind any mistakes while playing.&lt;br&gt; &lt;b&gt;Rewind Save Frequency:&lt;/b&gt; How often a rewind state will be created. Higher frequencies have greater system requirements.&lt;br&gt; &lt;b&gt;Rewind Buffer Size:&lt;/b&gt; How many saves will be kept for rewinding. Higher values have greater memory requirements.</source>
         <translation>&lt;b&gt;Habilitar rebobinado:&lt;/b&gt; Guarda estados periódicamente para poder rebobinar/retroceder en el tiempo mientras juegas.&lt;br&gt; &lt;b&gt;Frecuencia de guardado:&lt;/b&gt; Que tan seguido se guardarán los estados para el rebobinado. Frecuencias más altas aumentan los requerimientos del sistema.&lt;br&gt; &lt;b&gt;Tamaño del búfer:&lt;/b&gt; Cuántos estados se guardarán para rebobinar. Valores más altos aumentan los requerimientos de memoria.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="110"/>
+        <location filename="../emulationsettingswidget.cpp" line="109"/>
         <source>Runahead</source>
         <translation>Procesamiento anticipado</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="111"/>
+        <location filename="../emulationsettingswidget.cpp" line="110"/>
         <source>Simulates the system ahead of time and rolls back/replays to reduce input lag. Very high system requirements.</source>
         <translation>Simula el sistema de forma anticipada y regresa/repite el estado para reducir la latencia de entrada. Tiene requerimientos de sistema muy altos.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="124"/>
+        <location filename="../emulationsettingswidget.cpp" line="123"/>
         <source>Use Global Setting [Unlimited]</source>
         <translation>Utilizar configuración global [sin límite]</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="126"/>
+        <location filename="../emulationsettingswidget.cpp" line="125"/>
         <source>Use Global Setting [%1%]</source>
         <translation>Utilizar configuración global [%1%]</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="129"/>
+        <location filename="../emulationsettingswidget.cpp" line="128"/>
         <source>Unlimited</source>
         <translation>Sin límite</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="135"/>
+        <location filename="../emulationsettingswidget.cpp" line="134"/>
         <source>%1% [%2 FPS (NTSC) / %3 FPS (PAL)]</source>
         <translation>%1% [%2 FPS (NTSC) / %3 FPS (PAL)]</translation>
     </message>
     <message numerus="yes">
-        <location filename="../emulationsettingswidget.cpp" line="196"/>
+        <location filename="../emulationsettingswidget.cpp" line="195"/>
         <source>Rewind for %n frame(s), lasting %1 second(s) will require up to %2MB of RAM and %3MB of VRAM.</source>
         <translation>
             <numerusform>Rebobinar por %n fotograma, durante %1 segundo(s) requerirá hasta %2MB de RAM y %3MB de VRAM.</numerusform>
@@ -4687,12 +5439,12 @@ Logros: %5 (%6)
         </translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="207"/>
+        <location filename="../emulationsettingswidget.cpp" line="206"/>
         <source>Rewind is disabled because runahead is enabled. Runahead will significantly increase system requirements.</source>
         <translation>El rebobinado está deshabilitado porque el procesamiento anticipado está habilitado. El procesamiento anticipado aumentará significativamente los requerimientos del sistema.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="213"/>
+        <location filename="../emulationsettingswidget.cpp" line="212"/>
         <source>Rewind is not enabled. Please note that enabling rewind may significantly increase system requirements.</source>
         <translation>El rebobinado no esta habilitado. Ten en cuenta que habilitarlo puede aumentar significativamente los requerimientos del sistema.</translation>
     </message>
@@ -4717,17 +5469,17 @@ Logros: %5 (%6)
     <message>
         <location filename="../enhancementsettingswidget.ui" line="48"/>
         <source>Texture Filtering:</source>
-        <translation>Filtrado de textura:</translation>
+        <translation>Filtrado de texturas:</translation>
     </message>
     <message>
         <location filename="../enhancementsettingswidget.ui" line="58"/>
-        <location filename="../enhancementsettingswidget.cpp" line="70"/>
+        <location filename="../enhancementsettingswidget.cpp" line="77"/>
         <source>True Color Rendering (24-bit, disables dithering)</source>
         <translation>Renderizado de color verdadero (24 bits, deshabilita el tramado)</translation>
     </message>
     <message>
         <location filename="../enhancementsettingswidget.ui" line="65"/>
-        <location filename="../enhancementsettingswidget.cpp" line="77"/>
+        <location filename="../enhancementsettingswidget.cpp" line="84"/>
         <source>Scaled Dithering (scale dither pattern to resolution)</source>
         <translation>Escalado de tramado (escalar patrón de tramado a resolución)</translation>
     </message>
@@ -4747,231 +5499,259 @@ Logros: %5 (%6)
         <translation>Submuestreo:</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="99"/>
+        <location filename="../enhancementsettingswidget.ui" line="98"/>
+        <source>x</source>
+        <translation>x</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.ui" line="116"/>
         <source>Display Enhancements</source>
         <translation>Mejoras de imagen</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="105"/>
-        <location filename="../enhancementsettingswidget.cpp" line="59"/>
+        <location filename="../enhancementsettingswidget.ui" line="122"/>
+        <location filename="../enhancementsettingswidget.cpp" line="66"/>
         <source>Disable Interlacing (force progressive render/scan)</source>
         <translation>Deshabilitar entrelazado (forzar escaneo progresivo)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="112"/>
-        <location filename="../enhancementsettingswidget.cpp" line="80"/>
+        <location filename="../enhancementsettingswidget.ui" line="129"/>
+        <location filename="../enhancementsettingswidget.cpp" line="87"/>
         <source>Force NTSC Timings (60hz-on-PAL)</source>
         <translation>Forzar tiempos NTSC (60Hz en PAL)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="119"/>
+        <location filename="../enhancementsettingswidget.ui" line="136"/>
         <source>Force 4:3 For 24-Bit Display (disable widescreen for FMVs)</source>
         <translation>Forzar 4:3 para escenas de 24 bits (deshabilita pantalla panorámica en FMVs)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="126"/>
+        <location filename="../enhancementsettingswidget.ui" line="143"/>
         <source>Chroma Smoothing For 24-Bit Display (reduce FMV color blockyness)</source>
         <translation>Suavizado de croma para escenas de 24 bits (reduce el efecto pixelado en FMVs)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="136"/>
+        <location filename="../enhancementsettingswidget.ui" line="153"/>
         <source>PGXP (Precision Geometry Transform Pipeline)</source>
         <translation>PGXP (corrección de presición geométrica)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="142"/>
-        <location filename="../enhancementsettingswidget.cpp" line="112"/>
+        <location filename="../enhancementsettingswidget.ui" line="159"/>
+        <location filename="../enhancementsettingswidget.cpp" line="119"/>
         <source>Culling Correction</source>
         <translation>Corrección de culling</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="149"/>
-        <location filename="../enhancementsettingswidget.cpp" line="115"/>
+        <location filename="../enhancementsettingswidget.ui" line="166"/>
+        <location filename="../enhancementsettingswidget.cpp" line="122"/>
         <source>Perspective Correct Textures</source>
         <translation>Correción de perspectiva de texturas</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="156"/>
-        <location filename="../enhancementsettingswidget.cpp" line="109"/>
+        <location filename="../enhancementsettingswidget.ui" line="173"/>
+        <location filename="../enhancementsettingswidget.cpp" line="116"/>
         <source>Geometry Correction</source>
         <translation>Correción de geometría</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="163"/>
-        <location filename="../enhancementsettingswidget.cpp" line="129"/>
+        <location filename="../enhancementsettingswidget.ui" line="180"/>
+        <location filename="../enhancementsettingswidget.cpp" line="136"/>
         <source>CPU Mode (Very Slow)</source>
         <translation>Modo CPU (muy lento)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="170"/>
-        <location filename="../enhancementsettingswidget.cpp" line="123"/>
+        <location filename="../enhancementsettingswidget.ui" line="187"/>
+        <location filename="../enhancementsettingswidget.cpp" line="130"/>
         <source>Depth Buffer (Low Compatibility)</source>
         <translation>Búfer de profundidad (baja compatibilidad)</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="177"/>
-        <location filename="../enhancementsettingswidget.cpp" line="127"/>
+        <location filename="../enhancementsettingswidget.ui" line="194"/>
+        <location filename="../enhancementsettingswidget.cpp" line="134"/>
         <source>Preserve Projection Precision</source>
         <translation>Preservar la precisión de proyección</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.ui" line="184"/>
-        <location filename="../enhancementsettingswidget.cpp" line="119"/>
+        <location filename="../enhancementsettingswidget.ui" line="201"/>
+        <location filename="../enhancementsettingswidget.cpp" line="126"/>
         <source>Perspective Correct Colors</source>
         <translation>Correción de perspectiva de colores</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="55"/>
+        <location filename="../enhancementsettingswidget.cpp" line="59"/>
         <source>Downsampling</source>
         <translation>Submuestreo</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="55"/>
+        <location filename="../enhancementsettingswidget.cpp" line="59"/>
         <source>Disabled</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="56"/>
+        <location filename="../enhancementsettingswidget.cpp" line="60"/>
         <source>Downsamples the rendered image prior to displaying it. Can improve overall image quality in mixed 2D/3D games, but should be disabled for pure 3D games. Only applies to the hardware renderers.</source>
         <translation>Reduce el tamaño de la imagen renderizada antes de mostrarla. Puede mejorar la calidad general de la imagen en juegos 2D/3D mixtos, pero debería deshabilitarse para juegos exclusivamente 3D. Solo se aplica a los renderizadores por hardware.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="59"/>
-        <location filename="../enhancementsettingswidget.cpp" line="70"/>
-        <location filename="../enhancementsettingswidget.cpp" line="80"/>
+        <location filename="../enhancementsettingswidget.cpp" line="62"/>
+        <source>Downsampling Display Scale</source>
+        <translation>Escala de submuestreo</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="62"/>
+        <source>1x</source>
+        <translation>1x</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="63"/>
+        <source>Selects the resolution scale that will be applied to the final image. 1x will downsample to the original console resolution.</source>
+        <translation>Selecciona la escala de resolución que se aplicará a la imagen final. 1x escalará a la resolución original de la consola.</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="66"/>
+        <location filename="../enhancementsettingswidget.cpp" line="77"/>
         <location filename="../enhancementsettingswidget.cpp" line="87"/>
-        <location filename="../enhancementsettingswidget.cpp" line="89"/>
-        <location filename="../enhancementsettingswidget.cpp" line="99"/>
-        <location filename="../enhancementsettingswidget.cpp" line="105"/>
-        <location filename="../enhancementsettingswidget.cpp" line="109"/>
-        <location filename="../enhancementsettingswidget.cpp" line="119"/>
-        <location filename="../enhancementsettingswidget.cpp" line="123"/>
-        <location filename="../enhancementsettingswidget.cpp" line="127"/>
-        <location filename="../enhancementsettingswidget.cpp" line="129"/>
+        <location filename="../enhancementsettingswidget.cpp" line="94"/>
+        <location filename="../enhancementsettingswidget.cpp" line="96"/>
+        <location filename="../enhancementsettingswidget.cpp" line="106"/>
+        <location filename="../enhancementsettingswidget.cpp" line="112"/>
+        <location filename="../enhancementsettingswidget.cpp" line="116"/>
+        <location filename="../enhancementsettingswidget.cpp" line="126"/>
+        <location filename="../enhancementsettingswidget.cpp" line="130"/>
+        <location filename="../enhancementsettingswidget.cpp" line="134"/>
+        <location filename="../enhancementsettingswidget.cpp" line="136"/>
         <source>Unchecked</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="60"/>
+        <location filename="../enhancementsettingswidget.cpp" line="67"/>
         <source>Forces the rendering and display of frames to progressive mode. &lt;br&gt;This removes the &quot;combing&quot; effect seen in 480i games by rendering them in 480p. Usually safe to enable.&lt;br&gt; &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Fuerza el renderizado y visualización de fotogramas en modo progresivo.&lt;br&gt;Esto elimina el &quot;efecto peine&quot; producido por el entrelazado en juegos que usan el modo 480i renderizándolos en 480p. Normalmente es seguro habilitarlo.&lt;b&gt;&lt;u&gt;Puede que no sea compatible con todos los juegos.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="65"/>
+        <location filename="../enhancementsettingswidget.cpp" line="72"/>
         <source>Resolution Scale</source>
         <translation>Escala de resolución</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="66"/>
+        <location filename="../enhancementsettingswidget.cpp" line="73"/>
         <source>Setting this beyond 1x will enhance the resolution of rendered 3D polygons and lines. Only applies to the hardware backends. &lt;br&gt;This option is usually safe, with most games looking fine at higher resolutions. Higher resolutions require a more powerful GPU.</source>
         <translation>Seleccionar un valor mayor a 1x mejorará la resolución del renderizado de polígonos y líneas 3D. Solo se aplica a los renderizadores por hardware.&lt;br&gt;Generalmente es seguro activar esta opción. Resoluciones más altas requieren una GPU más potente.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="71"/>
+        <location filename="../enhancementsettingswidget.cpp" line="78"/>
         <source>Forces the precision of colours output to the console&apos;s framebuffer to use the full 8 bits of precision per channel. This produces nicer looking gradients at the cost of making some colours look slightly different. Disabling the option also enables dithering, which makes the transition between colours less sharp by applying a pattern around those pixels. Most games are compatible with this option, but there is a number which aren&apos;t and will have broken effects with it enabled. Only applies to the hardware renderers.</source>
         <translation>Fuerza la precisión de la salida de colores al búfer de fotogramas para que use la totalidad de los 8 bits de precisión por canal. Esto produce mejores degradados al costo de alterar algunos colores. Deshabilitar esta opción también activa el tramado, que hace la transición entre colores menos definida al aplicar un patrón sobre los pixeles. La mayoría de los juegos son compatibles con esta opción, pero hay algunos que no y pueden presentar efectos incorrectamente. Solo se aplica a los renderizadores por hardware.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="77"/>
-        <location filename="../enhancementsettingswidget.cpp" line="112"/>
-        <location filename="../enhancementsettingswidget.cpp" line="115"/>
+        <location filename="../enhancementsettingswidget.cpp" line="84"/>
+        <location filename="../enhancementsettingswidget.cpp" line="119"/>
+        <location filename="../enhancementsettingswidget.cpp" line="122"/>
         <source>Checked</source>
         <translation>Habilitado</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="78"/>
+        <location filename="../enhancementsettingswidget.cpp" line="85"/>
         <source>Scales the dither pattern to the resolution scale of the emulated GPU. This makes the dither pattern much less obvious at higher resolutions. &lt;br&gt;Usually safe to enable, and only supported by the hardware renderers.</source>
         <translation>Escala el patrón del tramado a la escala de resolución de la GPU emulada. Esto disimula el tramado en altas resoluciones.&lt;br&gt;Generalmente es seguro habilitarlo, y solo está soportado por los renderizadores por hardware.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="81"/>
+        <location filename="../enhancementsettingswidget.cpp" line="88"/>
         <source>Uses NTSC frame timings when the console is in PAL mode, forcing PAL games to run at 60hz. &lt;br&gt;For most games which have a speed tied to the framerate, this will result in the game running approximately 17% faster. &lt;br&gt;For variable frame rate games, it may not affect the speed.</source>
         <translation>Usa los tiempos de fotograma del modo NTSC cuando la consola está en modo PAL, forzando los juegos PAL a ejecutarse a 60Hz.&lt;br&gt;La mayoría de los juegos, que tienen su velocidad relacionada a los FPS, se ejecutarán aproximadamente un 17% más rápido.&lt;br&gt;Para juegos con velocidad de fotogramas variable, este problema no debería afectarles.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="87"/>
+        <location filename="../enhancementsettingswidget.cpp" line="94"/>
         <source>Force 4:3 For 24-bit Display</source>
         <translation>Forzar 4:3 para escenas de 24 bits</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="88"/>
+        <location filename="../enhancementsettingswidget.cpp" line="95"/>
         <source>Switches back to 4:3 display aspect ratio when displaying 24-bit content, usually FMVs.</source>
         <translation>Cambia al modo de pantalla 4:3 cuando se muestra contenido de 24 bits, generalmente FMVs.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="89"/>
+        <location filename="../enhancementsettingswidget.cpp" line="96"/>
         <source>Chroma Smoothing For 24-Bit Display</source>
         <translation>Suavizado de croma para escenas de 24 bits</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="90"/>
+        <location filename="../enhancementsettingswidget.cpp" line="97"/>
         <source>Smooths out blockyness between colour transitions in 24-bit content, usually FMVs. Only applies to the hardware renderers.</source>
         <translation>Suaviza el aspecto pixelado que se produce entre las transiciones de colores en contenido de 24 bits, generalmente en FMVs. Solo se aplica a los renderizadores por hardware.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="93"/>
+        <location filename="../enhancementsettingswidget.cpp" line="100"/>
         <source>Texture Filtering</source>
-        <translation>Filtrado de textura</translation>
+        <translation>Filtrado de texturas</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="95"/>
+        <location filename="../enhancementsettingswidget.cpp" line="102"/>
         <source>Smooths out the blockiness of magnified textures on 3D object by using filtering. &lt;br&gt;Will have a greater effect on higher resolution scales. Only applies to the hardware renderers. &lt;br&gt;The JINC2 and especially xBR filtering modes are very demanding, and may not be worth the speed penalty.</source>
         <translation>Suaviza el aspecto pixelado de las texturas magnificadas en objetos 3D utilizando filtros.&lt;br&gt;Tendrá mayor efecto a mayor escala de resolución. Sólo se aplica a los renderizadores por hardware.&lt;br&gt;Los filtros JINC2 y especialmente xBR son muy demandantes, y tal vez no valgan la pérdida en rendimiento.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="99"/>
+        <location filename="../enhancementsettingswidget.cpp" line="106"/>
         <source>Widescreen Hack</source>
         <translation>Hack de pantalla panorámica</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="100"/>
+        <location filename="../enhancementsettingswidget.cpp" line="107"/>
         <source>Scales vertex positions in screen-space to a widescreen aspect ratio, essentially increasing the field of view from 4:3 to the chosen display aspect ratio in 3D games. &lt;br&gt;For 2D games, or games which use pre-rendered backgrounds, this enhancement will not work as expected. &lt;br&gt;&lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Escala las posiciones de vértices en pantalla a una relación de aspecto panorámica, incrementando el campo de visión de 4:3 al aspecto seleccionado en juegos 3D.&lt;br&gt;En juegos 2D o con fondos prerenderizados, esta mejora no va a funcionar como se espera.&lt;br&gt;&lt;b&gt;&lt;u&gt;Tal vez no sea compatible con todos los juegos.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="105"/>
+        <location filename="../enhancementsettingswidget.cpp" line="112"/>
         <source>Use Software Renderer For Readbacks</source>
         <translation>Utilizar renderizador por software para lecturas</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="106"/>
+        <location filename="../enhancementsettingswidget.cpp" line="113"/>
         <source>Runs the software renderer in parallel for VRAM readbacks. On some systems, this may result in greater performance when using graphical enhancements with the hardware renderer.</source>
         <translation>Ejecuta el renderizador de software en paralelo para lecturas de VRAM. En algunos sistemas, esto puede resultar en un mayor rendimiento cuando se usan mejoras gráficas con el renderizador por hardware.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="110"/>
+        <location filename="../enhancementsettingswidget.cpp" line="117"/>
         <source>Reduces &quot;wobbly&quot; polygons and &quot;warping&quot; textures that are common in PS1 games. &lt;br&gt;Only works with the hardware renderers. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Reduce el efecto tembloroso de los polígonos y la deformación de texturas que son comunes en los juegos de PlayStation. &lt;br&gt;Solo funciona con los renderizadores por hardware. &lt;b&gt;&lt;u&gt;Puede no ser compatible con todos los juegos.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="113"/>
-        <source>Increases the precision of polygon culling, reducing the number of holes in geometry. Requires geometry correction enabled.</source>
-        <translation>Incrementa la precisión del culling de polígonos, reduciendo el número de huecos en la geometría. Requiere tener la correción de geometría activada.</translation>
-    </message>
-    <message>
-        <location filename="../enhancementsettingswidget.cpp" line="116"/>
-        <source>Uses perspective-correct interpolation for texture coordinates, straightening out warped textures. Requires geometry correction enabled.</source>
-        <translation>Utiliza interpolación con perspectiva correcta para las coordenadas de texturas, enderezando texturas deformadas. Requiere la correción de geometría activada.</translation>
-    </message>
-    <message>
         <location filename="../enhancementsettingswidget.cpp" line="120"/>
-        <source>Uses perspective-correct interpolation for vertex colors, which can improve visuals in some games, but cause rendering errors in others. Requires geometry correction enabled.</source>
-        <translation>Utiliza interpolación con perspectiva correcta para los colores de los vértices, lo cual puede mejorar la calidad visual en algunos juegos, pero provocar errores de renderizado en otros. Requiere la correción de geometría activada.</translation>
+        <source>Increases the precision of polygon culling, reducing the number of holes in geometry. Requires geometry correction enabled.</source>
+        <translation>Incrementa la precisión del culling de polígonos, reduciendo el número de huecos en la geometría. Requiere tener la correción de geometría habilitada.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="124"/>
+        <location filename="../enhancementsettingswidget.cpp" line="123"/>
+        <source>Uses perspective-correct interpolation for texture coordinates, straightening out warped textures. Requires geometry correction enabled.</source>
+        <translation>Utiliza interpolación con perspectiva correcta para las coordenadas de texturas, enderezando texturas deformadas. Requiere la correción de geometría habilitada.</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="127"/>
+        <source>Uses perspective-correct interpolation for vertex colors, which can improve visuals in some games, but cause rendering errors in others. Requires geometry correction enabled.</source>
+        <translation>Utiliza interpolación con perspectiva correcta para los colores de los vértices, lo cual puede mejorar la calidad visual en algunos juegos, pero provocar errores de renderizado en otros. Requiere la correción de geometría habilitada.</translation>
+    </message>
+    <message>
+        <location filename="../enhancementsettingswidget.cpp" line="131"/>
         <source>Attempts to reduce polygon Z-fighting by testing pixels against the depth values from PGXP. Low compatibility, but can work well in some games. Other games may need a threshold adjustment.</source>
         <translation>Intenta reducir conflictos de planos entre polígonos en el búfer Z al comparar los pixeles contra los valores de profundidad de PGXP. Tiene baja compatibilidad, pero puede funcionar bien en algunos juegos. Otros pueden necesitar un ajuste de umbral.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="128"/>
+        <location filename="../enhancementsettingswidget.cpp" line="135"/>
         <source>Adds additional precision to PGXP data post-projection. May improve visuals in some games.</source>
-        <translation>Añade precisión adicional a los datos de PGXP posproyección. Puede mejorar la visualización en algunos juegos.</translation>
+        <translation>Añade precisión adicional a los datos de PGXP posproyección. Puede mejorar el aspecto visual en algunos juegos.</translation>
     </message>
     <message>
-        <location filename="../enhancementsettingswidget.cpp" line="130"/>
+        <location filename="../enhancementsettingswidget.cpp" line="137"/>
         <source>Uses PGXP for all instructions, not just memory operations. Required for PGXP to correct wobble in some games, but has a very high performance cost.</source>
         <translation>Utiliza PGXP para todas las instrucciones, no solo para las operaciones de memoria. Es necesario para que PGXP corrija el temblor de polígonos en algunos juegos, pero tiene un costo de rendimiento muy alto.</translation>
+    </message>
+</context>
+<context>
+    <name>Error</name>
+    <message>
+        <location filename="../../util/opengl_device.cpp" line="480"/>
+        <source>Both texture buffers and SSBOs are not supported, or are of inadequate size.</source>
+        <translation>Los búferes de textura y SSBO no son compatibles, o tienen un tamaño inadecuado.</translation>
     </message>
 </context>
 <context>
@@ -5047,19 +5827,3046 @@ Logros: %5 (%6)
     </message>
 </context>
 <context>
-    <name>GPUDownsampleMode</name>
+    <name>FullscreenUI</name>
     <message>
-        <location filename="../../core/settings.cpp" line="987"/>
+        <location filename="../../core/fullscreen_ui.cpp" line="6800"/>
+        <source>${title}: Title of the game.
+${filetitle}: Name component of the game&apos;s filename.
+${serial}: Serial of the game.</source>
+        <translation>${title}: título del juego.
+${filetitle}: componente de nombre del archivo del juego.
+${serial}: número de serie del juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6801"/>
+        <source>1 Frame</source>
+        <translation>1 Fotograma</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6802"/>
+        <source>10 Frames</source>
+        <translation>10 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6803"/>
+        <source>100% [60 FPS (NTSC) / 50 FPS (PAL)]</source>
+        <translation>100% [60 FPS (NTSC) / 50 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6804"/>
+        <source>1000% [600 FPS (NTSC) / 500 FPS (PAL)]</source>
+        <translation>1000% [600 FPS (NTSC) / 500 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6805"/>
+        <source>10x</source>
+        <translation>10x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6806"/>
+        <source>10x (20x Speed)</source>
+        <translation>10x (velocidad 20x)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6807"/>
+        <source>11x</source>
+        <translation>11x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6808"/>
+        <source>125% [75 FPS (NTSC) / 62 FPS (PAL)]</source>
+        <translation>125% [75 FPS (NTSC) / 62 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6809"/>
+        <source>12x</source>
+        <translation>12x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6810"/>
+        <source>13x</source>
+        <translation>13x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6811"/>
+        <source>14x</source>
+        <translation>14x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6812"/>
+        <source>150% [90 FPS (NTSC) / 75 FPS (PAL)]</source>
+        <translation>150% [90 FPS (NTSC) / 75 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6813"/>
+        <source>15x</source>
+        <translation>15x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6814"/>
+        <source>16x</source>
+        <translation>16x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6815"/>
+        <source>175% [105 FPS (NTSC) / 87 FPS (PAL)]</source>
+        <translation>175% [105 FPS (NTSC) / 87 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6816"/>
+        <source>1x</source>
+        <translation>1x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6817"/>
+        <source>2 Frames</source>
+        <translation>2 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6818"/>
+        <source>20% [12 FPS (NTSC) / 10 FPS (PAL)]</source>
+        <translation>20% [12 FPS (NTSC) / 10 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6819"/>
+        <source>200% [120 FPS (NTSC) / 100 FPS (PAL)]</source>
+        <translation>200% [120 FPS (NTSC) / 100 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6820"/>
+        <source>250% [150 FPS (NTSC) / 125 FPS (PAL)]</source>
+        <translation>250% [150 FPS (NTSC) / 125 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6821"/>
+        <source>2x</source>
+        <translation>2x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6822"/>
+        <source>2x (Quad Speed)</source>
+        <translation>2x (velocidad cuádruple)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6823"/>
+        <source>3 Frames</source>
+        <translation>3 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6824"/>
+        <source>30% [18 FPS (NTSC) / 15 FPS (PAL)]</source>
+        <translation>30% [18 FPS (NTSC) / 15 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6825"/>
+        <source>300% [180 FPS (NTSC) / 150 FPS (PAL)]</source>
+        <translation>300% [180 FPS (NTSC) / 150 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6826"/>
+        <source>350% [210 FPS (NTSC) / 175 FPS (PAL)]</source>
+        <translation>350% [210 FPS (NTSC) / 175 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6827"/>
+        <source>3x</source>
+        <translation>3x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6828"/>
+        <source>3x (6x Speed)</source>
+        <translation>3x (velocidad 6x)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6829"/>
+        <source>3x (for 720p)</source>
+        <translation>3x (para 720p)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6830"/>
+        <source>4 Frames</source>
+        <translation>4 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6831"/>
+        <source>40% [24 FPS (NTSC) / 20 FPS (PAL)]</source>
+        <translation>40% [24 FPS (NTSC) / 20 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6832"/>
+        <source>400% [240 FPS (NTSC) / 200 FPS (PAL)]</source>
+        <translation>400% [240 FPS (NTSC) / 200 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6833"/>
+        <source>450% [270 FPS (NTSC) / 225 FPS (PAL)]</source>
+        <translation>450% [270 FPS (NTSC) / 225 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6834"/>
+        <source>4x</source>
+        <translation>4x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6835"/>
+        <source>4x (8x Speed)</source>
+        <translation>4x (velocidad 8x)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6836"/>
+        <source>5 Frames</source>
+        <translation>5 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6837"/>
+        <source>50% [30 FPS (NTSC) / 25 FPS (PAL)]</source>
+        <translation>50% [30 FPS (NTSC) / 25 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6838"/>
+        <source>500% [300 FPS (NTSC) / 250 FPS (PAL)]</source>
+        <translation>500% [300 FPS (NTSC) / 250 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6839"/>
+        <source>5x</source>
+        <translation>5x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6840"/>
+        <source>5x (10x Speed)</source>
+        <translation>5x (velocidad 10x)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6841"/>
+        <source>5x (for 1080p)</source>
+        <translation>5x (para 1080p)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6842"/>
+        <source>6 Frames</source>
+        <translation>6 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6843"/>
+        <source>60% [36 FPS (NTSC) / 30 FPS (PAL)]</source>
+        <translation>60% [36 FPS (NTSC) / 30 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6844"/>
+        <source>600% [360 FPS (NTSC) / 300 FPS (PAL)]</source>
+        <translation>600% [360 FPS (NTSC) / 300 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6845"/>
+        <source>6x</source>
+        <translation>6x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6846"/>
+        <source>6x (12x Speed)</source>
+        <translation>6x (velocidad 12x)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6847"/>
+        <source>6x (for 1440p)</source>
+        <translation>6x (para 1440p)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6848"/>
+        <source>7 Frames</source>
+        <translation>7 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6849"/>
+        <source>70% [42 FPS (NTSC) / 35 FPS (PAL)]</source>
+        <translation>70% [42 FPS (NTSC) / 35 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6850"/>
+        <source>700% [420 FPS (NTSC) / 350 FPS (PAL)]</source>
+        <translation>700% [420 FPS (NTSC) / 350 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6851"/>
+        <source>7x</source>
+        <translation>7x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6852"/>
+        <source>7x (14x Speed)</source>
+        <translation>7x (velocidad 14x)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6853"/>
+        <source>8 Frames</source>
+        <translation>8 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6854"/>
+        <source>80% [48 FPS (NTSC) / 40 FPS (PAL)]</source>
+        <translation>80% [48 FPS (NTSC) / 40 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6855"/>
+        <source>800% [480 FPS (NTSC) / 400 FPS (PAL)]</source>
+        <translation>800% [480 FPS (NTSC) / 400 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6856"/>
+        <source>8x</source>
+        <translation>8x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6857"/>
+        <source>8x (16x Speed)</source>
+        <translation>8x (velocidad 16x)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6858"/>
+        <source>9 Frames</source>
+        <translation>9 Fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6859"/>
+        <source>90% [54 FPS (NTSC) / 45 FPS (PAL)]</source>
+        <translation>90% [54 FPS (NTSC) / 45 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6860"/>
+        <source>900% [540 FPS (NTSC) / 450 FPS (PAL)]</source>
+        <translation>900% [540 FPS (NTSC) / 450 FPS (PAL)]</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6861"/>
+        <source>9x</source>
+        <translation>9x</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6862"/>
+        <source>9x (18x Speed)</source>
+        <translation>9x (velocidad 18x)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6863"/>
+        <source>9x (for 4K)</source>
+        <translation>9x (para 4K)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6864"/>
+        <source>A memory card with the name &apos;{}&apos; already exists.</source>
+        <translation>Una tarjeta de memoria con el nombre &apos;{}&apos; ya existe.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6865"/>
+        <source>A resume save state created at %s was found.
+
+Do you want to load this save and continue?</source>
+        <translation>Se encontró un estado guardado para resumir creado en %s.
+
+¿Quieres cargar este estado guardado y continuar?</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6866"/>
+        <source>About DuckStation</source>
+        <translation>Acerca de DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6867"/>
+        <source>Account</source>
+        <translation>Cuenta</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6868"/>
+        <source>Achievement Notifications</source>
+        <translation>Notificaciones de logros</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6869"/>
+        <source>Achievements</source>
+        <translation>Logros</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6870"/>
+        <source>Achievements Settings</source>
+        <translation>Configuración de logros</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6871"/>
+        <source>Achievements are not enabled.</source>
+        <translation>Logros deshabilitados.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6872"/>
+        <source>Add Search Directory</source>
+        <translation>Añadir directorio de búsqueda</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6873"/>
+        <source>Add Shader</source>
+        <translation>Añadir sombreador</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6874"/>
+        <source>Adds a new directory to the game search list.</source>
+        <translation>Añade un directorio nuevo a la lista de búsqueda de juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6875"/>
+        <source>Adds a new shader to the chain.</source>
+        <translation>Añade un sombreador nuevo a la cadena.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6876"/>
+        <source>Adds additional precision to PGXP data post-projection. May improve visuals in some games.</source>
+        <translation>Añade precisión adicional a los datos de PGXP posproyección. Puede mejorar el aspecto visual en algunos juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6877"/>
+        <source>Adjusts the emulation speed so the console&apos;s refresh rate matches the host when VSync and Audio Resampling are enabled.</source>
+        <translation>Ajusta la velocidad de emulación para que la tasa de refresco de la consola coincida con la del sistema cuando la sincronización vertical y el remuestreo de audio estén habilitados.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6878"/>
+        <source>Advanced Settings</source>
+        <translation>Configuración avanzada</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6879"/>
+        <source>All Time: {}</source>
+        <translation>Absoluto: {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6880"/>
+        <source>Allow Booting Without SBI File</source>
+        <translation>Permitir iniciar sin un archivo SBI</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6881"/>
+        <source>Allows loading protected games without subchannel information.</source>
+        <translation>Permite cargar juegos protegidos sin la información del subcanal.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6882"/>
+        <source>Apply Image Patches</source>
+        <translation>Aplicar parches de imagen</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6883"/>
+        <source>Apply Per-Game Settings</source>
+        <translation>Configuraciones por juego</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6884"/>
+        <source>Are you sure you want to clear the current post-processing chain? All configuration will be lost.</source>
+        <translation>¿Seguro que quieres vaciar la cadena de postprocesamiento actual? Se perderá toda la configuración.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6885"/>
+        <source>Aspect Ratio</source>
+        <translation>Relación de aspecto</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6886"/>
+        <source>Attempts to map the selected port to a chosen controller.</source>
+        <translation>Intenta asignar el puerto seleccionado a un control determinado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6887"/>
+        <source>Audio Backend</source>
+        <translation>Motor de audio</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6888"/>
+        <source>Audio Settings</source>
+        <translation>Configuración de audio</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6889"/>
+        <source>Auto-Detect</source>
+        <translation>Detectar automáticamente</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6890"/>
+        <source>Automatic Mapping</source>
+        <translation>Asignación automática</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6891"/>
+        <source>Automatic based on window size</source>
+        <translation>Automático según el tamaño de la ventana</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6892"/>
+        <source>Automatic mapping completed for {}.</source>
+        <translation>Asignación automática finalizada para {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6893"/>
+        <source>Automatic mapping failed for {}.</source>
+        <translation>Asignación automática fallida para {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6894"/>
+        <source>Automatic mapping failed, no devices are available.</source>
+        <translation>Asignación automática fallida, no hay dispositivos disponibles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6895"/>
+        <source>Automatically Load Cheats</source>
+        <translation>Cargar trucos automáticamente</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6896"/>
+        <source>Automatically applies patches to disc images when they are present, currently only PPF is supported.</source>
+        <translation>Aplica parches a las imagenes de disco automáticamente cuando ambos están presentes. Actualmente solo los parches PPF son compatibles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6897"/>
+        <source>Automatically loads and applies cheats on game start.</source>
+        <translation>Carga y aplica los trucos automáticamente al iniciar el juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6898"/>
+        <source>Automatically saves the emulator state when powering down or exiting. You can then resume directly from where you left off next time.</source>
+        <translation>Guarda automáticamente el estado del emulador al apagar o salir. Después podrás continuar desde donde dejaste la última vez.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6899"/>
+        <source>Automatically switches to fullscreen mode when the program is started.</source>
+        <translation>Cambia automáticamente a modo en pantalla completa cuando se inicia el programa.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6900"/>
+        <source>Avoids calls to C++ code, significantly speeding up the recompiler.</source>
+        <translation>Evita llamadas a código de C++, acelerando significativamente el recompilador.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6901"/>
+        <source>BIOS Directory</source>
+        <translation>Directorio de BIOS</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6902"/>
+        <source>BIOS Selection</source>
+        <translation>Selección de BIOS</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6903"/>
+        <source>BIOS Settings</source>
+        <translation>Configuración de BIOS</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6904"/>
+        <source>BIOS for {}</source>
+        <translation>BIOS para {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6905"/>
+        <source>BIOS to use when emulating {} consoles.</source>
+        <translation>BIOS a utilizar al emular {} consolas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6906"/>
+        <source>Back To Pause Menu</source>
+        <translation>Volver al menú de pausa</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6907"/>
+        <source>Backend Settings</source>
+        <translation>Configuración de motor</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6908"/>
+        <source>Behavior</source>
+        <translation>Comportamiento</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6909"/>
+        <source>Borderless Fullscreen</source>
+        <translation>Pantalla completa sin bordes</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6910"/>
+        <source>Buffer Size</source>
+        <translation>Tamaño del búfer</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6911"/>
+        <source>CD-ROM Emulation</source>
+        <translation>Emulación de CD-ROM</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6912"/>
+        <source>CPU Emulation</source>
+        <translation>Emulación de CPU</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6913"/>
+        <source>CPU Mode</source>
+        <translation>Modo de CPU</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6914"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6915"/>
+        <source>Change Disc</source>
+        <translation>Cambiar disco</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6916"/>
+        <source>Change settings for the emulator.</source>
+        <translation>Cambiar la configuración del emulador.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6917"/>
+        <source>Changes the aspect ratio used to display the console&apos;s output to the screen.</source>
+        <translation>Cambia la relación de aspecto utilizada para mostrar la salida de la consola en pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6918"/>
+        <source>Cheat List</source>
+        <translation>Lista de trucos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6919"/>
+        <source>Chooses the backend to use for rendering the console/game visuals.</source>
+        <translation>Elige el motor a utilizar para renderizar los gráficos de la consola/juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6920"/>
+        <source>Chroma Smoothing For 24-Bit Display</source>
+        <translation>Suavizado de croma para escenas de 24 bits</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6921"/>
+        <source>Clean Boot</source>
+        <translation>Inicio limpio</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6922"/>
+        <source>Clear Settings</source>
+        <translation>Limpiar configuración</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6923"/>
+        <source>Clear Shaders</source>
+        <translation>Eliminar sombreadores</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6924"/>
+        <source>Clears a shader from the chain.</source>
+        <translation>Elimina un sombreador de la cadena.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6925"/>
+        <source>Clears all settings set for this game.</source>
+        <translation>Limpia toda la configuración para este juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6926"/>
+        <source>Clears the mask/transparency bit in VRAM write dumps.</source>
+        <translation>Limpia el bit de enmascaramiento/transparencia en los volcados de escritura de VRAM.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6927"/>
+        <source>Close</source>
+        <translation>Cerrar</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6928"/>
+        <source>Close Game</source>
+        <translation>Cerrar juego</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6929"/>
+        <source>Close Menu</source>
+        <translation>Cerrar menú</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6930"/>
+        <source>Compatibility Rating</source>
+        <translation>Calificación de compatibilidad</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6931"/>
+        <source>Compatibility: </source>
+        <translation>Compatibilidad: </translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6932"/>
+        <source>Confirm Power Off</source>
+        <translation>Confirmar apagado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6933"/>
+        <source>Console Settings</source>
+        <translation>Configuración de la consola</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6934"/>
+        <source>Contributor List: https://github.com/stenzek/duckstation/blob/master/CONTRIBUTORS.md</source>
+        <translation>Lista de colaboradores: https://github.com/stenzek/duckstation/blob/master/CONTRIBUTORS.md</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6935"/>
+        <source>Controller Port {}</source>
+        <translation>Puerto de control {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6936"/>
+        <source>Controller Port {} Macros</source>
+        <translation>Macros del puerto de control {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6937"/>
+        <source>Controller Port {} Settings</source>
+        <translation>Configuración del puerto de control {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6938"/>
+        <source>Controller Port {}{}</source>
+        <translation>Puerto de control {}{}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6939"/>
+        <source>Controller Port {}{} Macros</source>
+        <translation>Macros del puerto de control {}{}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6940"/>
+        <source>Controller Port {}{} Settings</source>
+        <translation>Configuración del puerto de control {}{}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6941"/>
+        <source>Controller Settings</source>
+        <translation>Configuración de controles</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6942"/>
+        <source>Controller Type</source>
+        <translation>Tipo de control</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6943"/>
+        <source>Controller settings reset to default.</source>
+        <translation>Configuración del control restablecida a valores predeterminados.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6944"/>
+        <source>Controls</source>
+        <translation>Controles</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6945"/>
+        <source>Controls the volume of the audio played on the host when fast forwarding.</source>
+        <translation>Controla el volúmen de reproducción de audio durante el avance rápido en el sistema.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6946"/>
+        <source>Controls the volume of the audio played on the host.</source>
+        <translation>Controla el volúmen de reproducción de audio en el sistema.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6947"/>
+        <source>Copies the current global settings to this game.</source>
+        <translation>Copia la configuración global actual a la de este juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6948"/>
+        <source>Copies the global controller configuration to this game.</source>
+        <translation>Copia la configuración de control global actual a la de este juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6949"/>
+        <source>Copy Global Settings</source>
+        <translation>Copiar configuración global</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6950"/>
+        <source>Copy Settings</source>
+        <translation>Copiar configuración</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6951"/>
+        <source>Cover Settings</source>
+        <translation>Configuración de portada</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6952"/>
+        <source>Covers Directory</source>
+        <translation>Directorio de portadas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6953"/>
+        <source>Create</source>
+        <translation>Crear</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6954"/>
+        <source>Create Memory Card</source>
+        <translation>Crear tarjeta de memoria</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6955"/>
+        <source>Create Save State Backups</source>
+        <translation>Crear copias de seguridad de los estados guardados</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6956"/>
+        <source>Creates a new memory card file or folder.</source>
+        <translation>Crea un nuevo archivo o directorio de tarjeta de memoria.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6957"/>
+        <source>Crop Mode</source>
+        <translation>Modo de recorte</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6958"/>
+        <source>Culling Correction</source>
+        <translation>Corrección de culling</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6959"/>
+        <source>Current Game</source>
+        <translation>Juego actual</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6960"/>
+        <source>Debugging Settings</source>
+        <translation>Configuración de depuración</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6961"/>
+        <source>Default</source>
+        <translation>Predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6962"/>
+        <source>Default Boot</source>
+        <translation>Inicio predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6963"/>
+        <source>Default View</source>
+        <translation>Vista predeterminada</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6964"/>
+        <source>Default: Disabled</source>
+        <translation>Predeterminado: deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6965"/>
+        <source>Default: Enabled</source>
+        <translation>Predeterminado: habilitado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6966"/>
+        <source>Delete Save</source>
+        <translation>Eliminar guardado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6967"/>
+        <source>Delete State</source>
+        <translation>Eliminar estado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6968"/>
+        <source>Depth Buffer</source>
+        <translation>Búfer de profundidad</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6969"/>
+        <source>Details</source>
+        <translation>Detalles</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6970"/>
+        <source>Details unavailable for game not scanned in game list.</source>
+        <translation>Detalles no disponibles para juegos que no se encuentren en la lista de juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6971"/>
+        <source>Determines how large the on-screen messages and monitor are.</source>
+        <translation>Determina que tan grande son los mensajes en pantalla en relación al monitor.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6972"/>
+        <source>Determines how much latency there is between the audio being picked up by the host API, and played through speakers.</source>
+        <translation>Determina cuánta latencia hay entre el audio detectado por la API del sistema y su reproducción por los altavoces.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6973"/>
+        <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide.</source>
+        <translation>Determina cuanto del área generalmente no visible en un televisor recortar/ocultar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6974"/>
+        <source>Determines how the emulated CPU executes instructions.</source>
+        <translation>Determina cómo la CPU emulada ejecuta instrucciones.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6975"/>
+        <source>Determines how the emulated console&apos;s output is upscaled or downscaled to your monitor&apos;s resolution.</source>
+        <translation>Determina cómo se escalará la salida de la consola emulada a la resolución de tu monitor.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6976"/>
+        <source>Determines quality of audio when not running at 100% speed.</source>
+        <translation>Determina la calidad del audio cuando la velocidad no es del 100%.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6977"/>
+        <source>Determines the amount of audio buffered before being pulled by the host API.</source>
+        <translation>Determina la cantidad de audio almacenada antes de que lo levante la API del sistema.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6978"/>
+        <source>Determines the emulated hardware type.</source>
+        <translation>Determina el tipo de hardware emulado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6979"/>
+        <source>Determines the position on the screen when black borders must be added.</source>
+        <translation>Determina la posición de la pantalla cuando se añadan bordes negros.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6980"/>
+        <source>Determines whether a prompt will be displayed to confirm shutting down the emulator/game when the hotkey is pressed.</source>
+        <translation>Determina si se mostrará un mensaje de confirmación para cerrar el emulador/juego al presionar un atajo.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6981"/>
+        <source>Device Settings</source>
+        <translation>Configuración del dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6982"/>
+        <source>Disable All Enhancements</source>
+        <translation>Deshabilitar todas las mejoras</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6983"/>
+        <source>Disable Interlacing</source>
+        <translation>Deshabilitar entrelazado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6984"/>
+        <source>Disable Subdirectory Scanning</source>
+        <translation>Deshabilitar búsqueda en subdirectorios</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6985"/>
         <source>Disabled</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="987"/>
+        <location filename="../../core/fullscreen_ui.cpp" line="6986"/>
+        <source>Disables dithering and uses the full 8 bits per channel of color information.</source>
+        <translation>Deshabilita el tramado y utiliza la totalidad de los 8 bits por canal de información de color.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6987"/>
+        <source>Disables interlaced rendering and display in the GPU. Some games can render in 480p this way, but others will break.</source>
+        <translation>Deshabilita el renderizado entrelazado en la GPU. Algunos juegos pueden renderizarse a 480p, aunque otros pueden presentar fallos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6988"/>
+        <source>Discord Server</source>
+        <translation>Servidor de Discord</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6989"/>
+        <source>Display FPS Limit</source>
+        <translation>Mostrar límite de FPS</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6990"/>
+        <source>Display Settings</source>
+        <translation>Configuración de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6991"/>
+        <source>Displays popup messages on events such as achievement unlocks and leaderboard submissions.</source>
+        <translation>Muestra mensajes emergentes durante eventos como desbloqueo de logros y envíos a la tabla de posiciones.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6992"/>
+        <source>Displays popup messages when starting, submitting, or failing a leaderboard challenge.</source>
+        <translation>Muestra mensajes emergentes al iniciar, enviar o fallar un desafío de tabla de posiciones.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6993"/>
+        <source>Double-Click Toggles Fullscreen</source>
+        <translation>Doble clic para pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6994"/>
+        <source>Download Covers</source>
+        <translation>Descargar portadas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6995"/>
+        <source>Downloads covers from a user-specified URL template.</source>
+        <translation>Descarga portadas desde la URL especificada por el usuario.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6996"/>
+        <source>Downsamples the rendered image prior to displaying it. Can improve overall image quality in mixed 2D/3D games.</source>
+        <translation>Reduce el tamaño de la imagen renderizada antes de mostrarla. Puede mejorar la calidad general de la imagen en juegos 2D/3D mixtos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6997"/>
+        <source>Downsampling</source>
+        <translation>Submuestreo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6998"/>
+        <source>Downsampling Display Scale</source>
+        <translation>Escala de submuestreo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="6999"/>
+        <source>Duck icon by icons8 (https://icons8.com/icon/74847/platforms.undefined.short-title)</source>
+        <translation>Icono del pato por icons8 (https://icons8.com/icon/74847/platforms.undefined.short-title)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7000"/>
+        <source>DuckStation can automatically download covers for games which do not currently have a cover set. We do not host any cover images, the user must provide their own source for images.</source>
+        <translation>DuckStation puede descargar automáticamente imágenes de portada para juegos que no tengan una ya establecida. Nosotros no alojamos ninguna imagen de portada, por lo que el usuario debe proveer su propia fuente de imágenes.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7001"/>
+        <source>DuckStation is a free and open-source simulator/emulator of the Sony PlayStation(TM) console, focusing on playability, speed, and long-term maintainability.</source>
+        <translation>DuckStation es un emulador/simulador gratuito y de código abierto de la consola Sony PlayStation(TM), enfocándose en jugabilidad, velocidad y mantenimiento a largo plazo.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7002"/>
+        <source>Dump Replaceable VRAM Writes</source>
+        <translation>Volcar escrituras de VRAM reemplazables</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7003"/>
+        <source>Emulation Settings</source>
+        <translation>Configuración de emulación</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7004"/>
+        <source>Emulation Speed</source>
+        <translation>Velocidad de emulación</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7005"/>
+        <source>Enable 8MB RAM</source>
+        <translation>Habilitar 8MB de RAM</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7006"/>
+        <source>Enable Achievements</source>
+        <translation>Habilitar logros</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7007"/>
+        <source>Enable Discord Presence</source>
+        <translation>Habilitar Discord Presence</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7008"/>
+        <source>Enable Fast Boot</source>
+        <translation>Habilitar inicio rápido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7009"/>
+        <source>Enable In-Game Overlays</source>
+        <translation>Superposiciones dentro del juego</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7010"/>
+        <source>Enable Overclocking</source>
+        <translation>Habilitar overclocking</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7011"/>
+        <source>Enable PGXP Vertex Cache</source>
+        <translation>Habilitar caché de vértices (PGXP)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7012"/>
+        <source>Enable Post Processing</source>
+        <translation>Habilitar postprocesamiento</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7013"/>
+        <source>Enable Recompiler Block Linking</source>
+        <translation>Habilitar vinculación de bloques del recompilador</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7014"/>
+        <source>Enable Recompiler ICache</source>
+        <translation>Habilitar ICache del recompilador</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7015"/>
+        <source>Enable Recompiler Memory Exceptions</source>
+        <translation>Habilitar excepciones de memoria del recompilador</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7016"/>
+        <source>Enable Region Check</source>
+        <translation>Habilitar chequeo regional</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7017"/>
+        <source>Enable Rewinding</source>
+        <translation>Habilitar rebobinado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7018"/>
+        <source>Enable SDL Input Source</source>
+        <translation>Habilitar fuente de entrada SDL</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7019"/>
+        <source>Enable Subdirectory Scanning</source>
+        <translation>Habilitar búsqueda en subdirectorios</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7020"/>
+        <source>Enable TTY Logging</source>
+        <translation>Habilitar registro por terminal</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7021"/>
+        <source>Enable VRAM Write Texture Replacement</source>
+        <translation>Habilitar reemplazo de textura de escritura de VRAM</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7022"/>
+        <source>Enable VSync</source>
+        <translation>Habilitar sincronización vertical</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7023"/>
+        <source>Enable XInput Input Source</source>
+        <translation>Habilitar fuente de entrada XInput</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7024"/>
+        <source>Enable debugging when supported by the host&apos;s renderer API. Only for developer use.</source>
+        <translation>Habilita el modo de depuración cuando sea compatible con la API de renderizado del sistema. Solo para desarrolladores.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7025"/>
+        <source>Enables alignment and bus exceptions. Not needed for any known games.</source>
+        <translation>Habilita excepciones de alineamiento y buses. No es necesario para ningún juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7026"/>
+        <source>Enables an additional 6MB of RAM to obtain a total of 2+6 = 8MB, usually present on dev consoles.</source>
+        <translation>Habilita 6MB de RAM adicionales para obtener un total de 8MB (2MB+6MB), generalmente presente en consolas de desarrollo.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7027"/>
+        <source>Enables an additional three controller slots on each port. Not supported in all games.</source>
+        <translation>Habilita tres ranuras de control adicionales en cada puerto. No es compatible con todos los juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7028"/>
+        <source>Enables more precise frame pacing at the cost of battery life.</source>
+        <translation>Habilita un ritmo de fotogramas más preciso al mayor costo de batería.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7029"/>
+        <source>Enables the replacement of background textures in supported games.</source>
+        <translation>Habilita el reemplazo de texturas de fondo en juegos compatibles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7030"/>
+        <source>Encore Mode</source>
+        <translation>Modo Encore</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7031"/>
+        <source>Enhancements</source>
+        <translation>Mejoras</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7032"/>
+        <source>Ensures every frame generated is displayed for optimal pacing. Disable if you are having speed or sound issues.</source>
+        <translation>Asegura que se muestren todos los fotogramas generados para un ritmo óptimo. Deshabilitar si hay problemas de rendimiento o sonido.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7033"/>
+        <source>Enter the name of the input profile you wish to create.</source>
+        <translation>Ingresa el nombre para el nuevo perfil de entrada.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7034"/>
+        <source>Enter the name of the memory card you wish to create.</source>
+        <translation>Ingresa el nombre para la nueva tarjeta de memoria.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7035"/>
+        <source>Example: https://www.example-not-a-real-domain.com/covers/${serial}.jpg</source>
+        <translation>Ejemplo: https://www.ejemplo-dominio-ficticio.com/portadas/${serial}.jpg</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7036"/>
+        <source>Execution Mode</source>
+        <translation>Modo de ejecución</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7037"/>
+        <source>Exit</source>
+        <translation>Salir</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7038"/>
+        <source>Exit And Save State</source>
+        <translation>Salir y guardar estado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7039"/>
+        <source>Exit Without Saving</source>
+        <translation>Salir sin guardar</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7040"/>
+        <source>Exits the program.</source>
+        <translation>Salir del programa.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7041"/>
+        <source>Failed to copy text to clipboard.</source>
+        <translation>Fallo al copiar texto al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7042"/>
+        <source>Failed to create memory card &apos;{}&apos;.</source>
+        <translation>Fallo al crear la tarjeta de memoria &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7043"/>
+        <source>Failed to delete save state.</source>
+        <translation>Fallo al eliminar estado guardado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7044"/>
+        <source>Failed to delete {}.</source>
+        <translation>Fallo al eliminar &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7045"/>
+        <source>Failed to load &apos;{}&apos;.</source>
+        <translation>Fallo al cargar &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7046"/>
+        <source>Failed to load shader {}. It may be invalid.
+Error was:</source>
+        <translation>Fallo al cargar el sombreador {}. Puede que sea inválido.
+Error:</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7047"/>
+        <source>Failed to save input profile &apos;{}&apos;.</source>
+        <translation>Fallo al guardar perfil de entrada &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7048"/>
+        <source>Fast Boot</source>
+        <translation>Inicio rápido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7049"/>
+        <source>Fast Forward Speed</source>
+        <translation>Velocidad de avance rápido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7050"/>
+        <source>Fast Forward Volume</source>
+        <translation>Volumen durante avance rápido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7051"/>
+        <source>File Title</source>
+        <translation>Título de archivo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7052"/>
+        <source>Force 4:3 For 24-Bit Display</source>
+        <translation>Forzar 4:3 para escenas de 24 bits</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7053"/>
+        <source>Force NTSC Timings</source>
+        <translation>Forzar tiempos NTSC</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7054"/>
+        <source>Forces PAL games to run at NTSC timings, i.e. 60hz. Some PAL games will run at their &quot;normal&quot; speeds, while others will break.</source>
+        <translation>Fuerza que juegos PAL se ejecuten a tiempos NTSC (60hz). Algunos juegos PAL funcionarán a su velocidad &quot;normal&quot;, mientras que puede producir fallos en otros.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7055"/>
+        <source>Forces a full rescan of all games previously identified.</source>
+        <translation>Fuerza una búsqueda completa de todos los juegos identificados previamente.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7056"/>
+        <source>Forcibly mutes both CD-DA and XA audio from the CD-ROM. Can be used to disable background music in some games.</source>
+        <translation>Silecia a la fuerza el audio CD-DA y XA del CD-ROM. Puede utilizarse para deshabilitar la música de fondo en algunos juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7057"/>
+        <source>From File...</source>
+        <translation>Desde archivo...</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7058"/>
+        <source>Fullscreen Resolution</source>
+        <translation>Resolución de pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7059"/>
+        <source>GPU Adapter</source>
+        <translation>Adaptador de GPU</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7060"/>
+        <source>GPU Renderer</source>
+        <translation>Renderizador de GPU</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7061"/>
+        <source>GPU adapter will be applied after restarting.</source>
+        <translation>El adaptador de GPU será aplicado después de reiniciar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7062"/>
+        <source>Game Grid</source>
+        <translation>Cuadrícula de juegos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7063"/>
+        <source>Game List</source>
+        <translation>Lista de juegos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7064"/>
+        <source>Game List Settings</source>
+        <translation>Configuración de lista de juegos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7065"/>
+        <source>Game Properties</source>
+        <translation>Propiedades del juego</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7066"/>
+        <source>Game Quick Save</source>
+        <translation>Guardado rápido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7067"/>
+        <source>Game Slot {0}##game_slot_{0}</source>
+        <translation>Ranura de juego {0}##game_slot_{0}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7068"/>
+        <source>Game compatibility rating copied to clipboard.</source>
+        <translation>Calificación de compatibilidad del juego copiada al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7069"/>
+        <source>Game not loaded or no RetroAchievements available.</source>
+        <translation>Juego no cargado o RetroAchievements no está disponible.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7070"/>
+        <source>Game path copied to clipboard.</source>
+        <translation>Directorio del juego copiado al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7071"/>
+        <source>Game region copied to clipboard.</source>
+        <translation>Región del juego copiada al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7072"/>
+        <source>Game serial copied to clipboard.</source>
+        <translation>Número de serie del juego copiado al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7073"/>
+        <source>Game settings have been cleared for &apos;{}&apos;.</source>
+        <translation>Configuración por juego eliminada para &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7074"/>
+        <source>Game settings initialized with global settings for &apos;{}&apos;.</source>
+        <translation>Configuración por juego inicializada con la configuración global para &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7075"/>
+        <source>Game title copied to clipboard.</source>
+        <translation>Título del juego copiado al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7076"/>
+        <source>Game type copied to clipboard.</source>
+        <translation>Tipo del juego copiado al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7077"/>
+        <source>Game: {} ({})</source>
+        <translation>Juego: {} ({})</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7078"/>
+        <source>Genre: %s</source>
+        <translation>Género: %s</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7079"/>
+        <source>GitHub Repository</source>
+        <translation>Repositorio en GitHub</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7080"/>
+        <source>Global Slot {0} - {1}##global_slot_{0}</source>
+        <translation>Ranura global {0} - {1}##global_slot_{0}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7081"/>
+        <source>Global Slot {0}##global_slot_{0}</source>
+        <translation>Ranura global {0}##global_slot_{0}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7082"/>
+        <source>Hardcore Mode</source>
+        <translation>Modo Hardcore</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7083"/>
+        <source>Hardcore mode will be enabled on next game restart.</source>
+        <translation>El modo Hardcore será habilitado al reiniciar el juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7084"/>
+        <source>Hide Cursor In Fullscreen</source>
+        <translation>Ocultar cursor en pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7085"/>
+        <source>Hides the mouse pointer/cursor when the emulator is in fullscreen mode.</source>
+        <translation>Oculta el cursor/puntero del mouse cuando el emulador está en modo de pantalla completa.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7086"/>
+        <source>Hotkey Settings</source>
+        <translation>Configuración de atajos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7087"/>
+        <source>How many saves will be kept for rewinding. Higher values have greater memory requirements.</source>
+        <translation>Cuántos estados se guardarán para rebobinar. Valores más altos aumentan los requerimientos de memoria.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7088"/>
+        <source>How often a rewind state will be created. Higher frequencies have greater system requirements.</source>
+        <translation>Que tan seguido se guardarán los estados para el rebobinado. Frecuencias más altas aumentan los requerimientos del sistema.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7089"/>
+        <source>Identifies any new files added to the game directories.</source>
+        <translation>Identifica nuevos archivos añadidos a los directorios de juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7090"/>
+        <source>If not enabled, the current post processing chain will be ignored.</source>
+        <translation>Si no esta habilitado, la cadena de postprocesamiento actual será ignorada.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7091"/>
+        <source>In the form below, specify the URLs to download covers from, with one template URL per line. The following variables are available:</source>
+        <translation>En el formulario debajo, especifica las URL de las cuales descargar portadas, una por línea. Están disponibles las siguientes variables:</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7092"/>
+        <source>Increase Timer Resolution</source>
+        <translation>Incrementar la resolución del temporizador</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7093"/>
+        <source>Increases the field of view from 4:3 to the chosen display aspect ratio in 3D games.</source>
+        <translation>Incrementa el campo de visión de 4:3 al aspecto seleccionado en juegos 3D.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7094"/>
+        <source>Increases the precision of polygon culling, reducing the number of holes in geometry.</source>
+        <translation>Incrementa la precisión del culling de polígonos, reduciendo el número de huecos en la geometría.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7095"/>
+        <source>Infinite/Instantaneous</source>
+        <translation>Infinita/Instantánea</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7096"/>
+        <source>Inhibit Screensaver</source>
+        <translation>Deshabilitar salvapantallas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7097"/>
+        <source>Input Sources</source>
+        <translation>Fuentes de entrada</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7098"/>
+        <source>Input profile &apos;{}&apos; loaded.</source>
+        <translation>Perfil de entrada &apos;{}&apos; cargado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7099"/>
+        <source>Input profile &apos;{}&apos; saved.</source>
+        <translation>Perfil de entrada &apos;{}&apos; guardado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7100"/>
+        <source>Integration</source>
+        <translation>Integración</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7101"/>
+        <source>Interface Settings</source>
+        <translation>Configuración de interfaz</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7102"/>
+        <source>Internal Resolution Scale</source>
+        <translation>Escala de resolución interna</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7103"/>
+        <source>Internal Resolution Screenshots</source>
+        <translation>Capturas de pantalla a resolución interna</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7104"/>
+        <source>Issue Tracker</source>
+        <translation>Rastreador de problemas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7105"/>
+        <source>Last Played</source>
+        <translation>Última partida</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7106"/>
+        <source>Last Played: %s</source>
+        <translation>Última partida: %s</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7107"/>
+        <source>Launch a game by selecting a file/disc image.</source>
+        <translation>Inicia un juego seleccionando un archivo/imagen de disco.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7108"/>
+        <source>Launch a game from images scanned from your game directories.</source>
+        <translation>Inicia un juego desde las imágenes encontradas en tus directorios de juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7109"/>
+        <source>Leaderboard Notifications</source>
+        <translation>Notificaciones de tabla de posiciones</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7110"/>
+        <source>Leaderboards</source>
+        <translation>Tablas de posiciones</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7111"/>
+        <source>Leaderboards are not enabled.</source>
+        <translation>Tablas de posiciones deshabilitadas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7112"/>
+        <source>Limits how many frames are displayed to the screen. These frames are still rendered.</source>
+        <translation>Limita cuántos fotogramas se muestran en la pantalla. Estos fotogramas se renderizan de todos modos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7113"/>
+        <source>Load Devices From Save States</source>
+        <translation>Cargar dispositivos en estados guardados</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7114"/>
+        <source>Load Profile</source>
+        <translation>Cargar perfil</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7115"/>
+        <source>Load Resume State</source>
+        <translation>Cargar estado para resumir</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7116"/>
+        <source>Load State</source>
+        <translation>Cargar estado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7117"/>
+        <source>Loads a global save state.</source>
+        <translation>Carga un estado guardado global.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7118"/>
+        <source>Loads all replacement texture to RAM, reducing stuttering at runtime.</source>
+        <translation>Carga todos los reemplazos de textura en la memoria RAM, reduciendo entrecortes durante la ejecución.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7119"/>
+        <source>Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay.</source>
+        <translation>Carga la imagen del juego en la memoria RAM. Útil para cuando se usan directorios a través de una red.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7120"/>
+        <source>Log Level</source>
+        <translation>Nivel de registro</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7121"/>
+        <source>Log To Debug Console</source>
+        <translation>Registrar en consola de depuración</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7122"/>
+        <source>Log To File</source>
+        <translation>Registrar en archivo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7123"/>
+        <source>Log To System Console</source>
+        <translation>Registrar en consola del sistema</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7124"/>
+        <source>Logging</source>
+        <translation>Registro</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7125"/>
+        <source>Logging Settings</source>
+        <translation>Configuración de registro</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7126"/>
+        <source>Login</source>
+        <translation>Iniciar sesión</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7127"/>
+        <source>Login token generated on {}</source>
+        <translation>Token de acceso generado en {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7128"/>
+        <source>Logout</source>
+        <translation>Cerrar sesión</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7129"/>
+        <source>Logs BIOS calls to printf(). Not all games contain debugging messages.</source>
+        <translation>Registra mensajes de BIOS a printf(). No todos los juegos contienen mensajes de depuración.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7130"/>
+        <source>Logs in to RetroAchievements.</source>
+        <translation>Inicia sesión en RetroAchievements.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7131"/>
+        <source>Logs messages to duckstation.log in the user directory.</source>
+        <translation>Registra mensajes en el archivo &quot;duckstation.log&quot; dentro del directorio de usuario.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7132"/>
+        <source>Logs messages to the console window.</source>
+        <translation>Registra mensajes en la ventana de la consola.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7133"/>
+        <source>Logs messages to the debug console where supported.</source>
+        <translation>Registra mensajes en la consola de depuración cuando sea posible.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7134"/>
+        <source>Logs out of RetroAchievements.</source>
+        <translation>Cierra la sesión en RetroAchievements.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7135"/>
+        <source>Macro will toggle every {} frames.</source>
+        <translation>El macro se alternará cada {} fotogramas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7136"/>
+        <source>Macro {} Buttons</source>
+        <translation>Botones del macro {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7137"/>
+        <source>Macro {} Frequency</source>
+        <translation>Frecuencia del macro {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7138"/>
+        <source>Macro {} Trigger</source>
+        <translation>Desencadenador del macro {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7139"/>
+        <source>Makes games run closer to their console framerate, at a small cost to performance.</source>
+        <translation>Hace que los juegos tengan una fluidez más fiel a la consola, a un pequeño costo de rendimiento.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7140"/>
+        <source>Memory Card Directory</source>
+        <translation>Directorio de tarjeta de memoria</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7141"/>
+        <source>Memory Card Port {}</source>
+        <translation>Puerto {} de tarjeta de memoria</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7142"/>
+        <source>Memory Card Settings</source>
+        <translation>Configuración de tarjeta de memoria</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7143"/>
+        <source>Memory Card {} Type</source>
+        <translation>Tipo de la tarjeta de memoria {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7144"/>
+        <source>Memory card &apos;{}&apos; created.</source>
+        <translation>Tarjeta de memoria &apos;{}&apos; creada.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7145"/>
+        <source>Minimal Output Latency</source>
+        <translation>Latencia de salida mínima</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7146"/>
+        <source>Move Down</source>
+        <translation>Mover abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7147"/>
+        <source>Move Up</source>
+        <translation>Mover arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7148"/>
+        <source>Moves this shader higher in the chain, applying it earlier.</source>
+        <translation>Mueve este sombreador más arriba en la cadena, aplicándose antes.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7149"/>
+        <source>Moves this shader lower in the chain, applying it later.</source>
+        <translation>Mueve este sombreador más abajo en la cadena, aplicándose después.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7150"/>
+        <source>Multitap Mode</source>
+        <translation>Modo multitap</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7151"/>
+        <source>Mute All Sound</source>
+        <translation>Silenciar todo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7152"/>
+        <source>Mute CD Audio</source>
+        <translation>Silenciar audio de CD</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7153"/>
+        <source>No</source>
+        <translation>No</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7154"/>
+        <source>No Binding</source>
+        <translation>Sin asignar</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7155"/>
+        <source>No Buttons Selected</source>
+        <translation>No se seleccionaron botones</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7156"/>
+        <source>No Game Selected</source>
+        <translation>No se seleccionó un juego</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7157"/>
+        <source>No cheats found for {}.</source>
+        <translation>No se encontraron trucos para {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7158"/>
+        <source>No input profiles available.</source>
+        <translation>No hay perfiles de entrada disponibles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7159"/>
+        <source>No resume save state found.</source>
+        <translation>No se encontraron estados guardados para resumir.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7160"/>
+        <source>No save present in this slot.</source>
+        <translation>No hay guardado en esta ranura.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7161"/>
+        <source>No save states found.</source>
+        <translation>No se encontraron estados guardados.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7162"/>
+        <source>None (Double Speed)</source>
+        <translation>Ninguna (velocidad doble)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7163"/>
+        <source>None (Normal Speed)</source>
+        <translation>Ninguna (velocidad normal)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7164"/>
+        <source>Not Logged In</source>
+        <translation>Sesión no iniciada</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7165"/>
+        <source>Not Scanning Subdirectories</source>
+        <translation>Sin buscar en subdirectorios</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7166"/>
+        <source>OK</source>
+        <translation>Aceptar</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7167"/>
+        <source>OSD Scale</source>
+        <translation>Escala de mensajes en pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7168"/>
+        <source>On-Screen Display</source>
+        <translation>Mensajes en pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7169"/>
+        <source>Open in File Browser</source>
+        <translation>Abrir en explorador de archivos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7170"/>
+        <source>Operations</source>
+        <translation>Operaciones</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7171"/>
+        <source>Optimal Frame Pacing</source>
+        <translation>Ritmo de fotogramas óptimo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7172"/>
+        <source>Options</source>
+        <translation>Opciones</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7173"/>
+        <source>Output Latency</source>
+        <translation>Latencia de salida</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7174"/>
+        <source>Output Volume</source>
+        <translation>Volumen de salida</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7175"/>
+        <source>Overclocking Percentage</source>
+        <translation>Porcentaje de overclocking</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7176"/>
+        <source>Overlays or replaces normal triangle drawing with a wireframe/line view.</source>
+        <translation>Sobrepone o reemplaza el renderizado normal de triángulos con una visión de líneas/malla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7177"/>
+        <source>PGXP (Precision Geometry Transform Pipeline)</source>
+        <translation>PGXP (corrección de presición geométrica)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7178"/>
+        <source>PGXP Depth Clear Threshold</source>
+        <translation>Umbral de limpieza de profundidad (PGXP)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7179"/>
+        <source>PGXP Geometry Correction</source>
+        <translation>Correción de geometría (PGXP)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7180"/>
+        <source>PGXP Geometry Tolerance</source>
+        <translation>Tolerancia geométrica (PGXP)</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7181"/>
+        <source>PGXP Settings</source>
+        <translation>Configuración de PGXP</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7182"/>
+        <source>Patches</source>
+        <translation>Parches</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7183"/>
+        <source>Patches the BIOS to skip the boot animation. Safe to enable.</source>
+        <translation>Parchea el BIOS para saltar la animación de inicio de la consola. Es seguro de activar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7184"/>
+        <source>Path</source>
+        <translation>Directorio</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7185"/>
+        <source>Pause On Focus Loss</source>
+        <translation>Pausar al perder el foco</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7186"/>
+        <source>Pause On Menu</source>
+        <translation>Pausar al abrir el menú</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7187"/>
+        <source>Pause On Start</source>
+        <translation>Pausar al inicio</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7188"/>
+        <source>Pauses the emulator when a game is started.</source>
+        <translation>Pausa el emulador cuando se inicia un juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7189"/>
+        <source>Pauses the emulator when you minimize the window or switch to another application, and unpauses when you switch back.</source>
+        <translation>Pausa el emulador cuando se minimiza la ventana o se cambia a otra aplicación, y resume cuando se vuelve al emulador.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7190"/>
+        <source>Pauses the emulator when you open the quick menu, and unpauses when you close it.</source>
+        <translation>Pausa el emulador cuando se abre el menú rápido, y se reanuda al cerrarlo.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7191"/>
+        <source>Per-Game Configuration</source>
+        <translation>Configuración por juego</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7192"/>
+        <source>Per-game controller configuration initialized with global settings.</source>
+        <translation>Configuración de control por juego inicializada con la configuración global.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7193"/>
+        <source>Performance enhancement - jumps directly between blocks instead of returning to the dispatcher.</source>
+        <translation>Mejora de rendimiento: salta directamente entre bloques en lugar de volver al distribuidor.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7194"/>
+        <source>Perspective Correct Colors</source>
+        <translation>Correción de perspectiva de colores</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7195"/>
+        <source>Perspective Correct Textures</source>
+        <translation>Correción de perspectiva de texturas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7196"/>
+        <source>Plays sound effects for events such as achievement unlocks and leaderboard submissions.</source>
+        <translation>Reproduce efectos de sonido durante eventos como desbloqueo de logros y envíos a la tabla de posiciones.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7197"/>
+        <source>Port {} Controller Type</source>
+        <translation>Tipo de control del puerto {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7198"/>
+        <source>Position</source>
+        <translation>Posición</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7199"/>
+        <source>Post-Processing Settings</source>
+        <translation>Configuración de postprocesamiento</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7200"/>
+        <source>Post-processing chain cleared.</source>
+        <translation>Cadena de postprocesamiento eliminada.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7201"/>
+        <source>Post-processing shaders reloaded.</source>
+        <translation>Sombreadores de postprocesamiento recargados.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7202"/>
+        <source>Preload Images to RAM</source>
+        <translation>Precargar imágenes a RAM</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7203"/>
+        <source>Preload Replacement Textures</source>
+        <translation>Precargar reemplazos de textura</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7204"/>
+        <source>Presents frames on a background thread when fast forwarding or vsync is disabled.</source>
+        <translation>Presenta los fotogramas en un hilo en segundo plano durante el avance rápido o si la sincronización vertical está deshabilitada.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7205"/>
+        <source>Preserve Projection Precision</source>
+        <translation>Preservar la precisión de proyección</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7206"/>
+        <source>Prevents the emulator from producing any audible sound.</source>
+        <translation>Impide que el emulador produzca cualquier sonido.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7207"/>
+        <source>Prevents the screen saver from activating and the host from sleeping while emulation is running.</source>
+        <translation>Evita que se active el salvapantallas y se suspenda el sistema cuando el emulador se esté ejecutando.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7208"/>
+        <source>Provides vibration and LED control support over Bluetooth.</source>
+        <translation>Ofrece soporte para vibración y controles LED a través de Bluetooth.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7209"/>
+        <source>Push a controller button or axis now.</source>
+        <translation>Presiona un botón o eje del control ahora.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7210"/>
+        <source>Quick Save</source>
+        <translation>Guardado rápido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7211"/>
+        <source>RAIntegration is being used instead of the built-in achievements implementation.</source>
+        <translation>Se está utilizando RAIntegration en lugar de la implementación de logros incluída.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7212"/>
+        <source>Read Speedup</source>
+        <translation>Aceleración de lectura</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7213"/>
+        <source>Readahead Sectors</source>
+        <translation>Sectores de lectura asincrónica</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7214"/>
+        <source>Recompiler Fast Memory Access</source>
+        <translation>Memoria de acceso rápido del recompilador</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7215"/>
+        <source>Reduces &quot;wobbly&quot; polygons by attempting to preserve the fractional component through memory transfers.</source>
+        <translation>Reduce el efecto tembloroso de los polígonos al intentar mantener el componente fraccionario durante las transferencias de memoria.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7216"/>
+        <source>Reduces hitches in emulation by reading/decompressing CD data asynchronously on a worker thread.</source>
+        <translation>Reduce tirones durante la emulación al leer/descomprimir datos del CD de forma asincrónica en un hilo separado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7217"/>
+        <source>Reduces polygon Z-fighting through depth testing. Low compatibility with games.</source>
+        <translation>Reduce conflictos de planos entre polígonos en el búfer Z mediante la comprobación de profundidad. Baja compatibilidad con juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7218"/>
+        <source>Region</source>
+        <translation>Región</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7219"/>
+        <source>Region: </source>
+        <translation>Región: </translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7220"/>
+        <source>Release Date: %s</source>
+        <translation>Fecha de lanzamiento: %s</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7221"/>
+        <source>Reload Shaders</source>
+        <translation>Recargar sombreadores</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7222"/>
+        <source>Reloads the shaders from disk, applying any changes.</source>
+        <translation>Recarga los sombreadores desde el disco, aplicando cualquier cambio.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7223"/>
+        <source>Remove From Chain</source>
+        <translation>Eliminar de la cadena</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7224"/>
+        <source>Remove From List</source>
+        <translation>Eliminar de la lista</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7225"/>
+        <source>Removed stage {} ({}).</source>
+        <translation>Etapa {} ({}) eliminada.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7226"/>
+        <source>Removes this shader from the chain.</source>
+        <translation>Elimina este sombreador de la cadena.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7227"/>
+        <source>Renames existing save states when saving to a backup file.</source>
+        <translation>Renombra estados guardados existentes al guardar a un archivo de copia de seguridad.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7228"/>
+        <source>Rendering</source>
+        <translation>Renderizado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7229"/>
+        <source>Replaces these settings with a previously saved input profile.</source>
+        <translation>Reemplaza esta configuración con un perfil de control guardado anteriormente.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7230"/>
+        <source>Rescan All Games</source>
+        <translation>Volver a buscar todos los juegos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7231"/>
+        <source>Reset Memory Card Directory</source>
+        <translation>Reiniciar directorio de tarjeta de memoria</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7232"/>
+        <source>Reset Play Time</source>
+        <translation>Reiniciar tiempo de juego</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7233"/>
+        <source>Reset Settings</source>
+        <translation>Restablecer configuración</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7234"/>
+        <source>Reset System</source>
+        <translation>Reiniciar sistema</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7235"/>
+        <source>Resets all configuration to defaults (including bindings).</source>
+        <translation>Restablece toda la configuracion a los valores predeterminados (incluyendo asignaciones).</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7236"/>
+        <source>Resets memory card directory to default (user directory).</source>
+        <translation>Restablece el directorio de tarjeta de memoria al valor predeterminado (directorio de usuario).</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7237"/>
+        <source>Resolution change will be applied after restarting.</source>
+        <translation>El cambio de resolución se aplicará después de reiniciar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7238"/>
+        <source>Restores the state of the system prior to the last state loaded.</source>
+        <translation>Restablece el estado del sistema anterior al último estado cargado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7239"/>
+        <source>Resume</source>
+        <translation>Resumir</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7240"/>
+        <source>Resume Game</source>
+        <translation>Resumir juego</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7241"/>
+        <source>Rewind Save Frequency</source>
+        <translation>Frecuencia de guardado del rebobinado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7242"/>
+        <source>Rewind Save Slots</source>
+        <translation>Ranuras de guardado del rebobinado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7243"/>
+        <source>Rewind for {0} frames, lasting {1:.2f} seconds will require up to {3} MB of RAM and {4} MB of VRAM.</source>
+        <translation>Rebobinar por {0} fotogramas, durante {1:.2f} segundo(s) requerirá hasta {3}MB de RAM y {4}MB de VRAM.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7244"/>
+        <source>Rich presence inactive or unsupported.</source>
+        <translation>Rich Presence está inactiva o es incompatible.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7245"/>
+        <source>Runahead</source>
+        <translation>Procesamiento anticipado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7246"/>
+        <source>Runahead/Rewind</source>
+        <translation>Rebobinado/Procesamiento anticipado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7247"/>
+        <source>Runs the software renderer in parallel for VRAM readbacks. On some systems, this may result in greater performance.</source>
+        <translation>Ejecuta el renderizador de software en paralelo para lecturas de VRAM. En algunos sistemas, esto puede resultar en un mayor rendimiento.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7248"/>
+        <source>SDL DualShock 4 / DualSense Enhanced Mode</source>
+        <translation>Modo mejorado para DualShock 4/DualSense de SDL</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7249"/>
+        <source>Save Profile</source>
+        <translation>Guardar perfil</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7250"/>
+        <source>Save Screenshot</source>
+        <translation>Capturar pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7251"/>
+        <source>Save State</source>
+        <translation>Guardar estado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7252"/>
+        <source>Save State On Exit</source>
+        <translation>Guardar estado al salir</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7253"/>
+        <source>Saved {:%c}</source>
+        <translation>Guardado {:%c}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7254"/>
+        <source>Saves screenshots at internal render resolution and without postprocessing.</source>
+        <translation>Guarda las capturas de pantalla con la resolución de renderizado interna y sin postprocesamiento.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7255"/>
+        <source>Saves state periodically so you can rewind any mistakes while playing.</source>
+        <translation>Guarda estados periódicamente para poder rebobinar/retroceder en el tiempo mientras juegas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7256"/>
+        <source>Scaled Dithering</source>
+        <translation>Escalado de tramado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7257"/>
+        <source>Scales internal VRAM resolution by the specified multiplier. Some games require 1x VRAM resolution.</source>
+        <translation>Escala la resolución de la VRAM interna por el multiplicador especificado. Algunos juegos requieren una resolución de VRAM de 1x.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7258"/>
+        <source>Scales the dithering pattern with the internal rendering resolution, making it less noticeable. Usually safe to enable.</source>
+        <translation>Escala el patrón del tramado con la resolución de renderizado interna, provocando que se note menos. Generalmente es seguro de habilitar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7259"/>
+        <source>Scaling</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7260"/>
+        <source>Scan For New Games</source>
+        <translation>Buscar juegos nuevos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7261"/>
+        <source>Scanning Subdirectories</source>
+        <translation>Buscando subdirectorios</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7262"/>
+        <source>Screen Display</source>
+        <translation>Imagen</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7263"/>
+        <source>Search Directories</source>
+        <translation>Buscar directorios</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7264"/>
+        <source>Seek Speedup</source>
+        <translation>Aceleración de búsqueda</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7265"/>
+        <source>Select Device</source>
+        <translation>Seleccionar dispositivo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7266"/>
+        <source>Select Disc Image</source>
+        <translation>Seleccionar imagen de disco</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7267"/>
+        <source>Select Macro {} Binds</source>
+        <translation>Seleccionar asignaciones del macro {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7268"/>
+        <source>Selects the GPU to use for rendering.</source>
+        <translation>Selecciona la GPU a utilizar para el renderizado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7269"/>
+        <source>Selects the percentage of the normal clock speed the emulated hardware will run at.</source>
+        <translation>Selecciona el porcentaje de velocidad de reloj normal en el cual se ejecutará el hardware emulado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7270"/>
+        <source>Selects the resolution scale that will be applied to the final image. 1x will downsample to the original console resolution.</source>
+        <translation>Selecciona la escala de resolución que se aplicará a la imagen final. 1x escalará a la resolución original de la consola.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7271"/>
+        <source>Selects the resolution to use in fullscreen modes.</source>
+        <translation>Selecciona la resolución a utilizar en el modo a pantalla completa.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7272"/>
+        <source>Serial</source>
+        <translation>Número de serie</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7273"/>
+        <source>Session: {}</source>
+        <translation>Sesión: {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7274"/>
+        <source>Set Input Binding</source>
+        <translation>Establecer asignación de entrada</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7275"/>
+        <source>Set VRAM Write Dump Alpha Channel</source>
+        <translation>Establecer el canal alfa de la escritura de VRAM volcada</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7276"/>
+        <source>Sets a threshold for discarding precise values when exceeded. May help with glitches in some games.</source>
+        <translation>Establece un límite para descartar valores precisos cuendo se excedan. Puede ayudar a corregir defectos en algunos juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7277"/>
+        <source>Sets a threshold for discarding the emulated depth buffer. May help in some games.</source>
+        <translation>Establece un límite para descartar el búfer de profundidad emulado. Puede ayudar en algunos juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7278"/>
+        <source>Sets the fast forward speed. It is not guaranteed that this speed will be reached on all systems.</source>
+        <translation>Determina la velocidad del avance rápido. No se asegura que esa velocidad se vaya a alcanzar en todos los sistemas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7279"/>
+        <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached on all systems.</source>
+        <translation>Establece la velocidad de emulación de destino. No se asegura que esa velocidad se vaya a alcanzar en todos los sistemas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7280"/>
+        <source>Sets the turbo speed. It is not guaranteed that this speed will be reached on all systems.</source>
+        <translation>Determina la velocidad del modo turbo. No se asegura que esa velocidad se vaya a alcanzar en todos los sistemas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7281"/>
+        <source>Sets the verbosity of messages logged. Higher levels will log more messages.</source>
+        <translation>Establece el nivel de detalle de los mensajes en el registro. Niveles más altos mostrarán más mensajes.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7282"/>
+        <source>Sets which sort of memory card image will be used for slot {}.</source>
+        <translation>Establece que tipo de imagen de tarjeta de memoria se utilizará para la ranura {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7283"/>
+        <source>Setting {} binding {}.</source>
+        <translation>Configurando la asignación para el {} {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7284"/>
+        <source>Settings</source>
+        <translation>Configuración</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7285"/>
+        <source>Settings and Operations</source>
+        <translation>Configuración y operaciones</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7286"/>
+        <source>Shader {} added as stage {}.</source>
+        <translation>Sombreador {} añadido como etapa {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7287"/>
+        <source>Shared Card Name</source>
+        <translation>Nombre de la tarjeta de memoria compartida</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7288"/>
+        <source>Show CPU Usage</source>
+        <translation>Mostrar uso de la CPU</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7289"/>
+        <source>Show Controller Input</source>
+        <translation>Mostrar entrada del control</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7290"/>
+        <source>Show Enhancement Settings</source>
+        <translation>Mostrar configuración de mejoras</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7291"/>
+        <source>Show FPS</source>
+        <translation>Mostrar FPS</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7292"/>
+        <source>Show Frame Times</source>
+        <translation>Mostrar duración de fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7293"/>
+        <source>Show GPU Usage</source>
+        <translation>Mostrar uso de la GPU</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7294"/>
+        <source>Show OSD Messages</source>
+        <translation>Mostrar mensajes en pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7295"/>
+        <source>Show Resolution</source>
+        <translation>Mostrar resolución</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7296"/>
+        <source>Show Speed</source>
+        <translation>Mostrar velocidad</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7297"/>
+        <source>Show Status Indicators</source>
+        <translation>Mostrar indicadores de estado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7298"/>
+        <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
+        <translation>Muestra un historial visual de los tiempos de fotogramas en la esquina superior izquierda de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7299"/>
+        <source>Shows enhancement settings in the bottom-right corner of the screen.</source>
+        <translation>Muestra la configuración de mejoras en la esquina inferior derecha de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7300"/>
+        <source>Shows icons in the lower-right corner of the screen when a challenge/primed achievement is active.</source>
+        <translation>Muestra iconos en la esquina inferior derecha de la pantalla cuando un logro &quot;desafío&quot; esté activo.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7301"/>
+        <source>Shows on-screen-display messages when events occur.</source>
+        <translation>Muestra mensajes en pantalla cuando ocurran eventos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7302"/>
+        <source>Shows persistent icons when turbo is active or when paused.</source>
+        <translation>Muestra iconos persistentes cuando el modo turbo está habilitado o al pausar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7303"/>
+        <source>Shows the current controller state of the system in the bottom-left corner of the display.</source>
+        <translation>Muestra el estado actual del control del sistema en la esquina inferior izquierda de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7304"/>
+        <source>Shows the current emulation speed of the system in the top-right corner of the display as a percentage.</source>
+        <translation>Muestra el porcentaje de velocidad de emulación actual del sistema en la esquina superior derecha de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7305"/>
+        <source>Shows the current rendering resolution of the system in the top-right corner of the display.</source>
+        <translation>Muestra la resolución de renderizado actual del sistema en la esquina superior derecha de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7306"/>
+        <source>Shows the host&apos;s CPU usage based on threads in the top-right corner of the display.</source>
+        <translation>Muestra la utilización de la CPU del sistema por hilos en la esquina superior derecha de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7307"/>
+        <source>Shows the host&apos;s GPU usage in the top-right corner of the display.</source>
+        <translation>Muestra la utilización de la GPU del sistema en la esquina superior derecha de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7308"/>
+        <source>Shows the number of frames (or v-syncs) displayed per second by the system in the top-right corner of the display.</source>
+        <translation>Muestra el número de fotogramas (o sincronizaciones verticales) presentados por segundo por el sistema en la esquina superior derecha de la pantalla.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7309"/>
+        <source>Simulates the CPU&apos;s instruction cache in the recompiler. Can help with games running too fast.</source>
+        <translation>Simula el caché de instrucciones de la CPU en el recompilador. Puede ayudar cuando los juegos funcionen demasiado rápido.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7310"/>
+        <source>Simulates the region check present in original, unmodified consoles.</source>
+        <translation>Simula el chequeo regional presente en consolas originales sin modificar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7311"/>
+        <source>Simulates the system ahead of time and rolls back/replays to reduce input lag. Very high system requirements.</source>
+        <translation>Simula el sistema de forma anticipada y regresa/repite el estado para reducir la latencia de entrada. Tiene requerimientos de sistema muy altos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7312"/>
+        <source>Size</source>
+        <translation>Tamaño</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7313"/>
+        <source>Size: %.2f MB</source>
+        <translation>Tamaño: %.2f MB</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7314"/>
+        <source>Slow Boot</source>
+        <translation>Inicio lento</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7315"/>
+        <source>Smooths out blockyness between colour transitions in 24-bit content, usually FMVs. Only applies to the hardware renderers.</source>
+        <translation>Suaviza el aspecto pixelado que se produce entre las transiciones de colores en contenido de 24 bits, generalmente en FMVs. Solo se aplica a los renderizadores por hardware.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7316"/>
+        <source>Smooths out the blockiness of magnified textures on 3D objects.</source>
+        <translation>Suaviza el aspecto pixelado de las texturas magnificadas en objetos 3D.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7317"/>
+        <source>Sort By</source>
+        <translation>Ordenar por</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7318"/>
+        <source>Sort Reversed</source>
+        <translation>Invertir orden</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7319"/>
+        <source>Sound Effects</source>
+        <translation>Efectos de sonido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7320"/>
+        <source>Spectator Mode</source>
+        <translation>Modo espectador</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7321"/>
+        <source>Speed Control</source>
+        <translation>Control de velocidad</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7322"/>
+        <source>Speeds up CD-ROM reads by the specified factor. May improve loading speeds in some games, and break others.</source>
+        <translation>Acelera las lecturas del CD-ROM por el valor especificado. Puede mejorar los tiempos de carga en algunos juegos, mientras que puede producir fallos en otros.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7323"/>
+        <source>Speeds up CD-ROM seeks by the specified factor. May improve loading speeds in some games, and break others.</source>
+        <translation>Acelera las búsquedas del CD-ROM por el valor especificado. Puede mejorar los tiempos de carga en algunos juegos, mientras que puede producir fallos en otros.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7324"/>
+        <source>Stage {}: {}</source>
+        <translation>Etapa {}: {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7325"/>
+        <source>Start BIOS</source>
+        <translation>Iniciar BIOS</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7326"/>
+        <source>Start Download</source>
+        <translation>Iniciar descarga</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7327"/>
+        <source>Start File</source>
+        <translation>Iniciar archivo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7328"/>
+        <source>Start Fullscreen</source>
+        <translation>Iniciar en pantalla completa</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7329"/>
+        <source>Start the console without any disc inserted.</source>
+        <translation>Iniciar la consola sin ningún disco.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7330"/>
+        <source>Starts the console from where it was before it was last closed.</source>
+        <translation>Inicia la consola desde donde se dejó la última vez que se cerró.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7331"/>
+        <source>Stores the current settings to an input profile.</source>
+        <translation>Almacena la configuración actual en un perfil de entrada.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7332"/>
+        <source>Stretch Display Vertically</source>
+        <translation>Estirar imagen verticalmente</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7333"/>
+        <source>Stretch Mode</source>
+        <translation>Modo de estiramiento</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7334"/>
+        <source>Stretches the display to match the aspect ratio by multiplying vertically instead of horizontally.</source>
+        <translation>Estira la imagen para que coincida con la relación de aspecto al multiplicar verticalmente en lugar de horizontalmente.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7335"/>
+        <source>Summary</source>
+        <translation>Resumen</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7336"/>
+        <source>Switches back to 4:3 display aspect ratio when displaying 24-bit content, usually FMVs.</source>
+        <translation>Cambia al modo de pantalla 4:3 cuando se muestra contenido de 24 bits, generalmente FMVs.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7337"/>
+        <source>Switches between full screen and windowed when the window is double-clicked.</source>
+        <translation>Cambia entre pantalla completa y ventana al hacer doble clic en la misma.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7338"/>
+        <source>Sync To Host Refresh Rate</source>
+        <translation>Sincronizar al refresco de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7339"/>
+        <source>Synchronizes presentation of the console&apos;s frames to the host. Enable for smoother animations.</source>
+        <translation>Sincroniza la presentación de los fotogramas de la consola con el sistema .Habilitar para animaciones más fluídas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7340"/>
+        <source>Temporarily disables all enhancements, useful when testing.</source>
+        <translation>Deshabilita temporalmente todas las mejoras, útil para hacer pruebas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7341"/>
+        <source>Test Unofficial Achievements</source>
+        <translation>Probar logros no oficiales</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7342"/>
+        <source>Texture Dumping</source>
+        <translation>Volcado de texturas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7343"/>
+        <source>Texture Filtering</source>
+        <translation>Filtrado de texturas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7344"/>
+        <source>Texture Replacements</source>
+        <translation>Reemplazos de textura</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7345"/>
+        <source>The SDL input source supports most controllers.</source>
+        <translation>La fuente de entrada SDL soporta la mayoría de controles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7346"/>
+        <source>The XInput source provides support for XBox 360/XBox One/XBox Series controllers.</source>
+        <translation>La fuente de XInput permite el uso de controles de Xbox 360/Xbox One/Xbox Series.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7347"/>
+        <source>The audio backend determines how frames produced by the emulator are submitted to the host.</source>
+        <translation>El motor de audio determina como los fotogramas producidos por el emulador son enviados al sistema.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7348"/>
+        <source>The selected memory card image will be used in shared mode for this slot.</source>
+        <translation>La imagen de tarjeta de memoria seleccionada se utilizará en modo compartido para esta ranura.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7349"/>
+        <source>This game has no achievements.</source>
+        <translation>No hay logros para este juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7350"/>
+        <source>This game has no leaderboards.</source>
+        <translation>No hay tablas de posiciones para este juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7351"/>
+        <source>Threaded Presentation</source>
+        <translation>Hilo de presentación</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7352"/>
+        <source>Threaded Rendering</source>
+        <translation>Hilo de renderizado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7353"/>
+        <source>Time Played</source>
+        <translation>Tiempo jugado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7354"/>
+        <source>Time Played: %s</source>
+        <translation>Tiempo jugado: %s</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7355"/>
+        <source>Timing out in {:.0f} seconds...</source>
+        <translation>Quedando fuera en {:.0f} segundos...</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7356"/>
+        <source>Title</source>
+        <translation>Título</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7357"/>
+        <source>Toggle Analog</source>
+        <translation>Alternar analógico</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7358"/>
+        <source>Toggle Fast Forward</source>
+        <translation>Alternar avance rápido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7359"/>
+        <source>Toggle every %d frames</source>
+        <translation>Alternar cada %d fotogramas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7360"/>
+        <source>True Color Rendering</source>
+        <translation>Renderizado de color verdadero</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7361"/>
+        <source>Turbo Speed</source>
+        <translation>Velocidad turbo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7362"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7363"/>
+        <source>Undo Load State</source>
+        <translation>Deshacer estado cargado</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7364"/>
+        <source>Unknown</source>
+        <translation>Desconocido</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7365"/>
+        <source>Unlimited</source>
+        <translation>Sin límite</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7366"/>
+        <source>Use Blit Swap Chain</source>
+        <translation>Utilizar cadena de intercambio de blits</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7367"/>
+        <source>Use Debug GPU Device</source>
+        <translation>Utilizar dispositivo gráfico de depuración</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7368"/>
+        <source>Use Global Setting</source>
+        <translation>Utilizar configuración global</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7369"/>
+        <source>Use Light Theme</source>
+        <translation>Utilizar tema claro</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7370"/>
+        <source>Use Serial File Names</source>
+        <translation>Utilizar número de serie como nombres de archivo</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7371"/>
+        <source>Use Single Card For Multi-Disc Games</source>
+        <translation>Utilizar tarjeta única para juegos de múltiples discos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7372"/>
+        <source>Use Software Renderer For Readbacks</source>
+        <translation>Utilizar renderizador por software para lecturas</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7373"/>
+        <source>Username: {}</source>
+        <translation>Nombre de usuario: {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7374"/>
+        <source>Uses PGXP for all instructions, not just memory operations.</source>
+        <translation>Utiliza PGXP para todas las instrucciones, no solamente operaciones de memoria.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7375"/>
+        <source>Uses a blit presentation model instead of flipping. This may be needed on some systems.</source>
+        <translation>Utiliza un modelo de presentación blit en lugar de voltear. Puede ser necesario en algunos sistemas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7376"/>
+        <source>Uses a light coloured theme instead of the default dark theme.</source>
+        <translation>Utiliza un tema de colores claros en lugar del tema oscuro predeterminado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7377"/>
+        <source>Uses a second thread for drawing graphics. Speed boost, and safe to use.</source>
+        <translation>Utiliza un segundo hilo para dibujar los gráficos. Aumenta la velocidad, y es seguro de activar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7378"/>
+        <source>Uses game-specific settings for controllers for this game.</source>
+        <translation>Utiliza una configuración de controles específica para este juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7379"/>
+        <source>Uses perspective-correct interpolation for colors, which can improve visuals in some games.</source>
+        <translation>Utiliza interpolación con perspectiva correcta para los colores, lo cual puede mejorar la calidad visual en algunos juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7380"/>
+        <source>Uses perspective-correct interpolation for texture coordinates, straightening out warped textures.</source>
+        <translation>Utiliza interpolación con perspectiva correcta para las coordenadas de texturas, enderezando texturas deformadas.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7381"/>
+        <source>Uses screen positions to resolve PGXP data. May improve visuals in some games.</source>
+        <translation>Utiliza posiciones de pantalla para resolver los datos de PGXP. Puede mejorar el aspecto visual en algunos juegos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7382"/>
+        <source>Value: {} | Default: {} | Minimum: {} | Maximum: {}</source>
+        <translation>Valor: {} | Predeterminado: {} | Mínimo: {} | Máximo: {}</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7383"/>
+        <source>When enabled and logged in, DuckStation will scan for achievements on startup.</source>
+        <translation>Cuando esté habilitado y se haya iniciado sesión, DuckStation buscará logros al iniciarse.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7384"/>
+        <source>When enabled, DuckStation will assume all achievements are locked and not send any unlock notifications to the server.</source>
+        <translation>Cuando esté habilitado, DuckStation asumirá que todos los logros están bloqueados, y no enviará ninguna notificación de desbloqueo al servidor.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7385"/>
+        <source>When enabled, DuckStation will list achievements from unofficial sets. These achievements are not tracked by RetroAchievements.</source>
+        <translation>Cuando esté habilitado, DuckStation listará logros no oficiales. RetroAchievements no rastreará estos logros.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7386"/>
+        <source>When enabled, each session will behave as if no achievements have been unlocked.</source>
+        <translation>Cuando esté habilitado, cada sesión se tratará como si no se hubiese desbloqueado ningún logro.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7387"/>
+        <source>When enabled, memory cards and controllers will be overwritten when save states are loaded.</source>
+        <translation>Cuando se habilita, los controles y tarjetas de memoria se sobrescribirán cuando se carguen estados guardados.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7388"/>
+        <source>When enabled, per-game settings will be applied, and incompatible enhancements will be disabled.</source>
+        <translation>Cuando se habilita, se aplicarán las configuraciones por juego, y se desactivarán las mejoras incompatibles.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7389"/>
+        <source>When enabled, the minimum supported output latency will be used for the host API.</source>
+        <translation>Cuando se habilita, se utilizará la latencia de salida mínima soportada para la API del sistema.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7390"/>
+        <source>When playing a multi-disc game and using per-game (title) memory cards, use a single memory card for all discs.</source>
+        <translation>Cuando se ejecute un juego de múltiples discos y se utilicen tarjetas de memoria por juego, se utilizará una única tarjeta para todos los discos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7391"/>
+        <source>When this option is chosen, the clock speed set below will be used.</source>
+        <translation>Cuando se habilite esta opción, se utilizará la velocidad de reloj seleccionada.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7392"/>
+        <source>Wireframe Rendering</source>
+        <translation>Renderizado de mallas de polígonos</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7393"/>
+        <source>Writes textures which can be replaced to the dump directory.</source>
+        <translation>Escribe las texturas que pueden ser reemplazadas en el directorio de volcado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7394"/>
+        <source>Yes</source>
+        <translation>Sí</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7395"/>
+        <source>&quot;Challenge&quot; mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions.</source>
+        <translation>Modo &quot;desafío&quot; para los logros, incluyendo el seguimiento de tablas de posiciones. Deshabilita los estados guardados, trucos y funciones de ralentización.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7396"/>
+        <source>&quot;PlayStation&quot; and &quot;PSX&quot; are registered trademarks of Sony Interactive Entertainment Europe Limited. This software is not affiliated in any way with Sony Interactive Entertainment.</source>
+        <translation>&quot;PlayStation&quot; y &quot;PSX&quot; son marcas registradas de Sony Interactive Entertainment Europe Limited. Este software no está afiliado de ninguna manera con Sony Interactive Entertainment.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7397"/>
+        <source>{} deleted.</source>
+        <translation>{} eliminado.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7398"/>
+        <source>{} does not exist.</source>
+        <translation>{} no existe.</translation>
+    </message>
+    <message>
+        <location filename="../../core/fullscreen_ui.cpp" line="7399"/>
+        <source>{} is not a valid disc image.</source>
+        <translation>{} no es una imagen de disco válida.</translation>
+    </message>
+</context>
+<context>
+    <name>GPUDevice</name>
+    <message>
+        <location filename="../../util/opengl_device.cpp" line="318"/>
+        <location filename="../../util/opengl_device.cpp" line="479"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../../util/opengl_device.cpp" line="319"/>
+        <source>OpenGL renderer unavailable, your driver or hardware is not recent enough. OpenGL 3.1 or OpenGL ES 3.1 is required.</source>
+        <translation>Renderizador de OpenGL no disponible, tu hardware o controladores no son lo suficientemente modernos. Se requiere de OpenGL 3.1 o de OpenGL ES 3.1.</translation>
+    </message>
+</context>
+<context>
+    <name>GPUDownsampleMode</name>
+    <message>
+        <location filename="../../core/settings.cpp" line="1019"/>
+        <source>Disabled</source>
+        <translation>Deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1020"/>
         <source>Box (Downsample 3D/Smooth All)</source>
         <translation>Cuadro (submuestreo 3D/suavizar todo)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="988"/>
+        <location filename="../../core/settings.cpp" line="1021"/>
         <source>Adaptive (Preserve 3D/Smooth 2D)</source>
         <translation>Adaptable (preservar 3D/suavizar 2D)</translation>
     </message>
@@ -5067,27 +8874,38 @@ Logros: %5 (%6)
 <context>
     <name>GPURenderer</name>
     <message>
-        <location filename="../../core/settings.cpp" line="894"/>
+        <location filename="../../core/settings.cpp" line="914"/>
+        <source>Automatic</source>
+        <translation>Automático</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="916"/>
         <source>Hardware (D3D11)</source>
         <translation>Hardware (D3D11)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="894"/>
+        <location filename="../../core/settings.cpp" line="916"/>
         <source>Hardware (D3D12)</source>
         <translation>Hardware (D3D12)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="897"/>
+        <location filename="../../core/settings.cpp" line="919"/>
+        <source>Hardware (Metal)</source>
+        <translation>Hardware (Metal)</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="922"/>
         <source>Hardware (Vulkan)</source>
         <translation>Hardware (Vulkan)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="900"/>
+        <location filename="../../core/settings.cpp" line="925"/>
         <source>Hardware (OpenGL)</source>
         <translation>Hardware (OpenGL)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="902"/>
+        <location filename="../qthost.cpp" line="1502"/>
+        <location filename="../../core/settings.cpp" line="927"/>
         <source>Software</source>
         <translation>Software</translation>
     </message>
@@ -5095,102 +8913,102 @@ Logros: %5 (%6)
 <context>
     <name>GPUSettingsWidget</name>
     <message>
-        <location filename="../qtutils.cpp" line="696"/>
+        <location filename="../qtutils.cpp" line="698"/>
         <source>Automatic based on window size</source>
         <translation>Automático según el tamaño de la ventana</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="697"/>
+        <location filename="../qtutils.cpp" line="699"/>
         <source>1x</source>
         <translation>1x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="698"/>
+        <location filename="../qtutils.cpp" line="700"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="699"/>
+        <location filename="../qtutils.cpp" line="701"/>
         <source>3x (for 720p)</source>
         <translation>3x (para 720p)</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="700"/>
+        <location filename="../qtutils.cpp" line="702"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="701"/>
+        <location filename="../qtutils.cpp" line="703"/>
         <source>5x (for 1080p)</source>
         <translation>5x (para 1080p)</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="702"/>
+        <location filename="../qtutils.cpp" line="704"/>
         <source>6x (for 1440p)</source>
         <translation>6x (para 1440p)</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="703"/>
+        <location filename="../qtutils.cpp" line="705"/>
         <source>7x</source>
         <translation>7x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="704"/>
+        <location filename="../qtutils.cpp" line="706"/>
         <source>8x</source>
         <translation>8x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="705"/>
+        <location filename="../qtutils.cpp" line="707"/>
         <source>9x (for 4K)</source>
         <translation>9x (para 4K)</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="706"/>
+        <location filename="../qtutils.cpp" line="708"/>
         <source>10x</source>
         <translation>10x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="707"/>
+        <location filename="../qtutils.cpp" line="709"/>
         <source>11x</source>
         <translation>11x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="708"/>
+        <location filename="../qtutils.cpp" line="710"/>
         <source>12x</source>
         <translation>12x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="709"/>
+        <location filename="../qtutils.cpp" line="711"/>
         <source>13x</source>
         <translation>13x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="710"/>
+        <location filename="../qtutils.cpp" line="712"/>
         <source>14x</source>
         <translation>14x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="711"/>
+        <location filename="../qtutils.cpp" line="713"/>
         <source>15x</source>
         <translation>15x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="712"/>
+        <location filename="../qtutils.cpp" line="714"/>
         <source>16x</source>
         <translation>16x</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="738"/>
+        <location filename="../qtutils.cpp" line="740"/>
         <source>Disabled</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="741"/>
+        <location filename="../qtutils.cpp" line="743"/>
         <source>%1x MSAA</source>
         <translation>%1x MSAA</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="744"/>
+        <location filename="../qtutils.cpp" line="746"/>
         <source>%1x SSAA</source>
         <translation>%1x SSAA</translation>
     </message>
@@ -5198,110 +9016,128 @@ Logros: %5 (%6)
 <context>
     <name>GPUTextureFilter</name>
     <message>
-        <location filename="../../core/settings.cpp" line="955"/>
+        <location filename="../../core/settings.cpp" line="985"/>
         <source>Nearest-Neighbor</source>
         <translation>Punto más cercano</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="955"/>
+        <location filename="../../core/settings.cpp" line="986"/>
         <source>Bilinear</source>
         <translation>Bilinear</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="956"/>
+        <location filename="../../core/settings.cpp" line="987"/>
         <source>Bilinear (No Edge Blending)</source>
         <translation>Bilinear (sin unión de bordes)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="956"/>
+        <location filename="../../core/settings.cpp" line="988"/>
         <source>JINC2 (Slow)</source>
         <translation>JINC2 (lento)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="957"/>
+        <location filename="../../core/settings.cpp" line="989"/>
         <source>JINC2 (Slow, No Edge Blending)</source>
         <translation>JINC2 (lento, sin unión de bordes)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="958"/>
+        <location filename="../../core/settings.cpp" line="990"/>
         <source>xBR (Very Slow)</source>
         <translation>xBR (muy lento)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="959"/>
+        <location filename="../../core/settings.cpp" line="991"/>
         <source>xBR (Very Slow, No Edge Blending)</source>
         <translation>xBR (muy lento, sin unión de bordes)</translation>
     </message>
 </context>
 <context>
+    <name>GPUWireframeMode</name>
+    <message>
+        <location filename="../../core/settings.cpp" line="1049"/>
+        <source>Disabled</source>
+        <translation>Deshabilitado</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1049"/>
+        <source>Overlay Wireframe</source>
+        <translation>Superponer mallas</translation>
+    </message>
+    <message>
+        <location filename="../../core/settings.cpp" line="1050"/>
+        <source>Only Wireframe</source>
+        <translation>Mostrar solo mallas</translation>
+    </message>
+</context>
+<context>
     <name>GameList</name>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="102"/>
+        <location filename="../../core/game_list.cpp" line="106"/>
         <source>Disc</source>
         <translation>Disco</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="102"/>
+        <location filename="../../core/game_list.cpp" line="106"/>
         <source>PS-EXE</source>
         <translation>PS-EXE</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="102"/>
+        <location filename="../../core/game_list.cpp" line="106"/>
         <source>Playlist</source>
         <translation>Lista de reproducción</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="103"/>
+        <location filename="../../core/game_list.cpp" line="107"/>
         <source>PSF</source>
         <translation>PSF</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="951"/>
+        <location filename="../../core/game_list.cpp" line="968"/>
         <source>Never</source>
         <translation>Nunca</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="968"/>
+        <location filename="../../core/game_list.cpp" line="985"/>
         <source>Today</source>
         <translation>Hoy</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="973"/>
+        <location filename="../../core/game_list.cpp" line="990"/>
         <source>Yesterday</source>
         <translation>Ayer</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="996"/>
+        <location filename="../../core/game_list.cpp" line="1013"/>
         <source>{}h {}m</source>
         <translation>{}h {}m</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="998"/>
+        <location filename="../../core/game_list.cpp" line="1015"/>
         <source>{}h {}m {}s</source>
         <translation>{}h {}m {}s</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="1000"/>
+        <location filename="../../core/game_list.cpp" line="1017"/>
         <source>{}m {}s</source>
         <translation>{}m {}s</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="1002"/>
+        <location filename="../../core/game_list.cpp" line="1019"/>
         <source>{}s</source>
         <translation>{}s</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="1004"/>
+        <location filename="../../core/game_list.cpp" line="1021"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="1009"/>
+        <location filename="../../core/game_list.cpp" line="1026"/>
         <source>{} hours</source>
         <translation>{} horas</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/game_list.cpp" line="1011"/>
+        <location filename="../../core/game_list.cpp" line="1028"/>
         <source>{} minutes</source>
         <translation>{} minutos</translation>
     </message>
@@ -5309,32 +9145,32 @@ Logros: %5 (%6)
 <context>
     <name>GameListCompatibilityRating</name>
     <message>
-        <location filename="../../core/game_database.cpp" line="207"/>
+        <location filename="../../core/game_database.cpp" line="196"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="208"/>
+        <location filename="../../core/game_database.cpp" line="197"/>
         <source>Doesn&apos;t Boot</source>
         <translation>No inicia</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="209"/>
+        <location filename="../../core/game_database.cpp" line="198"/>
         <source>Crashes In Intro</source>
         <translation>Cuelga al inicio</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="210"/>
+        <location filename="../../core/game_database.cpp" line="199"/>
         <source>Crashes In-Game</source>
         <translation>Cuelga en juego</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="211"/>
+        <location filename="../../core/game_database.cpp" line="200"/>
         <source>Graphical/Audio Issues</source>
         <translation>Problemas audiovisuales</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="212"/>
+        <location filename="../../core/game_database.cpp" line="201"/>
         <source>No Issues</source>
         <translation>Sin problemas</translation>
     </message>
@@ -5342,72 +9178,72 @@ Logros: %5 (%6)
 <context>
     <name>GameListModel</name>
     <message>
-        <location filename="../gamelistmodel.cpp" line="605"/>
+        <location filename="../gamelistmodel.cpp" line="614"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="606"/>
+        <location filename="../gamelistmodel.cpp" line="615"/>
         <source>Serial</source>
         <translation>Número de serie</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="607"/>
+        <location filename="../gamelistmodel.cpp" line="616"/>
         <source>Title</source>
         <translation>Título</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="608"/>
+        <location filename="../gamelistmodel.cpp" line="617"/>
         <source>File Title</source>
         <translation>Título de archivo</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="609"/>
+        <location filename="../gamelistmodel.cpp" line="618"/>
         <source>Developer</source>
         <translation>Desarrollador</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="610"/>
+        <location filename="../gamelistmodel.cpp" line="619"/>
         <source>Publisher</source>
         <translation>Editor</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="611"/>
+        <location filename="../gamelistmodel.cpp" line="620"/>
         <source>Genre</source>
         <translation>Género</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="612"/>
+        <location filename="../gamelistmodel.cpp" line="621"/>
         <source>Year</source>
         <translation>Año</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="613"/>
+        <location filename="../gamelistmodel.cpp" line="622"/>
         <source>Players</source>
         <translation>Jugadores</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="614"/>
+        <location filename="../gamelistmodel.cpp" line="623"/>
         <source>Time Played</source>
         <translation>Tiempo jugado</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="615"/>
+        <location filename="../gamelistmodel.cpp" line="624"/>
         <source>Last Played</source>
         <translation>Última partida</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="616"/>
+        <location filename="../gamelistmodel.cpp" line="625"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="617"/>
+        <location filename="../gamelistmodel.cpp" line="626"/>
         <source>Region</source>
         <translation>Región</translation>
     </message>
     <message>
-        <location filename="../gamelistmodel.cpp" line="618"/>
+        <location filename="../gamelistmodel.cpp" line="627"/>
         <source>Compatibility</source>
         <translation>Compatibilidad</translation>
     </message>
@@ -5446,7 +9282,7 @@ Logros: %5 (%6)
     <message>
         <location filename="../gamelistsettingswidget.ui" line="76"/>
         <location filename="../gamelistsettingswidget.ui" line="135"/>
-        <location filename="../gamelistsettingswidget.cpp" line="105"/>
+        <location filename="../gamelistsettingswidget.cpp" line="107"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
@@ -5466,22 +9302,22 @@ Logros: %5 (%6)
         <translation>Volver a buscar todos los juegos</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="107"/>
+        <location filename="../gamelistsettingswidget.cpp" line="109"/>
         <source>Open Directory...</source>
         <translation>Abrir directorio...</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="115"/>
+        <location filename="../gamelistsettingswidget.cpp" line="117"/>
         <source>Select Search Directory</source>
         <translation>Seleccionar directorio para buscar</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="121"/>
+        <location filename="../gamelistsettingswidget.cpp" line="123"/>
         <source>Scan Recursively?</source>
         <translation>¿Buscar recursivamente?</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="122"/>
+        <location filename="../gamelistsettingswidget.cpp" line="124"/>
         <source>Would you like to scan the directory &quot;%1&quot; recursively?
 
 Scanning recursively takes more time, but will identify files in subdirectories.</source>
@@ -5490,7 +9326,7 @@ Scanning recursively takes more time, but will identify files in subdirectories.
 Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirectorios.</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="151"/>
+        <location filename="../gamelistsettingswidget.cpp" line="153"/>
         <source>Select Path</source>
         <translation>Seleccionar directorio</translation>
     </message>
@@ -5536,99 +9372,80 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
 <context>
     <name>GameSettingsTrait</name>
     <message>
-        <location filename="../../core/game_database.cpp" line="52"/>
         <source>Force Interpreter</source>
-        <translation>Forzar intérprete</translation>
+        <translation type="vanished">Forzar intérprete</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="53"/>
         <source>Force Software Renderer</source>
-        <translation>Forzar renderizador por software</translation>
+        <translation type="vanished">Forzar renderizador por software</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="54"/>
         <source>Force Software Renderer For Readbacks</source>
-        <translation>Forzar renderizador por software para lecturas</translation>
+        <translation type="vanished">Forzar renderizador por software para lecturas</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="55"/>
         <source>Force Interlacing</source>
-        <translation>Forzar entrelazado</translation>
+        <translation type="vanished">Forzar entrelazado</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="56"/>
         <source>Disable True Color</source>
-        <translation>Deshabilitar color verdadero</translation>
+        <translation type="vanished">Deshabilitar color verdadero</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="57"/>
         <source>Disable Upscaling</source>
-        <translation>Deshabilitar escalado de resolución</translation>
+        <translation type="vanished">Deshabilitar escalado de resolución</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="58"/>
         <source>Disable Scaled Dithering</source>
-        <translation>Deshabilitar escalado de tramado</translation>
+        <translation type="vanished">Deshabilitar escalado de tramado</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="59"/>
         <source>Disallow Forcing NTSC Timings</source>
-        <translation>Deshabilitar forzado de tiempos NTSC</translation>
+        <translation type="vanished">Deshabilitar forzado de tiempos NTSC</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="60"/>
         <source>Disable Widescreen</source>
-        <translation>Deshabilitar pantalla panorámica</translation>
+        <translation type="vanished">Deshabilitar pantalla panorámica</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="61"/>
         <source>Disable PGXP</source>
-        <translation>Deshabilitar PGXP</translation>
+        <translation type="vanished">Deshabilitar PGXP</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="62"/>
         <source>Disable PGXP Culling</source>
-        <translation>Deshabilitar culling (PGXP)</translation>
+        <translation type="vanished">Deshabilitar culling (PGXP)</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="63"/>
         <source>Disable PGXP Perspective Correct Textures</source>
-        <translation>Deshabilitar correción de perspectiva de texturas (PGXP)</translation>
+        <translation type="vanished">Deshabilitar correción de perspectiva de texturas (PGXP)</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="64"/>
         <source>Disable PGXP Perspective Correct Colors</source>
-        <translation>Deshabilitar correción de perspectiva de colores (PGXP)</translation>
+        <translation type="vanished">Deshabilitar correción de perspectiva de colores (PGXP)</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="65"/>
         <source>Disable PGXP Depth Buffer</source>
-        <translation>Deshabilitar búfer de profundidad (PGXP)</translation>
+        <translation type="vanished">Deshabilitar búfer de profundidad (PGXP)</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="66"/>
         <source>Force PGXP Vertex Cache</source>
-        <translation>Forzar caché de vértices (PGXP)</translation>
+        <translation type="vanished">Forzar caché de vértices (PGXP)</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="67"/>
         <source>Force PGXP CPU Mode</source>
-        <translation>Forzar modo CPU (PGXP)</translation>
+        <translation type="vanished">Forzar modo CPU (PGXP)</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="68"/>
         <source>Force Recompiler Memory Exceptions</source>
-        <translation>Forzar excepciones de memoria del recompilador</translation>
+        <translation type="vanished">Forzar excepciones de memoria del recompilador</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="69"/>
         <source>Force Recompiler ICache</source>
-        <translation>Forzar ICache del recompilador</translation>
+        <translation type="vanished">Forzar ICache del recompilador</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="70"/>
         <source>Force Recompiler LUT Fastmem</source>
-        <translation>Forzar memoria de acceso rápido LUT del recompilador</translation>
+        <translation type="vanished">Forzar memoria de acceso rápido LUT del recompilador</translation>
     </message>
 </context>
 <context>
@@ -5739,90 +9556,90 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
         <translation>Editar...</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="64"/>
-        <location filename="../gamesummarywidget.cpp" line="74"/>
-        <location filename="../gamesummarywidget.cpp" line="101"/>
-        <location filename="../gamesummarywidget.cpp" line="118"/>
-        <location filename="../gamesummarywidget.cpp" line="123"/>
-        <location filename="../gamesummarywidget.cpp" line="124"/>
-        <location filename="../gamesummarywidget.cpp" line="125"/>
+        <location filename="../gamesummarywidget.cpp" line="68"/>
+        <location filename="../gamesummarywidget.cpp" line="78"/>
+        <location filename="../gamesummarywidget.cpp" line="105"/>
+        <location filename="../gamesummarywidget.cpp" line="121"/>
         <location filename="../gamesummarywidget.cpp" line="126"/>
         <location filename="../gamesummarywidget.cpp" line="127"/>
+        <location filename="../gamesummarywidget.cpp" line="128"/>
+        <location filename="../gamesummarywidget.cpp" line="129"/>
+        <location filename="../gamesummarywidget.cpp" line="130"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="66"/>
+        <location filename="../gamesummarywidget.cpp" line="70"/>
         <source>%1 (Published by %2)</source>
         <translation>%1 (distribuido por %2)</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="72"/>
+        <location filename="../gamesummarywidget.cpp" line="76"/>
         <source>Published by %1</source>
         <translation>Distribuido por %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="79"/>
+        <location filename="../gamesummarywidget.cpp" line="83"/>
         <source>Released %1</source>
         <translation>Publicado el %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="85"/>
+        <location filename="../gamesummarywidget.cpp" line="89"/>
         <source>%1-%2 players</source>
         <translation>%1-%2 jugadores</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="87"/>
+        <location filename="../gamesummarywidget.cpp" line="91"/>
         <source>%1 players</source>
         <translation>%1 jugadores</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="94"/>
+        <location filename="../gamesummarywidget.cpp" line="98"/>
         <source>%1-%2 memory card blocks</source>
         <translation>%1-%2 bloques de tarjeta de memoria</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="96"/>
+        <location filename="../gamesummarywidget.cpp" line="100"/>
         <source>%1 memory card blocks</source>
         <translation>%1 bloques de tarjeta de memoria</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="137"/>
+        <location filename="../gamesummarywidget.cpp" line="140"/>
         <source>Use Global Settings</source>
         <translation>Utilizar configuración global</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="179"/>
+        <location filename="../gamesummarywidget.cpp" line="182"/>
         <source>Track %1</source>
         <translation>Pista %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="187"/>
+        <location filename="../gamesummarywidget.cpp" line="190"/>
         <source>&lt;not computed&gt;</source>
         <translation>&lt;sin calcular&gt;</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="215"/>
+        <location filename="../gamesummarywidget.cpp" line="218"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="215"/>
+        <location filename="../gamesummarywidget.cpp" line="218"/>
         <source>Failed to open CD image for hashing.</source>
-        <translation>Fallo al abrir la imagen de CD para calcular la suma de verificación.</translation>
+        <translation>Fallo al abrir la imagen de disco para calcular la suma de verificación.</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="323"/>
+        <location filename="../gamesummarywidget.cpp" line="326"/>
         <source>Revision: %1</source>
         <translation>Revisión: %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="323"/>
+        <location filename="../gamesummarywidget.cpp" line="326"/>
         <source>N/A</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="348"/>
+        <location filename="../gamesummarywidget.cpp" line="351"/>
         <source>Search on Redump.org</source>
         <translation>Buscar en Redump.org</translation>
     </message>
@@ -5841,13 +9658,13 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="38"/>
-        <location filename="../generalsettingswidget.cpp" line="84"/>
+        <location filename="../generalsettingswidget.cpp" line="99"/>
         <source>Automatically Load Cheats</source>
         <translation>Cargar trucos automáticamente</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="45"/>
-        <location filename="../generalsettingswidget.cpp" line="53"/>
+        <location filename="../generalsettingswidget.cpp" line="68"/>
         <source>Confirm Power Off</source>
         <translation>Confirmar apagado</translation>
     </message>
@@ -5858,13 +9675,13 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="59"/>
-        <location filename="../generalsettingswidget.cpp" line="72"/>
+        <location filename="../generalsettingswidget.cpp" line="87"/>
         <source>Pause On Focus Loss</source>
         <translation>Pausar al perder el foco</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="66"/>
-        <location filename="../generalsettingswidget.cpp" line="81"/>
+        <location filename="../generalsettingswidget.cpp" line="96"/>
         <source>Apply Per-Game Settings</source>
         <translation>Configuraciones por juego</translation>
     </message>
@@ -5875,25 +9692,25 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="80"/>
-        <location filename="../generalsettingswidget.cpp" line="64"/>
+        <location filename="../generalsettingswidget.cpp" line="79"/>
         <source>Inhibit Screensaver</source>
         <translation>Deshabilitar salvapantallas</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="87"/>
-        <location filename="../generalsettingswidget.cpp" line="76"/>
+        <location filename="../generalsettingswidget.cpp" line="91"/>
         <source>Load Devices From Save States</source>
         <translation>Cargar dispositivos en estados guardados</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="94"/>
-        <location filename="../generalsettingswidget.cpp" line="70"/>
+        <location filename="../generalsettingswidget.cpp" line="85"/>
         <source>Pause On Start</source>
         <translation>Pausar al inicio</translation>
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="101"/>
-        <location filename="../generalsettingswidget.cpp" line="91"/>
+        <location filename="../generalsettingswidget.cpp" line="106"/>
         <source>Enable Discord Presence</source>
         <translation>Habilitar Discord Presence</translation>
     </message>
@@ -5909,7 +9726,7 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="124"/>
-        <location filename="../generalsettingswidget.cpp" line="59"/>
+        <location filename="../generalsettingswidget.cpp" line="74"/>
         <source>Start Fullscreen</source>
         <translation>Iniciar en pantalla completa</translation>
     </message>
@@ -5920,7 +9737,7 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="138"/>
-        <location filename="../generalsettingswidget.cpp" line="67"/>
+        <location filename="../generalsettingswidget.cpp" line="82"/>
         <source>Render To Separate Window</source>
         <translation>Renderizar en la ventana principal</translation>
     </message>
@@ -5936,7 +9753,7 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="159"/>
-        <location filename="../generalsettingswidget.cpp" line="61"/>
+        <location filename="../generalsettingswidget.cpp" line="76"/>
         <source>Hide Cursor In Fullscreen</source>
         <translation>Ocultar cursor en pantalla completa</translation>
     </message>
@@ -5957,7 +9774,7 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../generalsettingswidget.ui" line="199"/>
-        <location filename="../generalsettingswidget.cpp" line="102"/>
+        <location filename="../generalsettingswidget.cpp" line="117"/>
         <source>Enable Automatic Update Check</source>
         <translation>Habilitar comprobación automática de actualizaciones</translation>
     </message>
@@ -5967,98 +9784,98 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
         <translation>Buscar actualizaciones...</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="53"/>
-        <location filename="../generalsettingswidget.cpp" line="56"/>
-        <location filename="../generalsettingswidget.cpp" line="61"/>
-        <location filename="../generalsettingswidget.cpp" line="64"/>
-        <location filename="../generalsettingswidget.cpp" line="67"/>
-        <location filename="../generalsettingswidget.cpp" line="81"/>
-        <location filename="../generalsettingswidget.cpp" line="102"/>
+        <location filename="../generalsettingswidget.cpp" line="68"/>
+        <location filename="../generalsettingswidget.cpp" line="71"/>
+        <location filename="../generalsettingswidget.cpp" line="76"/>
+        <location filename="../generalsettingswidget.cpp" line="79"/>
+        <location filename="../generalsettingswidget.cpp" line="82"/>
+        <location filename="../generalsettingswidget.cpp" line="96"/>
+        <location filename="../generalsettingswidget.cpp" line="117"/>
         <source>Checked</source>
         <translation>Habilitado</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="54"/>
+        <location filename="../generalsettingswidget.cpp" line="69"/>
         <source>Determines whether a prompt will be displayed to confirm shutting down the emulator/game when the hotkey is pressed.</source>
         <translation>Determina si se mostrará un mensaje de confirmación para cerrar el emulador/juego al presionar un atajo.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="56"/>
+        <location filename="../generalsettingswidget.cpp" line="71"/>
         <source>Save State On Exit</source>
         <translation>Guardar estado al salir</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="57"/>
+        <location filename="../generalsettingswidget.cpp" line="72"/>
         <source>Automatically saves the emulator state when powering down or exiting. You can then resume directly from where you left off next time.</source>
         <translation>Guarda automáticamente el estado del emulador al apagar o salir. Después podrás continuar desde donde dejaste la última vez.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="59"/>
-        <location filename="../generalsettingswidget.cpp" line="70"/>
-        <location filename="../generalsettingswidget.cpp" line="72"/>
-        <location filename="../generalsettingswidget.cpp" line="76"/>
-        <location filename="../generalsettingswidget.cpp" line="84"/>
+        <location filename="../generalsettingswidget.cpp" line="74"/>
+        <location filename="../generalsettingswidget.cpp" line="85"/>
+        <location filename="../generalsettingswidget.cpp" line="87"/>
         <location filename="../generalsettingswidget.cpp" line="91"/>
+        <location filename="../generalsettingswidget.cpp" line="99"/>
+        <location filename="../generalsettingswidget.cpp" line="106"/>
         <source>Unchecked</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="60"/>
+        <location filename="../generalsettingswidget.cpp" line="75"/>
         <source>Automatically switches to fullscreen mode when a game is started.</source>
         <translation>Cambia automáticamente a modo en pantalla completa cuando se inicia un juego.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="62"/>
+        <location filename="../generalsettingswidget.cpp" line="77"/>
         <source>Hides the mouse pointer/cursor when the emulator is in fullscreen mode.</source>
         <translation>Oculta el cursor/puntero del mouse cuando el emulador está en modo de pantalla completa.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="65"/>
+        <location filename="../generalsettingswidget.cpp" line="80"/>
         <source>Prevents the screen saver from activating and the host from sleeping while emulation is running.</source>
         <translation>Evita que se active el salvapantallas y se suspenda el sistema cuando el emulador se esté ejecutando.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="68"/>
+        <location filename="../generalsettingswidget.cpp" line="83"/>
         <source>Renders the display of the simulated console to the main window of the application, over the game list. If checked, the display will render in a separate window.</source>
         <translation>Renderiza la imagen de la consola emulada en la ventana principal de la aplicación, sobre la lista de juegos. Si se habilita, la imagen se renderizará en una ventana separada.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="71"/>
+        <location filename="../generalsettingswidget.cpp" line="86"/>
         <source>Pauses the emulator when a game is started.</source>
         <translation>Pausa el emulador cuando se inicia un juego.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="73"/>
+        <location filename="../generalsettingswidget.cpp" line="88"/>
         <source>Pauses the emulator when you minimize the window or switch to another application, and unpauses when you switch back.</source>
         <translation>Pausa el emulador cuando se minimiza la ventana o se cambia a otra aplicación, y resume cuando se vuelve al emulador.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="77"/>
+        <location filename="../generalsettingswidget.cpp" line="92"/>
         <source>When enabled, memory cards and controllers will be overwritten when save states are loaded. This can result in lost saves, and controller type mismatches. For deterministic save states, enable this option, otherwise leave disabled.</source>
         <translation>Cuando se habilita, los controles y tarjetas de memoria se sobrescribirán cuando se carguen estados guardados. Esto puede resultar en pérdida de datos guardados e incoherencias con el tipo de control. Habilitar esta opción para estados guardados consistentes.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="82"/>
+        <location filename="../generalsettingswidget.cpp" line="97"/>
         <source>When enabled, per-game settings will be applied, and incompatible enhancements will be disabled. You should leave this option enabled except when testing enhancements with incompatible games.</source>
-        <translation>Cuando se habilita se aplicarán las configuraciones por juego, y se desactivarán las mejoras incompatibles. Es recomendable dejar esta opción activada, a menos que quieras probar mejoras con juegos incompatibles.</translation>
+        <translation>Cuando se habilita, se aplicarán las configuraciones por juego, y se desactivarán las mejoras incompatibles. Es recomendable dejar esta opción habilitada, a menos que quieras probar mejoras con juegos incompatibles.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="85"/>
+        <location filename="../generalsettingswidget.cpp" line="100"/>
         <source>Automatically loads and applies cheats on game start.</source>
         <translation>Carga y aplica los trucos automáticamente al iniciar el juego.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="92"/>
+        <location filename="../generalsettingswidget.cpp" line="107"/>
         <source>Shows the game you are currently playing as part of your profile in Discord.</source>
         <translation>Muestra el juego que estás jugando actualmente en tu perfil de Discord.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="103"/>
+        <location filename="../generalsettingswidget.cpp" line="118"/>
         <source>Automatically checks for updates to the program on startup. Updates can be deferred until later or skipped entirely.</source>
         <translation>Busca actualizaciones automáticamente al iniciar el programa. Pueden posponerse para más adelante o directamente omitirse.</translation>
     </message>
     <message>
-        <location filename="../generalsettingswidget.cpp" line="110"/>
+        <location filename="../generalsettingswidget.cpp" line="125"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
@@ -6066,32 +9883,82 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
 <context>
     <name>GunCon</name>
     <message>
-        <location filename="../../core/guncon.cpp" line="223"/>
+        <location filename="../../core/guncon.cpp" line="274"/>
+        <source>Trigger</source>
+        <translation>Gatillo</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="275"/>
+        <source>Shoot Offscreen</source>
+        <translation>Disparar fuera de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="276"/>
+        <source>A</source>
+        <translation>A</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="277"/>
+        <source>B</source>
+        <translation>B</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="279"/>
+        <source>Relative Left</source>
+        <translation>Relativa hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="280"/>
+        <source>Relative Right</source>
+        <translation>Relativa hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="281"/>
+        <source>Relative Up</source>
+        <translation>Relativa hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="282"/>
+        <source>Relative Down</source>
+        <translation>Relativa hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="289"/>
         <source>Crosshair Image Path</source>
         <translation>Directorio para la imagen de mira</translation>
     </message>
     <message>
-        <location filename="../../core/guncon.cpp" line="224"/>
+        <location filename="../../core/guncon.cpp" line="290"/>
         <source>Path to an image to use as a crosshair/cursor.</source>
         <translation>Seleccionar una imagen para utilizar como punto de mira/cursor.</translation>
     </message>
     <message>
-        <location filename="../../core/guncon.cpp" line="225"/>
+        <location filename="../../core/guncon.cpp" line="292"/>
         <source>Crosshair Image Scale</source>
         <translation>Escala para la imagen de mira</translation>
     </message>
     <message>
-        <location filename="../../core/guncon.cpp" line="226"/>
+        <location filename="../../core/guncon.cpp" line="293"/>
         <source>Scale of crosshair image on screen.</source>
         <translation>Escala para la imagen de mira en pantalla.</translation>
     </message>
     <message>
-        <location filename="../../core/guncon.cpp" line="228"/>
+        <location filename="../../core/guncon.cpp" line="295"/>
+        <source>Cursor Color</source>
+        <translation>Color del cursor</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="296"/>
+        <source>Applies a color to the chosen crosshair images, can be used for multiple players. Specify in HTML/CSS format (e.g. #aabbcc)</source>
+        <translation>Aplica un color a las imágenes de mira seleccionadas, puede utilizarse para varios jugadores. Especificar en formato HTML/CSS (por ejemplo, #aabbcc)</translation>
+    </message>
+    <message>
+        <location filename="../../core/guncon.cpp" line="299"/>
         <source>X Scale</source>
         <translation>Escala X</translation>
     </message>
     <message>
-        <location filename="../../core/guncon.cpp" line="229"/>
+        <location filename="../../core/guncon.cpp" line="300"/>
         <source>Scales X coordinates relative to the center of the screen.</source>
         <translation>Escala coordenadas en el eje X de forma relativa al centro de la pantalla.</translation>
     </message>
@@ -6099,12 +9966,12 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
 <context>
     <name>HostInterface</name>
     <message>
-        <location filename="../../core/bios.cpp" line="306"/>
+        <location filename="../../core/bios.cpp" line="298"/>
         <source>Failed to load configured BIOS file &apos;%s&apos;</source>
         <translation>Fallo al cargar el BIOS &quot;%s&quot; configurado</translation>
     </message>
     <message>
-        <location filename="../../core/bios.cpp" line="361"/>
+        <location filename="../../core/bios.cpp" line="353"/>
         <source>No BIOS image found for %s region</source>
         <translation>No se encontró una imagen BIOS para la región %s</translation>
     </message>
@@ -6112,470 +9979,470 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
 <context>
     <name>Hotkeys</name>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="676"/>
-        <location filename="../../frontend-common/common_host.cpp" line="683"/>
-        <location filename="../../frontend-common/common_host.cpp" line="690"/>
-        <location filename="../../frontend-common/common_host.cpp" line="696"/>
-        <location filename="../../frontend-common/common_host.cpp" line="702"/>
-        <location filename="../../frontend-common/common_host.cpp" line="709"/>
-        <location filename="../../frontend-common/common_host.cpp" line="715"/>
-        <location filename="../../frontend-common/common_host.cpp" line="721"/>
-        <location filename="../../frontend-common/common_host.cpp" line="728"/>
-        <location filename="../../frontend-common/common_host.cpp" line="735"/>
-        <location filename="../../frontend-common/common_host.cpp" line="748"/>
+        <location filename="../../core/hotkeys.cpp" line="105"/>
+        <location filename="../../core/hotkeys.cpp" line="112"/>
+        <location filename="../../core/hotkeys.cpp" line="119"/>
+        <location filename="../../core/hotkeys.cpp" line="125"/>
+        <location filename="../../core/hotkeys.cpp" line="131"/>
+        <location filename="../../core/hotkeys.cpp" line="138"/>
+        <location filename="../../core/hotkeys.cpp" line="144"/>
+        <location filename="../../core/hotkeys.cpp" line="150"/>
+        <location filename="../../core/hotkeys.cpp" line="157"/>
+        <location filename="../../core/hotkeys.cpp" line="164"/>
+        <location filename="../../core/hotkeys.cpp" line="170"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="676"/>
+        <location filename="../../core/hotkeys.cpp" line="105"/>
         <source>Open Pause Menu</source>
         <translation>Abrir menú rápido</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="683"/>
+        <location filename="../../core/hotkeys.cpp" line="112"/>
         <source>Fast Forward</source>
         <translation>Avance rápido</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="690"/>
+        <location filename="../../core/hotkeys.cpp" line="120"/>
         <source>Toggle Fast Forward</source>
         <translation>Alternar avance rápido</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="696"/>
+        <location filename="../../core/hotkeys.cpp" line="125"/>
         <source>Turbo</source>
         <translation>Turbo</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="702"/>
+        <location filename="../../core/hotkeys.cpp" line="131"/>
         <source>Toggle Turbo</source>
         <translation>Alternar turbo</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="709"/>
+        <location filename="../../core/hotkeys.cpp" line="138"/>
         <source>Toggle Fullscreen</source>
         <translation>Alternar pantalla completa</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="715"/>
+        <location filename="../../core/hotkeys.cpp" line="144"/>
         <source>Toggle Pause</source>
         <translation>Alternar pausa</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="721"/>
+        <location filename="../../core/hotkeys.cpp" line="150"/>
         <source>Power Off System</source>
         <translation>Apagar sistema</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="728"/>
+        <location filename="../../core/hotkeys.cpp" line="157"/>
         <source>Save Screenshot</source>
         <translation>Capturar pantalla</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="735"/>
+        <location filename="../../core/hotkeys.cpp" line="165"/>
         <source>Open Achievement List</source>
         <translation>Abrir lista de logros</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="748"/>
+        <location filename="../../core/hotkeys.cpp" line="171"/>
         <source>Open Leaderboard List</source>
         <translation>Abrir tabla de posiciones</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="762"/>
-        <location filename="../../frontend-common/common_host.cpp" line="767"/>
-        <location filename="../../frontend-common/common_host.cpp" line="777"/>
-        <location filename="../../frontend-common/common_host.cpp" line="784"/>
-        <location filename="../../frontend-common/common_host.cpp" line="790"/>
-        <location filename="../../frontend-common/common_host.cpp" line="797"/>
-        <location filename="../../frontend-common/common_host.cpp" line="803"/>
-        <location filename="../../frontend-common/common_host.cpp" line="810"/>
-        <location filename="../../frontend-common/common_host.cpp" line="838"/>
-        <location filename="../../frontend-common/common_host.cpp" line="850"/>
-        <location filename="../../frontend-common/common_host.cpp" line="862"/>
+        <location filename="../../core/hotkeys.cpp" line="177"/>
+        <location filename="../../core/hotkeys.cpp" line="182"/>
+        <location filename="../../core/hotkeys.cpp" line="193"/>
+        <location filename="../../core/hotkeys.cpp" line="200"/>
+        <location filename="../../core/hotkeys.cpp" line="207"/>
+        <location filename="../../core/hotkeys.cpp" line="214"/>
+        <location filename="../../core/hotkeys.cpp" line="220"/>
+        <location filename="../../core/hotkeys.cpp" line="227"/>
+        <location filename="../../core/hotkeys.cpp" line="255"/>
+        <location filename="../../core/hotkeys.cpp" line="267"/>
+        <location filename="../../core/hotkeys.cpp" line="279"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="762"/>
+        <location filename="../../core/hotkeys.cpp" line="177"/>
         <source>Reset System</source>
         <translation>Reiniciar sistema</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="767"/>
+        <location filename="../../core/hotkeys.cpp" line="182"/>
         <source>Change Disc</source>
         <translation>Cambiar disco</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="777"/>
+        <location filename="../../core/hotkeys.cpp" line="194"/>
         <source>Swap Memory Card Slots</source>
         <translation>Intercambiar ranuras de memoria</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="784"/>
+        <location filename="../../core/hotkeys.cpp" line="200"/>
         <source>Frame Step</source>
         <translation>Avanzar fotograma</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="790"/>
+        <location filename="../../core/hotkeys.cpp" line="207"/>
         <source>Rewind</source>
         <translation>Rebobinar</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="797"/>
+        <location filename="../../core/hotkeys.cpp" line="214"/>
         <source>Toggle Cheats</source>
         <translation>Alternar trucos</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="803"/>
+        <location filename="../../core/hotkeys.cpp" line="220"/>
         <source>Toggle Patch Codes</source>
         <translation>Alternar parches</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="811"/>
+        <location filename="../../core/hotkeys.cpp" line="228"/>
         <source>Toggle Clock Speed Control (Overclocking)</source>
         <translation>Alternar control de velocidad de reloj (overclock)</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="839"/>
+        <location filename="../../core/hotkeys.cpp" line="256"/>
         <source>Increase Emulation Speed</source>
         <translation>Incrementar velocidad de emulación</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="851"/>
+        <location filename="../../core/hotkeys.cpp" line="268"/>
         <source>Decrease Emulation Speed</source>
         <translation>Decrementar velocidad de emulación</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="863"/>
+        <location filename="../../core/hotkeys.cpp" line="280"/>
         <source>Reset Emulation Speed</source>
         <translation>Reiniciar velocidad de emulación</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="874"/>
-        <location filename="../../frontend-common/common_host.cpp" line="880"/>
-        <location filename="../../frontend-common/common_host.cpp" line="906"/>
-        <location filename="../../frontend-common/common_host.cpp" line="912"/>
-        <location filename="../../frontend-common/common_host.cpp" line="918"/>
-        <location filename="../../frontend-common/common_host.cpp" line="924"/>
-        <location filename="../../frontend-common/common_host.cpp" line="930"/>
-        <location filename="../../frontend-common/common_host.cpp" line="941"/>
-        <location filename="../../frontend-common/common_host.cpp" line="947"/>
-        <location filename="../../frontend-common/common_host.cpp" line="968"/>
+        <location filename="../../core/hotkeys.cpp" line="291"/>
+        <location filename="../../core/hotkeys.cpp" line="297"/>
+        <location filename="../../core/hotkeys.cpp" line="326"/>
+        <location filename="../../core/hotkeys.cpp" line="332"/>
+        <location filename="../../core/hotkeys.cpp" line="338"/>
+        <location filename="../../core/hotkeys.cpp" line="344"/>
+        <location filename="../../core/hotkeys.cpp" line="350"/>
+        <location filename="../../core/hotkeys.cpp" line="360"/>
+        <location filename="../../core/hotkeys.cpp" line="366"/>
+        <location filename="../../core/hotkeys.cpp" line="387"/>
         <source>Graphics</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="875"/>
+        <location filename="../../core/hotkeys.cpp" line="292"/>
         <source>Toggle Software Rendering</source>
         <translation>Alternar renderizado por software</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="880"/>
+        <location filename="../../core/hotkeys.cpp" line="297"/>
         <source>Toggle PGXP</source>
         <translation>Alternar PGXP</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="907"/>
+        <location filename="../../core/hotkeys.cpp" line="327"/>
         <source>Increase Resolution Scale</source>
         <translation>Incrementar escala de resolución</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="913"/>
+        <location filename="../../core/hotkeys.cpp" line="333"/>
         <source>Decrease Resolution Scale</source>
         <translation>Decrementar escala de resolución</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="919"/>
+        <location filename="../../core/hotkeys.cpp" line="339"/>
         <source>Toggle Post-Processing</source>
         <translation>Alternar postprocesamiento</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="925"/>
+        <location filename="../../core/hotkeys.cpp" line="345"/>
         <source>Reload Post Processing Shaders</source>
         <translation>Recargar sombreadores de postprocesamiento</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="931"/>
+        <location filename="../../core/hotkeys.cpp" line="351"/>
         <source>Reload Texture Replacements</source>
         <translation>Recargar reemplazos de textura</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="941"/>
+        <location filename="../../core/hotkeys.cpp" line="360"/>
         <source>Toggle Widescreen</source>
         <translation>Alternar pantalla panorámica</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="948"/>
+        <location filename="../../core/hotkeys.cpp" line="367"/>
         <source>Toggle PGXP Depth Buffer</source>
         <translation>Alternar búfer de profundidad (PGXP)</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="968"/>
+        <location filename="../../core/hotkeys.cpp" line="387"/>
         <source>Toggle PGXP CPU Mode</source>
         <translation>Alternar modo CPU (PGXP)</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="995"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1014"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1026"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1040"/>
+        <location filename="../../core/hotkeys.cpp" line="415"/>
+        <location filename="../../core/hotkeys.cpp" line="434"/>
+        <location filename="../../core/hotkeys.cpp" line="446"/>
+        <location filename="../../core/hotkeys.cpp" line="460"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="995"/>
+        <location filename="../../core/hotkeys.cpp" line="415"/>
         <source>Toggle Mute</source>
         <translation>Alternar silencio</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1014"/>
+        <location filename="../../core/hotkeys.cpp" line="434"/>
         <source>Toggle CD Audio Mute</source>
         <translation>Alternar silencio de audio de CD</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1026"/>
+        <location filename="../../core/hotkeys.cpp" line="446"/>
         <source>Volume Up</source>
         <translation>Subir volumen</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1040"/>
+        <location filename="../../core/hotkeys.cpp" line="460"/>
         <source>Volume Down</source>
         <translation>Bajar volumen</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1057"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1062"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1067"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1072"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1078"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1085"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1091"/>
+        <location filename="../../core/hotkeys.cpp" line="476"/>
+        <location filename="../../core/hotkeys.cpp" line="481"/>
+        <location filename="../../core/hotkeys.cpp" line="486"/>
+        <location filename="../../core/hotkeys.cpp" line="491"/>
+        <location filename="../../core/hotkeys.cpp" line="497"/>
+        <location filename="../../core/hotkeys.cpp" line="504"/>
+        <location filename="../../core/hotkeys.cpp" line="510"/>
         <source>Save States</source>
         <translation>Estados guardados</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1058"/>
+        <location filename="../../core/hotkeys.cpp" line="477"/>
         <source>Load From Selected Slot</source>
         <translation>Cargar de la ranura seleccionada</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1063"/>
+        <location filename="../../core/hotkeys.cpp" line="482"/>
         <source>Save To Selected Slot</source>
         <translation>Guardar en la ranura seleccionada</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1068"/>
+        <location filename="../../core/hotkeys.cpp" line="487"/>
         <source>Select Previous Save Slot</source>
         <translation>Seleccionar ranura de guardado anterior</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1073"/>
+        <location filename="../../core/hotkeys.cpp" line="492"/>
         <source>Select Next Save Slot</source>
         <translation>Seleccionar ranura de guardado siguiente</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1078"/>
+        <location filename="../../core/hotkeys.cpp" line="497"/>
         <source>Undo Load State</source>
         <translation>Deshacer estado cargado</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1097"/>
+        <location filename="../../core/hotkeys.cpp" line="516"/>
         <source>Load Game State 1</source>
         <translation>Cargar estado de juego 1</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1098"/>
+        <location filename="../../core/hotkeys.cpp" line="517"/>
         <source>Save Game State 1</source>
         <translation>Guardar estado de juego 1</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1099"/>
+        <location filename="../../core/hotkeys.cpp" line="518"/>
         <source>Load Game State 2</source>
         <translation>Cargar estado de juego 2</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1100"/>
+        <location filename="../../core/hotkeys.cpp" line="519"/>
         <source>Save Game State 2</source>
         <translation>Guardar estado de juego 2</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1101"/>
+        <location filename="../../core/hotkeys.cpp" line="520"/>
         <source>Load Game State 3</source>
         <translation>Cargar estado de juego 3</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1102"/>
+        <location filename="../../core/hotkeys.cpp" line="521"/>
         <source>Save Game State 3</source>
         <translation>Guardar estado de juego 3</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1103"/>
+        <location filename="../../core/hotkeys.cpp" line="522"/>
         <source>Load Game State 4</source>
         <translation>Cargar estado de juego 4</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1104"/>
+        <location filename="../../core/hotkeys.cpp" line="523"/>
         <source>Save Game State 4</source>
         <translation>Guardar estado de juego 4</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1105"/>
+        <location filename="../../core/hotkeys.cpp" line="524"/>
         <source>Load Game State 5</source>
         <translation>Cargar estado de juego 5</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1106"/>
+        <location filename="../../core/hotkeys.cpp" line="525"/>
         <source>Save Game State 5</source>
         <translation>Guardar estado de juego 5</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1107"/>
+        <location filename="../../core/hotkeys.cpp" line="526"/>
         <source>Load Game State 6</source>
         <translation>Cargar estado de juego 6</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1108"/>
+        <location filename="../../core/hotkeys.cpp" line="527"/>
         <source>Save Game State 6</source>
         <translation>Guardar estado de juego 6</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1109"/>
+        <location filename="../../core/hotkeys.cpp" line="528"/>
         <source>Load Game State 7</source>
         <translation>Cargar estado de juego 7</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1110"/>
+        <location filename="../../core/hotkeys.cpp" line="529"/>
         <source>Save Game State 7</source>
         <translation>Guardar estado de juego 7</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1111"/>
+        <location filename="../../core/hotkeys.cpp" line="530"/>
         <source>Load Game State 8</source>
         <translation>Cargar estado de juego 8</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1112"/>
+        <location filename="../../core/hotkeys.cpp" line="531"/>
         <source>Save Game State 8</source>
         <translation>Guardar estado de juego 8</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1113"/>
+        <location filename="../../core/hotkeys.cpp" line="532"/>
         <source>Load Game State 9</source>
         <translation>Cargar estado de juego 9</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1114"/>
+        <location filename="../../core/hotkeys.cpp" line="533"/>
         <source>Save Game State 9</source>
         <translation>Guardar estado de juego 9</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1115"/>
+        <location filename="../../core/hotkeys.cpp" line="534"/>
         <source>Load Game State 10</source>
         <translation>Cargar estado de juego 10</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1116"/>
+        <location filename="../../core/hotkeys.cpp" line="535"/>
         <source>Save Game State 10</source>
         <translation>Guardar estado de juego 10</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1118"/>
+        <location filename="../../core/hotkeys.cpp" line="537"/>
         <source>Load Global State 1</source>
         <translation>Cargar estado global 1</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1119"/>
+        <location filename="../../core/hotkeys.cpp" line="538"/>
         <source>Save Global State 1</source>
         <translation>Guardar estado global 1</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1120"/>
+        <location filename="../../core/hotkeys.cpp" line="539"/>
         <source>Load Global State 2</source>
         <translation>Cargar estado global 2</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1121"/>
+        <location filename="../../core/hotkeys.cpp" line="540"/>
         <source>Save Global State 2</source>
         <translation>Guardar estado global 2</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1122"/>
+        <location filename="../../core/hotkeys.cpp" line="541"/>
         <source>Load Global State 3</source>
         <translation>Cargar estado global 3</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1123"/>
+        <location filename="../../core/hotkeys.cpp" line="542"/>
         <source>Save Global State 3</source>
         <translation>Guardar estado global 3</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1124"/>
+        <location filename="../../core/hotkeys.cpp" line="543"/>
         <source>Load Global State 4</source>
         <translation>Cargar estado global 4</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1125"/>
+        <location filename="../../core/hotkeys.cpp" line="544"/>
         <source>Save Global State 4</source>
         <translation>Guardar estado global 4</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1126"/>
+        <location filename="../../core/hotkeys.cpp" line="545"/>
         <source>Load Global State 5</source>
         <translation>Cargar estado global 5</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1127"/>
+        <location filename="../../core/hotkeys.cpp" line="546"/>
         <source>Save Global State 5</source>
         <translation>Guardar estado global 5</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1128"/>
+        <location filename="../../core/hotkeys.cpp" line="547"/>
         <source>Load Global State 6</source>
         <translation>Cargar estado global 6</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1129"/>
+        <location filename="../../core/hotkeys.cpp" line="548"/>
         <source>Save Global State 6</source>
         <translation>Guardar estado global 6</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1130"/>
+        <location filename="../../core/hotkeys.cpp" line="549"/>
         <source>Load Global State 7</source>
         <translation>Cargar estado global 7</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1131"/>
+        <location filename="../../core/hotkeys.cpp" line="550"/>
         <source>Save Global State 7</source>
         <translation>Guardar estado global 7</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1132"/>
+        <location filename="../../core/hotkeys.cpp" line="551"/>
         <source>Load Global State 8</source>
         <translation>Cargar estado global 8</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1133"/>
+        <location filename="../../core/hotkeys.cpp" line="552"/>
         <source>Save Global State 8</source>
         <translation>Guardar estado global 8</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1134"/>
+        <location filename="../../core/hotkeys.cpp" line="553"/>
         <source>Load Global State 9</source>
         <translation>Cargar estado global 9</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1135"/>
+        <location filename="../../core/hotkeys.cpp" line="554"/>
         <source>Save Global State 9</source>
         <translation>Guardar estado global 9</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1136"/>
+        <location filename="../../core/hotkeys.cpp" line="555"/>
         <source>Load Global State 10</source>
         <translation>Cargar estado global 10</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1137"/>
+        <location filename="../../core/hotkeys.cpp" line="556"/>
         <source>Save Global State 10</source>
         <translation>Guardar estado global 10</translation>
     </message>
@@ -6627,7 +10494,7 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
 <context>
     <name>InputBindingWidget</name>
     <message numerus="yes">
-        <location filename="../inputbindingwidgets.cpp" line="65"/>
+        <location filename="../inputbindingwidgets.cpp" line="69"/>
         <source>%n bindings</source>
         <translation>
             <numerusform>%n asignación</numerusform>
@@ -6635,8 +10502,8 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
         </translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="280"/>
-        <location filename="../inputbindingwidgets.cpp" line="296"/>
+        <location filename="../inputbindingwidgets.cpp" line="284"/>
+        <location filename="../inputbindingwidgets.cpp" line="300"/>
         <source>Push Button/Axis... [%1]</source>
         <translation>Presiona un botón/eje... [%1]</translation>
     </message>
@@ -6644,17 +10511,17 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
 <context>
     <name>InputVibrationBindingWidget</name>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="446"/>
+        <location filename="../inputbindingwidgets.cpp" line="452"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="447"/>
+        <location filename="../inputbindingwidgets.cpp" line="453"/>
         <source>No devices with vibration motors were detected.</source>
         <translation>No se detectaron dispositivos con motores de vibración.</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="453"/>
+        <location filename="../inputbindingwidgets.cpp" line="459"/>
         <source>Select vibration motor for %1.</source>
         <translation>Selecciona el motor de vibración para %1.</translation>
     </message>
@@ -6662,54 +10529,187 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
 <context>
     <name>LogLevel</name>
     <message>
-        <location filename="../../core/settings.cpp" line="733"/>
+        <location filename="../../core/settings.cpp" line="748"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="733"/>
+        <location filename="../../core/settings.cpp" line="748"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="733"/>
+        <location filename="../../core/settings.cpp" line="749"/>
         <source>Warning</source>
         <translation>Alerta</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="734"/>
+        <location filename="../../core/settings.cpp" line="749"/>
         <source>Performance</source>
         <translation>Rendimiento</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="734"/>
+        <location filename="../../core/settings.cpp" line="750"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="735"/>
+        <location filename="../../core/settings.cpp" line="750"/>
         <source>Verbose</source>
         <translation>Detalle</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="735"/>
+        <location filename="../../core/settings.cpp" line="751"/>
         <source>Developer</source>
         <translation>Desarrollador</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="735"/>
+        <location filename="../../core/settings.cpp" line="751"/>
         <source>Profile</source>
         <translation>Perfil</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="736"/>
+        <location filename="../../core/settings.cpp" line="752"/>
         <source>Debug</source>
         <translation>Depuración</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="736"/>
+        <location filename="../../core/settings.cpp" line="752"/>
         <source>Trace</source>
         <translation>Rastreo</translation>
+    </message>
+</context>
+<context>
+    <name>LogWindow</name>
+    <message>
+        <location filename="../logwindow.cpp" line="91"/>
+        <source>Log Window - %1 [%2]</source>
+        <translation>Ventana de registro - %1 [%2]</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="95"/>
+        <source>Log Window</source>
+        <translation>Ventana de registro</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="114"/>
+        <source>&amp;Clear</source>
+        <translation>&amp;Limpiar</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="116"/>
+        <source>&amp;Save...</source>
+        <translation>&amp;Guardar...</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="121"/>
+        <source>Cl&amp;ose</source>
+        <translation>C&amp;errar</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="124"/>
+        <source>&amp;Settings</source>
+        <translation>&amp;Configuración</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="126"/>
+        <source>Log To &amp;System Console</source>
+        <translation>Registrar en consola del &amp;sistema</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="130"/>
+        <source>Log To &amp;Debug Console</source>
+        <translation>Registrar en consola de &amp;depuración</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="134"/>
+        <source>Log To &amp;File</source>
+        <translation>Registrar en &amp;archivo</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="140"/>
+        <source>Attach To &amp;Main Window</source>
+        <translation>Adjuntar a la ventana &amp;principal</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="144"/>
+        <source>Show &amp;Timestamps</source>
+        <translation>Mostrar marcas de &amp;tiempo</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="150"/>
+        <source>&amp;Log Level</source>
+        <translation>Nivel de &amp;registro</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="159"/>
+        <source>&amp;Filters</source>
+        <translation>&amp;Filtros</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="250"/>
+        <source>Select Log File</source>
+        <translation>Seleccionar archivo de registro</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="250"/>
+        <source>Log Files (*.txt)</source>
+        <translation>Archivos de registro (*.txt)</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="257"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="257"/>
+        <source>Failed to open file for writing.</source>
+        <translation>Fallo al abrir archivo para escritura.</translation>
+    </message>
+    <message>
+        <location filename="../logwindow.cpp" line="264"/>
+        <source>Log was written to %1.
+</source>
+        <translation>Registro guardado en %1.
+</translation>
+    </message>
+</context>
+<context>
+    <name>MAC_APPLICATION_MENU</name>
+    <message>
+        <location filename="../qttranslations.cpp" line="33"/>
+        <source>Services</source>
+        <translation>Servicios</translation>
+    </message>
+    <message>
+        <location filename="../qttranslations.cpp" line="34"/>
+        <source>Hide %1</source>
+        <translation>Ocultar %1</translation>
+    </message>
+    <message>
+        <location filename="../qttranslations.cpp" line="35"/>
+        <source>Hide Others</source>
+        <translation>Ocultar otros</translation>
+    </message>
+    <message>
+        <location filename="../qttranslations.cpp" line="36"/>
+        <source>Show All</source>
+        <translation>Mostrar todos</translation>
+    </message>
+    <message>
+        <location filename="../qttranslations.cpp" line="37"/>
+        <source>Preferences...</source>
+        <translation>Preferencias...</translation>
+    </message>
+    <message>
+        <location filename="../qttranslations.cpp" line="38"/>
+        <source>Quit %1</source>
+        <translation>Salir de %1</translation>
+    </message>
+    <message>
+        <location filename="../qttranslations.cpp" line="39"/>
+        <source>About %1</source>
+        <translation>Acerca de %1</translation>
     </message>
 </context>
 <context>
@@ -6726,8 +10726,8 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../mainwindow.ui" line="39"/>
-        <location filename="../mainwindow.cpp" line="1197"/>
-        <location filename="../mainwindow.cpp" line="1436"/>
+        <location filename="../mainwindow.cpp" line="1163"/>
+        <location filename="../mainwindow.cpp" line="1416"/>
         <source>Change Disc</source>
         <translation>Cambiar disco</translation>
     </message>
@@ -6738,8 +10738,8 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../mainwindow.ui" line="63"/>
-        <location filename="../mainwindow.cpp" line="788"/>
-        <location filename="../mainwindow.cpp" line="1065"/>
+        <location filename="../mainwindow.cpp" line="738"/>
+        <location filename="../mainwindow.cpp" line="1031"/>
         <source>Load State</source>
         <translation>Cargar estado</translation>
     </message>
@@ -7116,7 +11116,7 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../mainwindow.ui" line="805"/>
-        <location filename="../mainwindow.cpp" line="785"/>
+        <location filename="../mainwindow.cpp" line="735"/>
         <source>Resume</source>
         <translation>Resumir</translation>
     </message>
@@ -7172,8 +11172,12 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../mainwindow.ui" line="893"/>
-        <source>Enable GDB server</source>
+        <source>Enable GDB Server</source>
         <translation>Habilitar servidor GDB</translation>
+    </message>
+    <message>
+        <source>Enable GDB server</source>
+        <translation type="vanished">Habilitar servidor GDB</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="902"/>
@@ -7227,11 +11231,13 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
     </message>
     <message>
         <location filename="../mainwindow.ui" line="962"/>
+        <location filename="../mainwindow.cpp" line="1214"/>
         <source>Start Big Picture Mode</source>
         <translation>Iniciar modo Big Picture</translation>
     </message>
     <message>
         <location filename="../mainwindow.ui" line="971"/>
+        <location filename="../mainwindow.cpp" line="1215"/>
         <source>Big Picture</source>
         <translation>Big Picture</translation>
     </message>
@@ -7241,89 +11247,85 @@ Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirector
         <translation>Descargador de portadas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="57"/>
+        <location filename="../mainwindow.cpp" line="62"/>
         <source>All File Types (*.bin *.img *.iso *.cue *.chd *.ecm *.mds *.pbp *.exe *.psexe *.ps-exe *.psf *.minipsf *.m3u);;Single-Track Raw Images (*.bin *.img *.iso);;Cue Sheets (*.cue);;MAME CHD Images (*.chd);;Error Code Modeler Images (*.ecm);;Media Descriptor Sidecar Images (*.mds);;PlayStation EBOOTs (*.pbp *.PBP);;PlayStation Executables (*.exe *.psexe *.ps-exe);;Portable Sound Format Files (*.psf *.minipsf);;Playlists (*.m3u)</source>
         <translation>Todos los archivos (*.bin *.img *.iso *.cue *.chd *.ecm *.mds *.pbp *.exe *.psexe *.psf *.minipsf *.m3u);;Imágenes de pista única (*.bin *.img *.iso);;Archivos CUE (*.cue);;Imágenes CHD de MAME(*.chd);;Imágenes Error Code Modeler (*.ecm);;Imágenes Media Descriptor Sidecar (*.mds);;PlayStation EBOOTs (*.pbp);;PlayStation Executables (*.exe *.psexe *.ps-exe);;Portable Sound Format (*.psf *.minipsf);;Listas de reproducción (*.m3u)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="232"/>
-        <location filename="../mainwindow.cpp" line="241"/>
-        <location filename="../mainwindow.cpp" line="330"/>
-        <location filename="../mainwindow.cpp" line="1085"/>
-        <location filename="../mainwindow.cpp" line="1350"/>
+        <location filename="../mainwindow.cpp" line="304"/>
+        <location filename="../mainwindow.cpp" line="1051"/>
+        <location filename="../mainwindow.cpp" line="1330"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="232"/>
+        <location filename="../mainwindow.cpp" line="304"/>
         <source>Failed to get window info from widget</source>
         <translation>Fallo al obtener información de la ventana del widget</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="241"/>
         <source>Failed to create host display device context.</source>
-        <translation>Fallo al crear el contexto del dispositivo de visualización del sistema.</translation>
+        <translation type="vanished">Fallo al crear el contexto del dispositivo de visualización del sistema.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="330"/>
         <source>Failed to get new window info from widget</source>
-        <translation>Fallo al obtener información de la nueva ventana del widget</translation>
+        <translation type="vanished">Fallo al obtener información de la nueva ventana del widget</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="601"/>
+        <location filename="../mainwindow.cpp" line="552"/>
         <source>Paused</source>
         <translation>En pausa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="709"/>
-        <location filename="../mainwindow.cpp" line="1182"/>
+        <location filename="../mainwindow.cpp" line="660"/>
+        <location filename="../mainwindow.cpp" line="1148"/>
         <source>Select Disc Image</source>
         <translation>Seleccionar imagen de disco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="724"/>
+        <location filename="../mainwindow.cpp" line="675"/>
         <source>Could not find any CD-ROM devices. Please ensure you have a CD-ROM drive connected and sufficient permissions to access it.</source>
         <translation>No se pudo encontrar ningún dispositivo de CD-ROM. Asegúrate de que tienes una unidad de CD-ROM conectada y los permisos de acceso necesarios.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="738"/>
+        <location filename="../mainwindow.cpp" line="689"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="742"/>
+        <location filename="../mainwindow.cpp" line="693"/>
         <source>Select disc drive:</source>
         <translation>Seleccionar unidad de disco:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="808"/>
+        <location filename="../mainwindow.cpp" line="758"/>
         <source>Resume (%1)</source>
         <translation>Continuar (%1)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="815"/>
-        <location filename="../mainwindow.cpp" line="932"/>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="765"/>
+        <location filename="../mainwindow.cpp" line="882"/>
+        <location filename="../mainwindow.cpp" line="921"/>
         <source>Game Save %1 (%2)</source>
         <translation>Estado de juego %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="774"/>
         <source>Edit Memory Cards...</source>
         <translation>Editar tarjetas de memoria...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="872"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Delete Save States...</source>
         <translation>Borrar estados guardados...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="878"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Confirm Save State Deletion</source>
         <translation>Confirmar borrado de estados guardados</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="879"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Are you sure you want to delete all save states for %1?
 
 The saves will not be recoverable.</source>
@@ -7332,67 +11334,67 @@ The saves will not be recoverable.</source>
 Una vez eliminados no se podrán recuperar.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="916"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>Load From File...</source>
         <translation>Cargar desde archivo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"/>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="910"/>
         <source>Select Save State File</source>
         <translation>Seleccionar archivo de estado guardado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="918"/>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="910"/>
         <source>Save States (*.sav)</source>
         <translation>Estados guardados (*.sav)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="924"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Undo Load State</source>
         <translation>Deshacer estado cargado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="932"/>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="882"/>
+        <location filename="../mainwindow.cpp" line="921"/>
         <source>Game Save %1 (Empty)</source>
         <translation>Estado de juego %1 (vacío)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="938"/>
-        <location filename="../mainwindow.cpp" line="977"/>
+        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="927"/>
         <source>Global Save %1 (%2)</source>
         <translation>Estado global %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="938"/>
-        <location filename="../mainwindow.cpp" line="977"/>
+        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="927"/>
         <source>Global Save %1 (Empty)</source>
         <translation>Estado global %1 (vacío)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="955"/>
+        <location filename="../mainwindow.cpp" line="905"/>
         <source>Save To File...</source>
         <translation>Guardar en archivo...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1004"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>&amp;Enabled Cheats</source>
         <translation>&amp;Trucos habilitados</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1006"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>&amp;Apply Cheats</source>
         <translation>&amp;Aplicar trucos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1060"/>
+        <location filename="../mainwindow.cpp" line="1026"/>
         <source>Load Resume State</source>
         <translation>Cargar estado para resumir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1061"/>
+        <location filename="../mainwindow.cpp" line="1027"/>
         <source>A resume save state was found for this game, saved at:
 
 %1.
@@ -7405,154 +11407,180 @@ Do you want to load this state, or start from a fresh boot?</source>
 ¿Quieres cargar este estado, o iniciar desde el principio?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1066"/>
+        <location filename="../mainwindow.cpp" line="1032"/>
         <source>Fresh Boot</source>
         <translation>Inicio de cero</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1067"/>
+        <location filename="../mainwindow.cpp" line="1033"/>
         <source>Delete And Boot</source>
         <translation>Eliminar e iniciar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1086"/>
+        <location filename="../mainwindow.cpp" line="1052"/>
         <source>Failed to delete save state file &apos;%1&apos;.</source>
         <translation>Fallo al eliminar el archivo de estado guardado &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1143"/>
+        <location filename="../mainwindow.cpp" line="1109"/>
         <source>Confirm Disc Change</source>
         <translation>Confirmar cambio de disco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1144"/>
+        <location filename="../mainwindow.cpp" line="1110"/>
         <source>Do you want to swap discs or boot the new image (via system reset)?</source>
         <translation>¿Quieres cambiar discos o iniciar la nueva imagen (reiniciando el sistema)?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1146"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Swap Disc</source>
         <translation>Cambiar disco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1147"/>
+        <location filename="../mainwindow.cpp" line="1113"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1148"/>
+        <location filename="../mainwindow.cpp" line="1114"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1167"/>
+        <location filename="../mainwindow.cpp" line="1133"/>
         <source>Start Disc</source>
         <translation>Iniciar disco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1232"/>
-        <location filename="../mainwindow.cpp" line="2702"/>
+        <location filename="../mainwindow.cpp" line="1198"/>
+        <location filename="../mainwindow.cpp" line="2742"/>
         <source>Cheat Manager</source>
         <translation>Administrador de trucos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1350"/>
+        <location filename="../mainwindow.cpp" line="1214"/>
+        <source>Stop Big Picture Mode</source>
+        <translation>Detener modo Big Picture</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1215"/>
+        <source>Exit Big Picture</source>
+        <translation>Salir de modo Big Picture</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1330"/>
         <source>You must select a disc to change discs.</source>
         <translation>Para cambiar discos, primero debes seleccionar uno.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1389"/>
+        <location filename="../mainwindow.cpp" line="1369"/>
         <source>Properties...</source>
         <translation>Propiedades...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1393"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>Open Containing Directory...</source>
         <translation>Abrir directorio contenedor...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1398"/>
+        <location filename="../mainwindow.cpp" line="1378"/>
         <source>Set Cover Image...</source>
         <translation>Establecer imágen de portada...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1408"/>
+        <location filename="../mainwindow.cpp" line="1388"/>
         <source>Default Boot</source>
         <translation>Inicio predeterminado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1411"/>
+        <location filename="../mainwindow.cpp" line="1391"/>
         <source>Fast Boot</source>
         <translation>Inicio rápido</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1417"/>
+        <location filename="../mainwindow.cpp" line="1397"/>
         <source>Full Boot</source>
         <translation>Inicio completo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1425"/>
+        <location filename="../mainwindow.cpp" line="1405"/>
         <source>Boot and Debug</source>
         <translation>Iniciar y depurar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1445"/>
+        <location filename="../mainwindow.cpp" line="1425"/>
         <source>Exclude From List</source>
         <translation>Excluir de la lista</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1448"/>
+        <location filename="../mainwindow.cpp" line="1428"/>
         <source>Reset Play Time</source>
         <translation>Reiniciar tiempo de juego</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1452"/>
+        <location filename="../mainwindow.cpp" line="1432"/>
         <source>Add Search Directory...</source>
         <translation>Añadir directorio de búsqueda...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1460"/>
+        <location filename="../mainwindow.cpp" line="1441"/>
         <source>Select Cover Image</source>
         <translation>Seleccionar imagen de portada</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1461"/>
         <source>All Cover Image Types (*.jpg *.jpeg *.png)</source>
-        <translation>Todos los archivos de imágenes (*.jpg *.jpeg *.png)</translation>
+        <translation type="vanished">Todos los archivos de imágenes (*.jpg *.jpeg *.png)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1467"/>
+        <location filename="../mainwindow.cpp" line="1459"/>
         <source>Cover Already Exists</source>
         <translation>La portada ya existe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1468"/>
+        <location filename="../mainwindow.cpp" line="1460"/>
         <source>A cover image for this game already exists, do you wish to replace it?</source>
         <translation>Una imágen de portada ya existe para este juego, ¿Quieres reemplazarla?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1482"/>
-        <location filename="../mainwindow.cpp" line="1488"/>
+        <location filename="../mainwindow.cpp" line="1455"/>
+        <location filename="../mainwindow.cpp" line="1469"/>
+        <location filename="../mainwindow.cpp" line="1474"/>
+        <location filename="../mainwindow.cpp" line="1479"/>
         <source>Copy Error</source>
         <translation>Error de copia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1482"/>
+        <location filename="../mainwindow.cpp" line="1441"/>
+        <source>All Cover Image Types (*.jpg *.jpeg *.png *.webp)</source>
+        <translation>Todos los archivos de imágenes (*.jpg *.jpeg *.png *.webp)</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1455"/>
+        <source>You must select a different file to the current cover image.</source>
+        <translation>Debes seleccionar un archivo de imagen diferente al actual.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1469"/>
         <source>Failed to remove existing cover &apos;%1&apos;</source>
         <translation>Fallo al eliminar la portada existente &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1488"/>
+        <location filename="../mainwindow.cpp" line="1474"/>
         <source>Failed to copy &apos;%1&apos; to &apos;%2&apos;</source>
         <translation>Fallo al copiar &quot;%1&quot; a &quot;%2&quot;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1498"/>
+        <location filename="../mainwindow.cpp" line="1479"/>
+        <source>Failed to remove &apos;%1&apos;</source>
+        <translation>Fallo al eliminar &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="1488"/>
         <source>Confirm Reset</source>
         <translation>Confirmar reinicio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1499"/>
+        <location filename="../mainwindow.cpp" line="1489"/>
         <source>Are you sure you want to reset the play time for &apos;%1&apos;?
 
 This action cannot be undone.</source>
@@ -7561,99 +11589,108 @@ This action cannot be undone.</source>
 Esta acción no se puede revertir.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1646"/>
+        <location filename="../mainwindow.cpp" line="1635"/>
         <source>%1x Scale</source>
         <translation>Escala %1x</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2054"/>
-        <location filename="../mainwindow.cpp" line="2061"/>
-        <location filename="../mainwindow.cpp" line="2070"/>
+        <location filename="../mainwindow.cpp" line="2048"/>
+        <location filename="../mainwindow.cpp" line="2055"/>
+        <location filename="../mainwindow.cpp" line="2064"/>
         <source>Destination File</source>
         <translation>Archivo de destino</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2054"/>
-        <location filename="../mainwindow.cpp" line="2070"/>
+        <location filename="../mainwindow.cpp" line="2048"/>
+        <location filename="../mainwindow.cpp" line="2064"/>
         <source>Binary Files (*.bin)</source>
         <translation>Archivos binarios (*.bin)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2062"/>
+        <location filename="../mainwindow.cpp" line="2056"/>
         <source>Binary Files (*.bin);;PNG Images (*.png)</source>
         <translation>Archivos binarios (*.bin);;Imágenes PNG (*.png)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2086"/>
         <source>Default</source>
-        <translation>Predeterminado</translation>
+        <translation type="vanished">Predeterminado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2087"/>
+        <location filename="../generalsettingswidget.cpp" line="14"/>
+        <source>Native</source>
+        <translation>Nativo</translation>
+    </message>
+    <message>
+        <location filename="../generalsettingswidget.cpp" line="15"/>
         <source>Fusion</source>
         <translation>Fusion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2088"/>
+        <location filename="../generalsettingswidget.cpp" line="16"/>
         <source>Dark Fusion (Gray)</source>
         <translation>Dark Fusion (gris)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2089"/>
+        <location filename="../generalsettingswidget.cpp" line="17"/>
         <source>Dark Fusion (Blue)</source>
         <translation>Dark Fusion (azul)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2090"/>
+        <location filename="../generalsettingswidget.cpp" line="18"/>
         <source>QDarkStyle</source>
         <translation>QDarkStyle</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2538"/>
+        <location filename="../mainwindow.cpp" line="2561"/>
         <source>Confirm Shutdown</source>
         <translation>Confirmar apagado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2539"/>
+        <location filename="../mainwindow.cpp" line="2562"/>
         <source>Are you sure you want to shut down the virtual machine?</source>
         <translation>¿Seguro que quieres apagar la máquina virtual?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2541"/>
+        <location filename="../mainwindow.cpp" line="2564"/>
         <source>Save State For Resume</source>
         <translation>Guardar estado para resumir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2617"/>
-        <location filename="../mainwindow.cpp" line="2622"/>
-        <location filename="../mainwindow.cpp" line="2642"/>
-        <location filename="../mainwindow.cpp" line="2651"/>
+        <location filename="../mainwindow.cpp" line="2641"/>
+        <location filename="../mainwindow.cpp" line="2646"/>
+        <location filename="../mainwindow.cpp" line="2666"/>
+        <location filename="../mainwindow.cpp" line="2675"/>
         <source>Memory Card Not Found</source>
         <translation>Tarjeta de memoria no encontrada</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2618"/>
+        <location filename="../mainwindow.cpp" line="2642"/>
         <source>Memory card &apos;%1&apos; does not exist. Do you want to create an empty memory card?</source>
         <translation>La tarjeta de memoria &quot;%1&quot; no existe. ¿Quieres crear una nueva tarjeta de memoria?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2623"/>
+        <location filename="../mainwindow.cpp" line="2647"/>
         <source>Failed to create memory card &apos;%1&apos;</source>
         <translation>Fallo al crear la tarjeta de memoria &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2643"/>
-        <location filename="../mainwindow.cpp" line="2652"/>
+        <location filename="../mainwindow.cpp" line="2667"/>
+        <location filename="../mainwindow.cpp" line="2676"/>
         <source>Memory card &apos;%1&apos; could not be found. Try starting the game and saving to create it.</source>
         <translation>No se puede encontrar la tarjeta de memoria &quot;%1&quot;. Intenta iniciar y guardar el juego para crearla.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2700"/>
+        <location filename="../mainwindow.cpp" line="2692"/>
+        <source>RA: Logged in as %1 (%2, %3 softcore). %4 unread messages.</source>
+        <translation>RA: Sesión iniciada como %1 (%2, %3 en modo normal). %4 mensajes sin leer.</translation>
+    </message>
+    <message>
+        <location filename="../mainwindow.cpp" line="2740"/>
         <source>Do not show again</source>
         <translation>No mostrar de nuevo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2704"/>
+        <location filename="../mainwindow.cpp" line="2744"/>
         <source>Using cheats can have unpredictable effects on games, causing crashes, graphical glitches, and corrupted saves. By using the cheat manager, you agree that it is an unsupported configuration, and we will not provide you with any assistance when games break.
 
 Cheats persist through save states even after being disabled, please remember to reset/reboot the game after turning off any codes.
@@ -7666,17 +11703,17 @@ Los trucos persisten a través de los estados guardados, incluso después de hab
 ¿Seguro que quieres continuar?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2779"/>
+        <location filename="../mainwindow.cpp" line="2819"/>
         <source>Updater Error</source>
         <translation>Error de actualización</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2785"/>
+        <location filename="../mainwindow.cpp" line="2825"/>
         <source>&lt;p&gt;Sorry, you are trying to update a DuckStation version which is not an official GitHub release. To prevent incompatibilities, the auto-updater is only enabled on official builds.&lt;/p&gt;&lt;p&gt;To obtain an official build, please follow the instructions under &quot;Downloading and Running&quot; at the link below:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/&quot;&gt;https://github.com/stenzek/duckstation/&lt;/a&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Estás intentando actualizar una versión de DuckStation no oficial de GitHub. Para prevenir incompatibilidades, el actualizador automático sólo está habilitado en compilaciones oficiales.&lt;/p&gt;&lt;p&gt;Para obtener una versión oficial, sigue las instrucciones en el apartado &quot;Downloading and Running&quot; (Descargando y Corriendo) en el siguiente enlace:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/stenzek/duckstation/&quot;&gt;https://github.com/stenzek/duckstation/&lt;/a&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2791"/>
+        <location filename="../mainwindow.cpp" line="2831"/>
         <source>Automatic updating is not supported on the current platform.</source>
         <translation>Las actualizaciones automáticas no son compatibles con la plataforma actual.</translation>
     </message>
@@ -7924,85 +11961,93 @@ Los trucos persisten a través de los estados guardados, incluso después de hab
 <context>
     <name>MemoryCardSettingsWidget</name>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="19"/>
+        <location filename="../memorycardsettingswidget.cpp" line="23"/>
         <source>All Memory Card Types (*.mcd *.mcr *.mc)</source>
         <translation>Todos los archivos de tarjeta de memoria (*.mcd *.mcr *.mc)</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="41"/>
+        <location filename="../memorycardsettingswidget.cpp" line="45"/>
         <source>Shared Settings</source>
         <translation>Configuración compartida</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="43"/>
-        <location filename="../memorycardsettingswidget.cpp" line="143"/>
+        <location filename="../memorycardsettingswidget.cpp" line="47"/>
+        <location filename="../memorycardsettingswidget.cpp" line="147"/>
         <source>Browse...</source>
         <translation>Buscar...</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="44"/>
-        <location filename="../memorycardsettingswidget.cpp" line="148"/>
+        <location filename="../memorycardsettingswidget.cpp" line="48"/>
+        <location filename="../memorycardsettingswidget.cpp" line="152"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="45"/>
+        <location filename="../memorycardsettingswidget.cpp" line="49"/>
         <source>Open Directory...</source>
         <translation>Abrir directorio...</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="48"/>
+        <location filename="../memorycardsettingswidget.cpp" line="52"/>
         <source>Memory Card Directory:</source>
         <translation>Directorio de tarjeta de memoria:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="61"/>
-        <location filename="../memorycardsettingswidget.cpp" line="66"/>
         <source>Use Single Card For Sub-Images</source>
-        <translation>Utilizar tarjeta única para múltiples discos</translation>
+        <translation type="vanished">Utilizar tarjeta única para múltiples discos</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="66"/>
+        <location filename="../memorycardsettingswidget.cpp" line="70"/>
         <source>Checked</source>
         <translation>Habilitado</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="67"/>
         <source>When using a multi-disc format (m3u/pbp) and per-game (title) memory cards, a single memory card will be used for all discs. If unchecked, a separate card will be used for each disc.</source>
-        <translation>Cuando se utilice un formato de discos múltiples (m3u/pbp) y tarjetas de memoria por juego, se utilizará una única tarjeta para todos los discos. Si se deshabilita, se utilizará una tarjeta diferente para cada disco.</translation>
+        <translation type="vanished">Cuando se utilice un formato de discos múltiples (m3u/pbp) y tarjetas de memoria por juego, se utilizará una única tarjeta para todos los discos. Si se deshabilita, se utilizará una tarjeta diferente para cada disco.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="76"/>
+        <location filename="../memorycardsettingswidget.cpp" line="65"/>
+        <location filename="../memorycardsettingswidget.cpp" line="70"/>
+        <source>Use Single Card For Multi-Disc Games</source>
+        <translation>Utilizar tarjeta única para juegos de múltiples discos</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="71"/>
+        <source>When playing a multi-disc game and using per-game (title) memory cards, a single memory card will be used for all discs. If unchecked, a separate card will be used for each disc.</source>
+        <translation>Cuando se ejecute un juego de múltiples discos y se utilicen tarjetas de memoria por juego, se utilizará una única tarjeta para todos los discos. Si se deshabilita, se utilizará una tarjeta diferente para cada disco.</translation>
+    </message>
+    <message>
+        <location filename="../memorycardsettingswidget.cpp" line="80"/>
         <source>If one of the &quot;separate card per game&quot; memory card types is chosen, these memory cards will be saved to the memory cards directory.</source>
         <translation>Si alguno de los modos &quot;separar tarjeta por juego&quot; es seleccionado, las tarjetas de memoria se guardarán el el directorio de tarjetas de memoria.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="89"/>
+        <location filename="../memorycardsettingswidget.cpp" line="93"/>
         <source>The memory card editor enables you to move saves between cards, as well as import cards of other formats.</source>
         <translation>El editor de tarjetas de memoria te permite mover guardados entre tarjetas e importar tarjetas en otros formatos.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="94"/>
+        <location filename="../memorycardsettingswidget.cpp" line="98"/>
         <source>Memory Card Editor...</source>
         <translation>Editor de tarjetas de memoria...</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="114"/>
+        <location filename="../memorycardsettingswidget.cpp" line="118"/>
         <source>Memory Card %1</source>
         <translation>Tarjeta de memoria %1</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="129"/>
+        <location filename="../memorycardsettingswidget.cpp" line="133"/>
         <source>Memory Card Type:</source>
         <translation>Tipo de tarjeta de memoria:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="153"/>
+        <location filename="../memorycardsettingswidget.cpp" line="157"/>
         <source>Shared Memory Card Path:</source>
         <translation>Directorio de tarjeta de memoria compartida:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="161"/>
+        <location filename="../memorycardsettingswidget.cpp" line="165"/>
         <source>Select path to memory card image</source>
         <translation>Seleccionar directorio para imagen de tarjeta de memoria</translation>
     </message>
@@ -8010,32 +12055,32 @@ Los trucos persisten a través de los estados guardados, incluso después de hab
 <context>
     <name>MemoryCardType</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1209"/>
+        <location filename="../../core/settings.cpp" line="1320"/>
         <source>No Memory Card</source>
         <translation>Sin tarjeta de memoria</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1209"/>
+        <location filename="../../core/settings.cpp" line="1321"/>
         <source>Shared Between All Games</source>
         <translation>Compartida entre todos los juegos</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1210"/>
+        <location filename="../../core/settings.cpp" line="1322"/>
         <source>Separate Card Per Game (Serial)</source>
         <translation>Tarjeta separada por juego (número de serie)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1211"/>
+        <location filename="../../core/settings.cpp" line="1323"/>
         <source>Separate Card Per Game (Title)</source>
         <translation>Tarjeta separada por juego (título)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1212"/>
+        <location filename="../../core/settings.cpp" line="1324"/>
         <source>Separate Card Per Game (File Title)</source>
         <translation>Tarjeta separada por juego (título de archivo)</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1213"/>
+        <location filename="../../core/settings.cpp" line="1325"/>
         <source>Non-Persistent Card (Do Not Save)</source>
         <translation>Tarjeta no persistente (sin guardar)</translation>
     </message>
@@ -8043,22 +12088,22 @@ Los trucos persisten a través de los estados guardados, incluso después de hab
 <context>
     <name>MultitapMode</name>
     <message>
-        <location filename="../../core/settings.cpp" line="1265"/>
+        <location filename="../../core/settings.cpp" line="1377"/>
         <source>Disabled</source>
         <translation>Deshabilitado</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1265"/>
+        <location filename="../../core/settings.cpp" line="1377"/>
         <source>Enable on Port 1 Only</source>
         <translation>Habilitar solamente en puerto 1</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1266"/>
+        <location filename="../../core/settings.cpp" line="1378"/>
         <source>Enable on Port 2 Only</source>
         <translation>Habilitar solamente en puerto 2</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="1266"/>
+        <location filename="../../core/settings.cpp" line="1378"/>
         <source>Enable on Ports 1 and 2</source>
         <translation>Habilitar en puertos 1 y 2</translation>
     </message>
@@ -8066,22 +12111,87 @@ Los trucos persisten a través de los estados guardados, incluso después de hab
 <context>
     <name>NeGcon</name>
     <message>
-        <location filename="../../core/negcon.cpp" line="258"/>
+        <location filename="../../core/negcon.cpp" line="244"/>
+        <source>D-Pad Up</source>
+        <translation>Botón de dirección hacia arriba</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="245"/>
+        <source>D-Pad Right</source>
+        <translation>Botón de dirección hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="246"/>
+        <source>D-Pad Down</source>
+        <translation>Botón de dirección hacia abajo</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="247"/>
+        <source>D-Pad Left</source>
+        <translation>Botón de dirección hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="248"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="249"/>
+        <source>A Button</source>
+        <translation>Botón A</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="250"/>
+        <source>B Button</source>
+        <translation>Botón B</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="251"/>
+        <source>I Button</source>
+        <translation>Botón I</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="252"/>
+        <source>II Button</source>
+        <translation>Botón II</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="253"/>
+        <source>Left Trigger</source>
+        <translation>Gatillo izquierdo</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="254"/>
+        <source>Right Trigger</source>
+        <translation>Gatillo derecho</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="255"/>
+        <source>Steering (Twist) Left</source>
+        <translation>Girar hacia la izquierda</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="256"/>
+        <source>Steering (Twist) Right</source>
+        <translation>Girar hacia la derecha</translation>
+    </message>
+    <message>
+        <location filename="../../core/negcon.cpp" line="264"/>
         <source>Steering Axis Deadzone</source>
         <translation>Zona muerta del eje de dirección</translation>
     </message>
     <message>
-        <location filename="../../core/negcon.cpp" line="259"/>
+        <location filename="../../core/negcon.cpp" line="265"/>
         <source>Sets deadzone size for steering axis.</source>
         <translation>Establece el tamaño para la zona muerta del eje de dirección.</translation>
     </message>
     <message>
-        <location filename="../../core/negcon.cpp" line="261"/>
+        <location filename="../../core/negcon.cpp" line="267"/>
         <source>Steering Axis Sensitivity</source>
         <translation>Sensibilidad del eje de dirección</translation>
     </message>
     <message>
-        <location filename="../../core/negcon.cpp" line="262"/>
+        <location filename="../../core/negcon.cpp" line="268"/>
         <source>Sets the steering axis scaling factor.</source>
         <translation>Establece el factor de escala del eje de dirección.</translation>
     </message>
@@ -8089,213 +12199,227 @@ Los trucos persisten a través de los estados guardados, incluso después de hab
 <context>
     <name>OSDMessage</name>
     <message>
-        <location filename="../mainwindow.cpp" line="437"/>
         <source>Acquired exclusive fullscreen.</source>
-        <translation>Pantalla completa exclusiva adquirida.</translation>
+        <translation type="vanished">Pantalla completa exclusiva adquirida.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="441"/>
         <source>Failed to acquire exclusive fullscreen.</source>
-        <translation>Fallo al adquirir pantalla completa exclusiva.</translation>
+        <translation type="vanished">Fallo al adquirir pantalla completa exclusiva.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="625"/>
         <source>Lost exclusive fullscreen.</source>
-        <translation>Se ha perdido la pantalla completa exclusiva.</translation>
+        <translation type="vanished">Se ha perdido la pantalla completa exclusiva.</translation>
     </message>
     <message>
-        <location filename="../../core/analog_controller.cpp" line="60"/>
+        <location filename="../../core/analog_controller.cpp" line="68"/>
         <source>Analog mode forcing is disabled by game settings. Controller will start in digital mode.</source>
         <translation>Forzado del modo analógico está deshabilitado por la configuración del juego. El control se iniciará en modo digital.</translation>
     </message>
     <message>
-        <location filename="../../core/cdrom.cpp" line="799"/>
+        <location filename="../../core/cdrom.cpp" line="785"/>
         <source>CD image preloading not available for multi-disc image &apos;%s&apos;</source>
-        <translation>La precarga de imagen de CD no está disponible para la imagen de múltiples discos &quot;%s&quot;</translation>
+        <translation>La precarga de imagen de disco no está disponible para la imagen de múltiples discos &quot;%s&quot;</translation>
     </message>
     <message>
-        <location filename="../../core/cdrom.cpp" line="807"/>
+        <location filename="../../core/cdrom.cpp" line="793"/>
         <source>Precaching CD image failed, it may be unreliable.</source>
-        <translation>Fallo al precachear la imagen de CD, podría ser inestable.</translation>
+        <translation>Fallo al precachear la imagen de disco, podría ser inestable.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="248"/>
+        <location filename="../../core/game_database.cpp" line="237"/>
         <source>CPU interpreter forced by game settings.</source>
         <translation>Intérprete de CPU forzado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="260"/>
+        <location filename="../../core/game_database.cpp" line="248"/>
         <source>Software renderer forced by game settings.</source>
         <translation>Renderizado por software forzado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="272"/>
+        <location filename="../../core/game_database.cpp" line="260"/>
         <source>Using software renderer for readbacks based on game settings.</source>
         <translation>Utilizando renderizador por software para lecturas en base a la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="284"/>
+        <location filename="../../core/game_database.cpp" line="271"/>
         <source>Interlacing forced by game settings.</source>
         <translation>Entrelazado forzado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="296"/>
+        <location filename="../../core/game_database.cpp" line="282"/>
         <source>True color disabled by game settings.</source>
         <translation>Color verdadero deshabilitado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="308"/>
+        <location filename="../../core/game_database.cpp" line="293"/>
         <source>Upscaling disabled by game settings.</source>
         <translation>Escalado deshabilitado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="320"/>
+        <location filename="../../core/game_database.cpp" line="304"/>
         <source>Scaled dithering disabled by game settings.</source>
         <translation>Escalado de tramado deshabilitado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="333"/>
+        <location filename="../../core/game_database.cpp" line="317"/>
         <source>Widescreen disabled by game settings.</source>
         <translation>Pantalla panorámica deshabilitada por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="347"/>
+        <location filename="../../core/game_database.cpp" line="329"/>
         <source>Forcing NTSC Timings disallowed by game settings.</source>
         <translation>Forzado de tiempos NTSC deshabilitado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="359"/>
+        <location filename="../../core/game_database.cpp" line="341"/>
         <source>PGXP geometry correction disabled by game settings.</source>
         <translation>Corrección de geometría (PGXP) deshabilitada por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="370"/>
+        <location filename="../../core/game_database.cpp" line="353"/>
         <source>PGXP culling disabled by game settings.</source>
         <translation>Culling (PGXP) deshabilitado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="383"/>
+        <location filename="../../core/game_database.cpp" line="365"/>
         <source>PGXP perspective corrected textures disabled by game settings.</source>
         <translation>Corrección de perspectiva de texturas (PGXP) deshabilitada por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="397"/>
+        <location filename="../../core/game_database.cpp" line="378"/>
         <source>PGXP perspective corrected colors disabled by game settings.</source>
         <translation>Corrección de perspectiva de colores (PGXP) deshabilitada por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="409"/>
+        <location filename="../../core/game_database.cpp" line="389"/>
         <source>PGXP vertex cache forced by game settings.</source>
         <translation>Caché de vértices (PGXP) forzado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="421"/>
+        <location filename="../../core/game_database.cpp" line="400"/>
         <source>PGXP CPU mode forced by game settings.</source>
         <translation>Modo CPU (PGXP) forzado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="433"/>
+        <location filename="../../core/game_database.cpp" line="411"/>
         <source>PGXP Depth Buffer disabled by game settings.</source>
         <translation>Búfer de profundidad (PGXP) deshabilitado por la configuración del juego.</translation>
     </message>
     <message>
-        <location filename="../../core/game_database.cpp" line="497"/>
+        <location filename="../../core/game_database.cpp" line="475"/>
+        <source>Controller in port {0} ({1}) is not supported for {2}.
+Supported controllers: {3}
+Please configure a supported controller from the list above.</source>
+        <translation>El control en el puerto {0} ({1}) no es compatible con {2}.
+Controles soportados: {3}
+Configura un control de la lista de arriba.</translation>
+    </message>
+    <message>
         <source>Controller in port %u (%s) is not supported for %s.
 Supported controllers: %s
 Please configure a supported controller from the list above.</source>
-        <translation>El control en el puerto %u (%s) no es compatible con %s.
+        <translation type="vanished">El control en el puerto %u (%s) no es compatible con %s.
 Controles soportados: %s
 Configura un control de la lista de arriba.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu.cpp" line="54"/>
-        <location filename="../../core/system.cpp" line="3414"/>
-        <location filename="../../core/system.cpp" line="4271"/>
         <source>Failed to load post processing shader chain.</source>
-        <translation>Fallo al cargar la cadena de sombreadores de postprocesamiento.</translation>
+        <translation type="vanished">Fallo al cargar la cadena de sombreadores de postprocesamiento.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="80"/>
         <source>%ux MSAA is not supported, using %ux instead.</source>
-        <translation>El nivel de MSAA %ux no es compatible, se utilizará %ux en su lugar.</translation>
+        <translation type="vanished">El nivel de MSAA %ux no es compatible, se utilizará %ux en su lugar.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="85"/>
+        <location filename="../../core/gpu_hw.cpp" line="450"/>
         <source>SSAA is not supported, using MSAA instead.</source>
         <translation>SSAA no es compatible, se utilizará MSAA en su lugar.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="90"/>
+        <location filename="../../core/gpu_hw.cpp" line="456"/>
         <source>Texture filter &apos;%s&apos; is not supported with the current renderer.</source>
         <translation>El filtro de textura &quot;%s&quot; no es compatible con el renderizador actual.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="98"/>
         <source>Adaptive downsampling is not supported with the current renderer, using box filter instead.</source>
-        <translation>El submuestreo adaptable no es compatible con el renderizador actual, usando el filtro de cuadro en su lugar.</translation>
+        <translation type="vanished">El submuestreo adaptable no es compatible con el renderizador actual, usando el filtro de cuadro en su lugar.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="170"/>
+        <location filename="../../core/gpu_hw.cpp" line="358"/>
         <source>Resolution scale set to %ux (display %ux%u, VRAM %ux%u)</source>
         <translation>Escala de resolución establecida en %ux (pantalla %ux%u, VRAM %ux%u)</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="180"/>
+        <location filename="../../core/gpu_hw.cpp" line="369"/>
         <source>Multisample anti-aliasing set to %ux (SSAA).</source>
         <translation>Suavizado de bordes de muestreo múltiple establecido en %ux (SSAA).</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="186"/>
+        <location filename="../../core/gpu_hw.cpp" line="374"/>
         <source>Multisample anti-aliasing set to %ux.</source>
         <translation>Suavizado de bordes de muestreo múltiple establecido en %ux.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw.cpp" line="250"/>
+        <location filename="../../core/gpu_hw.cpp" line="439"/>
+        <source>{}x MSAA is not supported, using {}x instead.</source>
+        <translation>El nivel de MSAA {}x no es compatible, se utilizará {}x en su lugar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/gpu_hw.cpp" line="467"/>
+        <source>Geometry shaders are not supported by your GPU, and are required for wireframe rendering.</source>
+        <translation>Los sombreadores de geometría no son compatibles con tu GPU, que son necesarios para renderizar las mallas de polígonos.</translation>
+    </message>
+    <message>
+        <location filename="../../core/gpu_hw.cpp" line="482"/>
+        <source>Resolution scale {0}x is not divisible by downsample scale {1}x, using {2}x instead.</source>
+        <translation>La escala de resolución {0}x no es divisible por la escala de submuestreo {1}x, utilizando {2}x en su lugar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/gpu_hw.cpp" line="531"/>
         <source>Resolution scale %ux not supported for adaptive smoothing, using %ux.</source>
         <translation>La escala de resolución %ux no es compatible con el suavizado adaptable, utilizando %ux en su lugar.</translation>
     </message>
     <message>
-        <location filename="../../core/gpu_hw_opengl.cpp" line="1323"/>
         <source>OpenGL renderer unavailable, your driver or hardware is not recent enough. OpenGL 3.1 or OpenGL ES 3.1 is required.</source>
-        <translation>Renderizador de OpenGL no disponible, tu hardware o controladores no son lo suficientemente modernos. Se requiere de OpenGL 3.1 o de OpenGL ES 3.0.</translation>
+        <translation type="vanished">Renderizador de OpenGL no disponible, tu hardware o controladores no son lo suficientemente modernos. Se requiere de OpenGL 3.1 o de OpenGL ES 3.0.</translation>
     </message>
     <message>
-        <location filename="../../core/memory_card.cpp" line="282"/>
+        <location filename="../../core/memory_card.cpp" line="288"/>
         <source>Memory card at &apos;%s&apos; could not be read, formatting.</source>
         <translation>No se pudo leer la tarjeta de memoria en &quot;%s&quot;, formateando.</translation>
     </message>
     <message>
-        <location filename="../../core/memory_card.cpp" line="327"/>
+        <location filename="../../core/memory_card.cpp" line="333"/>
         <source>Failed to save memory card to &apos;{}&apos;.</source>
         <translation>Fallo al guardar la tarjeta de memoria en &quot;{}&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/memory_card.cpp" line="339"/>
+        <location filename="../../core/memory_card.cpp" line="344"/>
         <source>Saved memory card to &apos;{}&apos;.</source>
         <translation>Tarjeta de memoria guardada en &quot;{}&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="196"/>
+        <location filename="../../core/pad.cpp" line="201"/>
         <source>Save state contains controller type %s in port %u, but %s is used. Switching.</source>
         <translation>El estado guardado contiene el tipo de control %s en el puerto %u, pero se está utilizando %s. Cambiando.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="204"/>
+        <location filename="../../core/pad.cpp" line="207"/>
         <source>Ignoring mismatched controller type %s in port %u.</source>
         <translation>Ignorando diferencias en el tipo de control %s en el puerto %u.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="259"/>
+        <location filename="../../core/pad.cpp" line="262"/>
         <source>Memory card %u present in save state but not in system. Creating temporary card.</source>
         <translation>La tarjeta de memoria %u está presente en el estado guardado pero no en el sistema. Creando tarjeta temporal.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="298"/>
+        <location filename="../../core/pad.cpp" line="300"/>
         <source>Memory card %u from save state does match current card data. Simulating replugging.</source>
         <translation>La tarjeta de memoria %u del estado guardado no coincide con los datos de la tarjeta actual. Simulando reconexión.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="316"/>
+        <location filename="../../core/pad.cpp" line="317"/>
         <source>Memory card %u present in save state but not in system. Ignoring card.</source>
         <translation>La tarjeta de memoria %u está presente en el estado guardado pero no en el sistema. Ignorando tarjeta.</translation>
     </message>
@@ -8305,413 +12429,465 @@ Configura un control de la lista de arriba.</translation>
         <translation>La tarjeta de memoria %u está presente en el estado guardado pero no en el sistema. Quitando tarjeta.</translation>
     </message>
     <message>
-        <location filename="../../core/pad.cpp" line="337"/>
+        <location filename="../../core/pad.cpp" line="336"/>
         <source>Memory card %u present in system but not in save state. Replugging card.</source>
         <translation>La tarjeta de memoria %u está presente en el estado guardado pero no en el sistema. Reconectando tarjeta.</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="651"/>
+        <location filename="../../core/settings.cpp" line="628"/>
         <source>PGXP is incompatible with the software renderer, disabling PGXP.</source>
         <translation>PGXP es incompatible con el renderizador por software, se deshabilitará.</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="671"/>
+        <location filename="../../core/settings.cpp" line="646"/>
         <source>Rewind is not supported on 32-bit ARM for Android.</source>
         <translation>El rebobinado no está disponible en dispositivos ARM de 32 bits.</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="678"/>
+        <location filename="../../core/settings.cpp" line="652"/>
         <source>Runahead is not supported on 32-bit ARM for Android.</source>
         <translation>El procesamiento anticipado no está disponible en dispositivos ARM de 32 bits.</translation>
     </message>
     <message>
-        <location filename="../../core/settings.cpp" line="686"/>
+        <location filename="../../core/settings.cpp" line="661"/>
         <source>Rewind is disabled because runahead is enabled.</source>
         <translation>El rebobinado está deshabilitado porque el procesamiento anticipado está habilitado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="969"/>
+        <location filename="../../core/system.cpp" line="1075"/>
         <source>System reset.</source>
         <translation>Sistema reiniciado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1018"/>
+        <location filename="../../core/system.cpp" line="1141"/>
         <source>Loading state from &apos;{}&apos;...</source>
         <translation>Cargando estado desde &quot;{}&quot;...</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1028"/>
+        <location filename="../../core/system.cpp" line="1149"/>
         <source>Loading state from &apos;%s&apos; failed. Resetting.</source>
         <translation>Fallo al cargar estado desde &quot;%s&quot;. Reiniciando.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1068"/>
+        <location filename="../../core/system.cpp" line="1189"/>
         <source>Save State</source>
         <translation>Guardar estado</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1069"/>
+        <location filename="../../core/system.cpp" line="1190"/>
         <source>Saving state to &apos;%s&apos; failed.</source>
         <translation>Fallo al guardar estado en &quot;%s&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1076"/>
+        <location filename="../../core/system.cpp" line="1198"/>
         <source>State saved to &apos;{}&apos;.</source>
         <translation>Estado guardado en &quot;{}&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1430"/>
+        <location filename="../../core/system.cpp" line="1560"/>
         <source>CPU clock speed is set to %u%% (%u / %u). This may result in instability.</source>
-        <translation>La velocidad de reloj del CPU está establecida en %u%% (%u / %u). Esto puede resultar en inestabilidad.</translation>
+        <translation>La velocidad de reloj del CPU está establecida en %u%% (%u / %u). Puede causar inestabilidad.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1437"/>
+        <location filename="../../core/system.cpp" line="1567"/>
         <source>CD-ROM read speedup set to %ux (effective speed %ux). This may result in instability.</source>
-        <translation>La aceleración de lectura de CD-ROM se estableció a %ux (velocidad efectiva %ux). Esto puede resultar en inestabilidad.</translation>
+        <translation>La aceleración de lectura de CD-ROM se estableció a %ux (velocidad efectiva %ux). Puede causar inestabilidad.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1446"/>
+        <location filename="../../core/system.cpp" line="1575"/>
         <source>CD-ROM seek speedup set to instant. This may result in instability.</source>
-        <translation>La aceleración de búsqueda de CD-ROM se estableció a instantánea. Esto puede resultar en inestabilidad.</translation>
+        <translation>La aceleración de búsqueda de CD-ROM se estableció a instantánea. Puede causar inestabilidad.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1453"/>
+        <location filename="../../core/system.cpp" line="1581"/>
         <source>CD-ROM seek speedup set to %ux. This may result in instability.</source>
-        <translation>La aceleración de búsqueda de CD-ROM se estableció a %ux. Esto puede resultar en inestabilidad.</translation>
+        <translation>La aceleración de búsqueda de CD-ROM se estableció a %ux. Puede causar inestabilidad.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1638"/>
+        <location filename="../../core/system.cpp" line="1989"/>
         <source>Failed to initialize %s renderer, falling back to software renderer.</source>
         <translation>Fallo al inicializar el renderizador %s, volviendo al renderizador por software.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1672"/>
+        <location filename="../../core/system.cpp" line="2027"/>
         <source>This save state was created with a different BIOS version or patch options. This may cause stability issues.</source>
         <translation>Este estado guardado se creó utilizando una versión diferente de BIOS o parches. Pueden producirse inestabilidades.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1745"/>
+        <location filename="../../core/system.cpp" line="2099"/>
         <source>WARNING: CPU overclock (%u%%) was different in save state (%u%%).</source>
         <translation>AVISO: El overclock de la CPU (%u%%) era diferente en el estado guardado (%u%%).</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1927"/>
-        <source>Failed to open CD image from save state &apos;%s&apos;: %s. Using existing image &apos;%s&apos;, this may result in instability.</source>
-        <translation>Fallo al abrir la imagen de CD del estado guardado &quot;%s&quot;: %s. Utilizando la imagen existente &quot;%s&quot;, esto puede resultar inestable.</translation>
+        <location filename="../../core/system.cpp" line="2265"/>
+        <source>Failed to open CD image from save state &apos;{}&apos;: {}.
+Using existing image &apos;{}&apos;, this may result in instability.</source>
+        <translation>Fallo al abrir imagen de disco del estado guardado &apos;{}&apos;: {}.
+Utilizando la imagen existente &apos;{}&apos;, puede causar inestabilidad.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2496"/>
+        <location filename="../../core/system.cpp" line="2275"/>
+        <location filename="../../core/system.cpp" line="2294"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="2725"/>
+        <source>{} cheats are now active.</source>
+        <translation>{} trucos están activados.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="2726"/>
+        <source>{} cheats are now inactive.</source>
+        <translation>{} trucos están desactivados.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="3510"/>
+        <source>Switching to {} CPU execution mode.</source>
+        <translation>Cambiando al modo de ejecución de CPU {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="4356"/>
+        <source>{} cheats are enabled. This may result in instability.</source>
+        <translation>{} trucos están activados. Puede causar inestabilidad.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="4419"/>
+        <source>Saved {} cheats to &apos;{}&apos;.</source>
+        <translation>Se guardaron {} trucos en &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="4434"/>
+        <source>Deleted cheat list &apos;{}&apos;.</source>
+        <translation>Se eliminó la lista de trucos &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="4531"/>
+        <source>Widescreen hack is now enabled, and aspect ratio is set to {}.</source>
+        <translation>Pantalla panorámica habilitada, la relación de aspecto se cambió a {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="4539"/>
+        <source>Widescreen hack is now disabled, and aspect ratio is set to {}.</source>
+        <translation>Pantalla panorámica deshabilitada, la relación de aspecto se cambió a {}.</translation>
+    </message>
+    <message>
+        <source>Failed to open CD image from save state &apos;%s&apos;: %s. Using existing image &apos;%s&apos;, this may result in instability.</source>
+        <translation type="vanished">Fallo al abrir la imagen de CD del estado guardado &quot;%s&quot;: %s. Utilizando la imagen existente &quot;%s&quot;, esto puede resultar inestable.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="2682"/>
         <source>Rewinding is not enabled.</source>
         <translation>El rebobinado no está habilitado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2538"/>
+        <location filename="../../core/system.cpp" line="2717"/>
         <source>No cheats are loaded.</source>
         <translation>No hay trucos cargados.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/system.cpp" line="2546"/>
         <source>%n cheats are now active.</source>
-        <translation>
+        <translation type="vanished">
             <numerusform>%n truco está activado.</numerusform>
             <numerusform>%n trucos están activados.</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/system.cpp" line="2547"/>
         <source>%n cheats are now inactive.</source>
-        <translation>
+        <translation type="vanished">
             <numerusform>%n truco está desactivado.</numerusform>
             <numerusform>%n trucos están desactivados.</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2893"/>
+        <location filename="../../core/system.cpp" line="3118"/>
         <source>Swapped memory card ports. Both ports have a memory card.</source>
         <translation>Ranuras de memoria intercambiadas. Ambas ranuras tienen una tarjeta de memoria.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2898"/>
+        <location filename="../../core/system.cpp" line="3124"/>
         <source>Swapped memory card ports. Port 2 has a memory card, Port 1 is empty.</source>
         <translation>Ranuras de memoria intercambiadas. La ranura 2 tiene una tarjeta de memoria, la ranura 1 está vacía.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2904"/>
+        <location filename="../../core/system.cpp" line="3129"/>
         <source>Swapped memory card ports. Port 1 has a memory card, Port 2 is empty.</source>
         <translation>Ranuras de memoria intercambiadas. La ranura 1 tiene una tarjeta de memoria, la ranura 2 está vacía.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2910"/>
+        <location filename="../../core/system.cpp" line="3133"/>
         <source>Swapped memory card ports. Neither port has a memory card.</source>
         <translation>Ranuras de memoria intercambiadas. Ninguna de las ranuras tienen una tarjeta de memoria.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2995"/>
+        <location filename="../../core/system.cpp" line="3220"/>
         <source>Failed to open disc image &apos;%s&apos;: %s.</source>
         <translation>Fallo al abrir la imagen de disco &quot;%s&quot;: %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3007"/>
+        <location filename="../../core/system.cpp" line="3233"/>
         <source>Inserted disc &apos;%s&apos; (%s).</source>
         <translation>Insertado disco &quot;%s&quot; (%s).</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3183"/>
+        <location filename="../../core/system.cpp" line="3414"/>
         <source>Failed to switch to subimage %u in &apos;%s&apos;: %s.</source>
         <translation>Fallo al cambiar a la subimagen %u en &quot;%s&quot;: %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3189"/>
+        <location filename="../../core/system.cpp" line="3422"/>
         <source>Switched to sub-image %s (%u) in &apos;%s&apos;.</source>
         <translation>Cambiado a la subimagen %s (%u) en &quot;%s&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3230"/>
+        <location filename="../../core/system.cpp" line="3464"/>
         <source>Switching to %s%s GPU renderer.</source>
         <translation>Cambiando al renderizador de GPU %s%s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3254"/>
+        <location filename="../../core/system.cpp" line="3488"/>
         <source>Switching to %s audio backend.</source>
         <translation>Cambiando al motor de audio %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3276"/>
         <source>Switching to %s CPU execution mode.</source>
-        <translation>Cambiando al modo de ejecución de CPU %s.</translation>
+        <translation type="vanished">Cambiando al modo de ejecución de CPU %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3289"/>
+        <location filename="../../core/system.cpp" line="3525"/>
         <source>Recompiler options changed, flushing all blocks.</source>
         <translation>Las opciones del recompilador cambiaron, liberando todos los bloques.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3354"/>
+        <location filename="../../core/system.cpp" line="3593"/>
         <source>PGXP enabled, recompiling all blocks.</source>
         <translation>PGXP habilitado, recompilando todos los bloques.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3355"/>
+        <location filename="../../core/system.cpp" line="3594"/>
         <source>PGXP disabled, recompiling all blocks.</source>
         <translation>PGXP deshabilitado, recompilando todos los bloques.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3799"/>
+        <location filename="../../core/system.cpp" line="4055"/>
         <source>Failed to save undo load state.</source>
         <translation>Fallo al guardar el deshacer del estado cargado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3860"/>
+        <location filename="../../core/system.cpp" line="4116"/>
         <source>Started dumping audio to &apos;%s&apos;.</source>
         <translation>Comenzando a volcar audio en &quot;%s&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3865"/>
+        <location filename="../../core/system.cpp" line="4121"/>
         <source>Failed to start dumping audio to &apos;%s&apos;.</source>
         <translation>Fallo al comenzar a volcar audio en &quot;%s&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3876"/>
+        <location filename="../../core/system.cpp" line="4131"/>
         <source>Stopped dumping audio.</source>
         <translation>Volcado de audio finalizado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3906"/>
+        <location filename="../../core/system.cpp" line="4161"/>
         <source>Screenshot file &apos;%s&apos; already exists.</source>
         <translation>La captura de pantalla &quot;%s&quot; ya existe.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3916"/>
+        <location filename="../../core/system.cpp" line="4170"/>
         <source>Failed to save screenshot to &apos;%s&apos;</source>
         <translation>Fallo al guardar la captura de pantalla &quot;%s&quot;</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3921"/>
+        <location filename="../../core/system.cpp" line="4174"/>
         <source>Screenshot saved to &apos;%s&apos;.</source>
         <translation>Captura de pantalla guardada en &quot;%s&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4097"/>
+        <location filename="../../core/system.cpp" line="4349"/>
         <source>Failed to load cheats from &apos;%s&apos;.</source>
         <translation>Fallo al cargar trucos desde &quot;%s&quot;.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/system.cpp" line="4104"/>
         <source>%n cheats are enabled. This may result in instability.</source>
-        <translation>
+        <translation type="vanished">
             <numerusform>%n truco está activado. Esto puede causar inestabilidad.</numerusform>
             <numerusform>%n trucos estan activados. Esto puede causar inestabilidad.</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4151"/>
+        <location filename="../../core/system.cpp" line="4403"/>
         <source>Failed to save cheat list to &apos;%s&apos;</source>
         <translation>Fallo al guardar la lista de trucos en &quot;%s&quot;</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/system.cpp" line="4168"/>
         <source>Saved %n cheats to &apos;%s&apos;.</source>
-        <translation>
+        <translation type="vanished">
             <numerusform>Se guardó %n truco en &quot;%s&quot;.</numerusform>
             <numerusform>Se guardaron %n trucos en &quot;%s&quot;.</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4184"/>
         <source>Deleted cheat list &apos;%s&apos;.</source>
-        <translation>Se eliminó la lista de trucos &quot;%s&quot;.</translation>
+        <translation type="vanished">Se eliminó la lista de trucos &quot;%s&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4227"/>
+        <location filename="../../core/system.cpp" line="4476"/>
         <source>Cheat &apos;%s&apos; enabled.</source>
         <translation>Truco &quot;%s&quot; activado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4232"/>
+        <location filename="../../core/system.cpp" line="4480"/>
         <source>Cheat &apos;%s&apos; disabled.</source>
         <translation>Truco &quot;%s&quot; desactivado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4249"/>
+        <location filename="../../core/system.cpp" line="4496"/>
         <source>Applied cheat &apos;%s&apos;.</source>
         <translation>Aplicado truco &quot;%s&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4254"/>
+        <location filename="../../core/system.cpp" line="4500"/>
         <source>Cheat &apos;%s&apos; is already enabled.</source>
         <translation>El truco &quot;%s&quot; ya está activado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4268"/>
+        <location filename="../../util/postprocessing.cpp" line="413"/>
+        <source>Failed to load post-processing chain: {}</source>
+        <translation>Fallo al cargar la cadena de postprocesamiento: {}</translation>
+    </message>
+    <message>
+        <location filename="../../util/postprocessing.cpp" line="548"/>
+        <location filename="../../util/postprocessing.cpp" line="568"/>
+        <source>No post-processing shaders are selected.</source>
+        <translation>No se seleccionaron sombreadores de postprocesamiento.</translation>
+    </message>
+    <message>
+        <location filename="../../util/postprocessing.cpp" line="555"/>
         <source>Post-processing is now enabled.</source>
         <translation>Postprocesamiento habilitado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4277"/>
+        <location filename="../../util/postprocessing.cpp" line="556"/>
         <source>Post-processing is now disabled.</source>
         <translation>Postprocesamiento deshabilitado.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4288"/>
         <source>Failed to load post-processing shader chain.</source>
-        <translation>Fallo al cargar la cadena de sombreadores de postprocesamiento.</translation>
+        <translation type="vanished">Fallo al cargar la cadena de sombreadores de postprocesamiento.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4290"/>
+        <location filename="../../util/postprocessing.cpp" line="578"/>
         <source>Post-processing shaders reloaded.</source>
         <translation>Sombreadores de postprocesamiento recargados.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4319"/>
         <source>Widescreen hack is now enabled, and aspect ratio is set to %s.</source>
-        <translation>Pantalla panorámica habilitada, la relación de aspecto se cambió a %s.</translation>
+        <translation type="vanished">Pantalla panorámica habilitada, la relación de aspecto se cambió a %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4327"/>
         <source>Widescreen hack is now disabled, and aspect ratio is set to %s.</source>
-        <translation>Pantalla panorámica deshabilitada, la relación de aspecto se cambió a %s.</translation>
+        <translation type="vanished">Pantalla panorámica deshabilitada, la relación de aspecto se cambió a %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="4343"/>
+        <location filename="../../core/system.cpp" line="4553"/>
         <source>Switching to %s renderer...</source>
         <translation>Cambiando al renderizador %s...</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="640"/>
+        <location filename="../../core/hotkeys.cpp" line="69"/>
         <source>Cannot load state for game without serial.</source>
         <translation>No se puede cargar estado para un juego sin número de serie.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="650"/>
+        <location filename="../../core/hotkeys.cpp" line="79"/>
         <source>No save state found in slot {}.</source>
         <translation>No se encontró un estado guardado en la ranura {}.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="664"/>
+        <location filename="../../core/hotkeys.cpp" line="93"/>
         <source>Cannot save state for game without serial.</source>
         <translation>No se puede guardar estado para un juego sin número de serie.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="742"/>
         <source>Achievements are disabled or unavailable for  game.</source>
-        <translation>Los logros están desactivados o no disponibles para este juego.</translation>
+        <translation type="vanished">Los logros están desactivados o no disponibles para este juego.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="755"/>
         <source>Leaderboards are disabled or unavailable for  game.</source>
-        <translation>Las tablas de posiciones están deshabilitadas o no disponibles para este juego.</translation>
+        <translation type="vanished">Las tablas de posiciones están deshabilitadas o no disponibles para este juego.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="825"/>
+        <location filename="../../core/hotkeys.cpp" line="242"/>
         <source>CPU clock speed control enabled (%u%% / %.3f MHz).</source>
         <translation>Control de la velocidad de reloj de la CPU habilitado (%u%% / %.3f MHz).</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="832"/>
+        <location filename="../../core/hotkeys.cpp" line="249"/>
         <source>CPU clock speed control disabled (%.3f MHz).</source>
         <translation>Control de la velocidad de reloj de la CPU deshabilitado (%u%% / %.3f MHz).</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="845"/>
-        <location filename="../../frontend-common/common_host.cpp" line="857"/>
-        <location filename="../../frontend-common/common_host.cpp" line="869"/>
+        <location filename="../../core/hotkeys.cpp" line="262"/>
+        <location filename="../../core/hotkeys.cpp" line="274"/>
+        <location filename="../../core/hotkeys.cpp" line="286"/>
         <source>Emulation speed set to %u%%.</source>
         <translation>Velocidad de emulación establecida a %u%%.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="891"/>
+        <location filename="../../core/hotkeys.cpp" line="308"/>
         <source>PGXP is now enabled.</source>
         <translation>PGXP está habilitado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="892"/>
+        <location filename="../../core/hotkeys.cpp" line="309"/>
         <source>PGXP is now disabled.</source>
         <translation>PGXP está deshabilitado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="935"/>
+        <location filename="../../core/hotkeys.cpp" line="355"/>
         <source>Texture replacements reloaded.</source>
         <translation>Reemplazos de textura recargados.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="962"/>
+        <location filename="../../core/hotkeys.cpp" line="381"/>
         <source>PGXP Depth Buffer is now enabled.</source>
         <translation>Búfer de profundidad (PGXP) habilitado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="963"/>
+        <location filename="../../core/hotkeys.cpp" line="382"/>
         <source>PGXP Depth Buffer is now disabled.</source>
         <translation>Búfer de profundidad (PGXP) deshabilitado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="982"/>
+        <location filename="../../core/hotkeys.cpp" line="402"/>
         <source>PGXP CPU mode is now enabled.</source>
         <translation>Modo CPU (PGXP) habilitado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="983"/>
+        <location filename="../../core/hotkeys.cpp" line="403"/>
         <source>PGXP CPU mode is now disabled.</source>
         <translation>Modo CPU (PGXP) deshabilitado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1004"/>
+        <location filename="../../core/hotkeys.cpp" line="425"/>
         <source>Volume: Muted</source>
         <translation>Volumen: silenciado</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1009"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1036"/>
-        <location filename="../../frontend-common/common_host.cpp" line="1052"/>
+        <location filename="../../core/hotkeys.cpp" line="430"/>
+        <location filename="../../core/hotkeys.cpp" line="457"/>
+        <location filename="../../core/hotkeys.cpp" line="471"/>
         <source>Volume: {}%</source>
         <translation>Volumen: {}%</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1021"/>
+        <location filename="../../core/hotkeys.cpp" line="441"/>
         <source>CD Audio Muted.</source>
         <translation>Audio de CD silenciado.</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/common_host.cpp" line="1022"/>
+        <location filename="../../core/hotkeys.cpp" line="442"/>
         <source>CD Audio Unmuted.</source>
         <translation>Audio de CD desilenciado.</translation>
     </message>
@@ -8719,77 +12895,115 @@ Configura un control de la lista de arriba.</translation>
 <context>
     <name>PlayStationMouse</name>
     <message>
-        <location filename="../../core/playstation_mouse.cpp" line="192"/>
         <source>Relative Mouse Mode</source>
-        <translation>Modo de mouse relativo</translation>
+        <translation type="vanished">Modo de mouse relativo</translation>
     </message>
     <message>
-        <location filename="../../core/playstation_mouse.cpp" line="193"/>
         <source>Locks the mouse cursor to the window, use for FPS games.</source>
-        <translation>Bloquea el cursor del mouse a la ventana, útil para juegos FPS.</translation>
+        <translation type="vanished">Bloquea el cursor del mouse a la ventana, útil para juegos FPS.</translation>
+    </message>
+    <message>
+        <location filename="../../core/playstation_mouse.cpp" line="203"/>
+        <source>Left Button</source>
+        <translation>Botón izquierdo</translation>
+    </message>
+    <message>
+        <location filename="../../core/playstation_mouse.cpp" line="204"/>
+        <source>Right Button</source>
+        <translation>Botón derecho</translation>
+    </message>
+    <message>
+        <location filename="../../core/playstation_mouse.cpp" line="210"/>
+        <source>Horizontal Sensitivity</source>
+        <translation>Sensibilidad horizontal</translation>
+    </message>
+    <message>
+        <location filename="../../core/playstation_mouse.cpp" line="211"/>
+        <location filename="../../core/playstation_mouse.cpp" line="214"/>
+        <source>Adjusts the correspondance between physical and virtual mouse movement.</source>
+        <translation>Ajusta la correspondencia entre moviemientos físicos y virtuales del mouse.</translation>
+    </message>
+    <message>
+        <location filename="../../core/playstation_mouse.cpp" line="213"/>
+        <source>Vertical Sensitivity</source>
+        <translation>Sensibilidad vertical</translation>
+    </message>
+</context>
+<context>
+    <name>PlaystationMouse</name>
+    <message>
+        <location filename="../../core/playstation_mouse.cpp" line="202"/>
+        <source>Pointer</source>
+        <translation>Cursor</translation>
+    </message>
+</context>
+<context>
+    <name>PostProcessing</name>
+    <message>
+        <location filename="../../util/postprocessing.cpp" line="174"/>
+        <source>{} [GLSL]</source>
+        <translation>{} [GLSL]</translation>
+    </message>
+    <message>
+        <location filename="../../util/postprocessing.cpp" line="200"/>
+        <source>{} [ReShade]</source>
+        <translation>{} [ReShade]</translation>
+    </message>
+    <message>
+        <location filename="../../util/postprocessing.cpp" line="414"/>
+        <source>Unknown Error</source>
+        <translation>Error desconocido</translation>
     </message>
 </context>
 <context>
     <name>PostProcessingChainConfigWidget</name>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="20"/>
         <source>Form</source>
-        <translation>Form</translation>
+        <translation type="vanished">Form</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="50"/>
         <source>Add</source>
-        <translation>Añadir</translation>
+        <translation type="vanished">Añadir</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="69"/>
         <source>Remove</source>
-        <translation>Eliminar</translation>
+        <translation type="vanished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="88"/>
         <source>Clear</source>
-        <translation>Limpiar</translation>
+        <translation type="vanished">Limpiar</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="107"/>
         <source>Move Up</source>
-        <translation>Mover arriba</translation>
+        <translation type="vanished">Mover arriba</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="126"/>
         <source>Move Down</source>
-        <translation>Mover abajo</translation>
+        <translation type="vanished">Mover abajo</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="145"/>
         <source>Options...</source>
-        <translation>Opciones...</translation>
+        <translation type="vanished">Opciones...</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="118"/>
         <source>No Shaders Available</source>
-        <translation>No hay sombreadores disponibles</translation>
+        <translation type="vanished">No hay sombreadores disponibles</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="130"/>
         <source>Error</source>
-        <translation>Error</translation>
+        <translation type="vanished">Error</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="130"/>
         <source>Failed to add shader. The log may contain more information.</source>
-        <translation>Error al añadir sombreador. El registro puede contener más información.</translation>
+        <translation type="vanished">Error al añadir sombreador. El registro puede contener más información.</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="162"/>
         <source>Question</source>
-        <translation>Pregunta</translation>
+        <translation type="vanished">Pregunta</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.cpp" line="162"/>
         <source>Are you sure you want to clear all shader stages?</source>
-        <translation>¿Seguro que quieres limpiar la configuración de sombreadores?</translation>
+        <translation type="vanished">¿Seguro que quieres limpiar la configuración de sombreadores?</translation>
     </message>
 </context>
 <context>
@@ -8815,48 +13029,91 @@ Configura un control de la lista de arriba.</translation>
         <translation>Cadena de postprocesamiento</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="27"/>
+        <location filename="../postprocessingsettingswidget.ui" line="97"/>
+        <source>Add</source>
+        <translation>Añadir</translation>
+    </message>
+    <message>
+        <location filename="../postprocessingsettingswidget.ui" line="117"/>
+        <source>Remove</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../postprocessingsettingswidget.ui" line="137"/>
+        <source>Clear</source>
+        <translation>Limpiar</translation>
+    </message>
+    <message>
+        <location filename="../postprocessingsettingswidget.ui" line="157"/>
+        <source>Move Up</source>
+        <translation>Mover arriba</translation>
+    </message>
+    <message>
+        <location filename="../postprocessingsettingswidget.ui" line="177"/>
+        <source>Move Down</source>
+        <translation>Mover abajo</translation>
+    </message>
+    <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="150"/>
+        <source>No Shaders Available</source>
+        <translation>No hay sombreadores disponibles</translation>
+    </message>
+    <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="165"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="27"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="166"/>
+        <source>Failed to add shader: %1</source>
+        <translation>Fallo al añadir sombreador: %1</translation>
+    </message>
+    <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="202"/>
+        <source>Question</source>
+        <translation>Pregunta</translation>
+    </message>
+    <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="202"/>
+        <source>Are you sure you want to clear all shader stages?</source>
+        <translation>¿Seguro que quieres limpiar la configuración de sombreadores?</translation>
+    </message>
+    <message>
         <source>The current post-processing chain is invalid, it has been reset.</source>
-        <translation>La cadena de postprocesamiento actual es inválida y se ha reiniciado.</translation>
+        <translation type="vanished">La cadena de postprocesamiento actual es inválida y se ha reiniciado.</translation>
     </message>
 </context>
 <context>
     <name>PostProcessingShaderConfigDialog</name>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="152"/>
         <source>%1 Shader Options</source>
-        <translation>Opciones del sombreador %1</translation>
+        <translation type="vanished">Opciones del sombreador %1</translation>
     </message>
 </context>
 <context>
     <name>PostProcessingShaderConfigWidget</name>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="57"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="335"/>
         <source>Red</source>
         <translation>Rojo</translation>
     </message>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="57"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="335"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="57"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="335"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="57"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="335"/>
         <source>Alpha</source>
         <translation>Alfa</translation>
     </message>
     <message>
-        <location filename="../postprocessingshaderconfigwidget.cpp" line="58"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="336"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
@@ -8864,12 +13121,12 @@ Configura un control de la lista de arriba.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../qtutils.cpp" line="684"/>
+        <location filename="../qtutils.cpp" line="686"/>
         <source>Failed to open URL</source>
         <translation>Fallo al abrir URL</translation>
     </message>
     <message>
-        <location filename="../qtutils.cpp" line="685"/>
+        <location filename="../qtutils.cpp" line="687"/>
         <source>Failed to open URL.
 
 The URL was: %1</source>
@@ -8899,29 +13156,29 @@ La URL era: %1</translation>
 <context>
     <name>QtHost</name>
     <message>
-        <location filename="../qthost.cpp" line="2074"/>
-        <location filename="../qthost.cpp" line="2100"/>
-        <location filename="../qthost.cpp" line="2116"/>
+        <location filename="../qthost.cpp" line="1949"/>
+        <location filename="../qthost.cpp" line="1975"/>
+        <location filename="../qthost.cpp" line="1991"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2075"/>
+        <location filename="../qthost.cpp" line="1950"/>
         <source>File &apos;%1&apos; does not exist.</source>
         <translation>El archivo &quot;%1&quot; no existe.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2101"/>
+        <location filename="../qthost.cpp" line="1976"/>
         <source>The specified save state does not exist.</source>
         <translation>El estado guardado especificado no existe.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2117"/>
+        <location filename="../qthost.cpp" line="1992"/>
         <source>Cannot use no-gui mode, because no boot filename was specified.</source>
         <translation>No se puede utilizar el modo No-GUI porque no se especificó un archivo de arranque.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2118"/>
+        <location filename="../qthost.cpp" line="1993"/>
         <source>Cannot use batch mode, because no boot filename was specified.</source>
         <translation>No se puede utilizar el modo por lotes porque no se especificó un archivo de arranque.</translation>
     </message>
@@ -8957,42 +13214,42 @@ La URL era: %1</translation>
 <context>
     <name>SaveStateSelectorUI</name>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="681"/>
+        <location filename="../../core/imgui_overlays.cpp" line="771"/>
         <source>Load</source>
         <translation>Cargar</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="683"/>
+        <location filename="../../core/imgui_overlays.cpp" line="773"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="685"/>
+        <location filename="../../core/imgui_overlays.cpp" line="775"/>
         <source>Select Previous</source>
         <translation>Seleccionar anterior</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="687"/>
+        <location filename="../../core/imgui_overlays.cpp" line="777"/>
         <source>Select Next</source>
         <translation>Seleccionar siguiente</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="744"/>
+        <location filename="../../core/imgui_overlays.cpp" line="835"/>
         <source>No Save State</source>
         <translation>Ningún estado guardado</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="817"/>
+        <location filename="../../core/imgui_overlays.cpp" line="909"/>
         <source>Global Slot %d</source>
         <translation>Ranura global %d</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="821"/>
+        <location filename="../../core/imgui_overlays.cpp" line="913"/>
         <source>Game Slot %d</source>
         <translation>Ranura de juego %d</translation>
     </message>
     <message>
-        <location filename="../../frontend-common/imgui_overlays.cpp" line="825"/>
+        <location filename="../../core/imgui_overlays.cpp" line="917"/>
         <source>%s Slot %d</source>
         <translation>%s ranura %d</translation>
     </message>
@@ -9000,21 +13257,49 @@ La URL era: %1</translation>
 <context>
     <name>SettingWidgetBinder</name>
     <message>
-        <location filename="../settingwidgetbinder.h" line="322"/>
-        <location filename="../settingwidgetbinder.h" line="452"/>
+        <location filename="../settingwidgetbinder.h" line="324"/>
+        <location filename="../settingwidgetbinder.h" line="454"/>
         <source>Default: </source>
         <translation>Predeterminado: </translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="421"/>
-        <location filename="../settingwidgetbinder.h" line="551"/>
+        <location filename="../settingwidgetbinder.h" line="423"/>
+        <location filename="../settingwidgetbinder.h" line="553"/>
         <source>Reset</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1077"/>
+        <location filename="../settingwidgetbinder.h" line="1066"/>
+        <source>Confirm Folder</source>
+        <translation>Confirmar directorio</translation>
+    </message>
+    <message>
+        <location filename="../settingwidgetbinder.h" line="1068"/>
+        <source>The chosen directory does not currently exist:
+
+%1
+
+Do you want to create this directory?</source>
+        <translation>El directorio seleccionado no existe:
+
+%1
+
+¿Quieres crear este directorio?</translation>
+    </message>
+    <message>
+        <location filename="../settingwidgetbinder.h" line="1091"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../settingwidgetbinder.h" line="1092"/>
+        <source>Folder path cannot be empty.</source>
+        <translation>El directorio no puede estar vacío.</translation>
+    </message>
+    <message>
+        <location filename="../settingwidgetbinder.h" line="1113"/>
         <source>Select folder for %1</source>
-        <translation>Seleccionar carpeta para %1</translation>
+        <translation>Seleccionar directorio para %1</translation>
     </message>
 </context>
 <context>
@@ -9025,252 +13310,591 @@ La URL era: %1</translation>
         <translation>Configuración de DuckStation</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="50"/>
+        <location filename="../settingsdialog.cpp" line="51"/>
         <source>Summary</source>
         <translation>Resumen</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="52"/>
+        <location filename="../settingsdialog.cpp" line="53"/>
         <source>&lt;strong&gt;Summary&lt;/strong&gt;&lt;hr&gt;This page shows information about the selected game, and allows you to validate your disc was dumped correctly.</source>
         <translation>&lt;strong&gt;Resumen&lt;/strong&gt;&lt;hr&gt;Esta página muestra información sobre el juego seleccionado, y te permite comprobar si tu disco fue volcado correctamente.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="67"/>
+        <location filename="../settingsdialog.cpp" line="68"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="69"/>
+        <location filename="../settingsdialog.cpp" line="70"/>
         <source>&lt;strong&gt;General Settings&lt;/strong&gt;&lt;hr&gt;These options control how the emulator looks and behaves.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Configuración general&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan como se ve y comporta el emulador.&lt;br&gt;&lt;br&gt;Pasa el cursor sobre alguna opción para más información.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="75"/>
+        <location filename="../settingsdialog.cpp" line="76"/>
         <source>Game List</source>
         <translation>Lista de juegos</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="77"/>
+        <location filename="../settingsdialog.cpp" line="78"/>
         <source>&lt;strong&gt;Game List Settings&lt;/strong&gt;&lt;hr&gt;The list above shows the directories which will be searched by DuckStation to populate the game list. Search directories can be added, removed, and switched to recursive/non-recursive.</source>
         <translation>&lt;strong&gt;Configuración de lista de juegos&lt;/strong&gt;&lt;hr&gt;La lista de arriba indica los directorios en los cuales se buscarán los juegos a aparecer en la lista. Se pueden añadir y quitar directorios, y buscar tanto de forma recursiva como no.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="82"/>
+        <location filename="../settingsdialog.cpp" line="83"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="84"/>
+        <location filename="../settingsdialog.cpp" line="85"/>
         <source>&lt;strong&gt;BIOS Settings&lt;/strong&gt;&lt;hr&gt;These options control which BIOS is used and how it will be patched.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Configuración de BIOS&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan que BIOS utilizar y como será parcheado.&lt;br&gt;&lt;br&gt;Pasa el cursor sobre alguna opción para más información.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="86"/>
+        <location filename="../settingsdialog.cpp" line="87"/>
         <source>Console</source>
         <translation>Consola</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="88"/>
+        <location filename="../settingsdialog.cpp" line="89"/>
         <source>&lt;strong&gt;Console Settings&lt;/strong&gt;&lt;hr&gt;These options determine the configuration of the simulated console.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Configuración de consola&lt;/strong&gt;&lt;hr&gt;Estas opciones determinan la configuración de la consola emulada.&lt;br&gt;&lt;br&gt;Pasa el cursor sobre alguna opción para más información.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="90"/>
+        <location filename="../settingsdialog.cpp" line="91"/>
         <source>Emulation</source>
         <translation>Emulación</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="92"/>
+        <location filename="../settingsdialog.cpp" line="93"/>
         <source>&lt;strong&gt;Emulation Settings&lt;/strong&gt;&lt;hr&gt;These options determine the speed and runahead behavior of the system.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Configuración de emulación&lt;/strong&gt;&lt;hr&gt;Estas opciones determinan la velocidad y el comportamiento del procesamiento anticipado del sistema.&lt;br&gt;&lt;br&gt;Pasa el cursor sobre alguna opción para más información.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="95"/>
+        <location filename="../settingsdialog.cpp" line="96"/>
         <source>Memory Cards</source>
         <translation>Tarjetas de memoria</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="97"/>
+        <location filename="../settingsdialog.cpp" line="98"/>
         <source>&lt;strong&gt;Memory Card Settings&lt;/strong&gt;&lt;hr&gt;This page lets you control what mode the memory card emulation will function in, and where the images for these cards will be stored on disk.</source>
         <translation>&lt;strong&gt;Configuración de memorias&lt;/strong&gt;&lt;hr&gt;Esta página te permite controlar en que modo funcionará la emulación de tarjetas de memoria, y dónde se guardarán los archivos en disco.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="100"/>
+        <location filename="../settingsdialog.cpp" line="101"/>
         <source>Display</source>
         <translation>Pantalla</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="102"/>
+        <location filename="../settingsdialog.cpp" line="103"/>
         <source>&lt;strong&gt;Display Settings&lt;/strong&gt;&lt;hr&gt;These options control the how the frames generated by the console are displayed on the screen.</source>
         <translation>&lt;strong&gt;Configuración de pantalla&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan como las imágenes generadas por la consola se muestran en pantalla.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="105"/>
+        <location filename="../settingsdialog.cpp" line="106"/>
         <source>Enhancements</source>
         <translation>Mejoras</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="107"/>
+        <location filename="../settingsdialog.cpp" line="108"/>
         <source>&lt;strong&gt;Enhancement Settings&lt;/strong&gt;&lt;hr&gt;These options control enhancements which can improve visuals compared to the original console. Mouse over each option for additional information.</source>
         <translation>&lt;strong&gt;Configuración de mejoras&lt;/strong&gt;&lt;hr&gt;Esta configuración controla las opciones que pueden mejorar los gráficos comparados a la consola original.&lt;br&gt;&lt;br&gt;Pasa el cursor sobre alguna opción para más información.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="113"/>
+        <location filename="../settingsdialog.cpp" line="114"/>
         <source>Post-Processing</source>
         <translation>Postprocesamiento</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="114"/>
+        <location filename="../settingsdialog.cpp" line="115"/>
         <source>&lt;strong&gt;Post-Processing Settings&lt;/strong&gt;&lt;hr&gt;Post processing allows you to alter the appearance of the image displayed on the screen with various filters. Shaders will be executed in sequence.</source>
         <translation>&lt;strong&gt;Configuración de postprocesamiento&lt;/strong&gt;&lt;hr&gt;El postprocesamiento te permite alterar la apariencia de la imagen mostrada en pantalla con varios filtros. Los sombreadores serán ejecutados en secuencia.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="118"/>
+        <location filename="../settingsdialog.cpp" line="119"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="120"/>
+        <location filename="../settingsdialog.cpp" line="121"/>
         <source>&lt;strong&gt;Audio Settings&lt;/strong&gt;&lt;hr&gt;These options control the audio output of the console. Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Configuración de audio&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan la salida de audio de la consola.&lt;br&gt;&lt;br&gt;Pasa el cursor sobre alguna opción para más información.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="123"/>
+        <location filename="../settingsdialog.cpp" line="124"/>
         <source>Achievements</source>
         <translation>Logros</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="125"/>
+        <location filename="../settingsdialog.cpp" line="126"/>
         <source>&lt;strong&gt;Achievement Settings&lt;/strong&gt;&lt;hr&gt;These options control RetroAchievements. Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Configuración de logros&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan los logros de RetroAchievements. Pasa el cursor sobre alguna opción para más información.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="145"/>
         <source>This DuckStation build was not compiled with RetroAchievements support.</source>
-        <translation>Esta versión de DuckStation no fue compilada con soporte para RetroAchievements.</translation>
+        <translation type="vanished">Esta versión de DuckStation no fue compilada con soporte para RetroAchievements.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="155"/>
+        <location filename="../settingsdialog.cpp" line="148"/>
         <source>Folders</source>
         <translation>Directorios</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="157"/>
+        <location filename="../settingsdialog.cpp" line="150"/>
         <source>&lt;strong&gt;Folder Settings&lt;/strong&gt;&lt;hr&gt;These options control where DuckStation will save runtime data files.</source>
         <translation>&lt;strong&gt;Configuración de directorios&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan dónde se guardaran las archivos de datos de DuckStation.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="160"/>
+        <location filename="../settingsdialog.cpp" line="153"/>
         <source>Advanced</source>
         <translation>Avanzada</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="162"/>
+        <location filename="../settingsdialog.cpp" line="155"/>
         <source>&lt;strong&gt;Advanced Settings&lt;/strong&gt;&lt;hr&gt;These options control logging and internal behavior of the emulator. Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Configuración avanzada&lt;/strong&gt;&lt;hr&gt;Estas opciones controlan el registro de mensajes y el comportamiento interno del emulador.&lt;br&gt;&lt;br&gt;Pasa el cursor sobre alguna opción para más información.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="219"/>
+        <location filename="../settingsdialog.cpp" line="212"/>
         <source>Confirm Restore Defaults</source>
         <translation>Confirmar el restablecimiento de valores predeterminados</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="220"/>
+        <location filename="../settingsdialog.cpp" line="213"/>
         <source>Are you sure you want to restore the default settings? Any preferences will be lost.</source>
         <translation>¿Seguro que quieres restablecer los valores predeterminados? Se perderán todas tus preferencias.</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="236"/>
+        <location filename="../settingsdialog.cpp" line="229"/>
         <source>Recommended Value</source>
         <translation>Valor recomendado</translation>
     </message>
     <message>
-        <location filename="../settingsdialog.cpp" line="505"/>
+        <location filename="../settingsdialog.cpp" line="498"/>
         <source>%1 [%2]</source>
         <translation>%1 [%2]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="124"/>
+        <location filename="../settingwidgetbinder.h" line="126"/>
         <source>Use Global Setting [Enabled]</source>
         <translation>Utilizar configuración global [Habilitado]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="125"/>
+        <location filename="../settingwidgetbinder.h" line="127"/>
         <source>Use Global Setting [Disabled]</source>
         <translation>Utilizar configuración global [Deshabilitado]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="133"/>
-        <location filename="../settingwidgetbinder.h" line="149"/>
+        <location filename="../settingwidgetbinder.h" line="135"/>
+        <location filename="../settingwidgetbinder.h" line="151"/>
         <source>Use Global Setting [%1]</source>
         <translation>Utilizar configuración global [%1]</translation>
     </message>
 </context>
 <context>
+    <name>SetupWizardDialog</name>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="14"/>
+        <source>DuckStation Setup Wizard</source>
+        <translation>Asistente de configuración de DuckStation</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="50"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Welcome to DuckStation!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;This wizard will help guide you through the configuration steps required to use the application. It is recommended if this is your first time installing DuckStation that you view the setup guide at &lt;a href=&quot;https://github.com/stenzek/duckstation#downloading-and-running&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/stenzek/duckstation#downloading-and-running&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;By default, DuckStation will connect to the server at &lt;a href=&quot;https://github.com/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;github.com&lt;/span&gt;&lt;/a&gt; to check for updates, and if available and confirmed, download update packages from &lt;a href=&quot;https://github.com/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;github.com&lt;/span&gt;&lt;/a&gt;. If you do not wish for DuckStation to make any network connections on startup, you should uncheck the Automatic Updates option now. The Automatic Update setting can be changed later at any time in Interface Settings.&lt;/p&gt;&lt;p&gt;Please choose a language and theme to begin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;¡Bienvenido a DuckStation!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;Este asistente te guiará a través de los pasos necesarios para configurar la aplicación. Si esta es tu primera vez utilizando DuckStation, es recomendable leer la guía de configuración en &lt;a href=&quot;https://github.com/stenzek/duckstation#downloading-and-running&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/stenzek/duckstation#downloading-and-running&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;DuckStation se conectará al servidor en &lt;a href=&quot;https://github.com/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;github.com&lt;/span&gt;&lt;/a&gt; para comprobar actualizaciones automáticamente, y si hay alguna disponible, descargar los paquetes de actualización. Si no quieres que DuckStation se conecte a alguna red al iniciar, debes deshabilitar la opción de actualizaciones automáticas ahora. Esta opción se puede cambiar en cualquier momento desde la configuración de interfaz.&lt;/p&gt;&lt;p&gt;Selecciona un idioma y tema para comenzar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="65"/>
+        <source>Language:</source>
+        <translation>Idioma:</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="82"/>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="105"/>
+        <source>Enable Automatic Updates</source>
+        <translation>Habilitar actualizaciones automáticas</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation requires a PS1 BIOS in order to run.&lt;/p&gt;&lt;p&gt;For legal reasons, you must obtain a BIOS &lt;span style=&quot; font-weight:700;&quot;&gt;from an actual PS1 unit that you own&lt;/span&gt; (borrowing doesn&apos;t count). You should use Caetla or another utility to create an image from your console&apos;s BIOS ROM on your PC.&lt;/p&gt;&lt;p&gt;Once dumped, this BIOS image should be placed in the bios folder within the data directory shown below, or you can instruct DuckStation to scan an alternative directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation necesita un BIOS de PS1 para funcionar.&lt;/p&gt;&lt;p&gt;Por razones legales, debes obtener un BIOS &lt;span style=&quot; font-weight:700;&quot;&gt;de una PS1 real de tu pertenencia&lt;/span&gt; (una prestada no cuenta). Deberías utilizar Caetla u otra herramienta para crear una imagen de la ROM del BIOS de tu consola en tu PC.&lt;/p&gt;&lt;p&gt;Una vez realizada la imagen del BIOS, debe ser ubicada en el directorio de BIOS indicado abajo, o puedes configurar DuckStation para que busque en otro directorio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="145"/>
+        <source>BIOS Directory:</source>
+        <translation>Directorio de BIOS:</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="155"/>
+        <source>Browse...</source>
+        <translation>Buscar...</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="162"/>
+        <source>Reset</source>
+        <translation>Restablecer</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="173"/>
+        <source>NTSC-J (Japan):</source>
+        <translation>NTSC-J (Japón):</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="190"/>
+        <source>NTSC-U/C (US/Canada):</source>
+        <translation>NTSC-U/C (Estados Unidos, Canadá):</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="207"/>
+        <source>PAL (Europe, Australia):</source>
+        <translation>PAL (Europa, Australia):</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="241"/>
+        <source>Open in Explorer...</source>
+        <translation>Abrir en explorador...</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="248"/>
+        <source>Refresh List</source>
+        <translation>Actualizar lista</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="286"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation will automatically scan and identify games from the selected directories below, and populate the game list. These games should be dumped from discs you own. Utilities such as ImgBurn can be used to create images of game discs in .bin/.cue format.&lt;/p&gt;&lt;p&gt;Supported formats for dumps include: &lt;span style=&quot; font-weight:700;&quot;&gt;.cue&lt;/span&gt; (Cue Sheets), &lt;span style=&quot; font-weight:700;&quot;&gt;.iso/.img&lt;/span&gt; (Single Track Image), &lt;span style=&quot; font-weight:700;&quot;&gt;.ecm&lt;/span&gt; (Error Code Modeling Image), &lt;span style=&quot; font-weight:700;&quot;&gt;.mds&lt;/span&gt; (Media Descriptor Sidecar), &lt;span style=&quot; font-weight:700;&quot;&gt;.chd&lt;/span&gt; (Compressed Hunks of Data), &lt;span style=&quot; font-weight:700;&quot;&gt;.pbp&lt;/span&gt; (PlayStation Portable, Only Decrypted).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation buscará e identificará juegos automáticamente en los directorios indicados abajo. Estos juegos deben ser volcados de discos de tu pertenencia. Pueden utilizarse herramientas como ImgBurn para crear imágenes de disco en formato .bin/.cue.&lt;/p&gt;&lt;p&gt;Entre los formatos compatibles se encuentran: &lt;span style=&quot; font-weight:700;&quot;&gt;.cue&lt;/span&gt; (archivo cue), &lt;span style=&quot; font-weight:700;&quot;&gt;.iso/.img&lt;/span&gt; (imagen de pista única), &lt;span style=&quot; font-weight:700;&quot;&gt;.ecm&lt;/span&gt; (imagen Error Code Modeling), &lt;span style=&quot; font-weight:700;&quot;&gt;.mds&lt;/span&gt; (Media Descriptor Sidecar), &lt;span style=&quot; font-weight:700;&quot;&gt;.chd&lt;/span&gt; (Compressed Hunks of Data), &lt;span style=&quot; font-weight:700;&quot;&gt;.pbp&lt;/span&gt; (PlayStation Portable, solo archivos desencriptados).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="301"/>
+        <source>Search Directories (will be scanned for games)</source>
+        <translation>Buscar en directorios (se escanearán los juegos)</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="327"/>
+        <source>Add...</source>
+        <translation>Añadir...</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="347"/>
+        <location filename="../setupwizarddialog.cpp" line="267"/>
+        <source>Remove</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="364"/>
+        <source>Search Directory</source>
+        <translation>Buscar directorio</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="369"/>
+        <source>Scan Recursively</source>
+        <translation>Buscar recursivamente</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="396"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, DuckStation will map your keyboard to the virtual controller.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;To use an external controller, you must map it first. &lt;/span&gt;On this screen, you can automatically map any controller which is currently connected. If your controller is not currently connected, you can plug it in now.&lt;/p&gt;&lt;p&gt;To change controller bindings in more detail, or use multi-tap, open the Settings menu and choose Controllers once you have completed the Setup Wizard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation asignará tu teclado al control virtual de forma predeterminada.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Para utilizar un control externo primero debes asignarlo. &lt;/span&gt;En esta pantalla puedes asignar automáticamente cualquier control que tengas conectado. Si tu control no está conectado aún, puedes hacerlo ahora.&lt;/p&gt;&lt;p&gt;Para cambiar las asignaciones del control en mayor detalle, o utilizar multitap, ve al menú de configuración y selecciona controles una vez que hayas completado el asistente de configuración.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="406"/>
+        <source>Controller Port 1</source>
+        <translation>Puerto de control 1</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="415"/>
+        <location filename="../setupwizarddialog.ui" line="485"/>
+        <source>Controller Mapped To:</source>
+        <translation>Control asignado a:</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="422"/>
+        <location filename="../setupwizarddialog.ui" line="475"/>
+        <source>Controller Type:</source>
+        <translation>Tipo de control:</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="431"/>
+        <location filename="../setupwizarddialog.ui" line="494"/>
+        <location filename="../setupwizarddialog.cpp" line="411"/>
+        <source>Default (Keyboard)</source>
+        <translation>Predeterminado (teclado)</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="451"/>
+        <location filename="../setupwizarddialog.ui" line="514"/>
+        <source>Automatic Mapping</source>
+        <translation>Asignación automática</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="469"/>
+        <source>Controller Port 2</source>
+        <translation>Puerto de control 2</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="561"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Setup Complete!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;You are now ready to run games.&lt;/p&gt;&lt;p&gt;Further options are available under the settings menu. You can also use the Big Picture UI for navigation entirely with a gamepad.&lt;/p&gt;&lt;p&gt;We hope you enjoy using DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;¡Configuración finalizada!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;Ya estás listo para ejecutar juegos.&lt;/p&gt;&lt;p&gt;Hay más opciones dentro del menú de configuración. También puedes utilizar el modo de interfaz Big Picture para navegar por la aplicación con solo un control.&lt;/p&gt;&lt;p&gt;Esperamos que disfrutes de DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="634"/>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="641"/>
+        <source>BIOS Image</source>
+        <translation>Imagen de BIOS</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="648"/>
+        <source>Game Directories</source>
+        <translation>Directorios de juegos</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="655"/>
+        <source>Controller Setup</source>
+        <translation>Configurar controles</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="662"/>
+        <source>Complete</source>
+        <translation>Listo</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="704"/>
+        <source>&amp;Back</source>
+        <translation>&amp;Anterior</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="711"/>
+        <location filename="../setupwizarddialog.cpp" line="141"/>
+        <source>&amp;Next</source>
+        <translation>&amp;Siguiente</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.ui" line="721"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="46"/>
+        <location filename="../setupwizarddialog.cpp" line="62"/>
+        <source>Warning</source>
+        <translation>Alerta</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="47"/>
+        <source>No BIOS images were found. DuckStation &lt;strong&gt;will not&lt;/strong&gt; be able to run games without a BIOS image.&lt;br&gt;&lt;br&gt;Are you sure you wish to continue without selecting a BIOS image?</source>
+        <translation>No se encontraron imagenes de BIOS. DuckStation &lt;strong&gt;no podrá&lt;/strong&gt; ejecutar juegos sin una imagen de BIOS.&lt;br&gt;&lt;br&gt;¿Quieres continuar sin seleccionar una imagen de BIOS?</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="63"/>
+        <source>No game directories have been selected. You will have to manually open any game dumps you want to play, DuckStation&apos;s list will be empty.
+
+Are you sure you want to continue?</source>
+        <translation>No se seleccionaron directorios de juegos. Deberás abrir manualmente las copias de los juegos que quieras ejecutar. La lista de juegos de DuckStation estará vacía.
+
+¿Seguro que quieres continuar?</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="141"/>
+        <source>&amp;Finish</source>
+        <translation>&amp;Terminar</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="147"/>
+        <source>Cancel Setup</source>
+        <translation>Cancelar configuración</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="148"/>
+        <source>Are you sure you want to cancel DuckStation setup?
+
+Any changes have been saved, and the wizard will run again next time you start DuckStation.</source>
+        <translation>¿Seguro que quieres cancelar la configuración de DuckStation?
+
+Los cambios hechos ya se guardaron, y el asistente aparecerá de nuevo la próxima vez que inicies DuckStation.</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="269"/>
+        <source>Open Directory...</source>
+        <translation>Abrir directorio...</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="277"/>
+        <source>Select Search Directory</source>
+        <translation>Seleccionar directorio para buscar</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="283"/>
+        <source>Scan Recursively?</source>
+        <translation>¿Buscar recursivamente?</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="284"/>
+        <source>Would you like to scan the directory &quot;%1&quot; recursively?
+
+Scanning recursively takes more time, but will identify files in subdirectories.</source>
+        <translation>¿Quieres buscar en el directorio &quot;%1&quot; recursivamente?
+
+Buscar recursivamente lleva más tiempo, pero identifica archivos en subdirectorios.</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="411"/>
+        <source>Default (None)</source>
+        <translation>Predeterminado (ninguno)</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="454"/>
+        <source>No devices available</source>
+        <translation>No hay dispositivos disponibles</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="468"/>
+        <source>Automatic Binding</source>
+        <translation>Asignación automática</translation>
+    </message>
+    <message>
+        <location filename="../setupwizarddialog.cpp" line="469"/>
+        <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
+        <translation>No se pudieron generar asignaciones para el dispositivo &quot;%1&quot;. El control/dispositivo de origen podría ser incompatible con las asignaciones automáticas.</translation>
+    </message>
+</context>
+<context>
     <name>System</name>
     <message>
-        <location filename="../../core/system.cpp" line="1308"/>
-        <location filename="../../core/system.cpp" line="3116"/>
+        <location filename="../../core/system.cpp" line="1424"/>
+        <location filename="../../core/system.cpp" line="3350"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1309"/>
+        <location filename="../../core/system.cpp" line="1425"/>
         <source>Failed to load save state file &apos;{}&apos; for booting.</source>
         <translation>Fallo al cargar el archivo de estado guardado &quot;{}&quot; para iniciar.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1788"/>
+        <location filename="../../core/system.cpp" line="2133"/>
         <source>Failed to load %s BIOS.</source>
         <translation>Fallo al cargar el BIOS %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1795"/>
+        <location filename="../../core/system.cpp" line="2140"/>
         <source>Incorrect BIOS image size</source>
         <translation>Tamaño de imagen del BIOS incorrecto</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1886"/>
+        <location filename="../../core/system.cpp" line="2224"/>
         <source>Save state is incompatible: minimum version is %u but state is version %u.</source>
         <translation>El estado guardado es incompatible: la versión mínima soportada es %u, pero el estado es versión %u.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1895"/>
+        <location filename="../../core/system.cpp" line="2232"/>
         <source>Save state is incompatible: maximum version is %u but state is version %u.</source>
         <translation>El estado guardado es incompatible: la versión máxima soportada es %u, pero el estado es versión %u.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1936"/>
+        <location filename="../../core/system.cpp" line="2276"/>
+        <source>Failed to open CD image &apos;{}&apos; used by save state: {}.</source>
+        <translation>Fallo al abrir la imagen de disco &apos;{}&apos; utilizada por el estado guardado: &apos;{}&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="2296"/>
+        <source>Failed to switch to subimage {} in CD image &apos;{}&apos; used by save state: {}.</source>
+        <translation>Fallo al cambiar a la subimagen {} en la imagen de disco &apos;{}&apos; utilizada por el estado guardado {}.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="2960"/>
+        <source>Per-game memory card cannot be used for slot {} as the running game has no code. Using shared card instead.</source>
+        <translation>La tarjeta de memoria por juego no puede utilizarse para la ranura {} ya que el juego no tiene un código. Se utilizará una tarjeta compartida en su lugar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="2979"/>
+        <source>Per-game memory card cannot be used for slot {} as the running game has no title. Using shared card instead.</source>
+        <translation>La tarjeta de memoria por juego no puede utilizarse para la ranura {} ya que el juego no tiene un título. Se utilizará una tarjeta compartida en su lugar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="3016"/>
+        <source>Using disc-specific memory card &apos;{}&apos; instead of per-game card.</source>
+        <translation>Utilizando tarjeta de memoria específica por disco &apos;{}&apos; en lugar de por juego.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="3038"/>
+        <source>Per-game memory card cannot be used for slot {} as the running game has no path. Using shared card instead.</source>
+        <translation>La tarjeta de memoria por juego no puede utilizarse para la ranura {} ya que el juego no tiene un directorio. Se utilizará una tarjeta compartida en su lugar.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="3342"/>
+        <source>You are attempting to run a libcrypt protected game without an SBI file:
+
+{0}: {1}
+
+The game will likely not run properly.
+
+Please check the README for instructions on how to add an SBI file.
+
+Do you wish to continue?</source>
+        <translation>Estás intentando ejecutar un juego protegido con LibCrypt sin un archivo SBI
+
+{0}: {1}
+
+Probablemente el juego no funcione correctamente.
+
+Lee las instrucciones en el archivo &quot;README&quot; sobre como añadir un archivo SBI.
+
+¿Quieres continuar?</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="3352"/>
+        <source>You are attempting to run a libcrypt protected game without an SBI file:
+
+{0}: {1}
+
+Your dump is incomplete, you must add the SBI file to run this game. 
+
+The name of the SBI file must match the name of the disc image.</source>
+        <translation>Estás intentando ejecutar un juego protegido con LibCrypt sin un archivo SBI
+
+{0}: {1}
+
+Tu copia del juego está incompleta, primero debes añadir el archivo SBI correspondiente para iniciar este juego.
+
+El nombre del archivo SBI debe coincidir con el nombre de la imagen de disco.</translation>
+    </message>
+    <message>
+        <location filename="../../core/system.cpp" line="4258"/>
+        <source>Invalid version {} ({} version {})</source>
+        <translation>Versión {} inválida ({} versión {})</translation>
+    </message>
+    <message>
         <source>Failed to open CD image &apos;%s&apos; used by save state: %s.</source>
-        <translation>Fallo al abrir la imagen de CD &quot;%s&quot; utilizada por el estado guardado: &quot;%s&quot;.</translation>
+        <translation type="vanished">Fallo al abrir la imagen de CD &quot;%s&quot; utilizada por el estado guardado: &quot;%s&quot;.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="1955"/>
         <source>Failed to switch to subimage %u in CD image &apos;%s&apos; used by save state: %s.</source>
-        <translation>Fallo al cambiar a la subimagen %u en la imagen de CD &quot;%s&quot; utilizada por el estado guardado %s.</translation>
+        <translation type="vanished">Fallo al cambiar a la subimagen %u en la imagen de CD &quot;%s&quot; utilizada por el estado guardado %s.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2783"/>
         <source>Per-game memory card cannot be used for slot %u as the running game has no code. Using shared card instead.</source>
-        <translation>La tarjeta de memoria por juego no puede utilizarse para la ranura %u ya que el juego no tiene un código. Se utilizará una tarjeta compartida en su lugar.</translation>
+        <translation type="vanished">La tarjeta de memoria por juego no puede utilizarse para la ranura %u ya que el juego no tiene un código. Se utilizará una tarjeta compartida en su lugar.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2800"/>
         <source>Per-game memory card cannot be used for slot %u as the running game has no title. Using shared card instead.</source>
-        <translation>La tarjeta de memoria por juego no puede utilizarse para la ranura %u ya que el juego no tiene un título. Se utilizará una tarjeta compartida en su lugar.</translation>
+        <translation type="vanished">La tarjeta de memoria por juego no puede utilizarse para la ranura %u ya que el juego no tiene un título. Se utilizará una tarjeta compartida en su lugar.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="2820"/>
         <source>Per-game memory card cannot be used for slot %u as the running game has no path. Using shared card instead.</source>
-        <translation>La tarjeta de memoria por juego no puede utilizarse para la ranura %u ya que el juego no tiene un directorio. Se utilizará una tarjeta compartida en su lugar.</translation>
+        <translation type="vanished">La tarjeta de memoria por juego no puede utilizarse para la ranura %u ya que el juego no tiene un directorio. Se utilizará una tarjeta compartida en su lugar.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3012"/>
+        <location filename="../../core/system.cpp" line="3238"/>
         <source>Game changed, reloading memory cards.</source>
         <translation>Juego cambiado, recargando las tarjetas de memoria.</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3105"/>
         <source>You are attempting to run a libcrypt protected game without an SBI file:
 
 %s: %s
@@ -9280,7 +13904,7 @@ The game will likely not run properly.
 Please check the README for instructions on how to add an SBI file.
 
 Do you wish to continue?</source>
-        <translation>Estás intentando ejecutar un juego protegido con LibCrypt sin un archivo SBI
+        <translation type="vanished">Estás intentando ejecutar un juego protegido con LibCrypt sin un archivo SBI
 
 %s: %s
 
@@ -9291,7 +13915,6 @@ Lee las instrucciones en el archivo &quot;README&quot; sobre como añadir un arc
 ¿Quieres continuar?</translation>
     </message>
     <message>
-        <location filename="../../core/system.cpp" line="3118"/>
         <source>You are attempting to run a libcrypt protected game without an SBI file:
 
 %s: %s
@@ -9299,7 +13922,7 @@ Lee las instrucciones en el archivo &quot;README&quot; sobre como añadir un arc
 Your dump is incomplete, you must add the SBI file to run this game. 
 
 The name of the SBI file must match the name of the disc image.</source>
-        <translation>Estás intentando ejecutar un juego protegido con LibCrypt sin un archivo SBI
+        <translation type="vanished">Estás intentando ejecutar un juego protegido con LibCrypt sin un archivo SBI
 
 %s: %s
 


### PR DESCRIPTION
Updated translation and also the language name from 'Español de Hispanoamérica' to 'Español de Latinoamérica', as it's the correct and preferred terminology.