### PR TITLE
Qt: Port over Cobalt Sky theme from PCSX2

### DIFF
--- a/src/duckstation-qt/interfacesettingswidget.cpp
+++ b/src/duckstation-qt/interfacesettingswidget.cpp
@@ -14,6 +14,7 @@ const char* InterfaceSettingsWidget::THEME_NAMES[] = {
   QT_TRANSLATE_NOOP("MainWindow", "Fusion"),
   QT_TRANSLATE_NOOP("MainWindow", "Dark Fusion (Gray)"),
   QT_TRANSLATE_NOOP("MainWindow", "Dark Fusion (Blue)"),
+  QT_TRANSLATE_NOOP("MainWindow", "Cobalt Sky"),
   QT_TRANSLATE_NOOP("MainWindow", "Grey Matter"),
   QT_TRANSLATE_NOOP("MainWindow", "Dark Ruby"),
   QT_TRANSLATE_NOOP("MainWindow", "QDarkStyle"),
@@ -21,7 +22,7 @@ const char* InterfaceSettingsWidget::THEME_NAMES[] = {
 };
 
 const char* InterfaceSettingsWidget::THEME_VALUES[] = {
-  "",  "fusion", "darkfusion", "darkfusionblue", "greymatter", "darkruby", "qdarkstyle", nullptr,
+  "",  "fusion", "darkfusion", "darkfusionblue", "cobaltsky","greymatter", "darkruby", "qdarkstyle", nullptr,
 };
 
 const char* InterfaceSettingsWidget::DEFAULT_THEME_NAME = "darkfusion";

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -2319,6 +2319,42 @@ void MainWindow::setStyleFromSettings()
 
     qApp->setPalette(darkPalette);
   }
+  	else if (theme == "cobaltsky")
+	{
+		// Custom palette by KamFretoZ, A soothing deep royal blue
+		// that are meant to be easy on the eyes as the main color.
+		// Alternative dark theme.
+		qApp->setStyle(QStyleFactory::create("Fusion"));
+
+		const QColor gray(150, 150, 150);
+		const QColor royalBlue(29, 41, 81);
+		const QColor darkishBlue(17, 30, 108);
+		const QColor lighterBlue(25, 32, 130);
+		const QColor highlight(36, 93, 218);
+		const QColor link(0, 202, 255);
+
+		QPalette darkPalette;
+		darkPalette.setColor(QPalette::Window, royalBlue);
+		darkPalette.setColor(QPalette::WindowText, Qt::white);
+		darkPalette.setColor(QPalette::Base, royalBlue.lighter());
+		darkPalette.setColor(QPalette::AlternateBase, darkishBlue);
+		darkPalette.setColor(QPalette::ToolTipBase, darkishBlue);
+		darkPalette.setColor(QPalette::ToolTipText, Qt::white);
+		darkPalette.setColor(QPalette::Text, Qt::white);
+		darkPalette.setColor(QPalette::Button, lighterBlue);
+		darkPalette.setColor(QPalette::ButtonText, Qt::white);
+		darkPalette.setColor(QPalette::Link, link);
+		darkPalette.setColor(QPalette::Highlight, highlight);
+		darkPalette.setColor(QPalette::HighlightedText, Qt::white);
+
+		darkPalette.setColor(QPalette::Active, QPalette::Button, lighterBlue);
+		darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, gray);
+		darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, gray);
+		darkPalette.setColor(QPalette::Disabled, QPalette::Text, gray);
+		darkPalette.setColor(QPalette::Disabled, QPalette::Light, gray);
+
+		qApp->setPalette(darkPalette);
+	}
   else if (theme == "greymatter")
   {
     qApp->setStyle(QStyleFactory::create("Fusion"));


### PR DESCRIPTION
This PR brings over the Cobalt Sky theme from PCSX2 to DuckStation:

Preview:
![Screenshot_20240402_150611](https://github.com/stenzek/duckstation/assets/14798312/d7b66c52-9580-4054-849e-3508d7ced99d)

![Screenshot_20240402_150739](https://github.com/stenzek/duckstation/assets/14798312/b8624443-001d-4bf2-86f2-514af3e0b832)

![Screenshot_20240402_151458](https://github.com/stenzek/duckstation/assets/14798312/212c7aa7-ff10-483c-ab26-d530ed7b4ca6)
