### PR TITLE
 Qt/WinUpdater: Remove "Update Complete" dialog

### DIFF
--- a/src/updater/cocoa_main.mm
+++ b/src/updater/cocoa_main.mm
@@ -114,8 +114,6 @@ int main(int argc, char* argv[])
 
     updater.CleanupStagingDirectory();
     
-    progress.ModalInformation("Update complete.");
-
     result = EXIT_SUCCESS;
   });
 

--- a/src/updater/win32_main.cpp
+++ b/src/updater/win32_main.cpp
@@ -94,8 +94,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLi
 
   updater.CleanupStagingDirectory();
 
-  progress.ModalInformation("Update complete.");
-
   progress.DisplayFormattedInformation("Launching '%s'...",
                                        StringUtil::WideStringToUTF8String(program_to_launch).c_str());
   ShellExecuteW(nullptr, L"open", program_to_launch.c_str(), nullptr, nullptr, SW_SHOWNORMAL);


### PR DESCRIPTION
removes Update Complete" dialog when an update is completed 