### PR TITLE
Qt/PAD: Enable/Disable Player LED for DualSense Controllers in Enhanced mode

### DIFF
--- a/src/core/fullscreen_ui.cpp
+++ b/src/core/fullscreen_ui.cpp
@@ -3707,6 +3707,10 @@ void FullscreenUI::DrawControllerSettingsPage()
   DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_WIFI, "SDL DualShock 4 / DualSense Enhanced Mode"),
                     FSUI_CSTR("Provides vibration and LED control support over Bluetooth."), "InputSources",
                     "SDLControllerEnhancedMode", false, bsi->GetBoolValue("InputSources", "SDL", true), false);
+  DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_LIGHTBULB, "SDL DualSense Player LED"),
+                    FSUI_CSTR("Enable/Disable the Player LED on DualSense controllers."), "InputSources",
+                    "SDLPS5PlayerLED", false, bsi->GetBoolValue("InputSources", "SDLControllerEnhancedMode", true),
+                    false);
 #ifdef _WIN32
   DrawToggleSetting(bsi, FSUI_ICONSTR(ICON_FA_COG, "Enable XInput Input Source"),
                     FSUI_CSTR("The XInput source provides support for XBox 360/XBox One/XBox Series controllers."),

--- a/src/duckstation-qt/controllerglobalsettingswidget.cpp
+++ b/src/duckstation-qt/controllerglobalsettingswidget.cpp
@@ -134,6 +134,9 @@ ControllerLEDSettingsDialog::ControllerLEDSettingsDialog(QWidget* parent, Contro
   linkButton(m_ui.SDL2LED, 2);
   linkButton(m_ui.SDL3LED, 3);
 
+  SettingsInterface* sif = dialog->getProfileSettingsInterface();
+
+  ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.enableSDLPS5PlayerLED, "InputSources", "SDLPS5PlayerLED", false);
   connect(m_ui.buttonBox->button(QDialogButtonBox::Close), &QPushButton::clicked, this, &QDialog::accept);
 }
 

--- a/src/duckstation-qt/controllerledsettingsdialog.ui
+++ b/src/duckstation-qt/controllerledsettingsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>501</width>
-    <height>108</height>
+    <height>128</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,14 +26,14 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QGroupBox" name="groupBox_2">
+   <item row="0" column="3">
+    <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
-      <string>SDL-1 LED</string>
+      <string>SDL-3 LED</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="ColorPickerButton" name="SDL1LED"/>
+       <widget class="ColorPickerButton" name="SDL3LED"/>
       </item>
      </layout>
     </widget>
@@ -50,24 +50,53 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="3">
-    <widget class="QGroupBox" name="groupBox_4">
+   <item row="0" column="1">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>SDL-3 LED</string>
+      <string>SDL-1 LED</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="ColorPickerButton" name="SDL3LED"/>
+       <widget class="ColorPickerButton" name="SDL1LED"/>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+   <item row="3" column="0" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
      </property>
-    </widget>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="enableSDLPS5PlayerLED">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Enable DualSense Player LED</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/util/input_manager.cpp
+++ b/src/util/input_manager.cpp
@@ -1283,6 +1283,7 @@ void InputManager::SetDefaultSourceConfig(SettingsInterface& si)
   si.ClearSection("InputSources");
   si.SetBoolValue("InputSources", "SDL", true);
   si.SetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
+  si.SetBoolValue("InputSources", "SDLPS5PlayerLED", false);
   si.SetBoolValue("InputSources", "XInput", false);
   si.SetBoolValue("InputSources", "RawInput", false);
 }

