### PR TITLE
Qt: Refine use of ellipsis in game list context menu

### DIFF
--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -889,7 +889,7 @@ void MainWindow::populateGameListContextMenu(const GameList::Entry* entry, QWidg
   if (!entry->IsDiscSet())
   {
     const bool has_any_states = resume_action->isEnabled() || load_state_menu->isEnabled();
-    QAction* delete_save_states_action = menu->addAction(tr("Delete Save States..."));
+    QAction* delete_save_states_action = menu->addAction(tr("Delete Save States"));
     delete_save_states_action->setEnabled(has_any_states);
     if (has_any_states)
     {
@@ -1609,7 +1609,7 @@ void MainWindow::onGameListEntryContextMenuRequested(const QPoint& point)
 
         menu.addSeparator();
 
-        connect(menu.addAction(tr("Select Disc")), &QAction::triggered, this, &MainWindow::onGameListEntryActivated);
+        connect(menu.addAction(tr("Select Disc...")), &QAction::triggered, this, &MainWindow::onGameListEntryActivated);
       }
 
       menu.addSeparator();


### PR DESCRIPTION
I checked the human interface guidelines for Windows, macOS, and KDE. They all agree that ellipsis should be used only when performing the selected action requires additional input from the user. A mere yes/no confirmation dialog is _not_ considered "additional input". That said, in several instances it's not clear what constitutes "additional input".

This PR is very conservative and only changes two instances where the decision is easy:
* "delete save states" does not need any further input, it simply asks the user to confirm (since it's a destructive action). No ellipsis needed.
* "select disc" requires the user to choose which disc they want to boot. Definitely needs an ellipsis.

Other actions like "Open containing directory", "Browse ISO", "Properties" arguably don't need the ellipsis either, but these are less clear cut and I've opted to leave them alone for now unless you tell me otherwise.