### PR TITLE
Fixed typo in F4 Cheat Type code

### DIFF
--- a/src/core/cheats.cpp
+++ b/src/core/cheats.cpp
@@ -1360,7 +1360,7 @@ void CheatCode::Apply() const
               DoMemoryWrite<u8>(address + 14, r15);
             if (r16 != wildcard)
               DoMemoryWrite<u8>(address + 15, r16);
-            address = address + 15;
+            address = address + 16;
           }
         }
         index += 5;


### PR DESCRIPTION
Typo in my code, this fix will make it work properly on multiple find & replaces.