### PR TITLE
GameDB: Rayman Brain Games

### DIFF
--- a/data/resources/gamedb.yaml
+++ b/data/resources/gamedb.yaml
@@ -130662,7 +130662,6 @@ SLUS-01265:
     rating: NoIssues
     versionTested: "0.1-1337-gcaf9943"
   controllers:
-    - AnalogController
     - DigitalController
   metadata:
     publisher: "UBI Soft Entertainment"


### PR DESCRIPTION
Just like regular Rayman, this game also requires **Digital Controller** only.