### PR TITLE
DiscordRPC: Show session time in Discord Rich Presence

### DIFF
--- a/src/core/achievements.cpp
+++ b/src/core/achievements.cpp
@@ -795,7 +795,7 @@ void Achievements::UpdateRichPresence(std::unique_lock<std::recursive_mutex>& lo
 
 #ifdef ENABLE_DISCORD_PRESENCE
   lock.unlock();
-  System::UpdateDiscordPresence();
+  System::UpdateDiscordPresence(false);
   lock.lock();
 #endif
 }

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -4138,9 +4138,8 @@ void System::ShutdownSystem(bool save_resume_state)
   if (save_resume_state)
     SaveResumeState();
 
-  if (s_system_executing)
-    s_state = State::Stopping;
-  else
+  s_state = State::Stopping;
+  if (!s_system_executing)
     DestroySystem();
 }
 

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -480,7 +480,7 @@ void SetRunaheadReplayFlag();
 
 #ifdef ENABLE_DISCORD_PRESENCE
 /// Called when rich presence changes.
-void UpdateDiscordPresence();
+void UpdateDiscordPresence(bool update_session_time);
 #endif
 
 namespace Internal {


### PR DESCRIPTION
This PR consists of two changes:

1. Backport of https://github.com/PCSX2/pcsx2/pull/10397.
2. Set `s_state` to `State::Stopping` unconditionally when shutting the game down. This fixes an issue where Discord RPC showed `Unknown Game` instead of `No Game Running` after shutting the game down.