### PR TITLE
Add some shaders to dolphinfx folder

### DIFF
--- a/data/resources/shaders/dolphinfx/crt/CRT-EASYMODE.glsl
+++ b/data/resources/shaders/dolphinfx/crt/CRT-EASYMODE.glsl
@@ -1,0 +1,277 @@
+//    CRT Shader by EasyMode
+//    License: GPL
+
+//    A flat CRT shader ideally for 1080p or higher displays.
+
+//    Recommended Settings:
+
+//    Video
+//    - Aspect Ratio:  4:3
+//    - Integer Scale: Off
+
+//    Shader
+//    - Filter: Nearest
+//    - Scale:  Don't Care
+
+//    Example RGB Mask Parameter Settings:
+
+//    Aperture Grille (Default)
+//    - Dot Width:  1
+//    - Dot Height: 1
+//    - Stagger:    0
+
+//    Lottes' Shadow Mask
+//    - Dot Width:  2
+//    - Dot Height: 1
+//    - Stagger:    3
+
+
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = Sharpness Horizontal
+OptionName = SHARPNESS_H
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.5
+
+[OptionRangeFloat]
+GUIName = Sharpness Vertical
+OptionName = SHARPNESS_V
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = Mask Strength
+OptionName = MASK_STRENGTH
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.01
+DefaultValue = 0.3
+
+[OptionRangeFloat]
+GUIName = Mask Dot Width
+OptionName = MASK_DOT_WIDTH
+MinValue = 1.0
+MaxValue = 100.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = Mask Dot Height
+OptionName = MASK_DOT_HEIGHT
+MinValue = 1.0
+MaxValue = 100.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = Mask Stagger
+OptionName = MASK_STAGGER
+MinValue = 0.0
+MaxValue = 100.0
+StepAmount = 1.0
+DefaultValue = 0.0
+
+[OptionRangeFloat]
+GUIName = Mask Size
+OptionName = MASK_SIZE
+MinValue = 1.0
+MaxValue = 100.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = Scanline Strength
+OptionName = SCANLINE_STRENGTH
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = Scanline Beam Width Min.
+OptionName = SCANLINE_BEAM_WIDTH_MIN
+MinValue = 0.5
+MaxValue = 5.0
+StepAmount = 0.5
+DefaultValue = 1.5
+
+[OptionRangeFloat]
+GUIName = Scanline Beam Width Max.
+OptionName = SCANLINE_BEAM_WIDTH_MAX
+MinValue = 0.5
+MaxValue = 5.0
+StepAmount = 0.5
+DefaultValue = 1.5
+
+[OptionRangeFloat]
+GUIName = Scanline Brightness Min.
+OptionName = SCANLINE_BRIGHT_MIN
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.35
+
+[OptionRangeFloat]
+GUIName = Scanline Brightness Max.
+OptionName = SCANLINE_BRIGHT_MAX
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.65
+
+[OptionRangeFloat]
+GUIName = Scanline Cutoff
+OptionName = SCANLINE_CUTOFF
+MinValue = 1.0
+MaxValue = 1000.0
+StepAmount = 1.0
+DefaultValue = 400.0
+
+[OptionRangeFloat]
+GUIName = Gamma Input
+OptionName = GAMMA_INPUT
+MinValue = 0.1
+MaxValue = 5.0
+StepAmount = 0.1
+DefaultValue = 2.0
+
+[OptionRangeFloat]
+GUIName = Gamma Output
+OptionName = GAMMA_OUTPUT
+MinValue = 0.1
+MaxValue = 5.0
+StepAmount = 0.1
+DefaultValue = 1.8
+
+[OptionRangeFloat]
+GUIName = Brightness Boost
+OptionName = BRIGHT_BOOST
+MinValue = 1.0
+MaxValue = 2.0
+StepAmount = 0.01
+DefaultValue = 1.2
+
+[OptionRangeFloat]
+GUIName = Dilation
+OptionName = DILATION
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[/configuration]
+*/
+
+#define FIX(c) max(abs(c), 1e-5)
+#define PI 3.141592653589
+
+#define TEX2D(c) dilate(SampleLocation(c))
+
+// Set to 0 to use linear filter and gain speed
+#define ENABLE_LANCZOS 1
+
+vec4 dilate(vec4 col)
+{
+    vec4 x = mix(vec4(1.0), col, GetOption(DILATION));
+
+    return col * x;
+}
+
+float curve_distance(float x, float sharp)
+{
+
+/*
+    apply half-circle s-curve to distance for sharper (more pixelated) interpolation
+    single line formula for Graph Toy:
+    0.5 - sqrt(0.25 - (x - step(0.5, x)) * (x - step(0.5, x))) * sign(0.5 - x)
+*/
+
+    float x_step = step(0.5, x);
+    float curve = 0.5 - sqrt(0.25 - (x - x_step) * (x - x_step)) * sign(0.5 - x);
+
+    return mix(x, curve, sharp);
+}
+
+mat4x4 get_color_matrix(vec2 co, vec2 dx)
+{
+    return mat4x4(TEX2D(co - dx), TEX2D(co), TEX2D(co + dx), TEX2D(co + 2.0 * dx));
+}
+
+vec3 filter_lanczos(vec4 coeffs, mat4x4 color_matrix)
+{
+    vec4 col        = color_matrix * coeffs;
+    vec4 sample_min = min(color_matrix[1], color_matrix[2]);
+    vec4 sample_max = max(color_matrix[1], color_matrix[2]);
+
+    col = clamp(col, sample_min, sample_max);
+
+    return col.rgb;
+}
+
+void main()
+{
+    vec2 vTexCoord = GetCoordinates();
+    vec2 nativeSize = 1.0 / GetInvNativePixelSize();
+    vec4 SourceSize = vec4(nativeSize, 1.0/nativeSize);
+
+    vec2 dx     = vec2(SourceSize.z, 0.0);
+    vec2 dy     = vec2(0.0, SourceSize.w);
+    vec2 pix_co = vTexCoord * SourceSize.xy - vec2(0.5, 0.5);
+    vec2 tex_co = (floor(pix_co) + vec2(0.5, 0.5)) * SourceSize.zw;
+    vec2 dist   = fract(pix_co);
+    float curve_x;
+    vec3 col, col2;
+
+#if ENABLE_LANCZOS
+    curve_x = curve_distance(dist.x, GetOption(SHARPNESS_H) * GetOption(SHARPNESS_H));
+
+    vec4 coeffs = PI * vec4(1.0 + curve_x, curve_x, 1.0 - curve_x, 2.0 - curve_x);
+
+    coeffs = FIX(coeffs);
+    coeffs = 2.0 * sin(coeffs) * sin(coeffs * 0.5) / (coeffs * coeffs);
+    coeffs /= dot(coeffs, vec4(1.0));
+
+    col  = filter_lanczos(coeffs, get_color_matrix(tex_co, dx));
+    col2 = filter_lanczos(coeffs, get_color_matrix(tex_co + dy, dx));
+#else
+    curve_x = curve_distance(dist.x, GetOption(SHARPNESS_H));
+
+    col  = mix(TEX2D(tex_co).rgb,      TEX2D(tex_co + dx).rgb,      curve_x);
+    col2 = mix(TEX2D(tex_co + dy).rgb, TEX2D(tex_co + dx + dy).rgb, curve_x);
+#endif
+
+    col = mix(col, col2, curve_distance(dist.y, GetOption(SHARPNESS_V)));
+    col = pow(col, vec3(GetOption(GAMMA_INPUT) / (GetOption(DILATION) + 1.0)));
+
+    float luma        = dot(vec3(0.2126, 0.7152, 0.0722), col);
+    float bright      = (max(col.r, max(col.g, col.b)) + luma) * 0.5;
+    float scan_bright = clamp(bright, GetOption(SCANLINE_BRIGHT_MIN), GetOption(SCANLINE_BRIGHT_MAX));
+    float scan_beam   = clamp(bright * GetOption(SCANLINE_BEAM_WIDTH_MAX), GetOption(SCANLINE_BEAM_WIDTH_MIN), GetOption(SCANLINE_BEAM_WIDTH_MAX));
+    float scan_weight = 1.0 - pow(cos(vTexCoord.y * 2.0 * PI * SourceSize.y) * 0.5 + 0.5, scan_beam) * GetOption(SCANLINE_STRENGTH);
+
+    float mask   = 1.0 - GetOption(MASK_STRENGTH);    
+    vec2 mod_fac = floor(vTexCoord * GetResolution().xy * SourceSize.xy / (SourceSize.xy * vec2(GetOption(MASK_SIZE), GetOption(MASK_DOT_HEIGHT) * GetOption(MASK_SIZE))));
+    int dot_no   = int(mod((mod_fac.x + mod(mod_fac.y, 2.0) * GetOption(MASK_STAGGER)) / GetOption(MASK_DOT_WIDTH), 3.0));
+    vec3 mask_weight;
+
+    if      (dot_no == 0) mask_weight = vec3(1.0,  mask, mask);
+    else if (dot_no == 1) mask_weight = vec3(mask, 1.0,  mask);
+    else                  mask_weight = vec3(mask, mask, 1.0);
+
+    if (SourceSize.y >= GetOption(SCANLINE_CUTOFF)) 
+        scan_weight = 1.0;
+
+    col2 = col.rgb;
+    col *= vec3(scan_weight);
+    col  = mix(col, col2, scan_bright);
+    col *= mask_weight;
+    col  = pow(col, vec3(1.0 / GetOption(GAMMA_OUTPUT)));
+
+    SetOutput(vec4(col * GetOption(BRIGHT_BOOST), 1.0));
+}

