### PR TITLE
Avoid deprecated `std::memory_order_consume`

### DIFF
--- a/src/util/imgui_manager.cpp
+++ b/src/util/imgui_manager.cpp
@@ -1117,7 +1117,7 @@ void ImGuiManager::ClearOSDMessages(bool clear_warnings)
 
 void ImGuiManager::AcquirePendingOSDMessages(Timer::Value current_time)
 {
-  std::atomic_thread_fence(std::memory_order_consume);
+  std::atomic_thread_fence(std::memory_order_acquire);
   if (s_state.osd_posted_messages.empty())
     return;
 


### PR DESCRIPTION
`std::memory_order_consume` was deprecated in C++26, and even before then, I don't know of any compiler that actually implements it differently from `memory_order_acquire`.