### PR TITLE
Qt: Refactor `GameListWidget` tool buttons and corresponding menu actions

### DIFF
--- a/src/duckstation-qt/gamelistwidget.cpp
+++ b/src/duckstation-qt/gamelistwidget.cpp
@@ -1487,8 +1487,8 @@ void GameListWidget::updateView(bool grid_view)
 
 void GameListWidget::updateToolbar(bool grid_view)
 {
-  m_ui.viewGridTitles->setEnabled(grid_view);
-  m_ui.gridScale->setEnabled(grid_view);
+  m_ui.viewGridTitles->setVisible(grid_view);
+  m_ui.gridScale->setVisible(grid_view);
 }
 
 void GameListWidget::onCoverScaleChanged(float scale)

--- a/src/duckstation-qt/gamelistwidget.h
+++ b/src/duckstation-qt/gamelistwidget.h
@@ -90,6 +90,7 @@ public:
   bool getShowGameIcons() const { return m_show_game_icons; }
   void setShowGameIcons(bool enabled);
   QIcon getIconForGame(const QString& path);
+  void refreshIcons();
 
   float getCoverScale() const { return m_cover_scale; }
   void setCoverScale(float scale);
@@ -101,10 +102,8 @@ public:
 Q_SIGNALS:
   void coverScaleChanged(float scale);
 
-private Q_SLOTS:
-  void rowsChanged(const QList<int>& rows);
-
 private:
+  void rowsChanged(const QList<int>& rows);
   QVariant data(const QModelIndex& index, int role, const GameList::Entry* ge) const;
 
   void loadCommonImages();
@@ -164,11 +163,10 @@ public:
 protected:
   void resizeEvent(QResizeEvent* e) override;
 
-private Q_SLOTS:
+private:
   void onHeaderSortIndicatorChanged(int, Qt::SortOrder);
   void onHeaderContextMenuRequested(const QPoint& point);
 
-private:
   void loadColumnVisibilitySettings();
   void loadColumnSortSettings();
   void saveColumnSortSettings();
@@ -198,10 +196,8 @@ protected:
   void wheelEvent(QWheelEvent* e) override;
   void resizeEvent(QResizeEvent* e) override;
 
-private Q_SLOTS:
-  void onCoverScaleChanged(float scale);
-
 private:
+  void onCoverScaleChanged(float scale);
   void adjustZoom(float delta);
 
   GameListModel* m_model = nullptr;
@@ -226,7 +222,6 @@ public:
   void resizeListViewColumnsToFit();
 
   void refresh(bool invalidate_cache);
-  void refreshModel();
   void cancelRefresh();
   void reloadThemeSpecificImages();
   void updateBackground(bool reload_image);

--- a/src/duckstation-qt/gamelistwidget.h
+++ b/src/duckstation-qt/gamelistwidget.h
@@ -221,7 +221,8 @@ public:
   ALWAYS_INLINE GameListListView* getListView() const { return m_list_view; }
   ALWAYS_INLINE GameListGridView* getGridView() const { return m_grid_view; }
 
-  void initialize();
+  void initialize(QAction* actionGameList, QAction* actionGameGrid, QAction* actionMergeDiscSets,
+                  QAction* actionListShowIcons, QAction* actionGridShowTitles);
   void resizeListViewColumnsToFit();
 
   void refresh(bool invalidate_cache);
@@ -232,9 +233,6 @@ public:
 
   bool isShowingGameList() const;
   bool isShowingGameGrid() const;
-  bool isShowingGridCoverTitles() const;
-  bool isMergingDiscSets() const;
-  bool isShowingGameIcons() const;
 
   const GameList::Entry* getSelectedEntry() const;
 
@@ -247,7 +245,6 @@ Q_SIGNALS:
   void entryContextMenuRequested(const QPoint& point);
 
   void addGameDirectoryRequested();
-  void layoutChanged();
 
 private Q_SLOTS:
   void onRefreshProgress(const QString& status, int current, int total, float time);
@@ -265,9 +262,9 @@ private Q_SLOTS:
 public Q_SLOTS:
   void showGameList();
   void showGameGrid();
-  void setShowCoverTitles(bool enabled);
   void setMergeDiscSets(bool enabled);
   void setShowGameIcons(bool enabled);
+  void setShowCoverTitles(bool enabled);
   void refreshGridCovers();
   void focusSearchWidget();
 
@@ -275,7 +272,8 @@ protected:
   void resizeEvent(QResizeEvent* event);
 
 private:
-  void updateToolbar();
+  void updateView(bool grid_view);
+  void updateToolbar(bool grid_view);
 
   Ui::GameListWidget m_ui;
 

--- a/src/duckstation-qt/gamelistwidget.ui
+++ b/src/duckstation-qt/gamelistwidget.ui
@@ -54,9 +54,6 @@
        <property name="text">
         <string>Game List</string>
        </property>
-       <property name="icon">
-        <iconset theme="list-check"/>
-       </property>
        <property name="checkable">
         <bool>true</bool>
        </property>
@@ -75,9 +72,6 @@
        </property>
        <property name="text">
         <string>Game Grid</string>
-       </property>
-       <property name="icon">
-        <iconset theme="function-line"/>
        </property>
        <property name="checkable">
         <bool>true</bool>
@@ -98,9 +92,6 @@
        <property name="text">
         <string>Merge Multi-Disc Games</string>
        </property>
-       <property name="icon">
-        <iconset theme="play-list-2-line"/>
-       </property>
        <property name="checkable">
         <bool>true</bool>
        </property>
@@ -119,9 +110,6 @@
        </property>
        <property name="text">
         <string>Show Titles</string>
