### PR TITLE
Renamed Mem Scanner Op Text&added Virtual Address

### DIFF
--- a/src/core/cheats.h
+++ b/src/core/cheats.h
@@ -204,22 +204,22 @@ class MemoryScan
 public:
   enum class Operator
   {
-    Equal,
-    NotEqual,
-    GreaterThan,
-    GreaterEqual,
-    LessThan,
-    LessEqual,
-    IncreasedBy,
-    DecreasedBy,
-    ChangedBy,
-    EqualLast,
-    NotEqualLast,
-    GreaterThanLast,
-    GreaterEqualLast,
+    Any,
     LessThanLast,
     LessEqualLast,
-    Any
+    GreaterThanLast,
+    GreaterEqualLast,
+    NotEqualLast,
+    EqualLast,
+    DecreasedBy,
+    IncreasedBy,
+    ChangedBy,
+    Equal,
+    NotEqual,
+    LessThan,
+    LessEqual,
+    GreaterThan,
+    GreaterEqual
   };
 
   struct Result

--- a/src/duckstation-qt/memoryscannerwindow.cpp
+++ b/src/duckstation-qt/memoryscannerwindow.cpp
@@ -91,9 +91,7 @@ MemoryScannerWindow::MemoryScannerWindow() : QWidget()
   m_ui.setupUi(this);
   connectUi();
 
-  char tempvar[256];
-  sprintf(tempvar, "Address of RAM for HxD Usage: 0x%p", Bus::g_ram);
-  m_ui.cheatEngineAddress->setText(tempvar);
+  m_ui.cheatEngineAddress->setText(tr("Address of RAM for HxD Usage: 0x%1").arg(reinterpret_cast<qulonglong>(Bus::g_unprotected_ram), 16, 16, QChar('0')));
 }
 
 MemoryScannerWindow::~MemoryScannerWindow() = default;

--- a/src/duckstation-qt/memoryscannerwindow.cpp
+++ b/src/duckstation-qt/memoryscannerwindow.cpp
@@ -90,6 +90,10 @@ MemoryScannerWindow::MemoryScannerWindow() : QWidget()
 {
   m_ui.setupUi(this);
   connectUi();
+
+  char tempvar[256];
+  sprintf(tempvar, "Address of RAM for HxD Usage: 0x%p", Bus::g_ram);
+  m_ui.cheatEngineAddress->setText(tempvar);
 }
 
 MemoryScannerWindow::~MemoryScannerWindow() = default;

--- a/src/duckstation-qt/memoryscannerwindow.ui
+++ b/src/duckstation-qt/memoryscannerwindow.ui
@@ -152,82 +152,82 @@
        <widget class="QComboBox" name="scanOperator">
         <item>
          <property name="text">
-          <string>Equal to...</string>
+          <string>Equal to Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Not Equal to...</string>
+          <string>Not Equal to Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Greater Than...</string>
+          <string>Greater Than Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Greater or Equal...</string>
+          <string>Greater or Equal to Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Less Than...</string>
+          <string>Less Than Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Less or Equal...</string>
+          <string>Less or Equal to Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Increased By...</string>
+          <string>Increased By Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Decreased By...</string>
+          <string>Decreased By Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Changed By...</string>
+          <string>Changed By Value</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Equal to Previous (Unchanged Value)</string>
+          <string>Equal to Previous Result (Unchanged Value)</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Not Equal to Previous (Changed Value)</string>
+          <string>Not Equal to Previous Result (Changed Value)</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Greater Than Previous</string>
+          <string>Greater Than Previous Result</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Greater or Equal to Previous</string>
+          <string>Greater or Equal to Previous Result</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Less Than Previous</string>
+          <string>Less Than Previous Result</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Less or Equal to Previous</string>
+          <string>Less or Equal to Previous Result</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Any Value</string>
+          <string>Any Value ('New Search' or 'Reset Result Value')</string>
          </property>
         </item>
        </widget>
@@ -446,6 +446,48 @@
          </property>
         </widget>
        </item>
