### PR TITLE
VulkanDevice: Accelerate texture downloads with `VK_EXT_external_memory_host`

### DIFF
--- a/src/util/vulkan_device.h
+++ b/src/util/vulkan_device.h
@@ -341,6 +341,9 @@ private:
 
   void RenderBlankFrame();
 
+  bool TryImportHostMemory(const void* data, u32 data_size, VkBufferUsageFlags buffer_usage, VkDeviceMemory* out_memory,
+                           VkBuffer* out_buffer, u32* out_offset);
+
   bool CheckDownloadBufferSize(u32 required_size);
   void DestroyDownloadBuffer();
 

--- a/src/util/vulkan_device.h
+++ b/src/util/vulkan_device.h
@@ -51,6 +51,7 @@ public:
     bool vk_khr_driver_properties : 1;
     bool vk_khr_dynamic_rendering : 1;
     bool vk_khr_push_descriptor : 1;
+    bool vk_ext_external_memory_host : 1;
   };
 
   static GPUTexture::Format GetFormatForVkFormat(VkFormat format);

--- a/src/util/vulkan_entry_points.inl
+++ b/src/util/vulkan_entry_points.inl
@@ -248,4 +248,8 @@ VULKAN_DEVICE_ENTRY_POINT(vkCmdEndRenderingKHR, false)
 // VK_KHR_push_descriptor
 VULKAN_DEVICE_ENTRY_POINT(vkCmdPushDescriptorSetKHR, false)
 
+// VK_EXT_external_memory_host
+VULKAN_DEVICE_ENTRY_POINT(vkGetMemoryHostPointerPropertiesEXT, false)
+
+
 #endif // VULKAN_DEVICE_ENTRY_POINT


### PR DESCRIPTION
With [VK_EXT_external_memory_host](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_EXT_external_memory_host.html), host memory can be directly imported into a `VkDeviceMemory`/`VkBuffer` without the need to allocate or copy from staging memory. When [minImportedHostPointerAlignment](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceExternalMemoryHostPropertiesEXT.html#_members) matches the page-size of the system, then basically _any_ host pointer can be imported into Vulkan by importing the entire span of `PAGE_SIZE`-chunks of memory into Vulkan and offsetting into it.

In the case of large texture downloads like upscaled screenshots, this saves a good chunk of memory from having to be allocated by directly writing texture-data into `void* out_data`.

This could work for any kind of CPU<->GPU transfer too.