### PR TITLE
Add *.psx as a supported PS-X EXE file type

### DIFF
--- a/src/core/fullscreen_ui.cpp
+++ b/src/core/fullscreen_ui.cpp
@@ -925,7 +925,7 @@ void FullscreenUI::DestroyResources()
 ImGuiFullscreen::FileSelectorFilters FullscreenUI::GetDiscImageFilters()
 {
   return {"*.bin",   "*.cue",    "*.iso", "*.img", "*.chd",     "*.ecm", "*.mds",
-          "*.psexe", "*.ps-exe", "*.exe", "*.psf", "*.minipsf", "*.m3u", "*.pbp"};
+          "*.psexe", "*.ps-exe", "*.exe", "*.psx", "*.psf", "*.minipsf", "*.m3u", "*.pbp"};
 }
 
 void FullscreenUI::DoStartPath(std::string path, std::string state, std::optional<bool> fast_boot)

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -776,7 +776,7 @@ u32 System::GetFrameTimeHistoryPos()
 bool System::IsExeFileName(std::string_view path)
 {
   return (StringUtil::EndsWithNoCase(path, ".exe") || StringUtil::EndsWithNoCase(path, ".psexe") ||
-          StringUtil::EndsWithNoCase(path, ".ps-exe"));
+          StringUtil::EndsWithNoCase(path, ".ps-exe") || StringUtil::EndsWithNoCase(path, ".psx"));
 }
 
 bool System::IsPsfFileName(std::string_view path)
@@ -788,7 +788,7 @@ bool System::IsLoadableFilename(std::string_view path)
 {
   static constexpr const std::array extensions = {
     ".bin", ".cue",     ".img",    ".iso", ".chd", ".ecm", ".mds", // discs
-    ".exe", ".psexe",   ".ps-exe",                                 // exes
+    ".exe", ".psexe",   ".ps-exe", ".psx",                         // exes
     ".psf", ".minipsf",                                            // psf
     ".m3u",                                                        // playlists
     ".pbp",

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -66,11 +66,11 @@ Log_SetChannel(MainWindow);
 
 static constexpr char DISC_IMAGE_FILTER[] = QT_TRANSLATE_NOOP(
   "MainWindow",
-  "All File Types (*.bin *.img *.iso *.cue *.chd *.ecm *.mds *.pbp *.exe *.psexe *.ps-exe *.psf *.minipsf "
+  "All File Types (*.bin *.img *.iso *.cue *.chd *.ecm *.mds *.pbp *.exe *.psexe *.ps-exe *.psx *.psf *.minipsf "
   "*.m3u);;Single-Track "
   "Raw Images (*.bin *.img *.iso);;Cue Sheets (*.cue);;MAME CHD Images (*.chd);;Error Code Modeler Images "
   "(*.ecm);;Media Descriptor Sidecar Images (*.mds);;PlayStation EBOOTs (*.pbp *.PBP);;PlayStation Executables (*.exe "
-  "*.psexe *.ps-exe);;Portable Sound Format Files (*.psf *.minipsf);;Playlists (*.m3u)");
+  "*.psexe *.ps-exe, *.psx);;Portable Sound Format Files (*.psf *.minipsf);;Playlists (*.m3u)");
 
 MainWindow* g_main_window = nullptr;
 


### PR DESCRIPTION
## Description
I've added *.psx as a supported PS-X EXE file type. The reason for this addition is that many PS1 demos and intros available on Pouet and Demozoo are in .psx format.