+       
+             <item>
+              <widget class="QTextEdit" name="cheatEngineAddress">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>833</width>
+                 <height>40</height>
+                </size>
+               </property>               
+               <property name="inputMethodHints">
+                <set>Qt::ImhNone</set>
+               </property>
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="verticalScrollBarPolicy">
+                <enum>Qt::ScrollBarAlwaysOff</enum>
+               </property>
+               <property name="horizontalScrollBarPolicy">
+                <enum>Qt::ScrollBarAlwaysOff</enum>
+               </property>
+               <property name="readOnly">
+                <bool>false</bool>
+               </property>
+               <property name="acceptRichText">
+                <bool>false</bool>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::TextEditable</set>
+               </property>
+               <property name="placeholderText">
+                <string notr="true"/>
+               </property>
+               <property name="text">
+                <string>cheat engine address string</string>
+               </property>
+              </widget>
+             </item>
+       
        <item>
         <spacer name="horizontalSpacer_2">
          <property name="orientation">

--- a/src/duckstation-qt/memoryscannerwindow.ui
+++ b/src/duckstation-qt/memoryscannerwindow.ui
@@ -152,67 +152,7 @@
        <widget class="QComboBox" name="scanOperator">
         <item>
          <property name="text">
-          <string>Equal to Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Not Equal to Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Greater Than Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Greater or Equal to Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Less Than Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Less or Equal to Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Increased By Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Decreased By Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Changed By Value</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Equal to Previous Result (Unchanged Value)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Not Equal to Previous Result (Changed Value)</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Greater Than Previous Result</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Greater or Equal to Previous Result</string>
+          <string>Any Value ('New Search' or 'Reset Result Value')</string>
          </property>
         </item>
         <item>
@@ -227,7 +167,67 @@
         </item>
         <item>
          <property name="text">
-          <string>Any Value ('New Search' or 'Reset Result Value')</string>
+          <string>Greater Than Previous Result</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Greater or Equal to Previous Result</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Not Equal to Previous Result (Changed Value)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Equal to Previous Result (Unchanged Value)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Decreased By Value</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Increased By Value</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Changed By Value</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Equal to Value</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Not Equal to Value</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Less Than Value</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Less or Equal to Value</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Greater Than Value</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Greater or Equal to Value</string>
          </property>
         </item>
        </widget>

--- a/src/duckstation-qt/translations/duckstation-qt_de.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_de.ts
@@ -2165,82 +2165,82 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Gleich...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>Ungleich...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Größer als...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Größer gleich...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Kleiner als...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Kleiner gleich...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Erhöht durch...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Verringert durch...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Geändert durch...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Gleich zum Vorherigen (unveränderter Wert)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Ungleich zum Vorherigen (geänderter Wert)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Größer zum Vorherigen</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Größer gleich zum Vorherigen</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Kleiner zum Vorherigen</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Kleiner gleich zum Vorherigen</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Beliebiger Wert</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_es-ES.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_es-ES.ts
@@ -2179,82 +2179,82 @@ Mensajes sin leer: {}</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Igual a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>Distinto a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Mayor que...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Mayor o igual que...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Menor que...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Menor o igual que...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Incrementado por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Disminuido por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Reemplazado por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Igual a valor anterior (sin cambios)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Distinto a valor anterior (con cambios)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Mayor que valor previo</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Mayor o igual a valor anterior</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Menor que valor anterior</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Menor o igual a valor anterior</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Cualquier valor</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_es.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_es.ts
@@ -2172,82 +2172,82 @@ Mensajes sin leer: {}</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Igual a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>Distinto a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Mayor que...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Mayor o igual...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Menor que...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Menor o igual...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Incrementado por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Decrementado por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Reemplazado por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Igual a valor previo (sin cambios)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Distinto a valor previo (con cambios)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Mayor que valor previo</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Mayor o igual a valor previo</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Menor a valor previo</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Menor o igual a valor previo</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Cualquier valor</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_fr.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_fr.ts
@@ -2167,82 +2167,82 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Équivaut à...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>N&apos;équivaut pas à...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Supérieur à...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Supérieur ou égal...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Inférieur à...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Inférieur ou égal...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Augmenté par...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Diminué par...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Changé par...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Équivaut au précédent (valeur inchangée)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Non-équivalent au précédent (valeur changée)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Supérieur au précédent</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Supérieur ou égal au précédent</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Inférieur au précédent</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Inférieur ou égal ou précédent</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Toute valeur</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_he.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_he.ts
@@ -2164,82 +2164,82 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_id.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_id.ts
@@ -2167,82 +2167,82 @@ Pesan belum dibaca: {}</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_it.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_it.ts
@@ -2170,82 +2170,82 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Uguale a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>Non uguale a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Maggiore di...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Maggiore o uguale a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Minore di...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Minore o uguale a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Aumentato di...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Diminuito di...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Cambiato di...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Uguale al precedente (valore non cambiato)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Non uguale al precedente (valore cambiato)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Maggiore del precedente</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Maggiore o uguale al precedente</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Minore del precedente</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Minore o uguale al precedente</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Qualsiasi valore</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_ja.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_ja.ts
@@ -2164,57 +2164,57 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>&quot;値&quot;と等しい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>&quot;値&quot;と異なる</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>&quot;値&quot;より大きい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>&quot;値&quot;より大きいか等しい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>&quot;値&quot;より小さい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>&quot;値&quot;より小さいか等しい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>&quot;値&quot;ずつ増加</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>&quot;値&quot;ずつ減少</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>&quot;値&quot;ずつ変化</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>以前と等しい (変更されていない値)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>以前と異なる (変更された値)</translation>
     </message>
     <message>
