### PR TITLE
Add debanding option to improve gradient smoothness with truecolor

### DIFF
--- a/src/core/fullscreen_ui.cpp
+++ b/src/core/fullscreen_ui.cpp
@@ -3997,6 +3997,10 @@ void FullscreenUI::DrawDisplaySettingsPage()
                     FSUI_CSTR("Disables dithering and uses the full 8 bits per channel of color information."), "GPU",
                     "TrueColor", true, is_hardware);
 
+  DrawToggleSetting(bsi, FSUI_CSTR("True Color Debanding"),
+                    FSUI_CSTR("Applies modern dithering techniques to further smooth out gradients when true color is enabled."), "GPU",
+                    "Debanding", false, is_hardware);
+
   DrawToggleSetting(bsi, FSUI_CSTR("Widescreen Hack"),
                     FSUI_CSTR("Increases the field of view from 4:3 to the chosen display aspect ratio in 3D games."),
                     "GPU", "WidescreenHack", false, is_hardware);

--- a/src/core/gpu_hw.h
+++ b/src/core/gpu_hw.h
@@ -252,6 +252,7 @@ private:
   GPUDownsampleMode m_downsample_mode = GPUDownsampleMode::Disabled;
   GPUWireframeMode m_wireframe_mode = GPUWireframeMode::Disabled;
   bool m_true_color = true;
+  bool m_debanding = false;
   bool m_clamp_uvs = false;
   bool m_compute_uv_range = false;
   bool m_pgxp_depth_buffer = false;

--- a/src/core/gpu_hw_shadergen.h
+++ b/src/core/gpu_hw_shadergen.h
@@ -11,7 +11,7 @@ public:
   GPU_HW_ShaderGen(RenderAPI render_api, u32 resolution_scale, u32 multisamples, bool per_sample_shading,
                    bool true_color, bool scaled_dithering, GPUTextureFilter texture_filtering, bool uv_limits,
                    bool pgxp_depth, bool disable_color_perspective, bool supports_dual_source_blend,
-                   bool supports_framebuffer_fetch);
+                   bool supports_framebuffer_fetch, bool debanding);
   ~GPU_HW_ShaderGen();
 
   std::string GenerateBatchVertexShader(bool textured);
@@ -51,4 +51,5 @@ private:
   bool m_uv_limits;
   bool m_pgxp_depth;
   bool m_disable_color_perspective;
+  bool m_debanding;
 };

--- a/src/core/imgui_overlays.cpp
+++ b/src/core/imgui_overlays.cpp
@@ -525,8 +525,13 @@ void ImGuiManager::DrawEnhancementsOverlay()
   {
     text.append_format(" {}x{}", g_settings.gpu_multisamples, g_settings.gpu_per_sample_shading ? "SSAA" : "MSAA");
   }
-  if (g_settings.gpu_true_color)
-    text.append(" TrueCol");
+  if (g_settings.gpu_true_color) {
+    if (g_settings.gpu_debanding) {
+      text.append(" TrueColDeband");
+    } else {
+      text.append(" TrueCol");
+    }
+  }
   if (g_settings.gpu_disable_interlacing)
     text.append(" ForceProg");
   if (g_settings.gpu_force_ntsc_timings && System::GetRegion() == ConsoleRegion::PAL)

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -190,6 +190,7 @@ void Settings::Load(SettingsInterface& si)
   gpu_use_software_renderer_for_readbacks = si.GetBoolValue("GPU", "UseSoftwareRendererForReadbacks", false);
   gpu_threaded_presentation = si.GetBoolValue("GPU", "ThreadedPresentation", true);
   gpu_true_color = si.GetBoolValue("GPU", "TrueColor", true);
