### PR TITLE
Qt: Unstretch the analog controller icon

### DIFF
--- a/src/duckstation-qt/controllerbindingwidget_analog_controller.ui
+++ b/src/duckstation-qt/controllerbindingwidget_analog_controller.ui
@@ -1061,8 +1061,8 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>400</width>
-         <height>266</height>
+         <width>420</width>
+         <height>300</height>
         </size>
        </property>
        <property name="text">


### PR DESCRIPTION
This PR fixes the analog controller icon where it's a bit too stretched.

Before:
![Screenshot_20231112_221240](https://github.com/stenzek/duckstation/assets/14798312/19462124-ce69-4578-b2a3-092b22af6759)

After:
![Screenshot_20231112_221534](https://github.com/stenzek/duckstation/assets/14798312/4a3763c4-6ea5-4d12-814b-bf18c57c9b3a)
