### PR TITLE
Qt: Search more things!

### DIFF
--- a/src/duckstation-qt/gamelistwidget.cpp
+++ b/src/duckstation-qt/gamelistwidget.cpp
@@ -970,7 +970,10 @@ public:
     if (m_filter_region != DiscRegion::Count && entry->region != m_filter_region)
       return false;
 
-    if (!m_filter_name.isEmpty() && !QString::fromStdString(entry->title).contains(m_filter_name, Qt::CaseInsensitive))
+    if (!m_filter_name.isEmpty() &&
+          !QString::fromStdString(entry->path).contains(m_filter_name, Qt::CaseInsensitive) &&
+          !QString::fromStdString(entry->serial).contains(m_filter_name, Qt::CaseInsensitive) &&
+          !QString::fromStdString(entry->title).contains(m_filter_name, Qt::CaseInsensitive))
       return false;
 
     return QSortFilterProxyModel::filterAcceptsRow(source_row, source_parent);


### PR DESCRIPTION
Make search include more entry strings. It now includes not only the title, but the path, serial as well.

Makes the search functionality more useful for when filenames might differ from the database ones and also allows for quick subdirectory filtering!

Preview:
![image](https://github.com/user-attachments/assets/57077c60-44e4-42c2-b117-7bdd7fec3214)

NOTE: More information per entry like developer or publisher could come in handy. For example, when you want to quickly see all your Phoenix games.