### PR TITLE
Two fixes for `AchievementLoginDialog`

### DIFF
--- a/src/duckstation-qt/achievementlogindialog.cpp
+++ b/src/duckstation-qt/achievementlogindialog.cpp
@@ -60,7 +60,7 @@ void AchievementLoginDialog::cancelClicked()
     });
   }
 
-  done(1);
+  reject();
 }
 
 void AchievementLoginDialog::processLoginResult(bool result, const QString& message)
@@ -114,7 +114,7 @@ void AchievementLoginDialog::processLoginResult(bool result, const QString& mess
     }
   }
 
-  done(0);
+  accept();
 }
 
 void AchievementLoginDialog::connectUi()

--- a/src/duckstation-qt/achievementlogindialog.ui
+++ b/src/duckstation-qt/achievementlogindialog.ui
@@ -3,26 +3,20 @@
  <class>AchievementLoginDialog</class>
  <widget class="QDialog" name="AchievementLoginDialog">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::WindowModality::WindowModal</enum>
   </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>410</width>
-    <height>190</height>
+    <width>420</width>
+    <height>260</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>410</width>
-    <height>190</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>410</width>
-    <height>190</height>
+    <height>210</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -40,7 +34,7 @@
         <string/>
        </property>
        <property name="pixmap">
-        <pixmap resource="resources/resources.qrc">:/icons/emblem-person-blue.png</pixmap>
+        <pixmap resource="resources/duckstation-qt.qrc">:/icons/emblem-person-blue.png</pixmap>
        </property>
       </widget>
      </item>
@@ -55,9 +49,6 @@
        </property>
        <property name="text">
         <string comment="Header text">RetroAchievements Login</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
       </widget>
      </item>
@@ -76,13 +67,7 @@
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
     </spacer>
    </item>
@@ -108,25 +93,28 @@
      <item row="1" column="1">
       <widget class="QLineEdit" name="password">
        <property name="echoMode">
-        <enum>QLineEdit::Password</enum>
+        <enum>QLineEdit::EchoMode::Password</enum>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
      <item>
-      <widget class="QLabel" name="status">
-       <property name="text">
-        <string>Ready...</string>
-       </property>
-      </widget>
+      <widget class="QLabel" name="status"/>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel</set>
+        <set>QDialogButtonBox::StandardButton::Cancel</set>
        </property>
       </widget>
      </item>
@@ -135,7 +123,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="resources/resources.qrc"/>
+  <include location="resources/duckstation-qt.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/duckstation-qt/achievementsettingswidget.cpp
+++ b/src/duckstation-qt/achievementsettingswidget.cpp
@@ -221,7 +221,7 @@ void AchievementSettingsWidget::onLoginLogoutPressed()
 
   AchievementLoginDialog login(this, Achievements::LoginRequestReason::UserInitiated);
   int res = login.exec();
-  if (res != 0)
+  if (res == QDialog::Rejected)
     return;
 
   updateLoginState();

--- a/src/duckstation-qt/audiosettingswidget.cpp
+++ b/src/duckstation-qt/audiosettingswidget.cpp
@@ -325,7 +325,7 @@ void AudioSettingsWidget::onStretchSettingsClicked()
                                     std::nullopt :
                                     std::optional<bool>(AudioStreamParameters::DEFAULT_STRETCH_USE_AA_FILTER));
 
-    dlg.done(0);
+    dlg.reject();
 
     QMetaObject::invokeMethod(this, &AudioSettingsWidget::onStretchSettingsClicked, Qt::QueuedConnection);
   });

--- a/src/duckstation-qt/coverdownloaddialog.cpp
+++ b/src/duckstation-qt/coverdownloaddialog.cpp
@@ -78,7 +78,7 @@ void CoverDownloadDialog::onCloseClicked()
   if (m_thread)
     cancelThread();
 
-  done(0);
+  reject();
 }
 
 void CoverDownloadDialog::updateEnabled()

--- a/src/duckstation-qt/gamecheatsettingswidget.cpp
+++ b/src/duckstation-qt/gamecheatsettingswidget.cpp
@@ -926,12 +926,12 @@ void CheatCodeEditorDialog::saveClicked()
                           tr("Failed to save cheat code:\n%1").arg(QString::fromStdString(error.GetDescription())));
   }
 
-  done(1);
+  accept();
 }
 
 void CheatCodeEditorDialog::cancelClicked()
 {
-  done(0);
+  reject();
 }
 
 void CheatCodeEditorDialog::onOptionTypeChanged(int index)

--- a/src/duckstation-qt/inputbindingdialog.cpp
+++ b/src/duckstation-qt/inputbindingdialog.cpp
@@ -30,7 +30,7 @@ InputBindingDialog::InputBindingDialog(SettingsInterface* sif, InputBindingInfo:
   connect(m_ui.addBinding, &QPushButton::clicked, this, &InputBindingDialog::onAddBindingButtonClicked);
   connect(m_ui.removeBinding, &QPushButton::clicked, this, &InputBindingDialog::onRemoveBindingButtonClicked);
   connect(m_ui.clearBindings, &QPushButton::clicked, this, &InputBindingDialog::onClearBindingsButtonClicked);
-  connect(m_ui.buttonBox, &QDialogButtonBox::rejected, [this]() { done(0); });
+  connect(m_ui.buttonBox, &QDialogButtonBox::rejected, [this]() { reject(); });
   updateList();
 
   // Only show the sensitivity controls for binds where it's applicable.

--- a/src/duckstation-qt/selectdiscdialog.cpp
+++ b/src/duckstation-qt/selectdiscdialog.cpp
@@ -38,7 +38,7 @@ void SelectDiscDialog::onListItemActivated(const QTreeWidgetItem* item)
     return;
 
   m_selected_path = item->data(0, Qt::UserRole).toString().toStdString();
-  done(1);
+  accept();
 }
 
 void SelectDiscDialog::updateStartEnabled()
@@ -53,12 +53,12 @@ void SelectDiscDialog::updateStartEnabled()
 
 void SelectDiscDialog::onSelectClicked()
 {
-  done(1);
+  accept();
 }
 
 void SelectDiscDialog::onCancelClicked()
 {
-  done(0);
+  reject();
 }
 
 void SelectDiscDialog::populateList(const std::string& disc_set_name)

--- a/src/duckstation-qt/setupwizarddialog.cpp
+++ b/src/duckstation-qt/setupwizarddialog.cpp
@@ -692,7 +692,7 @@ void SetupWizardDialog::onAchievementsLoginLogoutClicked()
 
   AchievementLoginDialog login(this, Achievements::LoginRequestReason::UserInitiated);
   int res = login.exec();
-  if (res != 0)
+  if (res == QDialog::Rejected)
     return;
 
   updateAchievementsEnableState();


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/775f480f-a454-4945-90a5-fc4ecd43a1e9)

After:
![after](https://github.com/user-attachments/assets/c012953d-0d9a-4911-a939-caa5baaaa038)
