### PR TITLE
Qt: Implement reset play time for disc sets

### DIFF
--- a/src/core/cdrom_async_reader.cpp
+++ b/src/core/cdrom_async_reader.cpp
@@ -34,7 +34,7 @@ void CDROMAsyncReader::StopThread()
     return;
 
   {
-    std::unique_lock<std::mutex> lock(m_mutex);
+    std::unique_lock lock(m_mutex);
     m_shutdown_flag.store(true);
     m_do_read_cv.notify_one();
   }
@@ -133,7 +133,7 @@ void CDROMAsyncReader::QueueReadSector(CDImage::LBA lba)
 
   // we need to toss away our readahead and start fresh
   DEBUG_LOG("Readahead buffer miss, queueing seek to {}", lba);
-  std::unique_lock<std::mutex> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   m_next_position_set.store(true);
   m_next_position = lba;
   m_do_read_cv.notify_one();
@@ -190,7 +190,7 @@ bool CDROMAsyncReader::WaitForReadToComplete()
   Timer wait_timer;
   DEBUG_LOG("Sector read pending, waiting");
 
-  std::unique_lock<std::mutex> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   m_notify_read_complete_cv.wait(
     lock, [this]() { return (m_buffer_count.load() > 0 || m_seek_error.load()) && !m_next_position_set.load(); });
   if (m_seek_error.load()) [[unlikely]]
@@ -213,7 +213,7 @@ void CDROMAsyncReader::WaitForIdle()
   if (!IsUsingThread())
     return;
 
-  std::unique_lock<std::mutex> lock(m_mutex);
+  std::unique_lock lock(m_mutex);
   m_notify_read_complete_cv.wait(lock, [this]() { return (!m_is_reading.load() && !m_next_position_set.load()); });
 }
 

