### PR TITLE
fix: few bugs and improvements

### DIFF
--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -181,14 +181,14 @@ inline std::optional<bool> FromChars(const std::string_view str, int base)
 {
   if (Strncasecmp("true", str.data(), str.length()) == 0 || Strncasecmp("yes", str.data(), str.length()) == 0 ||
       Strncasecmp("on", str.data(), str.length()) == 0 || Strncasecmp("1", str.data(), str.length()) == 0 ||
-      Strncasecmp("enabled", str.data(), str.length()) == 0 || Strncasecmp("1", str.data(), str.length()) == 0)
+      Strncasecmp("enabled", str.data(), str.length()) == 0)
   {
     return true;
   }
 
   if (Strncasecmp("false", str.data(), str.length()) == 0 || Strncasecmp("no", str.data(), str.length()) == 0 ||
       Strncasecmp("off", str.data(), str.length()) == 0 || Strncasecmp("0", str.data(), str.length()) == 0 ||
-      Strncasecmp("disabled", str.data(), str.length()) == 0 || Strncasecmp("0", str.data(), str.length()) == 0)
+      Strncasecmp("disabled", str.data(), str.length()) == 0)
   {
     return false;
   }

--- a/src/core/fullscreen_ui.cpp
+++ b/src/core/fullscreen_ui.cpp
@@ -5593,7 +5593,7 @@ bool FullscreenUI::OpenLoadStateSelectorForGame(const std::string& game_path)
   if (entry)
   {
     s_save_state_selector_loading = true;
-    if (PopulateSaveStateListEntries(entry->title.c_str(), entry->serial.c_str()) > 0)
+    if (PopulateSaveStateListEntries(entry->title, entry->serial) > 0)
     {
       s_save_state_selector_open = true;
       s_save_state_selector_resuming = false;
@@ -5611,7 +5611,7 @@ bool FullscreenUI::OpenSaveStateSelector(bool is_loading)
   s_save_state_selector_game_path = {};
   s_save_state_selector_loading = is_loading;
   s_save_state_selector_resuming = false;
-  if (PopulateSaveStateListEntries(System::GetGameTitle().c_str(), System::GetGameSerial().c_str()) > 0)
+  if (PopulateSaveStateListEntries(System::GetGameTitle(), System::GetGameSerial()) > 0)
   {
     s_save_state_selector_open = true;
     return true;

--- a/src/core/game_list.cpp
+++ b/src/core/game_list.cpp
@@ -594,7 +594,7 @@ bool GameList::ScanFile(std::string path, std::time_t timestamp, std::unique_loc
     entry.total_played_time = iter->second.total_played_time;
   }
 
-  ApplyCustomAttributes(path, &entry, custom_attributes_ini);
+  ApplyCustomAttributes(entry.path, &entry, custom_attributes_ini);
 
   lock.lock();
 
@@ -626,7 +626,7 @@ bool GameList::RescanCustomAttributesForPath(const std::string& path, const INIS
   if (!PopulateEntryFromPath(path, &entry))
     return false;
 
-  entry.path = std::move(path);
+  entry.path = path;
   entry.last_modified_time = sd.ModificationTime;
 
   const PlayedTimeMap played_time_map(LoadPlayedTimeMap(GetPlayedTimeFile()));
@@ -637,7 +637,7 @@ bool GameList::RescanCustomAttributesForPath(const std::string& path, const INIS
     entry.total_played_time = iter->second.total_played_time;
   }
 
-  ApplyCustomAttributes(path, &entry, custom_attributes_ini);
+  ApplyCustomAttributes(entry.path, &entry, custom_attributes_ini);
 
   std::unique_lock lock(s_mutex);
 

--- a/src/util/cd_image_m3u.cpp
+++ b/src/util/cd_image_m3u.cpp
@@ -161,7 +161,7 @@ bool CDImageM3u::SwitchSubImage(u32 index, Error* error)
 
 std::string CDImageM3u::GetSubImageMetadata(u32 index, std::string_view type) const
 {
-  if (index > m_entries.size())
+  if (index >= m_entries.size())
     return {};
 
   if (type == "title")


### PR DESCRIPTION
Fix:
- access to a moved `path` vairable
- possible out-of-border access for `m_entries`

Improve:
- duplicated `Strncasecmp` checks
- `std::string` -> c-string -> `std::string` conversion
- attempt to move a `const` variable