### PR TITLE
A super-simple shader can free pixel stretching and position translation on the XY axis.

### DIFF
--- a/data/resources/shaders/reshade/Shaders/XY-Pos-free.fx
+++ b/data/resources/shaders/reshade/Shaders/XY-Pos-free.fx
@@ -1,0 +1,84 @@
+#include "ReShade.fxh"
+
+//  CrashGG presents
+
+//  'XY-Pos-free' 
+
+//  A super-simple shader refined from the super-fast crt-cyclon.fx, It only provides
+//  the functions of free pixel stretching and position translation on the XY axis.
+//  Suitable for users who only want to fine-tune the screen zoom and position and do not like the bundled CRT-like effects.
+//  Fixed some bugs in the original version, adjusted the step progress and the range.
+
+//  This program is free software; you can redistribute it and/or modify it
+//  under the terms of the GNU General Public License as published by the Free
+//  Software Foundation; either version 2 of the License, or (at your option)
+//  any later version.
+
+
+uniform float zoomx <
+	ui_type = "drag";
+	ui_min = -0.3000;
+	ui_max = 0.3000;
+	ui_step = 0.0005;
+	ui_label = "Zoom Image X";
+> = 0.0000;
+
+uniform float zoomy <
+	ui_type = "drag";
+	ui_min = -0.3000;
+	ui_max = 0.3000;
+	ui_step = 0.0005;
+	ui_label = "Zoom Image Y";
+> = 0.0000;
+
+uniform float centerx <
+	ui_type = "drag";
+	ui_min = -9.99;
+	ui_max = 9.99;
+	ui_step = 0.01;
+	ui_label = "Image Center X";
+> = 0.00;
+
+uniform float centery <
+	ui_type = "drag";
+	ui_min = -9.99;
+	ui_max = 9.99;
+	ui_step = 0.01;
+	ui_label = "Image Center Y";
+> = 0.00;
+
+
+float2 Warp(float2 pos)
+{
+    pos = pos*2.0-1.0;
+    pos *= float2(1.0+pos.y*pos.y*0, 1.0+pos.x*pos.x*0);
+    pos = pos*0.5+0.5;
+
+    return pos;
+}
+
+
+float4 CRT_CYCLON_PS(float4 vpos: SV_Position, float2 vTexCoord : TEXCOORD0) : SV_Target
+{
+// zoom in and center screen
+    float2 pos = Warp((vTexCoord*float2(1.0-zoomx,1.0-zoomy)-float2(centerx,centery)/100.0));
+
+// Convergence
+    float3 res = tex2D(ReShade::BackBuffer,pos).rgb;
+
+// Vignette
+    float x = 0.0;
+	
+    return float4(res, 1.0);
+}
+
+
+
+technique CRT_CYCLON
+{
+   pass PS_CRT_CYCLON
+   {
+   	VertexShader = PostProcessVS;
+   	PixelShader  = CRT_CYCLON_PS;
+   }
+}


### PR DESCRIPTION
A super-simple shader refined from the super-fast crt-cyclon.fx,It only provides the functions of free pixel stretching and position translation on the XY axis. Suitable for users who only want to fine-tune the screen zoom and position and do not like the bundled CRT-like effects.Fixed some bugs in the original version, adjusted the step progress and the range.

Some games have black borders on the top and bottom of the screen that are difficult to remove.like Tekken 3:
crop: all boarders
wildscreen rendering on
Black borders on the top and bottom
![Tekken 3 (Japan, Asia) 2024-06-29-20-04-25](https://github.com/stenzek/duckstation/assets/80488411/d4f8ae43-d829-49a9-867c-98c310ddddb2)

crop: only overscan area
wildscreen rendering on
The black border at the top has been reduced, but a few pixels have been cropped at the bottom.The proportions of the screen are incorrect, the characters are squeezed and become thin and long.

![Tekken 3 (Japan, Asia) 2024-06-29-20-05-56](https://github.com/stenzek/duckstation/assets/80488411/888792a5-8e8d-4eed-9df1-f97baecf34f9)

crop: all boarders
wildscreen rendering on
Custom Aspect Ratio: 83:50
Post shader: XY-Pos-free
Zoom Image X:0.0665
Zoom Image Y:0.0665
Image Center X:-3.32
Image Center Y:-4.17

a perfect 16:9 screen:
![Tekken 3 (Japan, Asia) 2024-06-29-20-10-59](https://github.com/stenzek/duckstation/assets/80488411/63abbc81-f401-4da6-a0dc-c233f0cbe70c)

Some games have incorrect aspect ratio, such as tomb raider 3:
4:3 original:
![Tomb Raider III - Adventures of Lara Croft (USA) 2024-06-29-20-19-24](https://github.com/stenzek/duckstation/assets/80488411/72635db7-d26b-467b-97b3-57aac4bd89d9)

16:9 wildscreen rendering on:
![Tomb Raider III - Adventures of Lara Croft (USA) 2024-06-29-20-19-31](https://github.com/stenzek/duckstation/assets/80488411/d7a92723-6bdf-4ca4-82b0-7c536756d778)

Custom Aspect Ratio: 13:9
wildscreen rendering on
Post shader: XY-Pos-free
Zoom Image X:0.1875
Zoom Image Y:0
Image Center X:-9.38
Image Center Y:0
a perfect 16:9 screen:
![Tomb Raider III - Adventures of Lara Croft (USA) 2024-06-29-20-18-39](https://github.com/stenzek/duckstation/assets/80488411/b6248b25-66b2-4b25-99b7-fb86b5c57302)

