### PR TITLE
DiscordRPC: Add Rcheevos Icon Support

### DIFF
--- a/src/core/achievements.cpp
+++ b/src/core/achievements.cpp
@@ -523,6 +523,11 @@ const std::string& Achievements::GetGameIconPath()
   return s_game_icon;
 }
 
+const std::string& Achievements::GetGameIconURL()
+{
+  return s_game_icon_url;
+}
+
 const std::string& Achievements::GetRichPresenceString()
 {
   return s_rich_presence_string;

--- a/src/core/achievements.h
+++ b/src/core/achievements.h
@@ -115,6 +115,9 @@ bool HasRichPresence();
 /// Should be called with the lock held.
 const std::string& GetRichPresenceString();
 
+/// Returns the URL for the current icon of the game
+const std::string& GetGameIconURL();
+
 /// Returns the RetroAchievements title for the current game.
 /// Should be called with the lock held.
 const std::string& GetGameTitle();

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -5892,6 +5892,8 @@ void System::UpdateRichPresence(bool update_session_time)
     const auto lock = Achievements::GetLock();
     state_string = StringUtil::Ellipsise(Achievements::GetRichPresenceString(), 128);
     rp.state = state_string.c_str();
+    if (const std::string& icon_url = Achievements::GetGameIconURL(); !icon_url.empty())
+        rp.largeImageKey = icon_url.c_str();
   }
 
   dyn_libs::Discord_UpdatePresence(&rp);


### PR DESCRIPTION
This PR adds Rcheevos icon support to the Discord's Rich Presence

Preview:
![Screenshot_20240901_211909](https://github.com/user-attachments/assets/4c6f899f-8056-490b-beaf-fbb1233d1ef2)
