### PR TITLE
Cheat bugfix and new A8 cheat type

### DIFF
--- a/src/core/cheats.cpp
+++ b/src/core/cheats.cpp
@@ -1817,6 +1817,7 @@ private:
     ExtDecrement32 = 0x61,
     ExtConstantWriteIfMatch16 = 0xA6,
     ExtConstantWriteIfMatchWithRestore16 = 0xA7,
+    ExtConstantWriteIfMatchWithRestore8 = 0xA8,
     ExtConstantForceRange8 = 0xF0,
     ExtConstantForceRangeLimits16 = 0xF1,
     ExtConstantForceRangeRollRound16 = 0xF2,
@@ -2359,7 +2360,19 @@ void Cheats::GamesharkCheatCode::Apply() const
         index++;
       }
       break;
+      
+      case InstructionCode::ExtConstantWriteIfMatchWithRestore8:
+      {
+        const u8 value = DoMemoryRead<u8>(inst.address);
+        const u8 comparevalue = Truncate8(inst.value16 >> 8);
+        const u8 newvalue = Truncate8(inst.value16 & 0xFFu);
+        if (value == comparevalue)
+          DoMemoryWrite<u8>(inst.address, newvalue);
 
+        index++;
+      }
+      break;
+      
       case InstructionCode::ExtConstantForceRange8:
       {
         const u8 value = DoMemoryRead<u8>(inst.address);
@@ -3926,6 +3939,18 @@ void Cheats::GamesharkCheatCode::ApplyOnDisable() const
       }
       break;
 
+      case InstructionCode::ExtConstantWriteIfMatchWithRestore8:
+      {
+        const u8 value = DoMemoryRead<u8>(inst.address);
+        const u8 comparevalue = Truncate8(inst.value16 >> 8);
+        const u8 newvalue = Truncate8(inst.value16 & 0xFFu);
+        if (value == newvalue)
+          DoMemoryWrite<u8>(inst.address, comparevalue);
+
+        index++;
+      }
+      break;
+      
         [[unlikely]] default:
         {
           ERROR_LOG("Unhandled instruction code 0x{:02X} ({:08X} {:08X})", static_cast<u8>(inst.code.GetValue()),

--- a/src/duckstation-qt/gamecheatsettingswidget.cpp
+++ b/src/duckstation-qt/gamecheatsettingswidget.cpp
@@ -529,7 +529,7 @@ void GameCheatSettingsWidget::importCodes(const std::string& file_contents)
   }
 
   reloadList();
-  g_emu_thread->reloadCheats(true, true, false, true);
+  g_emu_thread->reloadCheats(true, false, false, true);
 }
 
 void GameCheatSettingsWidget::newCode()
@@ -544,7 +544,7 @@ void GameCheatSettingsWidget::newCode()
 
   // no need to reload cheats yet, it's not active. just refresh the list
   reloadList();
-  g_emu_thread->reloadCheats(true, true, false, true);
+  g_emu_thread->reloadCheats(true, false, false, true);
 }
 
 void GameCheatSettingsWidget::editCode(const std::string_view code_name)

--- a/src/duckstation-qt/gamecheatsettingswidget.cpp
+++ b/src/duckstation-qt/gamecheatsettingswidget.cpp
@@ -529,6 +529,7 @@ void GameCheatSettingsWidget::importCodes(const std::string& file_contents)
   }
 
   reloadList();
+  g_emu_thread->reloadCheats(true, true, false, true);
 }
 
 void GameCheatSettingsWidget::newCode()
@@ -543,6 +544,7 @@ void GameCheatSettingsWidget::newCode()
 
   // no need to reload cheats yet, it's not active. just refresh the list
   reloadList();
+  g_emu_thread->reloadCheats(true, true, false, true);
 }
 
 void GameCheatSettingsWidget::editCode(const std::string_view code_name)


### PR DESCRIPTION
* Added needed g_emu_thread->reloadCheats calls after the reloadList() calls on entering a new code or importing new codes.

Without it I had to import new codes and then manually edit one of them for it to show up in the cheat counts and possibly even work

* Added cheat type A8 which is the byte equivalent of the A7 cheat type as there will be a need of this type.