### PR TITLE
Disable cheats by default and fix the "Deinterlacing" description

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -87,7 +87,7 @@ struct Settings
   bool load_devices_from_save_states : 1 = false;
   bool apply_compatibility_settings : 1 = true;
   bool apply_game_settings : 1 = true;
-  bool enable_cheats : 1 = true;
+  bool enable_cheats : 1 = false;
   bool disable_all_enhancements : 1 = false;
   bool enable_discord_presence : 1 = false;
 

--- a/src/duckstation-qt/graphicssettingswidget.cpp
+++ b/src/duckstation-qt/graphicssettingswidget.cpp
@@ -270,7 +270,7 @@ GraphicsSettingsWidget::GraphicsSettingsWidget(SettingsWindow* dialog, QWidget* 
     tr("Changes the aspect ratio used to display the console's output to the screen. The default is Auto (Game Native) "
        "which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era."));
   dialog->registerWidgetHelp(
-    m_ui.displayCropMode, tr("Deinterlacing"),
+    m_ui.displayDeinterlacing, tr("Deinterlacing"),
     QString::fromUtf8(Settings::GetDisplayDeinterlacingModeName(Settings::DEFAULT_DISPLAY_DEINTERLACING_MODE)),
     tr("Determines which algorithm is used to convert interlaced frames to progressive for display on your system. "
        "Generally, the \"Disable Interlacing\" enhancement provides better quality output, but some games require "


### PR DESCRIPTION
Kinda same fix as my previous PR, the "Deinterlacing" setting was using the "Crop" setting var name.
\+ disable cheats by default, since you confirmed on Discord it wasn't the intended behavior.