--- a/data/resources/shaders/dolphinfx/crt/CRT-HYLLIAN.glsl
+++ b/data/resources/shaders/dolphinfx/crt/CRT-HYLLIAN.glsl
@@ -1,0 +1,504 @@
+//    Hyllian's CRT Shader
+
+//    Copyright (C) 2011-2024 Hyllian - sergiogdb@gmail.com
+
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+
+//    The above copyright notice and this permission notice shall be included in
+//    all copies or substantial portions of the Software.
+
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//    THE SOFTWARE.
+
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = HIGH RESOLUTION SCANLINES
+OptionName = SCANLINES_HIRES
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName =VERTICAL SCANLINES
+OptionName = VSCANLINES
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 0.0
+
+[OptionRangeFloat]
+GUIName = BEAM PROFILE
+OptionName = BEAM_PROFILE
+MinValue = 0.0
+MaxValue = 2.0
+StepAmount = 1.0
+DefaultValue = 0.0
+
+[OptionRangeFloat]
+GUIName = HORIZONTAL FILTER PROFILE
+OptionName = HFILTER_PROFILE
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = COLOR BOOST
+OptionName = COLOR_BOOST
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 1.40
+
+[OptionRangeFloat]
+GUIName = SHARPNESS HACK
+OptionName = SHARPNESS_HACK
+MinValue = 1.0
+MaxValue = 4.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = PHOSPHOR LAYOUT
+OptionName = PHOSPHOR_LAYOUT
+MinValue = 0.0
+MaxValue = 15.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = MASK INTENSITY
+OptionName = MASK_INTENSITY
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.65
+
+[OptionRangeFloat]
+GUIName = MIN BEAM WIDTH
+OptionName = BEAM_MIN_WIDTH
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.01
+DefaultValue = 0.86
+
+[OptionRangeFloat]
+GUIName = MAX BEAM WIDTH
+OptionName = BEAM_MAX_WIDTH
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.01
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = SCANLINES STRENGTH
+OptionName = SCANLINES_STRENGTH
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.01
+DefaultValue = 0.58
+
+[OptionRangeFloat]
+GUIName = MONITOR SUBPIXELS LAYOUT
+OptionName = MONITOR_SUBPIXELS
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 0.0
+
+[OptionRangeFloat]
+GUIName = ANTI RINGING
+OptionName = CRT_ANTI_RINGING
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = INPUT GAMMA
+OptionName = CRT_InputGamma
+MinValue = 1.0
+MaxValue = 3.0
+StepAmount = 0.05
+DefaultValue = 2.4
+
+[OptionRangeFloat]
+GUIName = OUTPUT GAMMA
+OptionName = CRT_OutputGamma
+MinValue = 1.0
+MaxValue = 3.0
+StepAmount = 0.05
+DefaultValue = 2.2
+
+[/configuration]
+*/
+
+
+#define GAMMA_IN(color)     pow(color, vec3(GetOption(CRT_InputGamma), GetOption(CRT_InputGamma), GetOption(CRT_InputGamma)))
+#define GAMMA_OUT(color)    pow(color, vec3(1.0 / GetOption(CRT_OutputGamma), 1.0 / GetOption(CRT_OutputGamma), 1.0 / GetOption(CRT_OutputGamma)))
+
+const vec3 Y = vec3(0.2627, 0.6780, 0.0593);
+
+
+//    A collection of CRT mask effects that work with LCD subpixel structures for
+//    small details
+
+//    author: hunterk
+//    license: public domain
+
+// Mask code pasted from subpixel_masks.h. Masks 3 and 4 added.
+vec3 mask_weights(vec2 coord, float mask_intensity, int phosphor_layout, float monitor_subpixels){
+   vec3 weights = vec3(1.,1.,1.);
+   float on = 1.;
+   float off = 1.-mask_intensity;
+   vec3 red     = monitor_subpixels==1.0 ? vec3(on,  off, off) : vec3(off, off, on );
+   vec3 green   = vec3(off, on,  off);
+   vec3 blue    = monitor_subpixels==1.0 ? vec3(off, off, on ) : vec3(on,  off, off);
+   vec3 magenta = vec3(on,  off, on );
+   vec3 yellow  = monitor_subpixels==1.0 ? vec3(on,  on,  off) : vec3(off, on,  on );
+   vec3 cyan    = monitor_subpixels==1.0 ? vec3(off, on,  on ) : vec3(on,  on,  off);
+   vec3 black   = vec3(off, off, off);
+   vec3 white   = vec3(on,  on,  on );
+   int w, z = 0;
+   
+   // This pattern is used by a few layouts, so we'll define it here
+   vec3 aperture_weights = mix(magenta, green, floor(mod(coord.x, 2.0)));
+   
+   if(phosphor_layout == 0) return weights;
+
+   else if(phosphor_layout == 1){
+      // classic aperture for RGB panels; good for 1080p, too small for 4K+
+      // aka aperture_1_2_bgr
+      weights  = aperture_weights;
+      return weights;
+   }
+
+   else if(phosphor_layout == 2){
+      // Classic RGB layout; good for 1080p and lower
+      vec3 bw3[3] = vec3[](red, green, blue);
+      
+      z = int(floor(mod(coord.x, 3.0)));
+      
+      weights = bw3[z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 3){
+      // black and white aperture; good for weird subpixel layouts and low brightness; good for 1080p and lower
+      vec3 bw3[3] = vec3[](black, white, black);
+      
+      z = int(floor(mod(coord.x, 3.0)));
+      
+      weights = bw3[z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 4){
+      // reduced TVL aperture for RGB panels. Good for 4k.
+      // aperture_2_4_rgb
+      
+      vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
+      
+      w = int(floor(mod(coord.x, 4.0)));
+      
+      weights = big_ap_rgb[w];
+      return weights;
+   }
+   
+   else if(phosphor_layout == 5){
+      // black and white aperture; good for weird subpixel layouts and low brightness; good for 4k 
+      vec3 bw4[4] = vec3[](black, black, white, white);
+      
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = bw4[z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 6){
+      // aperture_1_4_rgb; good for simulating lower 
+      vec3 ap4[4] = vec3[](red, green, blue, black);
+      
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = ap4[z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 7){
+      // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
+      // aka delta_1_2x1_bgr
+      vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
+      weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
+      return weights;
+   }
+
+   else if(phosphor_layout == 8){
+      // delta_2_4x1_rgb
+      vec3 delta[2][4] = {
+         {red, yellow, cyan, blue},
+         {cyan, blue, red, yellow}
+      };
+      
+      w = int(floor(mod(coord.y, 2.0)));
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = delta[w][z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 9){
+      // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+      vec3 delta1[2][4] = {
+         {red,  green, blue, black},
+         {blue, black, red,  green}
+      };
+      
+      w = int(floor(mod(coord.y, 2.0)));
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = delta1[w][z];
+      return weights;
+   }
+   
+   else if(phosphor_layout == 10){
+      // delta_2_4x2_rgb
+      vec3 delta[4][4] = {
+         {red,  yellow, cyan, blue},
+         {red,  yellow, cyan, blue},
+         {cyan, blue,   red,  yellow},
+         {cyan, blue,   red,  yellow}
+      };
+      
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = delta[w][z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 11){
+      // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
+      vec3 slotmask[4][6] = {
+         {red, green, blue,    red, green, blue,},
+         {red, green, blue,  black, black, black},
+         {red, green, blue,    red, green, blue,},
+         {black, black, black, red, green, blue,}
+      };
+      
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 6.0)));
+
+      // use the indexes to find which color to apply to the current pixel
+      weights = slotmask[w][z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 12){
+      // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
+      vec3 slotmask[4][6] = {
+         {black,  white, black,   black,  white, black,},
+         {black,  white, black,  black, black, black},
+         {black,  white, black,  black,  white, black,},
+         {black, black, black,  black,  white, black,}
+      };
+      
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 6.0)));
+
+      // use the indexes to find which color to apply to the current pixel
+      weights = slotmask[w][z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 13){
+      // based on MajorPainInTheCactus' HDR slot mask
+      vec3 slot[4][8] = {
+         {red,   green, blue,  black, red,   green, blue,  black},
+         {red,   green, blue,  black, black, black, black, black},
+         {red,   green, blue,  black, red,   green, blue,  black},
+         {black, black, black, black, red,   green, blue,  black}
+      };
+      
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 8.0)));
+      
+      weights = slot[w][z];
+      return weights;
+   }
+
+   else if(phosphor_layout == 14){
+      // same as above but for RGB panels
+      vec3 slot2[4][10] = {
+         {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+         {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+         {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+         {red,   red,    black, black, black, black, green,  green, blue,  blue }
+      };
+   
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 10.0)));
+      
+      weights = slot2[w][z];
+      return weights;
+   }
+   
+   else if(phosphor_layout == 15){
+      // slot_3_7x6_rgb
+      vec3 slot[6][14] = {
+         {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+         {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+         {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+         {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+         {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+         {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
+      };
+      
+      w = int(floor(mod(coord.y, 6.0)));
+      z = int(floor(mod(coord.x, 14.0)));
+      
+      weights = slot[w][z];
+      return weights;
+   }
+
+
+   
+   else return weights;
+}
+
+// Horizontal cubic filter.
+// Some known filters use these values:
+
+//    B = 0.5, C = 0.0        =>  A sharp almost gaussian filter.
+//    B = 0.0, C = 0.0        =>  Hermite cubic filter.
+//    B = 1.0, C = 0.0        =>  Cubic B-Spline filter.
+//    B = 0.0, C = 0.5        =>  Catmull-Rom Spline filter.
+//    B = C = 1.0/3.0         =>  Mitchell-Netravali cubic filter.
+//    B = 0.3782, C = 0.3109  =>  Robidoux filter.
+//    B = 0.2620, C = 0.3690  =>  Robidoux Sharp filter.
+
+// For more info, see: http://www.imagemagick.org/Usage/img_diagrams/cubic_survey.gif
+
+mat4x4 get_hfilter_profile()
+{
+	float bf = 1.0;
+	float cf = 0.0;
+
+	if (GetOption(HFILTER_PROFILE) == 1) {bf = 1.0/3.0;     cf = 1.0/3.0;}
+
+        return mat4x4(            (-bf - 6.0*cf)/6.0,         (3.0*bf + 12.0*cf)/6.0,     (-3.0*bf - 6.0*cf)/6.0,             bf/6.0,
+                                        (12.0 - 9.0*bf - 6.0*cf)/6.0, (-18.0 + 12.0*bf + 6.0*cf)/6.0,                      0.0, (6.0 - 2.0*bf)/6.0,
+                                       -(12.0 - 9.0*bf - 6.0*cf)/6.0, (18.0 - 15.0*bf - 12.0*cf)/6.0,      (3.0*bf + 6.0*cf)/6.0,             bf/6.0,
+                                                   (bf + 6.0*cf)/6.0,                           -cf,                      0.0,               0.0);
+         
+         
+}
+
+
+#define scanlines_strength (4.0*profile.x)
+#define beam_min_width     profile.y
+#define beam_max_width     profile.z
+#define color_boost        profile.w
+
+
+vec4 get_beam_profile()
+{
+	vec4 bp = vec4(GetOption(SCANLINES_STRENGTH), GetOption(BEAM_MIN_WIDTH), GetOption(BEAM_MAX_WIDTH), GetOption(COLOR_BOOST));
+
+	if (BEAM_PROFILE == 1)  bp = vec4(0.58, 0.86, 1.00, 1.60); // Catmull-rom
+	if (BEAM_PROFILE == 2)  bp = vec4(0.58, 0.72, 1.00, 1.75); // Catmull-rom
+
+	return bp;
+}
+
+
+void main()
+{
+    vec2 vTexCoord = GetCoordinates();
+    vec2 SourceSize = 1.0 / GetInvNativePixelSize(); // This work with previous build.
+
+    vec4 profile = get_beam_profile();
+
+    vec2 TextureSize = mix(vec2(SourceSize.x * GetOption(SHARPNESS_HACK), SourceSize.y), vec2(SourceSize.x, SourceSize.y * GetOption(SHARPNESS_HACK)), GetOption(VSCANLINES));
+
+    vec2 dx = mix(vec2(1.0/TextureSize.x, 0.0), vec2(0.0, 1.0/TextureSize.y), GetOption(VSCANLINES));
+    vec2 dy = mix(vec2(0.0, 1.0/TextureSize.y), vec2(1.0/TextureSize.x, 0.0), GetOption(VSCANLINES));
+
+    vec2 pix_coord = vTexCoord.xy*TextureSize.xy - vec2(0.5, 0.5);
+
+    vec2 tc = ( (SCANLINES_HIRES > 0.5) ? (mix(vec2(floor(pix_coord.x), pix_coord.y), vec2(pix_coord.x, floor(pix_coord.y)), GetOption(VSCANLINES)) + vec2(0.5, 0.5)) : (floor(pix_coord) + vec2(0.5, 0.5)) )/TextureSize;
+
+    pix_coord = mix(pix_coord, pix_coord.yx, GetOption(VSCANLINES));
+
+    vec2 fp = fract(pix_coord);
+
+    vec3 c00 = GAMMA_IN(SampleLocation(tc     - dx     ).xyz);
+    vec3 c01 = GAMMA_IN(SampleLocation(tc              ).xyz);
+    vec3 c02 = GAMMA_IN(SampleLocation(tc     + dx     ).xyz);
+    vec3 c03 = GAMMA_IN(SampleLocation(tc + 2.0*dx     ).xyz);
+
+    vec3 c10 = (SCANLINES_HIRES > 0.5) ? c00 : GAMMA_IN(SampleLocation(tc     - dx +dy ).xyz);
+    vec3 c11 = (SCANLINES_HIRES > 0.5) ? c01 : GAMMA_IN(SampleLocation(tc          +dy ).xyz);
+    vec3 c12 = (SCANLINES_HIRES > 0.5) ? c02 : GAMMA_IN(SampleLocation(tc     + dx +dy ).xyz);
+    vec3 c13 = (SCANLINES_HIRES > 0.5) ? c03 : GAMMA_IN(SampleLocation(tc + 2.0*dx +dy ).xyz);
+
+    mat4x4 invX = get_hfilter_profile();
+
+    mat4x3 color_matrix0 = mat4x3(c00, c01, c02, c03);
+    mat4x3 color_matrix1 = mat4x3(c10, c11, c12, c13);
+    
+    vec4 invX_Px    = vec4(fp.x*fp.x*fp.x, fp.x*fp.x, fp.x, 1.0) * invX;
+    vec3 color0     = color_matrix0 * invX_Px;
+    vec3 color1     = color_matrix1 * invX_Px;
+
+    // Get min/max samples
+    vec3 min_sample0 = min(c01,c02);
+    vec3 max_sample0 = max(c01,c02);
+    vec3 min_sample1 = min(c11,c12);
+    vec3 max_sample1 = max(c11,c12);
+    
+    // Anti-ringing
+    vec3 aux = color0;
+    color0 = clamp(color0, min_sample0, max_sample0);
+    color0 = mix(aux, color0, GetOption(CRT_ANTI_RINGING) * step(0.0, (c00-c01)*(c02-c03)));
+    aux = color1;
+    color1 = clamp(color1, min_sample1, max_sample1);
+    color1 = mix(aux, color1, GetOption(CRT_ANTI_RINGING) * step(0.0, (c10-c11)*(c12-c13)));
+
+    float pos0 = fp.y;
+    float pos1 = 1 - fp.y;
+
+    vec3 lum0 = mix(vec3(beam_min_width), vec3(beam_max_width), color0);
+    vec3 lum1 = mix(vec3(beam_min_width), vec3(beam_max_width), color1);
+
+    vec3 d0 = scanlines_strength*pos0/(lum0*lum0+0.0000001);
+    vec3 d1 = scanlines_strength*pos1/(lum1*lum1+0.0000001);
+
+    d0 = exp(-d0*d0);
+    d1 = exp(-d1*d1);
+
+    vec3 color = (color0*d0+color1*d1);            
+
+    color  = GAMMA_OUT(color);
+
+    vec2 mask_coords =vTexCoord.xy * GetResolution().xy;
+
+    mask_coords = mix(mask_coords.xy, mask_coords.yx, GetOption(VSCANLINES));
+
+    color.rgb*=GAMMA_OUT(mask_weights(mask_coords,  GetOption(MASK_INTENSITY), int(GetOption(PHOSPHOR_LAYOUT)), GetOption(MONITOR_SUBPIXELS)));
+
+    SetOutput(vec4(color_boost*color, 1.0));
+}

--- a/data/resources/shaders/dolphinfx/crt/CRT-HYLLIAN.glsl
+++ b/data/resources/shaders/dolphinfx/crt/CRT-HYLLIAN.glsl
@@ -58,8 +58,8 @@ DefaultValue = 1.0
 [OptionRangeFloat]
 GUIName = COLOR BOOST
 OptionName = COLOR_BOOST
-MinValue = 0.0
-MaxValue = 1.0
+MinValue = 1.0
+MaxValue = 3.0
 StepAmount = 0.05
 DefaultValue = 1.40
 
@@ -110,6 +110,14 @@ MinValue = 0.0
 MaxValue = 1.0
 StepAmount = 0.01
 DefaultValue = 0.58
+
+[OptionRangeFloat]
+GUIName = SCANLINES CUTOFF
+OptionName = SCANLINES_CUTOFF
+MinValue = 0.0
+MaxValue = 1000.0
+StepAmount = 1.0
+DefaultValue = 390.0
 
 [OptionRangeFloat]
 GUIName = MONITOR SUBPIXELS LAYOUT
@@ -490,9 +498,9 @@ void main()
     d0 = exp(-d0*d0);
     d1 = exp(-d1*d1);
 
-    vec3 color = (color0*d0+color1*d1);            
+    vec3 color = (TextureSize.y <= SCANLINES_CUTOFF) ? (color0*d0+color1*d1) : GAMMA_IN(SampleLocation(vTexCoord).xyz);            
 
-    color  = GAMMA_OUT(color);
+    color  = color_boost*GAMMA_OUT(color);
 
     vec2 mask_coords =vTexCoord.xy * GetResolution().xy;
 
@@ -500,5 +508,5 @@ void main()
 
     color.rgb*=GAMMA_OUT(mask_weights(mask_coords,  GetOption(MASK_INTENSITY), int(GetOption(PHOSPHOR_LAYOUT)), GetOption(MONITOR_SUBPIXELS)));
 
-    SetOutput(vec4(color_boost*color, 1.0));
+    SetOutput(vec4(color, 1.0));
 }

--- a/data/resources/shaders/dolphinfx/crt/ZFAST-CRT-COMPOSITE.glsl
+++ b/data/resources/shaders/dolphinfx/crt/ZFAST-CRT-COMPOSITE.glsl
@@ -1,0 +1,180 @@
+//    zfast_crt - A very simple CRT shader.
+
+//    Copyright (C) 2017 Greg Hogan (SoltanGris42)
+//	edited by metallic 77.
+//	ported to slang by gregoricavichioli & hunterk.
+//      ported to dolphinfx by Hyllian.
+
+//    This program is free software; you can redistribute it and/or modify it
+//    under the terms of the GNU General Public License as published by the Free
+//    Software Foundation; either version 2 of the License, or (at your option)
+//    any later version.
+
+
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = Curvature
+OptionName = Curvature
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = Convergence X-Axis
+OptionName = blurx
+MinValue = -1.0
+MaxValue =  2.0
+StepAmount = 0.05
+DefaultValue = 0.85
+
+[OptionRangeFloat]
+GUIName = Convergence Y-Axis
+OptionName = blury
+MinValue = -1.0
+MaxValue =  1.0
+StepAmount = 0.05
+DefaultValue = -0.10
+
+[OptionRangeFloat]
+GUIName = Scanline Amount (Low)
+OptionName = HIGHSCANAMOUNT1
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.4
+
+[OptionRangeFloat]
+GUIName = Scanline Amount (High)
+OptionName = HIGHSCANAMOUNT2
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.3
+
+[OptionRangeFloat]
+GUIName = Mask Type
+OptionName = TYPE
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 0.0
+
+[OptionRangeFloat]
+GUIName = Mask Effect Amount
+OptionName = MASK_DARK
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.3
+
+[OptionRangeFloat]
+GUIName = Mask/Scanline Fade
+OptionName = MASK_FADE
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.7
+
+[OptionRangeFloat]
+GUIName = Saturation
+OptionName = sat
+MinValue = 0.0
+MaxValue = 3.0
+StepAmount = 0.05
+DefaultValue = 1.0
+
+[OptionRangeFloat]
+GUIName = Flicker
+OptionName = FLICK
+MinValue = 0.0
+MaxValue = 50.0
+StepAmount = 1.0
+DefaultValue = 10.0
+
+[/configuration]
+*/
+
+#define pi 3.14159
+
+#define blur_y GetOption(blury)/(SourceSize.y*2.0)
+#define blur_x GetOption(blurx)/(SourceSize.x*2.0)
+#define iTimer (float(GetTime())*2.0)
+#define flicker GetOption(FLICK)/1000.0
+
+// Distortion of scanlines, and end of screen alpha.
+vec2 Warp(vec2 pos)
+{
+    pos  = pos*2.0-1.0;    
+    pos *= vec2(1.0 + (pos.y*pos.y)*0.03, 1.0 + (pos.x*pos.x)*0.05);
+    
+    return pos*0.5 + 0.5;
+}
+
+
+void main()
+{
+    vec2 vTexCoord  = GetCoordinates();
+    vec2 texSize = 1.0 / GetInvNativePixelSize();
+    vec4 SourceSize = vec4(texSize, 1.0 / texSize);
+    
+    float maskFade = 0.3333*GetOption(MASK_FADE);
+    float omega    = 2.0*pi*SourceSize.y;
+
+    vec2 pos,corn;
+    if (GetOption(Curvature) == 1.0) 
+{
+    pos = Warp(vTexCoord.xy);
+    corn = min(pos,vec2(1.0)-pos); // This is used to mask the rounded
+    corn.x = 0.00001/corn.x;           // corners later on
+   
+}
+
+     else pos = vTexCoord;    
+     float OGL2Pos = pos.y*SourceSize.y;
+     float cent = floor(OGL2Pos)+0.5;
+     float ycoord = cent*SourceSize.w; 
+     ycoord = mix(pos.y,ycoord,0.6);
+     pos = vec2(pos.x,ycoord);
+
+
+     vec3 sample1 = sin(iTimer)*flicker + SampleLocation(vec2(pos.x + blur_x, pos.y - blur_y)).rgb;
+     vec3 sample2 =                0.5*SampleLocation(pos).rgb;
+     vec3 sample3 = sin(iTimer)*flicker + SampleLocation(vec2(pos.x - blur_x, pos.y + blur_y)).rgb;
+    
+     vec3 colour = vec3 (sample1.r*0.5  + sample2.r, 
+                         sample1.g*0.25 + sample2.g + sample3.g*0.25, 
+                                          sample2.b + sample3.b*0.5);
+    
+     vec3 interl = colour;
+     vec3 lumweight=vec3(0.22,0.71,0.07);
+     float lumsat = dot(colour,lumweight);
+   
+     vec3 graycolour = vec3(lumsat);
+     colour = vec3(mix(graycolour,colour.rgb,sat));
+
+     float SCANAMOUNT = mix(GetOption(HIGHSCANAMOUNT1),GetOption(HIGHSCANAMOUNT2),max(max(colour.r,colour.g),colour.b));
+         
+
+    if (SourceSize.y > 400.0) {
+    colour ;
+    } 
+else {
+    colour *= SCANAMOUNT * sin(fract(OGL2Pos)*3.14159)+1.0-SCANAMOUNT;
+    colour *= SCANAMOUNT * sin(fract(1.0-OGL2Pos)*3.14159)+1.0-SCANAMOUNT;
+    colour *= SCANAMOUNT * sin(fract(1.0+OGL2Pos)*3.14159)+1.0-SCANAMOUNT;
+    }
+
+     float steps; if (GetOption(TYPE) == 0.0) steps = 0.5; else steps = 0.3333;
+     float whichmask = fract(vTexCoord.x*GetResolution().x*steps);
+     float mask = 1.0 + float(whichmask < steps) * (-GetOption(MASK_DARK));
+
+    colour.rgb = mix(mask*colour, colour, dot(colour.rgb,vec3(maskFade)));
+
+    if (GetOption(Curvature) == 1.0 && corn.y < corn.x || GetOption(Curvature) == 1.0 && corn.x < 0.00001 )
+    colour = vec3(0.0); 
+
+    SetOutput(vec4(colour.rgb, 1.0));
+}

--- a/data/resources/shaders/dolphinfx/edge-smoothing/DDT.glsl
+++ b/data/resources/shaders/dolphinfx/edge-smoothing/DDT.glsl
@@ -1,0 +1,110 @@
+//    Hyllian's DDT Shader
+
+//    Copyright (C) 2011-2024 Hyllian - sergiogdb@gmail.com
+
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+
+//    The above copyright notice and this permission notice shall be included in
+//    all copies or substantial portions of the Software.
+
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//    THE SOFTWARE.
+
+
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = Bilinear Fallback Threshold
+OptionName = BIL_FALLBACK
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.05
+DefaultValue = 0.6
+
+[/configuration]
+*/
+
+const vec3 Y = vec3(0.2126729, 0.7151522, 0.0721750);
+
+float luma(vec3 color)
+{
+    return dot(color, Y);
+}
+
+vec3 bilinear(float p, float q, vec3 A, vec3 B, vec3 C, vec3 D)
+{
+    return ((1-p)*(1-q)*A + p*(1-q)*B + (1-p)*q*C + p*q*D);
+}
+
+void main()
+{
+    vec2 texCoord = GetCoordinates();
+    vec2 nativeSize = 1.0 / GetInvNativePixelSize();
+
+    vec2 loc = texCoord*nativeSize;
+    vec2 pos = fract(loc) - vec2(0.5, 0.5); // pos = pixel position
+    vec2 dir = sign(pos); // dir = pixel direction
+
+    vec2 dx = vec2(1.0/nativeSize.x, 0.0);
+    vec2 dy = vec2(0.0, 1.0/nativeSize.y);
+
+    vec2 g1 = dir*dx;
+    vec2 g2 = dir*dy;
+
+    vec2 tc = (floor(loc)+vec2(0.5,0.5))/nativeSize;
+
+    vec3 A = SampleLocation(tc       ).rgb;
+    vec3 B = SampleLocation(tc +g1   ).rgb;
+    vec3 C = SampleLocation(tc    +g2).rgb;
+    vec3 D = SampleLocation(tc +g1+g2).rgb;
+
+    float a = luma(A);
+    float b = luma(B);
+    float c = luma(C);
+    float d = luma(D);
+
+    float p = abs(pos.x);
+    float q = abs(pos.y);
+
+    float k = distance(pos,g1);
+    float l = distance(pos,g2);
+
+    float wd1 = abs(a-d);
+    float wd2 = abs(b-c);
+
+    vec3 color = bilinear(p, q, A, B, C, D);
+
+    if ( wd1 < wd2 )
+    {
+        if (k < l)
+        {
+            C = A + D - B;
+        }
+        else
+        {
+            B = A + D - C;
+        }
+    }
+    else if (wd1 > wd2)
+    {
+        D = B + C - A;
+    }
+
+
+    vec3 ddt = bilinear(p, q, A, B, C, D);
+
+    color = mix(color, ddt, smoothstep(0.0, BIL_FALLBACK, abs(wd2-wd1)));
+
+    SetOutput(vec4(color, 1.0));
+}

--- a/data/resources/shaders/dolphinfx/edge-smoothing/XBR.glsl
+++ b/data/resources/shaders/dolphinfx/edge-smoothing/XBR.glsl
@@ -1,0 +1,276 @@
+//    Hyllian's xBR-lv2-standalone Shader
+
+//    Copyright (C) 2011-2024 Hyllian - sergiogdb@gmail.com
+
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+
+//    The above copyright notice and this permission notice shall be included in
+//    all copies or substantial portions of the Software.
+
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//    THE SOFTWARE.
+
+
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = COLOR DISTINCTION THRESHOLD
+OptionName = XBR_EQ_THRESHOLD
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.01
+DefaultValue = 0.32
+
+[OptionRangeFloat]
+GUIName = SMOOTHNESS THRESHOLD
+OptionName = XBR_LV2_COEFFICIENT
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.1
+DefaultValue = 0.3
+
+[OptionRangeFloat]
+GUIName = COLOR BLENDING
+OptionName = XBR_BLENDING
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[/configuration]
+*/
+
+// Uncomment just one of the three params below to choose the corner detection
+//#define CORNER_A
+//#define CORNER_B
+#define CORNER_C
+
+#define lv2_cf (GetOption(XBR_LV2_COEFFICIENT)+2.0)
+#define P(x,y) (vec2(x,y)*vec2(dx,dy))
+
+const  vec4 Ao = vec4( 1.0, -1.0, -1.0, 1.0 );
+const  vec4 Bo = vec4( 1.0,  1.0, -1.0,-1.0 );
+const  vec4 Co = vec4( 1.5,  0.5, -0.5, 0.5 );
+const  vec4 Ax = vec4( 1.0, -1.0, -1.0, 1.0 );
+const  vec4 Bx = vec4( 0.5,  2.0, -0.5,-2.0 );
+const  vec4 Cx = vec4( 1.0,  1.0, -0.5, 0.0 );
+const  vec4 Ay = vec4( 1.0, -1.0, -1.0, 1.0 );
+const  vec4 By = vec4( 2.0,  0.5, -2.0,-0.5 );
+const  vec4 Cy = vec4( 2.0,  0.0, -1.0, 0.5 );
+const  vec4 Ci = vec4(0.25, 0.25, 0.25, 0.25);
+
+const vec3 v2f = vec3( 65536, 256, 1); // vec to float encode
+const vec3 Y = vec3(0.2627, 0.6780, 0.0593);
+
+// Return if A components are less than or equal B ones.
+vec4 LTE(vec4 A, vec4 B)
+{
+    return step(A, B);
+}
+
+// Return if A components are less than B ones.
+vec4 LT(vec4 A, vec4 B)
+{
+    return vec4(lessThan(A, B));
+}
+
+// Return logically inverted vector components. BEWARE: Only works with 0.0 or 1.0 components.
+vec4 NOT(vec4 A)
+{
+    return (vec4(1.0) - A);
+}
+
+// Compare two vectors and return their components are different.
+vec4 diff(vec4 A, vec4 B)
+{
+    return vec4(notEqual(A, B));
+}
+
+float dist(vec3 A, vec3 B)
+{
+    return dot(abs(A-B), Y);
+}
+
+// Calculate color distance between two vectors of four pixels
+vec4 dist4(mat4x3 A, mat4x3 B)
+{
+    return vec4(dist(A[0],B[0]), dist(A[1],B[1]), dist(A[2],B[2]), dist(A[3],B[3]));
+}
+
+// Tests if color components are under a threshold. In this case they are considered 'equal'.
+vec4 eq(mat4x3 A, mat4x3 B)
+{
+    return (step(dist4(A, B), vec4(GetOption(XBR_EQ_THRESHOLD))));
+}
+
+// Determine if two vector components are NOT equal based on a threshold.
+vec4 neq(mat4x3 A, mat4x3 B)
+{
+    return (vec4(1.0, 1.0, 1.0, 1.0) - eq(A, B));
+}
+
+// Calculate weighted distance among pixels in some directions.
+vec4 weighted_distance(mat4x3 a, mat4x3 b, mat4x3 c, mat4x3 d, mat4x3 e, mat4x3 f, mat4x3 g, mat4x3 h)
+{
+    return (dist4(a,b) + dist4(a,c) + dist4(d,e) + dist4(d,f) + 4.0*dist4(g,h));
+}
+
+
+
+void main()
+{
+    vec2 texCoord = GetCoordinates();
+    vec2 SourceSize = 1.0 / GetInvNativePixelSize();
+    float aa_factor = 2.0* (1.0/GetResolution().x) * SourceSize.x;
+
+    vec4 edri, edr, edr_l, edr_u, px; // px = pixel, edr = edge detection rule
+    vec4 irlv0, irlv1, irlv2l, irlv2u;
+    vec4 fx, fx_l, fx_u; // inequations of straight lines.
+    vec3 res1, res2;
+    vec4 fx45i, fx45, fx30, fx60;
+
+    float dx = 1.0/SourceSize.x;
+    float dy = 1.0/SourceSize.y;
+
+    vec2 loc = texCoord*SourceSize.xy;
+
+    vec2 fp  = fract(loc);
+
+    vec2 tc = (floor(loc)+vec2(0.5,0.5))/SourceSize;
+
+   //    A1 B1 C1
+   // A0  A  B  C C4
+   // D0  D  E  F F4
+   // G0  G  H  I I4
+   //    G5 H5 I5
+
+    vec3 A1 = SampleLocation(tc+P(-1.0,-2.0)).xyz;
+    vec3 B1 = SampleLocation(tc+P( 0.0,-2.0)).xyz;
+    vec3 C1 = SampleLocation(tc+P( 1.0,-2.0)).xyz;
+    vec3 A  = SampleLocation(tc+P(-1.0,-1.0)).xyz;
+    vec3 B  = SampleLocation(tc+P( 0.0,-1.0)).xyz;
+    vec3 C  = SampleLocation(tc+P( 1.0,-1.0)).xyz;
+    vec3 D  = SampleLocation(tc+P(-1.0, 0.0)).xyz;
+    vec3 E  = SampleLocation(tc+P( 0.0, 0.0)).xyz;
+    vec3 F  = SampleLocation(tc+P( 1.0, 0.0)).xyz;
+    vec3 G  = SampleLocation(tc+P(-1.0, 1.0)).xyz;
+    vec3 H  = SampleLocation(tc+P( 0.0, 1.0)).xyz;
+    vec3 I  = SampleLocation(tc+P( 1.0, 1.0)).xyz;
+    vec3 G5 = SampleLocation(tc+P(-1.0, 2.0)).xyz;
+    vec3 H5 = SampleLocation(tc+P( 0.0, 2.0)).xyz;
+    vec3 I5 = SampleLocation(tc+P( 1.0, 2.0)).xyz;
+    vec3 A0 = SampleLocation(tc+P(-2.0,-1.0)).xyz;
+    vec3 D0 = SampleLocation(tc+P(-2.0, 0.0)).xyz;
+    vec3 G0 = SampleLocation(tc+P(-2.0,-1.0)).xyz;
+    vec3 C4 = SampleLocation(tc+P( 2.0,-1.0)).xyz;
+    vec3 F4 = SampleLocation(tc+P( 2.0, 0.0)).xyz;
+    vec3 I4 = SampleLocation(tc+P( 2.0, 1.0)).xyz;
+
+    mat4x3 b  = mat4x3(B, D, H, F);
+    mat4x3 c  = mat4x3(C, A, G, I);
+    mat4x3 d  = mat4x3(D, H, F, B);
+    mat4x3 e  = mat4x3(E, E, E, E);
+    mat4x3 f  = mat4x3(F, B, D, H);
+    mat4x3 g  = mat4x3(G, I, C, A);
+    mat4x3 h  = mat4x3(H, F, B, D);
+    mat4x3 i  = mat4x3(I, C, A, G);
+
+    mat4x3 i4 = mat4x3(I4, C1, A0, G5);
+    mat4x3 i5 = mat4x3(I5, C4, A1, G0);
+    mat4x3 h5 = mat4x3(H5, F4, B1, D0);
+    mat4x3 f4 = mat4x3(F4, B1, D0, H5);
+
+    vec4 b_   = v2f * b;
+    vec4 c_   = v2f * c;
+    vec4 d_   = b_.yzwx;
+    vec4 e_   = v2f * e;
+    vec4 f_   = b_.wxyz;
+    vec4 g_   = c_.zwxy;
+    vec4 h_   = b_.zwxy;
+    vec4 i_   = c_.wxyz;
+
+    vec4 i4_  = v2f * i4;
+    vec4 i5_  = v2f * i5;
+    vec4 h5_  = v2f * h5;
+    vec4 f4_  = h5_.yzwx;
+
+    // These inequations define the line below which interpolation occurs.
+    fx    = ( Ao*fp.y + Bo*fp.x );
+    fx_l  = ( Ax*fp.y + Bx*fp.x );
+    fx_u  = ( Ay*fp.y + By*fp.x );
+
+    irlv0 = diff(e_,f_) * diff(e_,h_);
+    irlv1 = irlv0;
+
+#ifdef CORNER_B
+    irlv1      = saturate(irlv0 * ( neq(f,b) * neq(h,d) + eq(e,i) * neq(f,i4) * neq(h,i5) + eq(e,g) + eq(e,c) ) );
+#endif
+#ifdef CORNER_C
+    irlv1     = saturate(irlv0  * ( neq(f,b) * neq(f,c) + neq(h,d) * neq(h,g) + eq(e,i) * (neq(f,f4) * neq(f,i4) + neq(h,h5) * neq(h,i5)) + eq(e,g) + eq(e,c)) );
+#endif
+
+    irlv2l = diff(e_,g_) * diff( d_, g_);
+    irlv2u = diff(e_,c_) * diff( b_, c_);
+
+    if (GetOption(XBR_BLENDING) == 1.0) {
+        vec4 delta  = vec4(aa_factor);
+        vec4 deltaL = vec4(0.5, 1.0, 0.5, 1.0) * aa_factor;
+        vec4 deltaU = deltaL.yxwz;
+
+        fx45i = saturate( 0.5 + (fx   - Co - Ci) / delta  );
+        fx45  = saturate( 0.5 + (fx   - Co     ) / delta  );
+        fx30  = saturate( 0.5 + (fx_l - Cx     ) / deltaL );
+        fx60  = saturate( 0.5 + (fx_u - Cy     ) / deltaU );
+    }
+    else {
+        fx45i = LT( Co + Ci, fx   );
+        fx45  = LT(      Co, fx   );
+        fx30  = LT(      Cx, fx_l );
+        fx60  = LT(      Cy, fx_u );
+    }
+       
+    vec4 wd1 = weighted_distance( e, c,  g, i, h5, f4, h, f);
+    vec4 wd2 = weighted_distance( h, d, i5, f, i4,  b, e, i);
+
+    vec4 d_fg = dist4(f, g);
+    vec4 d_hc = dist4(h, c);
+
+    edri      = LTE(wd1, wd2) * irlv0;
+    edr       = LT( wd1, wd2) * irlv1 * NOT(edri.yzwx * edri.wxyz);
+    edr_l     = LTE( lv2_cf * d_fg, d_hc ) * irlv2l * edr * (NOT(edri.yzwx) * eq(e, c));
+    edr_u     = LTE( lv2_cf * d_hc, d_fg ) * irlv2u * edr * (NOT(edri.wxyz) * eq(e, g));
+
+    fx45i = edri   * fx45i;
+    fx45  = edr    * fx45;
+    fx30  = edr_l  * fx30;
+    fx60  = edr_u  * fx60;
+
+    px = LTE(dist4(e,f), dist4(e,h));
+
+    vec4 maximos = max(max(fx30, fx60), max(fx45, fx45i));
+
+    res1 = mix(E, mix(H, F, px.x), maximos.x);
+    res2 = mix(E, mix(B, D, px.z), maximos.z);
+
+    vec3 res1a = mix(res1, res2, step(dist(E, res1), dist(E, res2)));
+
+    res1 = mix(E, mix(F, B, px.y), maximos.y);
+    res2 = mix(E, mix(D, H, px.w), maximos.w);
+
+    vec3 res1b = mix(res1, res2, step(dist(E, res1), dist(E, res2)));
+
+    vec3 res = mix(res1a, res1b, step(dist(E, res1a), dist(E, res1b)));
+
+    SetOutput(vec4(res, 1.0));
+}

--- a/data/resources/shaders/dolphinfx/interpolation/JINC2.glsl
+++ b/data/resources/shaders/dolphinfx/interpolation/JINC2.glsl
@@ -1,0 +1,144 @@
+
+//   Hyllian's jinc windowed-jinc 2-lobe with anti-ringing Shader
+   
+//   Copyright (C) 2011-2024 Hyllian - sergiogdb@gmail.com
+
+//   This program is free software; you can redistribute it and/or
+//   modify it under the terms of the GNU General Public License
+//   as published by the Free Software Foundation; either version 2
+//   of the License, or (at your option) any later version.
+
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+
+//   You should have received a copy of the GNU General Public License
+//   along with this program; if not, write to the Free Software
+//   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = Window Sinc Param
+OptionName = JINC2_WINDOW_SINC
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.01
+DefaultValue = 0.50
+
+[OptionRangeFloat]
+GUIName = Sinc Param
+OptionName = JINC2_SINC
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.01
+DefaultValue = 0.88
+
+[OptionRangeFloat]
+GUIName = Anti-ringing Strength
+OptionName = JINC2_AR_STRENGTH
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 0.1
+DefaultValue = 0.5
+
+[/configuration]
+*/
+
+#define halfpi  1.5707963267948966192313216916398
+#define pi    3.1415926535897932384626433832795
+#define wa    (JINC2_WINDOW_SINC*pi)
+#define wb    (JINC2_SINC*pi)
+
+// Calculates the distance between two points
+float d(vec2 pt1, vec2 pt2)
+{
+  vec2 v = pt2 - pt1;
+  return sqrt(dot(v,v));
+}
+
+vec3 min4(vec3 a, vec3 b, vec3 c, vec3 d)
+{
+    return min(a, min(b, min(c, d)));
+}
+
+vec3 max4(vec3 a, vec3 b, vec3 c, vec3 d)
+{
+    return max(a, max(b, max(c, d)));
+}
+
+vec4 resampler(vec4 x)
+{
+	vec4 res;
+	res.x = (x.x==0.0) ?  wa*wb  :  sin(x.x*wa)*sin(x.x*wb)/(x.x*x.x);
+	res.y = (x.y==0.0) ?  wa*wb  :  sin(x.y*wa)*sin(x.y*wb)/(x.y*x.y);
+	res.z = (x.z==0.0) ?  wa*wb  :  sin(x.z*wa)*sin(x.z*wb)/(x.z*x.z);
+	res.w = (x.w==0.0) ?  wa*wb  :  sin(x.w*wa)*sin(x.w*wb)/(x.w*x.w);
+	return res;
+}
+
+void main()
+{
+    vec2 SourceSize = 1.0 / GetInvNativePixelSize();
+    vec2 invSourceSize = 1.0 / SourceSize;
+    vec2 vTexCoord = GetCoordinates();
+
+    vec3 color;
+    mat4x4 weights;
+
+    vec2 dx = vec2(1.0, 0.0);
+    vec2 dy = vec2(0.0, 1.0);
+
+    vec2 pc = vTexCoord*SourceSize;
+
+    vec2 tc = (floor(pc-vec2(0.5,0.5))+vec2(0.5,0.5));
+     
+    weights[0] = resampler(vec4(d(pc, tc    -dx    -dy), d(pc, tc           -dy), d(pc, tc    +dx    -dy), d(pc, tc+2.0*dx    -dy)));
+    weights[1] = resampler(vec4(d(pc, tc    -dx       ), d(pc, tc              ), d(pc, tc    +dx       ), d(pc, tc+2.0*dx       )));
+    weights[2] = resampler(vec4(d(pc, tc    -dx    +dy), d(pc, tc           +dy), d(pc, tc    +dx    +dy), d(pc, tc+2.0*dx    +dy)));
+    weights[3] = resampler(vec4(d(pc, tc    -dx+2.0*dy), d(pc, tc       +2.0*dy), d(pc, tc    +dx+2.0*dy), d(pc, tc+2.0*dx+2.0*dy)));
+
+    dx = dx * invSourceSize;
+    dy = dy * invSourceSize;
+    tc = tc * invSourceSize;
+     
+     // reading the texels
+     
+    vec3 c00 = SampleLocation(tc    -dx    -dy).xyz;
+    vec3 c10 = SampleLocation(tc           -dy).xyz;
+    vec3 c20 = SampleLocation(tc    +dx    -dy).xyz;
+    vec3 c30 = SampleLocation(tc+2.0*dx    -dy).xyz;
+    vec3 c01 = SampleLocation(tc    -dx       ).xyz;
+    vec3 c11 = SampleLocation(tc              ).xyz;
+    vec3 c21 = SampleLocation(tc    +dx       ).xyz;
+    vec3 c31 = SampleLocation(tc+2.0*dx       ).xyz;
+    vec3 c02 = SampleLocation(tc    -dx    +dy).xyz;
+    vec3 c12 = SampleLocation(tc           +dy).xyz;
+    vec3 c22 = SampleLocation(tc    +dx    +dy).xyz;
+    vec3 c32 = SampleLocation(tc+2.0*dx    +dy).xyz;
+    vec3 c03 = SampleLocation(tc    -dx+2.0*dy).xyz;
+    vec3 c13 = SampleLocation(tc       +2.0*dy).xyz;
+    vec3 c23 = SampleLocation(tc    +dx+2.0*dy).xyz;
+    vec3 c33 = SampleLocation(tc+2.0*dx+2.0*dy).xyz;
+
+    //  Get min/max samples
+    vec3 min_sample = min4(c11, c21, c12, c22);
+    vec3 max_sample = max4(c11, c21, c12, c22);
+
+    color = mat4x3(c00, c10, c20, c30) * weights[0];
+    color+= mat4x3(c01, c11, c21, c31) * weights[1];
+    color+= mat4x3(c02, c12, c22, c32) * weights[2];
+    color+= mat4x3(c03, c13, c23, c33) * weights[3];
+    color = color/(dot(weights * vec4(1.0), vec4(1.0)));
+
+    // Anti-ringing
+    vec3 aux = color;
+    color = clamp(color, min_sample, max_sample);
+
+    color = mix(aux, color, JINC2_AR_STRENGTH);
+ 
+    // final sum and weight normalization
+    SetOutput(vec4(color, 1.0));
+}

--- a/data/resources/shaders/dolphinfx/pixel-art/PIXELLATE.glsl
+++ b/data/resources/shaders/dolphinfx/pixel-art/PIXELLATE.glsl
@@ -1,0 +1,76 @@
+//    Pixellate Shader
+//    Copyright (c) 2011, 2012 Fes
+//    Permission to use, copy, modify, and/or distribute this software for any
+//    purpose with or without fee is hereby granted, provided that the above
+//    copyright notice and this permission notice appear in all copies.
+//    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//    SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//    IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//    (Fes gave their permission to have this shader distributed under this
+//    licence in this forum post:
+//        http://board.byuu.org/viewtopic.php?p=57295#p57295
+
+
+/*
+[configuration]
+
+[OptionRangeFloat]
+GUIName = Linear Gamma Weight
+OptionName = INTERPOLATE_IN_LINEAR_GAMMA
+MinValue = 0.0
+MaxValue = 1.0
+StepAmount = 1.0
+DefaultValue = 1.0
+
+[/configuration]
+*/
+
+void main()
+{
+   vec2 vTexCoord  = GetCoordinates();
+   vec2 SourceSize = 1.0 / GetInvNativePixelSize();
+   vec2 texelSize  = 1.0 / SourceSize.xy;
+   vec2 OutputSize = GetResolution().xy;
+
+   vec2 range = vec2(abs(SourceSize.x / (OutputSize.x * SourceSize.x)), abs(SourceSize.y / (OutputSize.y * SourceSize.y)));
+   range = range / 2.0 * 0.999;
+
+   float left   = vTexCoord.x - range.x;
+   float top    = vTexCoord.y + range.y;
+   float right  = vTexCoord.x + range.x;
+   float bottom = vTexCoord.y - range.y;
+   
+   vec3 topLeftColor;
+   vec3 bottomRightColor;
+   vec3 bottomLeftColor;
+   vec3 topRightColor;
+
+   if (GetOption(INTERPOLATE_IN_LINEAR_GAMMA) > 0.5){
+   topLeftColor     = pow(SampleLocation((floor(vec2(left, top)     / texelSize) + vec2(0.5)) * texelSize).rgb, vec3(2.2));
+   bottomRightColor = pow(SampleLocation((floor(vec2(right, bottom) / texelSize) + vec2(0.5)) * texelSize).rgb, vec3(2.2));
+   bottomLeftColor  = pow(SampleLocation((floor(vec2(left, bottom)  / texelSize) + vec2(0.5)) * texelSize).rgb, vec3(2.2));
+   topRightColor    = pow(SampleLocation((floor(vec2(right, top)    / texelSize) + vec2(0.5)) * texelSize).rgb, vec3(2.2));
+   }else{
+   topLeftColor     = SampleLocation((floor(vec2(left, top)     / texelSize) + vec2(0.5)) * texelSize).rgb;
+   bottomRightColor = SampleLocation((floor(vec2(right, bottom) / texelSize) + vec2(0.5)) * texelSize).rgb;
+   bottomLeftColor  = SampleLocation((floor(vec2(left, bottom)  / texelSize) + vec2(0.5)) * texelSize).rgb;
+   topRightColor    = SampleLocation((floor(vec2(right, top)    / texelSize) + vec2(0.5)) * texelSize).rgb;}
+
+   vec2 border = clamp(round(vTexCoord / texelSize) * texelSize, vec2(left, bottom), vec2(right, top));
+
+   float totalArea = 4.0 * range.x * range.y;
+
+   vec3 averageColor;
+   averageColor  = ((border.x - left)  * (top - border.y)    / totalArea) * topLeftColor;
+   averageColor += ((right - border.x) * (border.y - bottom) / totalArea) * bottomRightColor;
+   averageColor += ((border.x - left)  * (border.y - bottom) / totalArea) * bottomLeftColor;
+   averageColor += ((right - border.x) * (top - border.y)    / totalArea) * topRightColor;
+
+   vec4 color = (GetOption(INTERPOLATE_IN_LINEAR_GAMMA) > 0.5) ? vec4(pow(averageColor, vec3(1.0 / 2.2)), 1.0) : vec4(averageColor, 1.0);
+
+   SetOutput(color);
+}


### PR DESCRIPTION
This is a first pack of shaders ported to dolphinfx specs.

It includes: crt-hyllian, crt-easymode, zfast-crt, ddt, xbr, jinc2 and pixellate.