### PR TITLE
Take widescreen hack into account when determining automatic resolution scale

### DIFF
--- a/src/core/gpu_hw.cpp
+++ b/src/core/gpu_hw.cpp
@@ -525,8 +525,17 @@ u32 GPU_HW::CalculateResolutionScale() const
                          static_cast<s32>(m_crtc_state.display_height) :
                          (m_console_is_pal ? (PAL_VERTICAL_ACTIVE_END - PAL_VERTICAL_ACTIVE_START) :
                                              (NTSC_VERTICAL_ACTIVE_END - NTSC_VERTICAL_ACTIVE_START));
+
+    float widescreen_multiplier = 1.0f;
+    if (g_settings.gpu_widescreen_hack) {
+        // Multiply scale factor by aspect ratio relative to 4:3, so that widescreen resolution is as close as possible to native screen resolution.
+        // Otherwise, anamorphic stretching would result in increasingly less horizontal resolution (relative to native screen resolution)
+        // as the aspect ratio gets wider.
+        widescreen_multiplier = std::max(1.0, (float(g_gpu_device->GetWindowWidth()) / g_gpu_device->GetWindowHeight()) / (4.0 / 3.0));
+    }
+
     const s32 preferred_scale =
-      static_cast<s32>(std::ceil(static_cast<float>(g_gpu_device->GetWindowHeight()) / height));
+      static_cast<s32>(std::ceil(static_cast<float>(g_gpu_device->GetWindowHeight() * widescreen_multiplier) / height));
     Log_VerboseFmt("Height = {}, preferred scale = {}", height, preferred_scale);
 
     scale = static_cast<u32>(std::clamp<s32>(preferred_scale, 1, max_resolution_scale));


### PR DESCRIPTION
At widescreen aspect ratios, a greater resolution scale factor is required to maintain crisp visuals. For instance, a 16:9 output requires ~1.333× the resolution scale of a 4:3 output (as 16:9 is ~1.333× wider than 4:3).

This improves visuals at widescreen aspect ratios when the widescreen hack is enabled, especially for ultrawide.

Mechanically, this will result in increased GPU demands for widescreen users, so it should be considered whether we want to always do this or have an option to toggle this. It's probably fine for dedicated GPU users nowadays, but some integrated GPUs may struggle with higher output resolutions.

## Preview

*Click to view at full size.*

### Before (21:9, 3440×1440 output)

![Screenshot_20240121_234528 webp](https://github.com/stenzek/duckstation/assets/180032/c9134d17-3449-4121-b13e-e1a3f4e1f9fb)

### After (21:9, 3440×1440 output)

![Screenshot_20240121_234350 webp](https://github.com/stenzek/duckstation/assets/180032/cd349f65-2487-464a-9783-6b97c4b9d45e)

### Before (closeup of 16:9 3840×2160 output, 4× zoom)

![Before](https://github.com/stenzek/duckstation/assets/180032/c942cd63-5088-4230-8fd0-addd5322fc2d)

### After (closeup of 16:9 3840×2160 output, 4× zoom)

![After](https://github.com/stenzek/duckstation/assets/180032/1f70b54d-2762-47e3-8d61-2f48debc959b)