### PR TITLE
Fixed issue with cheats import failing on DS format cheats

### DIFF
--- a/src/core/cheats.cpp
+++ b/src/core/cheats.cpp
@@ -661,10 +661,8 @@ bool CheatList::LoadFromString(const std::string& str, Format format)
     return LoadFromPCSXRString(str);
   else if (format == Format::Libretro)
     return LoadFromLibretroString(str);
-  else if (format == Format::EPSXe)
-    return LoadFromEPSXeString(str);
-  else
-    return false;
+  format = Format::EPSXe;
+  return LoadFromEPSXeString(str);
 }
 
 bool CheatList::SaveToPCSXRFile(const char* filename)


### PR DESCRIPTION
Reverted part of cheats.cpp back to earlier code. The new code causes the import of DuckStation format cheats to fail unnecessarily.  Eg. Importing this will fail: 

#Show sides of screen that are blacked out
A706E00A 0C012400
A706DFD2 0C012400