### PR TITLE
Flatpak: Grant access to Gamescope socket for Steam Deck

### DIFF
--- a/scripts/packaging/flatpak/org.duckstation.DuckStation.yaml
+++ b/scripts/packaging/flatpak/org.duckstation.DuckStation.yaml
@@ -19,6 +19,8 @@ finish-args:
   - "--talk-name=org.freedesktop.ScreenSaver"
   - "--socket=wayland"
   - "--socket=fallback-x11"
+  # Required for Gamescope on Steam Deck OLED when using the Vulkan renderer
+  - --filesystem=xdg-run/gamescope-0:ro
 
 modules:
   # Dependencies.


### PR DESCRIPTION
* See flathub/org.DolphinEmu.dolphin-emu#178
* Bug only occurs on the Steam Deck OLED when using the Vulkan renderer.


To replicate the error, on a Steam Deck OLED, install the Gamescope Flatpak, set renderer to Vulkan, launch a ROM in Game Mode through the DuckStation GUI, see error. Gamescope Flatpak is primarily used for HDR in other Flatpaks (Dolphin, PrimeHack, Heroic, etc.).

![image](https://github.com/user-attachments/assets/745b9487-b8ed-4d3f-bb55-6e02c152ba92)