@@ -2224,27 +2224,27 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>以前より大きい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>以前より大きいか等しい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>以前より小さい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>以前より小さいか等しい</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>任意の値</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_ko.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_ko.ts
@@ -2178,57 +2178,57 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>같음...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>같지 않음...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>보다 큰...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>크거나 같음...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>작음...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>작거나 같음...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>증가...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>감소...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>변경...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>이전과 같음(변경되지 않음)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>이전과 같지 않음(변경된 값)</translation>
     </message>
     <message>
@@ -2238,27 +2238,27 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>이전보다 큼</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>이전보다 크거나 같음</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>이전보다 작음</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>이전보다 작거나 같음</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>모든 값</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_nl.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_nl.ts
@@ -2166,82 +2166,82 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_pl.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_pl.ts
@@ -12474,37 +12474,37 @@ Czy na pewno chcesz kontynuować?</translation>
         <translation>Operator:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="155"/>
+        <location filename="../memoryscannerwindow.ui" line="205"/>
         <source>Equal to Value</source>
         <translation>Jest równy...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="160"/>
+        <location filename="../memoryscannerwindow.ui" line="210"/>
         <source>Not Equal to Value</source>
         <translation>Nie jest równy...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="165"/>
+        <location filename="../memoryscannerwindow.ui" line="225"/>
         <source>Greater Than Value</source>
         <translation>Większy niż...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="170"/>
+        <location filename="../memoryscannerwindow.ui" line="230"/>
         <source>Greater or Equal to Value</source>
         <translation>Większy lub równy...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="175"/>
+        <location filename="../memoryscannerwindow.ui" line="215"/>
         <source>Less Than Value</source>
         <translation>Mniejszy niż...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="180"/>
+        <location filename="../memoryscannerwindow.ui" line="220"/>
         <source>Less or Equal to Value</source>
         <translation>Mniejszy lub równy...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="185"/>
+        <location filename="../memoryscannerwindow.ui" line="195"/>
         <source>Increased By Value</source>
         <translation>Zwiększony o...</translation>
     </message>
@@ -12514,42 +12514,42 @@ Czy na pewno chcesz kontynuować?</translation>
         <translation>Zmniejszony o...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="195"/>
+        <location filename="../memoryscannerwindow.ui" line="200"/>
         <source>Changed By Value</source>
         <translation>Zmieniony o...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="200"/>
+        <location filename="../memoryscannerwindow.ui" line="185"/>
         <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Równy poprzedniej (niezmieniona wartość)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="205"/>
+        <location filename="../memoryscannerwindow.ui" line="180"/>
         <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Nie jest równy poprzedniej (zmieniona wartość)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="210"/>
+        <location filename="../memoryscannerwindow.ui" line="170"/>
         <source>Greater Than Previous Result</source>
         <translation>Większy niż poprzedni</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="215"/>
