### PR TITLE
Fix ui_step for crt-consumer.fx

### DIFF
--- a/data/resources/shaders/reshade/Shaders/crt/crt-consumer.fx
+++ b/data/resources/shaders/reshade/Shaders/crt/crt-consumer.fx
@@ -111,7 +111,7 @@ uniform float beamlow <
 	ui_type = "drag";
 	ui_min = 0.5;
 	ui_max = 2.5;
-	ui_step = 0.0;
+	ui_step = 0.05;
 	ui_label = "Scanlines dark";
 > = 1.45;
 
@@ -119,7 +119,7 @@ uniform float beamhigh <
 	ui_type = "drag";
 	ui_min = 0.5;
 	ui_max = 2.5;
-	ui_step = 0.0;
+	ui_step = 0.05;
 	ui_label = "Scanlines bright";
 > = 1.05;
 


### PR DESCRIPTION
For crt-consumer.fx, the ui_step was set to 0, for Scanlines bright/dark.
This PR changes it to 0.05 (same as in Retroarch).


<details>
  <summary> Click for boring and obvious explanation as to why UI_Step=0 is bad</summary>
When ui_step = 0, Changing the values for Scanlines bright/dark through the UI, forces the value of the shader parameter to the minimum (0.5), and makes it impossible to change it to anything else.
This forces the user to remove and re-add the shader, and still being unable to change the values for Scanlines bright/dark to the desired value.   
</details>

_Shameless begging: Stenzek please add the Duckstation shader system to PCSX2_ 🥺