### PR TITLE
Debugger/MemoryScanner: Add 'Freeze Selected'

### DIFF
--- a/src/core/memory_scanner.cpp
+++ b/src/core/memory_scanner.cpp
@@ -340,6 +340,14 @@ bool MemoryWatchList::AddEntry(std::string description, u32 address, MemoryAcces
   return true;
 }
 
+bool MemoryWatchList::GetEntryFreeze(u32 index) const
+{
+  if (index >= m_entries.size())
+    return false;
+
+  return m_entries[index].freeze;
+}
+
 void MemoryWatchList::RemoveEntry(u32 index)
 {
   if (index >= m_entries.size())

--- a/src/core/memory_scanner.h
+++ b/src/core/memory_scanner.h
@@ -112,6 +112,8 @@ public:
   u32 GetEntryCount() const { return static_cast<u32>(m_entries.size()); }
 
   bool AddEntry(std::string description, u32 address, MemoryAccessSize size, bool is_signed, bool freeze);
+  bool GetEntryFreeze(u32 index) const;
+
   void RemoveEntry(u32 index);
   bool RemoveEntryByDescription(const char* description);
   bool RemoveEntryByAddress(u32 address);

--- a/src/duckstation-qt/memoryscannerwindow.cpp
+++ b/src/duckstation-qt/memoryscannerwindow.cpp
@@ -171,6 +171,7 @@ void MemoryScannerWindow::connectUi()
   });
   connect(m_ui.scanAddWatch, &QPushButton::clicked, this, &MemoryScannerWindow::addToWatchClicked);
   connect(m_ui.scanAddManualAddress, &QPushButton::clicked, this, &MemoryScannerWindow::addManualWatchAddressClicked);
+  connect(m_ui.scanFreezeWatch, &QPushButton::clicked, this, &MemoryScannerWindow::freezeWatchClicked);
   connect(m_ui.scanRemoveWatch, &QPushButton::clicked, this, &MemoryScannerWindow::removeWatchClicked);
   connect(m_ui.scanTable, &QTableWidget::currentItemChanged, this, &MemoryScannerWindow::scanCurrentItemChanged);
   connect(m_ui.watchTable, &QTableWidget::currentItemChanged, this, &MemoryScannerWindow::watchCurrentItemChanged);
@@ -208,6 +209,7 @@ void MemoryScannerWindow::enableUi(bool enabled)
   m_ui.scanAddWatch->setEnabled(enabled && !m_ui.scanTable->selectedItems().empty());
   m_ui.watchTable->setEnabled(enabled);
   m_ui.scanAddManualAddress->setEnabled(enabled);
+  m_ui.scanFreezeWatch->setEnabled(enabled && !m_ui.watchTable->selectedItems().empty());
   m_ui.scanRemoveWatch->setEnabled(enabled && !m_ui.watchTable->selectedItems().empty());
 }
 
@@ -330,6 +332,22 @@ void MemoryScannerWindow::addManualWatchAddressClicked()
   updateWatch();
 }
 
+void MemoryScannerWindow::freezeWatchClicked()
+{
+  const int indexFirst = getSelectedWatchIndexFirst();
+  const int indexLast = getSelectedWatchIndexLast();
+  if (indexFirst < 0)
+    return;
+
+  const bool freeze = m_watch.GetEntryFreeze(indexFirst);
+
+  for (int index = indexLast; index >= indexFirst; index--)
+  {
+    m_watch.SetEntryFreeze(static_cast<u32>(index), !freeze);
+    updateWatch();
+  }
+}
+
 void MemoryScannerWindow::removeWatchClicked()
 {
   const int indexFirst = getSelectedWatchIndexFirst();
@@ -351,6 +369,7 @@ void MemoryScannerWindow::scanCurrentItemChanged(QTableWidgetItem* current, QTab
 
 void MemoryScannerWindow::watchCurrentItemChanged(QTableWidgetItem* current, QTableWidgetItem* previous)
 {
+  m_ui.scanFreezeWatch->setEnabled((current != nullptr));
   m_ui.scanRemoveWatch->setEnabled((current != nullptr));
 }
 
@@ -569,6 +588,7 @@ void MemoryScannerWindow::updateWatch()
   }
 
   m_ui.scanSaveWatch->setEnabled(!entries.empty());
+  m_ui.scanFreezeWatch->setEnabled(false);
   m_ui.scanRemoveWatch->setEnabled(false);
 }
 

--- a/src/duckstation-qt/memoryscannerwindow.h
+++ b/src/duckstation-qt/memoryscannerwindow.h
@@ -37,6 +37,7 @@ private Q_SLOTS:
 
   void addToWatchClicked();
   void addManualWatchAddressClicked();
+  void freezeWatchClicked();
   void removeWatchClicked();
   void scanCurrentItemChanged(QTableWidgetItem* current, QTableWidgetItem* previous);
   void watchCurrentItemChanged(QTableWidgetItem* current, QTableWidgetItem* previous);

--- a/src/duckstation-qt/memoryscannerwindow.ui
+++ b/src/duckstation-qt/memoryscannerwindow.ui
@@ -437,12 +437,22 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="scanFreezeWatch">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Freeze Selected Entries</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="scanRemoveWatch">
          <property name="enabled">
           <bool>false</bool>
          </property>
          <property name="text">
-          <string>Remove Selected Entries from Watch List</string>
+          <string>Remove Selected Entries</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
* Adds 'Freeze Selected Entries' which upon multiple watch entries selected, will freeze/unfreeze them to the opposite of the first entry's state.
* Change "Remove Selected Entries from Watch List" -> "Remove Selected Entries"

This functionality has been useful for me. If you dislike this approach please don't hesitate to let me know and I'll change it. I figure it would be nice to have this feature.

Screenshots

### Before
<img width="635" alt="image" src="https://github.com/user-attachments/assets/e771e087-0b73-4233-8c04-69d41f4c0892">

### After
<img width="635" alt="image" src="https://github.com/user-attachments/assets/9c763d54-e44f-4c46-a2f2-71cdc6d02ba3">
