### PR TITLE
README: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DuckStation - PlayStation 1, aka. PSX Emulator
+
 [Features](#features) | [Downloading and Running](#downloading-and-running) | [Building](#building) | [Disclaimers](#disclaimers)
 
 **Latest Builds for Windows 10/11 (x64/ARM64), Linux (AppImage/Flatpak x64/ARM32/ARM64), and macOS (11.0+ Universal):** https://github.com/stenzek/duckstation/releases/tag/latest
@@ -111,19 +112,19 @@ or, if you have FlatHub set up:
  - Run `flatpak install org.duckstation.DuckStation`.
 
 Use `flatpak run org.duckstation.DuckStation` to start, or select `DuckStation` in the launcher of your desktop environment. Follow the Setup Wizard to get started.
- 
+
 ### macOS
 
-Universal MacOS builds are provided for both x64 and ARM64 (Apple Silicon).
+Universal macOS builds are provided for both x86_64 (Intel) and ARM64 (Apple Silicon).
 
-MacOS Big Sir (11.0) is required, as this is also the minimum requirement for Qt.
+macOS Big Sur (11.0) is required, as this is also the minimum requirement for Qt.
 
 To download:
  - Go to https://github.com/stenzek/duckstation/releases/tag/latest, and download `duckstation-mac-release.zip`.
  - Extract the zip by double-clicking it.
- - Open DuckStation.app, optionally moving it to your desired location first.
+ - Open `DuckStation.app`, optionally moving it to your desired location first.
  - Depending on GateKeeper configuration, you may need to right click -> Open the first time you run it, as code signing certificates are out of the question for a project which brings in zero revenue.
- 
+
 ### Android
 
 You will need a device with armv7 (32-bit ARM), AArch64 (64-bit ARM), or x86_64 (64-bit x86). 64-bit is preferred, the requirements are higher for 32-bit, you'll probably want at least a 1.5GHz CPU.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,6 +1,7 @@
 Tradução:
 
 # DuckStation - Emulador de PlayStation 1, também conhecido como PSX
+
 [Últimas Notícias](#latest-news) | [Recursos](#features) | [Download e Execução](#downloading-and-running) | [Compilação](#building) | [Avisos Legais](#disclaimers)
 
 **Últimas Versões para Windows 10/11, Linux (AppImage/Flatpak) e macOS:** https://github.com/stenzek/duckstation/releases/tag/latest
@@ -93,19 +94,19 @@ ou, se você tiver o FlatHub configurado:
  - Execute `flatpak install org.duckstation.DuckStation`.
 
 Use `flatpak run org.duckstation.DuckStation` para iniciar, ou selecione `DuckStation` no lançador do seu ambiente de desktop. Siga o Assistente de Configuração para começar.
- 
+
 ### macOS
 
-São fornecidas compilações universais do MacOS para x64 e ARM64 (Apple Silicon).
+São fornecidas compilações universais do macOS para x86_64 (Intel) e ARM64 (Apple Silicon).
 
-MacOS Big Sir (11.0) é necessário, pois também é o requisito mínimo para o Qt.
+macOS Big Sur (11.0) é necessário, pois também é o requisito mínimo para o Qt.
 
 Para baixar:
  - Acesse https://github.com/stenzek/duckstation/releases/tag/latest e baixe `duckstation-mac-release.zip`.
  - Extraia o arquivo ZIP dando um duplo clique nele.
- - Abra o DuckStation.app, opcionalmente movendo-o para a localização desejada antes.
+ - Abra o `DuckStation.app`, opcionalmente movendo-o para a localização desejada antes.
  - Dependendo da configuração do GateKeeper, você pode precisar clicar com o botão direito -> Abrir na primeira vez que executá-lo, já que certificados de assinatura de código estão fora de questão para um projeto que não gera receita alguma.
- 
+
 ### Android
 
 Você precisará de um dispositivo com armv7 (32 bits ARM), AArch64 (64 bits ARM) ou x86_64 (64 bits x86). 64 bits são preferíveis, os requisitos são mais altos para 32 bits, você provavelmente vai querer pelo menos um CPU de 1,5 GHz.


### PR DESCRIPTION
Qt 6.8 bumped the minimum target platform to Monterey. DuckStation has been using 6.9.x for some time.

Also replace `x64` with `x86_64`, the latter is more common on Apple platforms.