+        <location filename="../memoryscannerwindow.ui" line="175"/>
         <source>Greater or Equal to Previous Result</source>
         <translation>Większy lub równy poprzedniemu</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="220"/>
+        <location filename="../memoryscannerwindow.ui" line="160"/>
         <source>Less Than Previous Result</source>
         <translation>Mniejszy niż poprzedni</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="225"/>
+        <location filename="../memoryscannerwindow.ui" line="165"/>
         <source>Less or Equal to Previous Result</source>
         <translation>Mniejszy lub równy poprzedniemu</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="230"/>
+        <location filename="../memoryscannerwindow.ui" line="155"/>
         <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Dowolna wartość</translation>
     </message>

--- a/src/duckstation-qt/translations/duckstation-qt_pl.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_pl.ts
@@ -12475,82 +12475,82 @@ Czy na pewno chcesz kontynuować?</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="155"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Jest równy...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="160"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>Nie jest równy...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="165"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Większy niż...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="170"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Większy lub równy...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="175"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Mniejszy niż...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="180"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Mniejszy lub równy...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="185"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Zwiększony o...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="190"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Zmniejszony o...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="195"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Zmieniony o...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="200"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Równy poprzedniej (niezmieniona wartość)</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="205"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Nie jest równy poprzedniej (zmieniona wartość)</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="210"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Większy niż poprzedni</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="215"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Większy lub równy poprzedniemu</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="220"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Mniejszy niż poprzedni</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="225"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Mniejszy lub równy poprzedniemu</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="230"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Dowolna wartość</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_pt-BR.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_pt-BR.ts
@@ -12462,82 +12462,82 @@ Tem certeza de que deseja continuar?</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="155"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Equivale a...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="160"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>Diferente de...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="165"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Maior que...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="170"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Maior ou igual...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="175"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Menor que...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="180"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Menor ou igual...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="185"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Aumentado por...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="190"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Diminuir por...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="195"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Alterado por...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="200"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Igual ao anteriror (valor inalterado)</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="205"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Diferente do anterior (valor alterado)</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="210"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Maior do que o anterior</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="215"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Maior ou igual ao anterior</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="220"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Menor que o anterior</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="225"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Menor ou igual ao anterior</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="230"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Qualquer valor</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_pt-BR.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_pt-BR.ts
@@ -12461,37 +12461,37 @@ Tem certeza de que deseja continuar?</translation>
         <translation>Operador:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="155"/>
+        <location filename="../memoryscannerwindow.ui" line="205"/>
         <source>Equal to Value</source>
         <translation>Equivale a...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="160"/>
+        <location filename="../memoryscannerwindow.ui" line="210"/>
         <source>Not Equal to Value</source>
         <translation>Diferente de...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="165"/>
+        <location filename="../memoryscannerwindow.ui" line="225"/>
         <source>Greater Than Value</source>
         <translation>Maior que...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="170"/>
+        <location filename="../memoryscannerwindow.ui" line="230"/>
         <source>Greater or Equal to Value</source>
         <translation>Maior ou igual...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="175"/>
+        <location filename="../memoryscannerwindow.ui" line="215"/>
         <source>Less Than Value</source>
         <translation>Menor que...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="180"/>
+        <location filename="../memoryscannerwindow.ui" line="220"/>
         <source>Less or Equal to Value</source>
         <translation>Menor ou igual...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="185"/>
+        <location filename="../memoryscannerwindow.ui" line="195"/>
         <source>Increased By Value</source>
         <translation>Aumentado por...</translation>
     </message>
@@ -12501,42 +12501,42 @@ Tem certeza de que deseja continuar?</translation>
         <translation>Diminuir por...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="195"/>
+        <location filename="../memoryscannerwindow.ui" line="200"/>
         <source>Changed By Value</source>
         <translation>Alterado por...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="200"/>
+        <location filename="../memoryscannerwindow.ui" line="185"/>
         <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Igual ao anteriror (valor inalterado)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="205"/>
+        <location filename="../memoryscannerwindow.ui" line="180"/>
         <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Diferente do anterior (valor alterado)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="210"/>
