### PR TITLE
GPU: Add "Force Frame Timings" option

### DIFF
--- a/src/core/fullscreen_ui.cpp
+++ b/src/core/fullscreen_ui.cpp
@@ -4270,6 +4270,12 @@ void FullscreenUI::DrawDisplaySettingsPage()
     "Display", "Scaling", Settings::DEFAULT_DISPLAY_SCALING, &Settings::ParseDisplayScaling,
     &Settings::GetDisplayScalingName, &Settings::GetDisplayScalingDisplayName, DisplayScalingMode::Count);
 
+  DrawEnumSetting(
+    bsi, FSUI_CSTR("Force Frame Timings"),
+    FSUI_CSTR("Utilizes the chosen frame timing regardless of the active region."),
+    "GPU", "ForceFrameTimings", Settings::DEFAULT_FORCE_FRAME_TIMINGS_MODE, &Settings::ParseForceFrameTimings,
+    &Settings::GetForceFrameTimingsName, &Settings::GetForceFrameTimingsDisplayName, ForceFrameTimingsMode::Count);
+
   if (is_hardware)
   {
     DrawToggleSetting(bsi, FSUI_CSTR("True Color Rendering"),
@@ -4308,12 +4314,6 @@ void FullscreenUI::DrawDisplaySettingsPage()
     FSUI_CSTR("Disables interlaced rendering and display in the GPU. Some games can render in 480p this way, "
               "but others will break."),
     "GPU", "DisableInterlacing", true);
-
-  DrawToggleSetting(
-    bsi, FSUI_CSTR("Force NTSC Timings"),
-    FSUI_CSTR("Forces PAL games to run at NTSC timings, i.e. 60hz. Some PAL games will run at their \"normal\" "
-              "speeds, while others will break."),
-    "GPU", "ForceNTSCTimings", false);
 
   MenuHeading(FSUI_CSTR("Advanced"));
 

--- a/src/core/game_database.cpp
+++ b/src/core/game_database.cpp
@@ -75,7 +75,7 @@ static constexpr const std::array<const char*, static_cast<u32>(GameDatabase::Tr
   "DisableTextureFiltering",
   "DisableSpriteTextureFiltering",
   "DisableScaledDithering",
-  "DisableForceNTSCTimings",
+  "DisableForceFrameTimings",
   "DisableWidescreen",
   "DisablePGXP",
   "DisablePGXPCulling",
@@ -105,7 +105,7 @@ static constexpr const std::array<const char*, static_cast<u32>(GameDatabase::Tr
   TRANSLATE_NOOP("GameDatabase", "Disable Texture Filtering"),
   TRANSLATE_NOOP("GameDatabase", "Disable Sprite Texture Filtering"),
   TRANSLATE_NOOP("GameDatabase", "Disable Scaled Dithering"),
-  TRANSLATE_NOOP("GameDatabase", "Disable Force NTSC Timings"),
+  TRANSLATE_NOOP("GameDatabase", "Disable Force Frame Timings"),
   TRANSLATE_NOOP("GameDatabase", "Disable Widescreen"),
   TRANSLATE_NOOP("GameDatabase", "Disable PGXP"),
   TRANSLATE_NOOP("GameDatabase", "Disable PGXP Culling"),
@@ -590,12 +590,12 @@ void GameDatabase::Entry::ApplySettings(Settings& settings, bool display_osd_mes
     settings.gpu_widescreen_hack = false;
   }
 
-  if (HasTrait(Trait::DisableForceNTSCTimings))
+  if (HasTrait(Trait::DisableForceFrameTimings))
   {
-    if (display_osd_messages && settings.gpu_force_ntsc_timings)
-      APPEND_MESSAGE(TRANSLATE_SV("GameDatabase", "Force NTSC timings disabled."));
+    if (display_osd_messages && settings.gpu_force_frame_timings != ForceFrameTimingsMode::Disabled)
+      APPEND_MESSAGE(TRANSLATE_SV("GameDatabase", "Force frame timings disabled."));
 
-    settings.gpu_force_ntsc_timings = false;
+    settings.gpu_force_frame_timings = ForceFrameTimingsMode::Disabled;
   }
 
   if (HasTrait(Trait::DisablePGXP))

--- a/src/core/game_database.h
+++ b/src/core/game_database.h
@@ -40,7 +40,7 @@ enum class Trait : u32
   DisableTextureFiltering,
   DisableSpriteTextureFiltering,
   DisableScaledDithering,
-  DisableForceNTSCTimings,
+  DisableForceFrameTimings,
   DisableWidescreen,
   DisablePGXP,
   DisablePGXPCulling,

--- a/src/core/gpu.h
+++ b/src/core/gpu.h
@@ -505,7 +505,7 @@ protected:
   bool m_set_texture_disable_mask = false;
   bool m_drawing_area_changed = false;
   bool m_force_progressive_scan = false;
-  bool m_force_ntsc_timings = false;
+  ForceFrameTimingsMode m_force_frame_timings = ForceFrameTimingsMode::Disabled;
 
   struct CRTCState
   {

--- a/src/core/imgui_overlays.cpp
+++ b/src/core/imgui_overlays.cpp
@@ -444,8 +444,10 @@ void ImGuiManager::DrawEnhancementsOverlay()
   }
   if (g_settings.gpu_disable_interlacing)
     text.append(" ForceProg");
-  if (g_settings.gpu_force_ntsc_timings && System::GetRegion() == ConsoleRegion::PAL)
+  if (g_settings.gpu_force_frame_timings == ForceFrameTimingsMode::NTSC && System::GetRegion() == ConsoleRegion::PAL)
     text.append(" PAL60");
+  if (g_settings.gpu_force_frame_timings == ForceFrameTimingsMode::PAL && System::GetRegion() != ConsoleRegion::PAL)
+    text.append(" NTSC50");
   if (g_settings.gpu_texture_filter != GPUTextureFilter::Nearest)
   {
     if (g_settings.gpu_sprite_texture_filter != g_settings.gpu_texture_filter)

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -122,7 +122,6 @@ struct Settings
   bool gpu_force_round_texcoords : 1 = false;
   bool gpu_accurate_blending : 1 = false;
   bool gpu_disable_interlacing : 1 = true;
-  bool gpu_force_ntsc_timings : 1 = false;
   bool gpu_widescreen_hack : 1 = false;
   bool gpu_pgxp_enable : 1 = false;
   bool gpu_pgxp_culling : 1 = true;
@@ -133,6 +132,7 @@ struct Settings
   bool gpu_pgxp_preserve_proj_fp : 1 = false;
   bool gpu_pgxp_depth_buffer : 1 = false;
   bool gpu_pgxp_disable_2d : 1 = false;
+  ForceFrameTimingsMode gpu_force_frame_timings = DEFAULT_FORCE_FRAME_TIMINGS_MODE;
   GPUTextureFilter gpu_texture_filter = DEFAULT_GPU_TEXTURE_FILTER;
   GPUTextureFilter gpu_sprite_texture_filter = DEFAULT_GPU_TEXTURE_FILTER;
   GPULineDetectMode gpu_line_detect_mode = DEFAULT_GPU_LINE_DETECT_MODE;
@@ -434,6 +434,10 @@ struct Settings
   static const char* GetDisplayScalingName(DisplayScalingMode mode);
   static const char* GetDisplayScalingDisplayName(DisplayScalingMode mode);
 
+  static std::optional<ForceFrameTimingsMode> ParseForceFrameTimings(const char* str);
+  static const char* GetForceFrameTimingsName(ForceFrameTimingsMode mode);
+  static const char* GetForceFrameTimingsDisplayName(ForceFrameTimingsMode mode);
+
   static std::optional<DisplayExclusiveFullscreenControl> ParseDisplayExclusiveFullscreenControl(const char* str);
   static const char* GetDisplayExclusiveFullscreenControlName(DisplayExclusiveFullscreenControl mode);
   static const char* GetDisplayExclusiveFullscreenControlDisplayName(DisplayExclusiveFullscreenControl mode);
@@ -492,6 +496,7 @@ struct Settings
   static constexpr DisplayAlignment DEFAULT_DISPLAY_ALIGNMENT = DisplayAlignment::Center;
   static constexpr DisplayRotation DEFAULT_DISPLAY_ROTATION = DisplayRotation::Normal;
   static constexpr DisplayScalingMode DEFAULT_DISPLAY_SCALING = DisplayScalingMode::BilinearSmooth;
+  static constexpr ForceFrameTimingsMode DEFAULT_FORCE_FRAME_TIMINGS_MODE = ForceFrameTimingsMode::Disabled;
   static constexpr DisplayExclusiveFullscreenControl DEFAULT_DISPLAY_EXCLUSIVE_FULLSCREEN_CONTROL =
     DisplayExclusiveFullscreenControl::Automatic;
   static constexpr DisplayScreenshotMode DEFAULT_DISPLAY_SCREENSHOT_MODE = DisplayScreenshotMode::ScreenResolution;

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -4304,7 +4304,7 @@ void System::CheckForSettingsChanges(const Settings& old_settings)
         g_settings.gpu_sprite_texture_filter != old_settings.gpu_sprite_texture_filter ||
         g_settings.gpu_line_detect_mode != old_settings.gpu_line_detect_mode ||
         g_settings.gpu_disable_interlacing != old_settings.gpu_disable_interlacing ||
-        g_settings.gpu_force_ntsc_timings != old_settings.gpu_force_ntsc_timings ||
+        g_settings.gpu_force_frame_timings != old_settings.gpu_force_frame_timings ||
         g_settings.gpu_downsample_mode != old_settings.gpu_downsample_mode ||
         g_settings.gpu_downsample_scale != old_settings.gpu_downsample_scale ||
         g_settings.gpu_wireframe_mode != old_settings.gpu_wireframe_mode ||
@@ -4531,9 +4531,9 @@ void System::WarnAboutUnsafeSettings()
                                         TinyString(TRANSLATE_SV("System", "Instant")) :
                                         TinyString::from_format("{}x", g_settings.cdrom_seek_speedup)));
     }
-    if (g_settings.gpu_force_ntsc_timings)
+    if (g_settings.gpu_force_frame_timings != ForceFrameTimingsMode::Disabled)
     {
-      append(ICON_FA_TV, TRANSLATE_SV("System", "Force NTSC timings is enabled. Games may run at incorrect speeds."));
+      append(ICON_FA_TV, TRANSLATE_SV("System", "Force frame timings is enabled. Games may run at incorrect speeds."));
     }
     if (!g_settings.IsUsingSoftwareRenderer())
     {

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -275,3 +275,12 @@ enum class SaveStateCompressionMode : u8
 
   Count,
 };
+
+enum class ForceFrameTimingsMode : u8
+{
+  Disabled,
+  NTSC,
+  PAL,
+  
+  Count,
+};

--- a/src/duckstation-qt/graphicssettingswidget.ui
+++ b/src/duckstation-qt/graphicssettingswidget.ui
@@ -201,7 +201,7 @@
           <item row="7" column="1">
            <widget class="QComboBox" name="displayScaling"/>
           </item>
-          <item row="8" column="0" colspan="2">
+          <item row="9" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_2">
             <item row="1" column="1">
              <widget class="QCheckBox" name="pgxpDepthBuffer">
@@ -214,13 +214,6 @@
              <widget class="QCheckBox" name="disableInterlacing">
               <property name="text">
                <string>Disable Interlacing</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QCheckBox" name="forceNTSCTimings">
-              <property name="text">
-               <string>Force NTSC Timings</string>
               </property>
              </widget>
             </item>
@@ -273,6 +266,16 @@
           </item>
           <item row="3" column="1">
            <widget class="QComboBox" name="spriteTextureFiltering"/>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="forceFrameTimingsLabel">
+            <property name="text">
+             <string>Force Frame Timings:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QComboBox" name="forceFrameTimings"/>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
## Description
I've revamped the "Force NTSC Timings" option to enable users to enforce both NTSC and PAL timings. The option has been renamed to "Force Frame Timings" and I've replaced the toggle with a drop-down menu.

## Reason for the PR
Many homebrew PS1 projects rely on Hitmod as their music player. In earlier versions of Hitmod, music doesn’t play at the correct tempo at 60fps. This new option allows NTSC productions to run at 50fps, ensuring proper music playback.