### PR TITLE
Log: Allow read-only access to the log file

### DIFF
--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -505,7 +505,7 @@ void Log::SetFileOutputParams(bool enabled, const char* filename, bool timestamp
 
   if (enabled)
   {
-    s_state.file_handle = FileSystem::OpenManagedCFile(filename, "wb");
+    s_state.file_handle = FileSystem::OpenManagedSharedCFile(filename, "wb", FileSystem::FileShareMode::DenyWrite);
     if (!s_state.file_handle) [[unlikely]]
     {
       ExecuteCallbacks(PackCategory(Channel::Log, Level::Error, Color::Default), nullptr,


### PR DESCRIPTION
This PR allows the log file to be read by the user while still retaining the write permission to duckstation while its still running.

There are cases where this could be useful, for example previously you would have to close duckstation before you can send the log file to Discord or other sites. This fixes it. 