### PR TITLE
Pin action-automatic-releases to latest commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create Preview Release
         if: github.ref == 'refs/heads/master'
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "preview"
@@ -76,7 +76,7 @@ jobs:
 
       - name: Create Rolling Release
         if: github.ref == 'refs/heads/dev'
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"


### PR DESCRIPTION
GitHub Actions supply chain attacks are sadly a thing ([recent example](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/)) and this action is in a privileged position where it could potentially do a lot of damage.

The bigger issue is that this action has been unmaintained for >3 years, but addressing that will require much larger changes to the release workflow and I wasn't sure how to proceed.

Let me know if I should pin the flatpak actions too.