### PR TITLE
Qt: Fix crash on triggering certain actions before display widget is created

### DIFF
--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -3200,7 +3200,7 @@ MainWindow::SystemLock MainWindow::pauseAndLockSystem()
 
   // Now we'll either have a borderless window, or a regular window (if we were exclusive fullscreen).
   QWidget* dialog_parent = getDisplayContainer();
-  if (dialog_parent->parent())
+  if (!dialog_parent || dialog_parent->parent())
     dialog_parent = this;
 
   return SystemLock(dialog_parent, was_paused, was_fullscreen);


### PR DESCRIPTION
`getDisplayContainer()` can return `nullptr` if the display widget hasn't been created yet, e.g. before starting a game.

I believe this regressed in b07998512e4222317d54de9343c58f166af80a1f. I'm not sure if this is the correct (or complete) fix though.