### PR TITLE
Remove vertical spacer preventing Tweaks/Hacks from expanding

### DIFF
--- a/src/duckstation-qt/advancedsettingswidget.ui
+++ b/src/duckstation-qt/advancedsettingswidget.ui
@@ -158,19 +158,6 @@
      </layout>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <resources>


### PR DESCRIPTION
The Advanced Settings UI had a vertical spacer at the bottom. This space would expand when the window expanded.
Instead, it's more useful to expand the Tweaks/Hacks table, since this table is larger than the default window size.