+        <location filename="../memoryscannerwindow.ui" line="170"/>
         <source>Greater Than Previous Result</source>
         <translation>Maior do que o anterior</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="215"/>
+        <location filename="../memoryscannerwindow.ui" line="175"/>
         <source>Greater or Equal to Previous Result</source>
         <translation>Maior ou igual ao anterior</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="220"/>
+        <location filename="../memoryscannerwindow.ui" line="160"/>
         <source>Less Than Previous Result</source>
         <translation>Menor que o anterior</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="225"/>
+        <location filename="../memoryscannerwindow.ui" line="165"/>
         <source>Less or Equal to Previous Result</source>
         <translation>Menor ou igual ao anterior</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="230"/>
+        <location filename="../memoryscannerwindow.ui" line="155"/>
         <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Qualquer valor</translation>
     </message>

--- a/src/duckstation-qt/translations/duckstation-qt_pt-PT.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_pt-PT.ts
@@ -2165,82 +2165,82 @@ Unread messages: {}</source>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Igual a...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>Diferente de...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Maior Que...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Maior ou Igual...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Menor Que...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Menor ou Igual...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Aumentado Por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Diminuido Por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Mudado Por...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Igual ao Anteriror (Valor Inalterado)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Diferente do Anterior (Valor Alterado)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Maior Que o Anterior</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Maior ou Igual ao Anterior</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Menor que o Anterior</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Menor ou Igual ao Anterior</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Qualquer Valor</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_ru.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_ru.ts
@@ -12676,82 +12676,82 @@ Are you sure you want to continue?</source>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="155"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation type="unfinished">Равно...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="160"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation type="unfinished">Не равно...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="165"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation type="unfinished">Больше, чем...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="170"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation type="unfinished">Больше или равно...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="175"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation type="unfinished">Меньше, чем...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="180"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal Value</source>
         <translation type="unfinished">Меньше или равно...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="185"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation type="unfinished">Увеличилось на...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="190"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation type="unfinished">Уменьшилось на...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="195"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation type="unfinished">Изменилось на...</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="200"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation type="unfinished">Равно предыдущему (неизменное значение)</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="205"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation type="unfinished">Не равно предыдущему (измененное значение)</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="210"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation type="unfinished">Больше, чем предыдущий</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="215"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation type="unfinished">Больше или равно предыдущему</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="220"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation type="unfinished">Меньше, чем предыдущий</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="225"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation type="unfinished">Меньше или равно предыдущему</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="230"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation type="unfinished">Любое значение</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_ru.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_ru.ts
@@ -12675,37 +12675,37 @@ Are you sure you want to continue?</source>
         <translation type="unfinished">Оператор:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="155"/>
+        <location filename="../memoryscannerwindow.ui" line="205"/>
         <source>Equal to Value</source>
         <translation type="unfinished">Равно...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="160"/>
+        <location filename="../memoryscannerwindow.ui" line="210"/>
         <source>Not Equal to Value</source>
         <translation type="unfinished">Не равно...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="165"/>
+        <location filename="../memoryscannerwindow.ui" line="225"/>
         <source>Greater Than Value</source>
         <translation type="unfinished">Больше, чем...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="170"/>
+        <location filename="../memoryscannerwindow.ui" line="230"/>
         <source>Greater or Equal to Value</source>
         <translation type="unfinished">Больше или равно...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="175"/>
+        <location filename="../memoryscannerwindow.ui" line="215"/>
         <source>Less Than Value</source>
         <translation type="unfinished">Меньше, чем...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="180"/>
+        <location filename="../memoryscannerwindow.ui" line="220"/>
         <source>Less or Equal Value</source>
         <translation type="unfinished">Меньше или равно...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="185"/>
+        <location filename="../memoryscannerwindow.ui" line="195"/>
         <source>Increased By Value</source>
         <translation type="unfinished">Увеличилось на...</translation>
     </message>
@@ -12715,42 +12715,42 @@ Are you sure you want to continue?</source>
         <translation type="unfinished">Уменьшилось на...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="195"/>
+        <location filename="../memoryscannerwindow.ui" line="200"/>
         <source>Changed By Value</source>
         <translation type="unfinished">Изменилось на...</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="200"/>