--- a/src/core/game_list.cpp
+++ b/src/core/game_list.cpp
@@ -761,7 +761,7 @@ void GameList::PopulateEntryAchievements(Entry* entry, const Achievements::Progr
 void GameList::UpdateAchievementData(const std::span<u8, 16> hash, u32 game_id, u32 num_achievements, u32 num_unlocked,
                                      u32 num_unlocked_hardcore)
 {
-  std::unique_lock<std::recursive_mutex> lock(s_mutex);
+  std::unique_lock lock(s_mutex);
   llvm::SmallVector<u32, 32> changed_indices;
 
   for (size_t i = 0; i < s_entries.size(); i++)
@@ -801,7 +801,7 @@ void GameList::UpdateAllAchievementData()
       WARNING_LOG("Failed to load achievements progress: {}", error.GetDescription());
   }
 
-  std::unique_lock<std::recursive_mutex> lock(s_mutex);
+  std::unique_lock lock(s_mutex);
 
   // this is pretty jank, but the frontend should collapse it into a single update
   std::vector<u32> changed_indices;
@@ -856,7 +856,7 @@ void GameList::UpdateAllAchievementData()
 
 std::unique_lock<std::recursive_mutex> GameList::GetLock()
 {
-  return std::unique_lock<std::recursive_mutex>(s_mutex);
+  return std::unique_lock(s_mutex);
 }
 
 const GameList::Entry* GameList::GetEntryByIndex(u32 index)
@@ -1437,7 +1437,7 @@ void GameList::AddPlayedTimeForSerial(const std::string& serial, std::time_t las
   VERBOSE_LOG("Add {} seconds play time to {} -> now {}", static_cast<unsigned>(add_time), serial.c_str(),
               static_cast<unsigned>(pt.total_played_time));
 
-  std::unique_lock<std::recursive_mutex> lock(s_mutex);
+  std::unique_lock lock(s_mutex);
   const GameDatabase::Entry* dbentry = GameDatabase::GetEntryForSerial(serial);
   llvm::SmallVector<u32, 32> changed_indices;
 
@@ -1476,7 +1476,7 @@ void GameList::ClearPlayedTimeForSerial(const std::string& serial)
 
   UpdatePlayedTimeFile(GetPlayedTimeFile(), serial, 0, 0);
 
-  std::unique_lock<std::recursive_mutex> lock(s_mutex);
+  std::unique_lock lock(s_mutex);
   for (GameList::Entry& entry : s_entries)
   {
     if (entry.serial != serial)
@@ -1528,7 +1528,7 @@ std::time_t GameList::GetCachedPlayedTimeForSerial(const std::string& serial)
   if (serial.empty())
     return 0;
 
-  std::unique_lock<std::recursive_mutex> lock(s_mutex);
+  std::unique_lock lock(s_mutex);
   for (GameList::Entry& entry : s_entries)
   {
     if (entry.serial == serial)

--- a/src/core/game_list.h
+++ b/src/core/game_list.h
@@ -18,8 +18,6 @@
 
 class ProgressCallback;
 
-struct SystemBootParameters;
-
 namespace GameList {
 enum class EntryType : u8
 {
@@ -116,7 +114,12 @@ EntryList TakeEntryList();
 
 /// Add played time for the specified serial.
 void AddPlayedTimeForSerial(const std::string& serial, std::time_t last_time, std::time_t add_time);
+
+/// Resets played time for the specified serial to zero.
 void ClearPlayedTimeForSerial(const std::string& serial);
+
+/// Resets played time for the specified entry to zero.
+void ClearPlayedTimeForEntry(const Entry* entry);
 
 /// Returns the total time played for a game. Requires the game to be scanned in the list.
 std::time_t GetCachedPlayedTimeForSerial(const std::string& serial);
@@ -160,7 +163,7 @@ void UpdateAchievementData(const std::span<u8, 16> hash, u32 game_id, u32 num_ac
                            u32 num_unlocked_hardcore);
 void UpdateAllAchievementData();
 
-}; // namespace GameList
+} // namespace GameList
 
 namespace Host {
 /// Asynchronously starts refreshing the game list.

--- a/src/core/host.cpp
+++ b/src/core/host.cpp
@@ -103,7 +103,7 @@ std::string Host::Internal::ComputeDataDirectory()
 
 std::unique_lock<std::mutex> Host::GetSettingsLock()
 {
-  return std::unique_lock<std::mutex>(s_settings_mutex);
+  return std::unique_lock(s_settings_mutex);
 }
 
 SettingsInterface* Host::GetSettingsInterface()

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -1207,7 +1207,7 @@ void System::RecreateGPU(GPURenderer renderer)
 
 void System::LoadSettings(bool display_osd_messages)
 {
-  std::unique_lock<std::mutex> lock = Host::GetSettingsLock();
+  auto lock = Host::GetSettingsLock();
   const SettingsInterface& si = *Host::GetSettingsInterface();
   const SettingsInterface& controller_si = GetControllerSettingsLayer(lock);
   const SettingsInterface& hotkey_si = GetHotkeySettingsLayer(lock);
@@ -1244,7 +1244,7 @@ void System::LoadSettings(bool display_osd_messages)
 
 void System::ReloadInputSources()
 {
-  std::unique_lock<std::mutex> lock = Host::GetSettingsLock();
+  auto lock = Host::GetSettingsLock();
   const SettingsInterface& controller_si = GetControllerSettingsLayer(lock);
   InputManager::ReloadSources(controller_si, lock);
 
@@ -1262,7 +1262,7 @@ void System::ReloadInputBindings()
   if (!IsValid())
     return;
 
-  std::unique_lock<std::mutex> lock = Host::GetSettingsLock();
+  auto lock = Host::GetSettingsLock();
   const SettingsInterface& controller_si = GetControllerSettingsLayer(lock);
   const SettingsInterface& hotkey_si = GetHotkeySettingsLayer(lock);
   InputManager::ReloadBindings(controller_si, hotkey_si);

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -1047,7 +1047,7 @@ void MainWindow::onCheatsMenuAboutToShow()
 const GameList::Entry* MainWindow::resolveDiscSetEntry(const GameList::Entry* entry,
                                                        std::unique_lock<std::recursive_mutex>& lock)
 {
-  if (!entry || entry->type != GameList::EntryType::DiscSet)
+  if (!entry || !entry->IsDiscSet())
     return entry;
 
   // disc set... need to figure out the disc we want
@@ -1523,14 +1523,6 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
           switchToEmulationView();
         });
       }
-
-      menu.addSeparator();
-
-      connect(menu.addAction(tr("Exclude From List")), &QAction::triggered,
-              [this, entry]() { getSettingsWindow()->getGameListSettingsWidget()->addExcludedPath(entry->path); });
-
-      connect(menu.addAction(tr("Reset Play Time")), &QAction::triggered,
-              [this, entry]() { clearGameListEntryPlayTime(entry); });
     }
     else
     {
@@ -1555,12 +1547,15 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
       menu.addSeparator();
 
       connect(menu.addAction(tr("Select Disc")), &QAction::triggered, this, &MainWindow::onGameListEntryActivated);
-
-      menu.addSeparator();
-
-      connect(menu.addAction(tr("Exclude From List")), &QAction::triggered,
-              [this, entry]() { getSettingsWindow()->getGameListSettingsWidget()->addExcludedPath(entry->path); });
     }
+
+    menu.addSeparator();
+
+    connect(menu.addAction(tr("Exclude From List")), &QAction::triggered,
+            [this, entry]() { getSettingsWindow()->getGameListSettingsWidget()->addExcludedPath(entry->path); });
+
+    connect(menu.addAction(tr("Reset Play Time")), &QAction::triggered,
+            [this, entry]() { clearGameListEntryPlayTime(entry); });
   }
 
   menu.addSeparator();
@@ -1628,7 +1623,7 @@ void MainWindow::clearGameListEntryPlayTime(const GameList::Entry* entry)
     return;
   }
 
-  GameList::ClearPlayedTimeForSerial(entry->serial);
+  GameList::ClearPlayedTimeForEntry(entry);
   m_game_list_widget->refresh(false);
 }
 

--- a/src/util/http_downloader.cpp
+++ b/src/util/http_downloader.cpp
@@ -45,7 +45,7 @@ void HTTPDownloader::CreateRequest(std::string url, Request::Callback callback, 
   req->progress = progress;
   req->start_time = Timer::GetCurrentValue();
 
-  std::unique_lock<std::mutex> lock(m_pending_http_request_lock);
+  std::unique_lock lock(m_pending_http_request_lock);
   if (LockedGetActiveRequestCount() < m_max_active_requests)
   {
     if (!StartRequest(req))
@@ -67,7 +67,7 @@ void HTTPDownloader::CreatePostRequest(std::string url, std::string post_data, R
   req->progress = progress;
   req->start_time = Timer::GetCurrentValue();
 
-  std::unique_lock<std::mutex> lock(m_pending_http_request_lock);
+  std::unique_lock lock(m_pending_http_request_lock);
   if (LockedGetActiveRequestCount() < m_max_active_requests)
   {
     if (!StartRequest(req))
@@ -199,13 +199,13 @@ void HTTPDownloader::LockedPollRequests(std::unique_lock<std::mutex>& lock)
 
 void HTTPDownloader::PollRequests()
 {
-  std::unique_lock<std::mutex> lock(m_pending_http_request_lock);
+  std::unique_lock lock(m_pending_http_request_lock);
   LockedPollRequests(lock);
 }
 
 void HTTPDownloader::WaitForAllRequests()
 {
-  std::unique_lock<std::mutex> lock(m_pending_http_request_lock);
+  std::unique_lock lock(m_pending_http_request_lock);
   while (!m_pending_http_requests.empty())
   {
     // Don't burn too much CPU.
@@ -232,7 +232,7 @@ u32 HTTPDownloader::LockedGetActiveRequestCount()
 
 bool HTTPDownloader::HasAnyRequests()
 {
-  std::unique_lock<std::mutex> lock(m_pending_http_request_lock);
+  std::unique_lock lock(m_pending_http_request_lock);
   return !m_pending_http_requests.empty();
 }
 

--- a/src/util/http_downloader_winhttp.cpp
+++ b/src/util/http_downloader_winhttp.cpp
@@ -110,7 +110,7 @@ void CALLBACK HTTPDownloaderWinHttp::HTTPStatusCallback(HINTERNET hRequest, DWOR
       DebugAssert(hRequest == req->hRequest);
 
       HTTPDownloaderWinHttp* parent = static_cast<HTTPDownloaderWinHttp*>(req->parent);
-      std::unique_lock<std::mutex> lock(parent->m_pending_http_request_lock);
+      std::unique_lock lock(parent->m_pending_http_request_lock);
       Assert(std::none_of(parent->m_pending_http_requests.begin(), parent->m_pending_http_requests.end(),
                           [req](HTTPDownloader::Request* it) { return it == req; }));
 

--- a/src/util/imgui_manager.cpp
+++ b/src/util/imgui_manager.cpp
@@ -1064,7 +1064,7 @@ void ImGuiManager::AddOSDMessage(std::string key, std::string message, float dur
   msg.last_y = -1.0f;
   msg.is_warning = is_warning;
 
-  std::unique_lock<std::mutex> lock(s_state.osd_messages_lock);
+  std::unique_lock lock(s_state.osd_messages_lock);
   s_state.osd_posted_messages.push_back(std::move(msg));
 }
 
@@ -1075,14 +1075,14 @@ void ImGuiManager::RemoveKeyedOSDMessage(std::string key, bool is_warning)
   msg.duration = 0.0f;
   msg.is_warning = is_warning;
 
-  std::unique_lock<std::mutex> lock(s_state.osd_messages_lock);
+  std::unique_lock lock(s_state.osd_messages_lock);
   s_state.osd_posted_messages.push_back(std::move(msg));
 }
 
 void ImGuiManager::ClearOSDMessages(bool clear_warnings)
 {
   {
-    std::unique_lock<std::mutex> lock(s_state.osd_messages_lock);
+    std::unique_lock lock(s_state.osd_messages_lock);
     if (clear_warnings)
     {
       s_state.osd_posted_messages.clear();

--- a/src/util/media_capture.cpp
+++ b/src/util/media_capture.cpp
@@ -255,7 +255,7 @@ GPUTexture* MediaCaptureBase::GetRenderTexture()
 
 bool MediaCaptureBase::DeliverVideoFrame(GPUTexture* stex)
 {
-  std::unique_lock<std::mutex> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   // If the encoder thread reported an error, stop the capture.
   if (m_encoding_error.load(std::memory_order_acquire))
@@ -330,7 +330,7 @@ void MediaCaptureBase::EncoderThreadEntryPoint()
   Threading::SetNameOfCurrentThread("Media Capture Encoding");
 
   Error error;
-  std::unique_lock<std::mutex> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   for (;;)
   {
@@ -417,7 +417,7 @@ bool MediaCaptureBase::DeliverAudioFrames(const s16* frames, u32 num_frames)
   if ((audio_buffer_size - m_audio_buffer_size.load(std::memory_order_acquire)) < num_frames)
   {
     // Need to wait for it to drain a bit.
-    std::unique_lock<std::mutex> lock(m_lock);
+    std::unique_lock lock(m_lock);
     m_frame_encoded_cv.wait(lock, [this, &num_frames, &audio_buffer_size]() {
       return (!m_capturing.load(std::memory_order_acquire) ||
               ((audio_buffer_size - m_audio_buffer_size.load(std::memory_order_acquire)) >= num_frames));
@@ -441,7 +441,7 @@ bool MediaCaptureBase::DeliverAudioFrames(const s16* frames, u32 num_frames)
   if (!IsCapturingVideo() && buffer_size >= m_audio_frame_size)
   {
     // If we're not capturing video, push "frames" when we hit the audio packet size.
-    std::unique_lock<std::mutex> lock(m_lock);
+    std::unique_lock lock(m_lock);
     if (!m_capturing.load(std::memory_order_acquire))
       return false;
 
@@ -493,7 +493,7 @@ void MediaCaptureBase::ClearState()
 
 bool MediaCaptureBase::EndCapture(Error* error)
 {
-  std::unique_lock<std::mutex> lock(m_lock);
+  std::unique_lock lock(m_lock);
   if (!InternalEndCapture(lock, error))
   {
     DeleteOutputFile();
@@ -574,7 +574,7 @@ void MediaCaptureBase::UpdateCaptureThreadUsage(double pct_divider, double time_
 
 void MediaCaptureBase::Flush()
 {
-  std::unique_lock<std::mutex> lock(m_lock);
+  std::unique_lock lock(m_lock);
 
   if (m_encoding_error)
     return;
@@ -2063,7 +2063,7 @@ bool MediaCaptureFFmpeg::IsCapturingVideo() const
 
 time_t MediaCaptureFFmpeg::GetElapsedTime() const
 {
-  std::unique_lock<std::mutex> lock(m_lock);
+  std::unique_lock lock(m_lock);
   s64 seconds;
   if (m_video_stream)
   {


### PR DESCRIPTION
A few things I'm not sure about:

* ~Should I use `entry->disc_set_name` or `entry->title`? is there a difference if the entry is a discset?~ Ended up using `entry->path` because `disc_set_name` is empty for the actual `DiscSet` list entry.
* I don't fully understand the locking (and the use of a recursive mutex doesn't make it any easier). It seems that the whole thing is already executed with the lock held, starting from `MainWindow::onGameListEntryContextMenuRequested`, so maybe I don't need to lock again in `clearGameListEntryPlayTime()`? Assuming that the triggered menu action is executed synchronously inside `menu.exec()`...
* I kept changes to a minimum but, if desired, repeated invocations of `GameList::ClearPlayedTimeForSerial` could be optimized by passing a list of serials, so that we iterate `s_entries` only once when resetting multiple entries.