-       </property>
-       <property name="icon">
-        <iconset theme="price-tag-3-line"/>
        </property>
        <property name="checkable">
         <bool>true</bool>

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -401,7 +401,7 @@ void MainWindow::createDisplayWidget(bool fullscreen, bool render_to_main, bool 
     m_ui.actionViewSystemDisplay->setChecked(true);
   }
 
-  updateDisplayRelatedActions(true, render_to_main, fullscreen);
+  updateDisplayRelatedActions(true, fullscreen);
   updateShortcutActions(false);
 
   updateDisplayWidgetCursor();
@@ -483,7 +483,7 @@ void MainWindow::destroyDisplayWidget(bool show_game_list)
 
   m_exclusive_fullscreen_requested = false;
 
-  updateDisplayRelatedActions(false, false, false);
+  updateDisplayRelatedActions(false, false);
   updateShortcutActions(false);
 }
 
@@ -497,17 +497,13 @@ void MainWindow::updateDisplayWidgetCursor()
   m_display_widget->updateCursor(s_system_valid && !s_system_paused && shouldHideMouseCursor());
 }
 
-void MainWindow::updateDisplayRelatedActions(bool has_surface, bool render_to_main, bool fullscreen)
+void MainWindow::updateDisplayRelatedActions(bool has_surface, bool fullscreen)
 {
   // rendering to main, or switched to gamelist/grid
   m_ui.actionViewSystemDisplay->setEnabled(wantsDisplayWidget() && QtHost::CanRenderToMainWindow());
   m_ui.menuWindowSize->setEnabled(has_surface && !fullscreen);
   m_ui.actionFullscreen->setEnabled(has_surface);
-
-  {
-    QSignalBlocker blocker(m_ui.actionFullscreen);
-    m_ui.actionFullscreen->setChecked(fullscreen);
-  }
+  m_ui.actionFullscreen->setChecked(fullscreen);
 }
 
 void MainWindow::focusDisplayWidget()

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -2736,7 +2736,7 @@ void MainWindow::refreshGameList(bool invalidate_cache)
 
 void MainWindow::refreshGameListModel()
 {
-  m_game_list_widget->refreshModel();
+  m_game_list_widget->getModel()->refresh();
 }
 
 void MainWindow::cancelGameListRefresh()

--- a/src/duckstation-qt/mainwindow.h
+++ b/src/duckstation-qt/mainwindow.h
@@ -271,7 +271,7 @@ private:
   void createDisplayWidget(bool fullscreen, bool render_to_main, bool use_main_window_pos);
   void destroyDisplayWidget(bool show_game_list);
   void updateDisplayWidgetCursor();
-  void updateDisplayRelatedActions(bool has_surface, bool render_to_main, bool fullscreen);
+  void updateDisplayRelatedActions(bool has_surface, bool fullscreen);
 
   void doSettings(const char* category = nullptr);
   void openGamePropertiesForCurrentGame(const char* category = nullptr);

--- a/src/duckstation-qt/mainwindow.h
+++ b/src/duckstation-qt/mainwindow.h
@@ -213,7 +213,6 @@ private Q_SLOTS:
 
   void onGameListRefreshComplete();
   void onGameListRefreshProgress(const QString& status, int current, int total);
-  void onGameListLayoutChanged();
   void onGameListSelectionChanged();
   void onGameListEntryActivated();
   void onGameListEntryContextMenuRequested(const QPoint& point);

--- a/src/duckstation-qt/mainwindow.ui
+++ b/src/duckstation-qt/mainwindow.ui
@@ -743,9 +743,6 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked">
-    <bool>false</bool>
-   </property>
    <property name="text">
     <string>Lock Toolbar</string>
    </property>
@@ -786,6 +783,9 @@
    </property>
   </action>
   <action name="actionViewGameList">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset theme="list-check"/>
    </property>
@@ -794,6 +794,9 @@
    </property>
   </action>
   <action name="actionViewSystemDisplay">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="enabled">
     <bool>false</bool>
    </property>
@@ -826,6 +829,9 @@
    </property>
   </action>
   <action name="actionViewGameGrid">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset theme="function-line"/>
    </property>
@@ -840,6 +846,9 @@
    <property name="checked">
     <bool>true</bool>
    </property>
+   <property name="icon">
+    <iconset theme="play-list-2-line"/>
+   </property>
    <property name="text">
     <string>Merge Multi-Disc Games</string>
    </property>
@@ -851,8 +860,14 @@
    <property name="checked">
     <bool>true</bool>
    </property>
+   <property name="icon">
+    <iconset theme="price-tag-3-line"/>
+   </property>
    <property name="text">
     <string>Show Titles (Grid View)</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Titles</string>
    </property>
   </action>
   <action name="actionGridViewZoomIn">

--- a/src/duckstation-qt/mainwindow.ui
+++ b/src/duckstation-qt/mainwindow.ui
@@ -421,6 +421,9 @@
    </property>
   </action>
   <action name="actionFullscreen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="icon">
     <iconset theme="fullscreen-line"/>
    </property>


### PR DESCRIPTION
The main idea is to leverage the power of QAction to keep UI state synchronized in cases where the same action can be performed through multiple UI controls, e.g. a menu item and a toolbar button. Currently DuckStation does most of its UI state management manually.

The only user-visible changes are:
* The "game list" / "game grid" / "system display" menu items are checkable and their state is synchronized with the buttons in GameListWidget. This was the main motivation for this PR. Also, a QActionGroup is used to enforce mutual exclusion.
* The "grid titles" button and "grid scale" slider are hidden when the widget is showing the list view, instead of just being disabled.

I'll do more testing tomorrow but I didn't find anything broken yet.