+        <location filename="../memoryscannerwindow.ui" line="185"/>
         <source>Equal to Previous Result (Unchanged Value)</source>
         <translation type="unfinished">Равно предыдущему (неизменное значение)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="205"/>
+        <location filename="../memoryscannerwindow.ui" line="180"/>
         <source>Not Equal to Previous Result (Changed Value)</source>
         <translation type="unfinished">Не равно предыдущему (измененное значение)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="210"/>
+        <location filename="../memoryscannerwindow.ui" line="170"/>
         <source>Greater Than Previous Result</source>
         <translation type="unfinished">Больше, чем предыдущий</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="215"/>
+        <location filename="../memoryscannerwindow.ui" line="175"/>
         <source>Greater or Equal to Previous Result</source>
         <translation type="unfinished">Больше или равно предыдущему</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="220"/>
+        <location filename="../memoryscannerwindow.ui" line="160"/>
         <source>Less Than Previous Result</source>
         <translation type="unfinished">Меньше, чем предыдущий</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="225"/>
+        <location filename="../memoryscannerwindow.ui" line="165"/>
         <source>Less or Equal to Previous Result</source>
         <translation type="unfinished">Меньше или равно предыдущему</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="230"/>
+        <location filename="../memoryscannerwindow.ui" line="155"/>
         <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation type="unfinished">Любое значение</translation>
     </message>

--- a/src/duckstation-qt/translations/duckstation-qt_tr.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_tr.ts
@@ -2178,82 +2178,82 @@ Okunmamış Mesajlar: {}</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="296"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>Eşittir Şuna...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="301"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>Eşit Değildir Şuna...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="306"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>Büyüktür Den...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="311"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>Büyük yada Eşittir...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="316"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>Azdır...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="321"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>Az yada Eşittir...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="326"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>Yükselir Den...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="331"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>Azalır dan...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="336"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>Değiştirilir den...</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="341"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Öncekine Eşit: (Değişmemiş Veri)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="346"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Öncekine Eşit Değil (Değişmiş Veri)</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="351"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>Öncekinden Büyük</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="356"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>Öncekinden Eşit yada Büyük</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="361"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>Öncekinden Az</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="366"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>Öncekinden Eşit yada Az</translation>
     </message>
     <message>
         <location filename="../cheatmanagerdialog.ui" line="371"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>Herhangi Bir Değer</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_zh-CN.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_zh-CN.ts
@@ -12477,82 +12477,82 @@ The saves will not be recoverable.</source>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="155"/>
-        <source>Equal to...</source>
+        <source>Equal to Value</source>
         <translation>等于…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="160"/>
-        <source>Not Equal to...</source>
+        <source>Not Equal to Value</source>
         <translation>不等于…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="165"/>
-        <source>Greater Than...</source>
+        <source>Greater Than Value</source>
         <translation>大于…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="170"/>
-        <source>Greater or Equal...</source>
+        <source>Greater or Equal to Value</source>
         <translation>大于或等于…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="175"/>
-        <source>Less Than...</source>
+        <source>Less Than Value</source>
         <translation>小于…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="180"/>
-        <source>Less or Equal...</source>
+        <source>Less or Equal to Value</source>
         <translation>小于或等于…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="185"/>
-        <source>Increased By...</source>
+        <source>Increased By Value</source>
         <translation>增加了…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="190"/>
-        <source>Decreased By...</source>
+        <source>Decreased By Value</source>
         <translation>减少了…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="195"/>
-        <source>Changed By...</source>
+        <source>Changed By Value</source>
         <translation>更改了…</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="200"/>
-        <source>Equal to Previous (Unchanged Value)</source>
+        <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>等于前一个 (值未变化)</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="205"/>
-        <source>Not Equal to Previous (Changed Value)</source>
+        <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>不等于前一个 (值有变化)</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="210"/>
-        <source>Greater Than Previous</source>
+        <source>Greater Than Previous Result</source>
         <translation>大于前一个</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="215"/>
-        <source>Greater or Equal to Previous</source>
+        <source>Greater or Equal to Previous Result</source>
         <translation>大于或等于前一个</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="220"/>
