### PR TITLE
GameDB: Fix Starblade Alpha JPN hash

### DIFF
--- a/data/resources/gamedb.yaml
+++ b/data/resources/gamedb.yaml
@@ -154590,6 +154590,8 @@ SLPS-00022:
     - DigitalController
     - NeGcon
     - PlayStationMouse
+  codes:
+    - HASH-F864E385DC3A1F79
   metadata:
     publisher: "Namco"
     developer: "High-Tech Lab Japan"
@@ -154610,8 +154612,6 @@ SLUS-00057:
     - DigitalController
     - NeGcon
     - PlayStationMouse
-  codes:
-    - HASH-F864E385DC3A1F79
   metadata:
     publisher: "Namco"
     developer: "High-Tech Lab Japan"


### PR DESCRIPTION
The PSX.EXE hash was set to the USA version instead of the JPN version.