### PR TITLE
PSFLoader: Fix recursive _lib loading

### DIFF
--- a/src/core/psf_loader.cpp
+++ b/src/core/psf_loader.cpp
@@ -193,14 +193,12 @@ bool PSFLoader::LoadLibraryPSF(const std::string& path, bool use_pc_sp, Error* e
     const std::string lib_path = Path::BuildRelativePath(path, lib_name.value());
     INFO_LOG("Loading parent PSF '{}'", Path::GetFileName(lib_path));
 
-    // We should use the initial SP/PC from the **first** parent lib.
-    const bool lib_use_pc_sp = (depth == 0);
-    if (!LoadLibraryPSF(lib_path.c_str(), lib_use_pc_sp, error, depth + 1))
+    // We should use the initial SP/PC from the deepest **first** parent lib.
+    if (!LoadLibraryPSF(lib_path.c_str(), use_pc_sp, error, depth + 1))
       return false;
 
     // Don't apply the PC/SP from the minipsf file.
-    if (lib_use_pc_sp)
-      use_pc_sp = false;
+    use_pc_sp = false;
   }
 
   // apply the main psf


### PR DESCRIPTION
As stated by Neill Corlett, the first _lib needs to be loaded recursively and the deepest one is the one that loads the PC/SP
This is the currently behaviour of mednafen and highly experimental plugin