### PR TITLE
Fix binary_span_reader_writer.h (off-by-one error)

### DIFF
--- a/src/common/binary_span_reader_writer.h
+++ b/src/common/binary_span_reader_writer.h
@@ -62,7 +62,7 @@ public:
 private:
   ALWAYS_INLINE bool Read(void* buf, size_t size)
   {
-    if ((m_pos + size) < m_buf.size()) [[likely]]
+    if ((m_pos + size) <= m_buf.size()) [[likely]]
     {
       std::memcpy(buf, &m_buf[m_pos], size);
       m_pos += size;
@@ -74,7 +74,7 @@ private:
 
   ALWAYS_INLINE bool Peek(void* buf, size_t size)
   {
-    if ((m_pos + size) < m_buf.size()) [[likely]]
+    if ((m_pos + size) <= m_buf.size()) [[likely]]
     {
       std::memcpy(buf, &m_buf[m_pos], size);
       return true;
@@ -119,7 +119,7 @@ public:
 private:
   ALWAYS_INLINE bool Write(void* buf, size_t size)
   {
-    if ((m_pos + size) < m_buf.size()) [[likely]]
+    if ((m_pos + size) <= m_buf.size()) [[likely]]
     {
       std::memcpy(&m_buf[m_pos], buf, size);
       m_pos += size;


### PR DESCRIPTION
Found what I believe to be an off-by-one error while debugging a PINE api user.

When stack trace is:

BinarySpanReader::Read(void* buf, unsigned __int64 size) `(the function I believe that contains the error)`
BinarySpanReader::ReadT<u32>()
BinarySpanReader::ReadU32() `<-- called by switch case no. MsgRead64: "const PhysicalMemoryAddress addr = rdbuf.ReadU32();"`
PINESocket::HandleCommand(PINEServer::IPCCommand command, BinarySpanReader rdbuf)
PINESocket::ProcessCommandsInBuffer()
...

and m_pos == 0 && size == 4 && m_buf.size() == 4 (large enough to contain a u32)
the comparison fails, even though I think it should succeed and pull out a u32, followed by moving m_pos forward 4 bytes.

Feel free to contact me if you require further details.

Also, If I'm wrong or making an incorrect assumption, please let me know!