### PR TITLE
BPM: Light Mode color scheme update

### DIFF
--- a/src/util/imgui_fullscreen.cpp
+++ b/src/util/imgui_fullscreen.cpp
@@ -3035,19 +3035,19 @@ void ImGuiFullscreen::SetTheme(bool light)
   else
   {
     // light
-    UIBackgroundColor = HEX_TO_IMVEC4(0xf5f5f6, 0xff);
+    UIBackgroundColor = HEX_TO_IMVEC4(0xc8c8c8, 0xff);
     UIBackgroundTextColor = HEX_TO_IMVEC4(0x000000, 0xff);
     UIBackgroundLineColor = HEX_TO_IMVEC4(0xe1e2e1, 0xff);
     UIBackgroundHighlightColor = HEX_TO_IMVEC4(0xe1e2e1, 0xff);
-    UIPrimaryColor = HEX_TO_IMVEC4(0x0d47a1, 0xff);
-    UIPrimaryLightColor = HEX_TO_IMVEC4(0x5472d3, 0xff);
-    UIPrimaryDarkColor = HEX_TO_IMVEC4(0x002171, 0xff);
+    UIPrimaryColor = HEX_TO_IMVEC4(0x2a3e78, 0xff);
+    UIPrimaryLightColor = HEX_TO_IMVEC4(0x235cd9, 0xff);
+    UIPrimaryDarkColor = HEX_TO_IMVEC4(0x1d2953, 0xff);
     UIPrimaryTextColor = HEX_TO_IMVEC4(0xffffff, 0xff);
-    UIDisabledColor = HEX_TO_IMVEC4(0xaaaaaa, 0xff);
+    UIDisabledColor = HEX_TO_IMVEC4(0x999999, 0xff);
     UITextHighlightColor = HEX_TO_IMVEC4(0x8e8e8e, 0xff);
     UIPrimaryLineColor = HEX_TO_IMVEC4(0x000000, 0xff);
-    UISecondaryColor = HEX_TO_IMVEC4(0x3d5afe, 0xff);
-    UISecondaryStrongColor = HEX_TO_IMVEC4(0x0031ca, 0xff);
+    UISecondaryColor = HEX_TO_IMVEC4(0x2a3e78, 0xff);
+    UISecondaryStrongColor = HEX_TO_IMVEC4(0x464db1, 0xff);
     UISecondaryWeakColor = HEX_TO_IMVEC4(0xc0cfff, 0xff);
     UISecondaryTextColor = HEX_TO_IMVEC4(0x000000, 0xff);
   }


### PR DESCRIPTION
This PR tweaks the color scheme of BPM's Light Mode to be less bright, less saturated blue accent color, and no more eye-burning.

## Preview

### Before
![Screenshot_20240410_150341](https://github.com/stenzek/duckstation/assets/14798312/710286e6-183f-44d5-9917-ba924428e409)

![Screenshot_20240410_150353](https://github.com/stenzek/duckstation/assets/14798312/58c7260f-478e-4ab1-9d2c-c9cce9bf1763)

![Screenshot_20240410_150358](https://github.com/stenzek/duckstation/assets/14798312/29c1ae20-5970-43f6-b22c-7993c03fe9b2)

### After

![Screenshot_20240410_150439](https://github.com/stenzek/duckstation/assets/14798312/c28d47b3-5557-4d1c-b1c2-6c77bcba3bc7)

![Screenshot_20240410_150450](https://github.com/stenzek/duckstation/assets/14798312/68ac56be-ba07-49d3-a51c-20f9bd7191c4)

![Screenshot_20240410_150455](https://github.com/stenzek/duckstation/assets/14798312/40bc2357-71e4-4650-82af-203c35814958)
