### PR TITLE
 CI/AppImage: Use fuse3 compatible appimagetool

### DIFF
--- a/scripts/appimage/make-appimage.sh
+++ b/scripts/appimage/make-appimage.sh
@@ -79,9 +79,9 @@ declare -a REMOVE_LIBS=(
 
 set -e
 
-LINUXDEPLOY=./linuxdeploy-x86_64.AppImage
-LINUXDEPLOY_PLUGIN_QT=./linuxdeploy-plugin-qt-x86_64.AppImage
-APPIMAGETOOL=./appimagetool-x86_64.AppImage
+LINUXDEPLOY=./linuxdeploy-x86_64
+LINUXDEPLOY_PLUGIN_QT=./linuxdeploy-plugin-qt-x86_64
+APPIMAGETOOL=./appimagetool-x86_64
 PATCHELF=patchelf
 
 if [ ! -f "$LINUXDEPLOY" ]; then
@@ -95,7 +95,8 @@ if [ ! -f "$LINUXDEPLOY_PLUGIN_QT" ]; then
 fi
 
 if [ ! -f "$APPIMAGETOOL" ]; then
-	retry_command wget -O "$APPIMAGETOOL" https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+	APPIMAGETOOLURL=$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/[()",{} ]/\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$' | head -1)
+	retry_command wget -O "$APPIMAGETOOL" "$APPIMAGETOOLURL"
 	chmod +x "$APPIMAGETOOL"
 fi
 
@@ -207,5 +208,4 @@ done
 
 echo "Generating AppImage..."
 rm -f "$NAME.AppImage"
-$APPIMAGETOOL -v "$OUTDIR" "$NAME.AppImage"
-
+ARCH=x86_64 VERSION=test "$APPIMAGETOOL" -s "$OUTDIR" && mv ./*.AppImage "$NAME.AppImage"


### PR DESCRIPTION
Uses this appimagetool: https://github.com/probonopd/go-appimage

Fixes a common issue with libfuse2 not being installed by default in newer distros as it can use libfuse3 instead. (It also works if only libfuse2 is installed as well just in case).

I'm sorry for the `VERSION=test` hack I did there, this appimagetool needs that variable as it uses it to add the version to the title of the appimage. Normally that would be the output of `./*AppDir/AppRun --version` but it seems duckstation doesn't support that flag.

EDIT: Artifact if needed: https://github.com/Samueru-sama/duckstation/actions/runs/9899316061/artifacts/1693128006

This appimagetool also uses zstd compression, which results in a slightly smaller appimage.

-------------------------------------------------------------

Btw `go-appimage` can also do the job of linuxdeploy and it has a deploy everything mode, which makes the appimage be able to work **everywhere** including in much older distros and musl distros at the cost of increasing the size of the appimage by ~40 MiB **edit actually it may be about 10 MiB lol**
