### PR TITLE
Adjust crop area for `Silent Hill`

### DIFF
--- a/src/duckstation-qt/qthost.cpp
+++ b/src/duckstation-qt/qthost.cpp
@@ -3394,7 +3394,6 @@ int main(int argc, char* argv[])
   // Always kick off update check. It'll take over if the user is booting a game fullscreen.
   g_main_window->startupUpdateCheck();
 
-  // Skip the update check if we're booting a game directly.
   if (autoboot)
     g_emu_thread->bootSystem(std::move(autoboot));
 


### PR DESCRIPTION
Basically a left shift by one line to avoid a black bar on the right edge and avoid cropping one line of content on the left edge.

The offset value is -8 because 8 is the dot clock divider for the native resolution of this game (320x224 for the NA version), but all values between -1 and -8 work identically as long as start and end offsets are the same.

The screenshots below were taken at 9x IR, so 1 line == 9px. I also tested at native resolution and with/without the widescreen hack.

Before:
<img width="2880" height="2160" alt="before" src="https://github.com/user-attachments/assets/89adb03d-804a-4113-b342-41e78bb141b4" />

After:
<img width="2880" height="2160" alt="after" src="https://github.com/user-attachments/assets/28c39640-a021-4e57-a86d-1938ea58c90e" />