+  gpu_debanding = si.GetBoolValue("GPU", "Debanding", false);
   gpu_scaled_dithering = si.GetBoolValue("GPU", "ScaledDithering", true);
   gpu_texture_filter =
     ParseTextureFilterName(
@@ -456,6 +457,7 @@ void Settings::Save(SettingsInterface& si) const
   si.SetBoolValue("GPU", "ThreadedPresentation", gpu_threaded_presentation);
   si.SetBoolValue("GPU", "UseSoftwareRendererForReadbacks", gpu_use_software_renderer_for_readbacks);
   si.SetBoolValue("GPU", "TrueColor", gpu_true_color);
+  si.SetBoolValue("GPU", "Debanding", gpu_debanding);
   si.SetBoolValue("GPU", "ScaledDithering", gpu_scaled_dithering);
   si.SetStringValue("GPU", "TextureFilter", GetTextureFilterName(gpu_texture_filter));
   si.SetStringValue("GPU", "DownsampleMode", GetDownsampleModeName(gpu_downsample_mode));
@@ -614,6 +616,7 @@ void Settings::FixIncompatibleSettings(bool display_osd_messages)
     g_settings.gpu_multisamples = 1;
     g_settings.gpu_per_sample_shading = false;
     g_settings.gpu_true_color = false;
+    g_settings.gpu_debanding = false;
     g_settings.gpu_scaled_dithering = false;
     g_settings.gpu_texture_filter = GPUTextureFilter::Nearest;
     g_settings.gpu_disable_interlacing = false;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -111,6 +111,7 @@ struct Settings
   bool gpu_disable_texture_copy_to_self = false;
   bool gpu_per_sample_shading = false;
   bool gpu_true_color = true;
+  bool gpu_debanding = false;
   bool gpu_scaled_dithering = true;
   GPUTextureFilter gpu_texture_filter = DEFAULT_GPU_TEXTURE_FILTER;
   GPUDownsampleMode gpu_downsample_mode = DEFAULT_GPU_DOWNSAMPLE_MODE;

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -3626,6 +3626,7 @@ void System::CheckForSettingsChanges(const Settings& old_settings)
         g_settings.gpu_fifo_size != old_settings.gpu_fifo_size ||
         g_settings.gpu_max_run_ahead != old_settings.gpu_max_run_ahead ||
         g_settings.gpu_true_color != old_settings.gpu_true_color ||
+        g_settings.gpu_debanding != old_settings.gpu_debanding ||
         g_settings.gpu_scaled_dithering != old_settings.gpu_scaled_dithering ||
         g_settings.gpu_texture_filter != old_settings.gpu_texture_filter ||
         g_settings.gpu_disable_interlacing != old_settings.gpu_disable_interlacing ||

--- a/src/duckstation-qt/enhancementsettingswidget.cpp
+++ b/src/duckstation-qt/enhancementsettingswidget.cpp
@@ -81,6 +81,11 @@ EnhancementSettingsWidget::EnhancementSettingsWidget(SettingsWindow* dialog, QWi
        "a pattern around those pixels. Most games are compatible with this option, but there is a number which aren't "
        "and will have broken effects with it enabled. Only applies to the hardware renderers."));
   dialog->registerWidgetHelp(
+    m_ui.debanding, tr("True Color Debanding"), tr("Unchecked"),
+    tr("Applies modern dithering techniques to further smooth out gradients when true color is enabled. "
+      "This debanding is performed during rendering (as opposed to a post-processing step), which allows it to be fast while preserving detail. "
+      "Debanding increases the file size of screenshots due to the subtle dithering pattern present in screenshots."));
+  dialog->registerWidgetHelp(
     m_ui.scaledDithering, tr("Scaled Dithering (scale dither pattern to resolution)"), tr("Checked"),
     tr("Scales the dither pattern to the resolution scale of the emulated GPU. This makes the dither pattern much less "
        "obvious at higher resolutions. <br>Usually safe to enable, and only supported by the hardware renderers."));

--- a/src/duckstation-qt/enhancementsettingswidget.ui
+++ b/src/duckstation-qt/enhancementsettingswidget.ui
@@ -49,10 +49,17 @@
       <item row="2" column="1">
        <widget class="QComboBox" name="textureFiltering"/>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="4" column="0">
        <widget class="QCheckBox" name="trueColor">
         <property name="text">
          <string>True Color Rendering (24-bit, disables dithering)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QCheckBox" name="debanding">
+        <property name="text">
+         <string>True Color Debanding</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This option only has an effect if true color is also enabled.

Most PS1 games don't exhibit that much banding with true color, but there are particular cases where flickering induced by a lack of color precision is visible, such as Driver in its nighttime levels. You may also notice more banding if you play with bilinear texture filtering enabled, in which case debanding will help.

Compared to the existing deband post-processing shader, this works with internal rendering which makes it both faster and more precise. No loss of detail occurs, and no tweaking of thresholds is required.

The option is disabled by default as its effect is subtle in most games, and it increases the file size of screenshots due to the subtle dithering pattern.

The debanding algorithm used is very fast (only a handful of instructions), and is also the one that happens to be used in Godot :slightly_smiling_face: 

## Preview

*Click to view at full size.*

Before | After
-|-
![driver_without_debanding](https://github.com/stenzek/duckstation/assets/180032/41a603bc-c566-4442-b559-dbd4ae3a1630) | ![driver_debanding](https://github.com/stenzek/duckstation/assets/180032/5fc010b6-883c-4006-915a-41d7cafdbee3)

This kind of flickering on the parking lot's floor and ceiling completely goes away once debanding is enabled:

https://github.com/stenzek/duckstation/assets/180032/ee325ce0-ddbc-41a3-8452-7472e8de7ff9