-        <source>Less Than Previous</source>
+        <source>Less Than Previous Result</source>
         <translation>小于前一个</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="225"/>
-        <source>Less or Equal to Previous</source>
+        <source>Less or Equal to Previous Result</source>
         <translation>小于或等于前一个</translation>
     </message>
     <message>
         <location filename="../memoryscannerwindow.ui" line="230"/>
-        <source>Any Value</source>
+        <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>任何值</translation>
     </message>
     <message>

--- a/src/duckstation-qt/translations/duckstation-qt_zh-CN.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_zh-CN.ts
@@ -12476,37 +12476,37 @@ The saves will not be recoverable.</source>
         <translation>操作员:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="155"/>
+        <location filename="../memoryscannerwindow.ui" line="205"/>
         <source>Equal to Value</source>
         <translation>等于…</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="160"/>
+        <location filename="../memoryscannerwindow.ui" line="210"/>
         <source>Not Equal to Value</source>
         <translation>不等于…</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="165"/>
+        <location filename="../memoryscannerwindow.ui" line="225"/>
         <source>Greater Than Value</source>
         <translation>大于…</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="170"/>
+        <location filename="../memoryscannerwindow.ui" line="230"/>
         <source>Greater or Equal to Value</source>
         <translation>大于或等于…</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="175"/>
+        <location filename="../memoryscannerwindow.ui" line="215"/>
         <source>Less Than Value</source>
         <translation>小于…</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="180"/>
+        <location filename="../memoryscannerwindow.ui" line="220"/>
         <source>Less or Equal to Value</source>
         <translation>小于或等于…</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="185"/>
+        <location filename="../memoryscannerwindow.ui" line="195"/>
         <source>Increased By Value</source>
         <translation>增加了…</translation>
     </message>
@@ -12516,42 +12516,42 @@ The saves will not be recoverable.</source>
         <translation>减少了…</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="195"/>
+        <location filename="../memoryscannerwindow.ui" line="200"/>
         <source>Changed By Value</source>
         <translation>更改了…</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="200"/>
+        <location filename="../memoryscannerwindow.ui" line="185"/>
         <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>等于前一个 (值未变化)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="205"/>
+        <location filename="../memoryscannerwindow.ui" line="180"/>
         <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>不等于前一个 (值有变化)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="210"/>
+        <location filename="../memoryscannerwindow.ui" line="170"/>
         <source>Greater Than Previous Result</source>
         <translation>大于前一个</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="215"/>
+        <location filename="../memoryscannerwindow.ui" line="175"/>
         <source>Greater or Equal to Previous Result</source>
         <translation>大于或等于前一个</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="220"/>
+        <location filename="../memoryscannerwindow.ui" line="160"/>
         <source>Less Than Previous Result</source>
         <translation>小于前一个</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="225"/>
+        <location filename="../memoryscannerwindow.ui" line="165"/>
         <source>Less or Equal to Previous Result</source>
         <translation>小于或等于前一个</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="230"/>
+        <location filename="../memoryscannerwindow.ui" line="155"/>
         <source>Any Value ('New Search' or 'Reset Result Value')</source>
         <translation>任何值</translation>
     </message>


### PR DESCRIPTION
Renamed the Memory Scanner Operator Text for clarity. Replaced '...' with 'Value' and 'Previous' with 'Previous Result'.
Also changed "Any Value" to "Any Value ('New Search' or 'Reset Result Value')"

Reordered the Memory Scanner Operator Text into a more intuitive order:

Any Value ('New Search' or 'Reset Result Value') 
Less Than Previous Result
Less or Equal to Previous Result
Greater Than Previous Result
Greater or Equal to Previous Result
Not Equal to Previous Result (Changed Value)
Equal to Previous Result (Unchanged Value)
Increased By Value
Decreased By Value
Changed By Value
Equal to Value
Not Equal to Value
Greater Than Value
Greater or Equal to Value
Less Than Value
Less or Equal to Value


The Virtual Address extra will display the virtual address of DuckStation's PSX RAM so it can be easily edited with the likes of HXD or another tool where the location of the virtual memory needs to be known.