--- a/src/util/sdl_input_source.cpp
+++ b/src/util/sdl_input_source.cpp
@@ -173,6 +173,7 @@ bool SDLInputSource::Initialize(SettingsInterface& si, std::unique_lock<std::mut
 void SDLInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std::mutex>& settings_lock)
 {
   const bool old_controller_enhanced_mode = m_controller_enhanced_mode;
+  const bool old_controller_ps5_player_led = m_controller_ps5_player_led;
 
 #ifdef __APPLE__
   const bool old_enable_iokit_driver = m_enable_iokit_driver;
@@ -188,7 +189,9 @@ void SDLInputSource::UpdateSettings(SettingsInterface& si, std::unique_lock<std:
   constexpr bool drivers_changed = false;
 #endif
 
-  if (m_controller_enhanced_mode != old_controller_enhanced_mode || drivers_changed)
+  if (m_controller_enhanced_mode != old_controller_enhanced_mode ||
+      m_controller_ps5_player_led != old_controller_ps5_player_led ||
+      drivers_changed)
   {
     settings_lock.unlock();
     ShutdownSubsystem();
@@ -228,6 +231,7 @@ void SDLInputSource::LoadSettings(SettingsInterface& si)
   }
 
   m_controller_enhanced_mode = si.GetBoolValue("InputSources", "SDLControllerEnhancedMode", false);
+  m_controller_ps5_player_led = si.GetBoolValue("InputSources", "SDLPS5PlayerLED", false);
   m_sdl_hints = si.GetKeyValueList("SDLHints");
 
 #ifdef __APPLE__
@@ -275,6 +279,7 @@ void SDLInputSource::SetHints()
 
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, m_controller_enhanced_mode ? "1" : "0");
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, m_controller_enhanced_mode ? "1" : "0");
+  SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED, m_controller_ps5_player_led ? "1" : "0");
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
   SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS3, "1");
 

--- a/src/util/sdl_input_source.h
+++ b/src/util/sdl_input_source.h
@@ -96,6 +96,7 @@ private:
 
   bool m_sdl_subsystem_initialized = false;
   bool m_controller_enhanced_mode = false;
+  bool m_controller_ps5_player_led = false;
 
 #ifdef __APPLE__
   bool m_enable_iokit_driver = false;


### PR DESCRIPTION
Port of:
https://github.com/PCSX2/pcsx2/pull/10864

Note, since the [Copy function here](https://github.com/PCSX2/pcsx2/pull/10864/files#diff-91056592066d19480eb6fd8b5387fb67d262b932a3c95b1d22362beac3712c57R333) does not exist in duckstation, this line was not added, everything else works just as on PCSX2.
I noticed RawInput was also not ported, but I didn't want to clutter this PR with both changes.

Reposting my description I originally posted in the PCSX2 PR below.

---- 
### Description of Changes
This change adds a toggle to enable/disable the Player LED on DualSense controllers.
Not to be confused with the primary LED. The Player LED is a non-customizable bright white array of white LEDs that indicate the player number. Image of before and after.
![image](https://github.com/PCSX2/pcsx2/assets/14857235/cab139dd-da38-4a70-9327-0d8af3afa1e6)

The UI change is added to the LEDSettingsDialog / controllerledsettingsdialog.ui
![image](https://github.com/user-attachments/assets/3549a402-c173-4ef8-baff-7e2401850151)


### Rationale behind Changes
* RAW mode does not have Player LEDs on.
* Turning on Enhanced Mode turns on the Player LED in addition to the primary LED.
* There is no option to disable the Player LEDs currently. You can only customize the primary LED.
* A user may want to completely disable all LEDs on their controller. Currently you can disable the Primary LED but not the Player LED. This is distracting/bright when playing in low lighting conditions.
* You can already tell which player is which due to the customized primary LED colors.


### Suggested Testing Steps
1. Connect DualSense controller. Note the player LED is off.
2. Turn on Enhanced DS4/DS5 mode under the DuckStation Controller Settings.
-- if on master --
3. Note the Player LED is ON. You can customize the Main LED but not the Player LED.
-- if on this branch --
3. Note the Player LED is still OFF.
4. Enter the LED Settings Dialog [controllerledsettingsdialog.ui] (The lightbulb icon) and utilize the new Checkbox. You should see all connected controllers enable/disable their player indicator LEDs. You can customize the Main LED per-controller as usual.
----