### PR TITLE
Qt: Misc Fixes

### DIFF
--- a/src/core/negcon_rumble.cpp
+++ b/src/core/negcon_rumble.cpp
@@ -761,7 +761,7 @@ static const SettingInfo s_settings[] = {
 
 const Controller::ControllerInfo NeGconRumble::INFO = {ControllerType::NeGconRumble,
                                                        "NeGconRumble",
-                                                       TRANSLATE_NOOP("ControllerType", "NeGcon with Rumble"),
+                                                       TRANSLATE_NOOP("ControllerType", "NeGcon (Rumble)"),
                                                        ICON_PF_GAMEPAD,
                                                        s_binding_info,
                                                        s_settings,

--- a/src/duckstation-qt/controllersettingswindow.ui
+++ b/src/duckstation-qt/controllersettingswindow.ui
@@ -50,6 +50,9 @@
        <height>32</height>
       </size>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="0" column="1">

--- a/src/duckstation-qt/controllersettingswindow.ui
+++ b/src/duckstation-qt/controllersettingswindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1284</width>
-    <height>672</height>
+    <height>674</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -63,7 +63,7 @@
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="controllerProfileLayout">
      <item>
       <layout class="QHBoxLayout" name="editProfileLayout">
        <item>
@@ -74,7 +74,14 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="currentProfile"/>
+        <widget class="QComboBox" name="currentProfile">
+         <property name="minimumSize">
+          <size>
+           <width>200</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QPushButton" name="newProfile">

--- a/src/duckstation-qt/controllersettingswindow.ui
+++ b/src/duckstation-qt/controllersettingswindow.ui
@@ -40,7 +40,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>160</width>
+       <width>200</width>
        <height>16777215</height>
       </size>
      </property>

--- a/src/duckstation-qt/qtthemes.cpp
+++ b/src/duckstation-qt/qtthemes.cpp
@@ -186,7 +186,7 @@ void QtHost::SetStyleFromSettings()
     darkPalette.setColor(QPalette::Button, lighterGray);
     darkPalette.setColor(QPalette::ButtonText, Qt::white);
     darkPalette.setColor(QPalette::Link, blue);
-    darkPalette.setColor(QPalette::Highlight, lighterGray.darker());
+    darkPalette.setColor(QPalette::Highlight, lighterGray.lighter());
     darkPalette.setColor(QPalette::HighlightedText, Qt::white);
     darkPalette.setColor(QPalette::PlaceholderText, QColor(Qt::white).darker());
 


### PR DESCRIPTION
This PR adds in fixes mainly to the controller setting's virtual controller list, making it slightly wider and the text word wrapped to account for localization.

See commits for list of changes.

Before:
![Screenshot_20240910_201558](https://github.com/user-attachments/assets/f8313137-3607-4658-8932-5f3c94b8ed64)


After:
![Screenshot_20240910_201549](https://github.com/user-attachments/assets/3f8e7996-6d37-4a0c-a83e-c620afc96fa5)
