### PR TITLE
Qt: Widen the `Size` and `Raw Size` columns in game list view

### DIFF
--- a/src/duckstation-qt/gamelistwidget.cpp
+++ b/src/duckstation-qt/gamelistwidget.cpp
@@ -1634,11 +1634,11 @@ void GameListListView::resizeColumnsToFit()
                                              200, // publisher
                                              200, // genre
                                              50,  // year
-                                             100, // players
+                                             75,  // players
                                              85,  // time played
                                              85,  // last played
-                                             80,  // file size
-                                             80,  // size
+                                             85,  // file size
+                                             85,  // size
                                              55,  // region
                                              100, // achievements
                                              100  // compatibility

--- a/src/duckstation-qt/gamelistwidget.h
+++ b/src/duckstation-qt/gamelistwidget.h
@@ -264,7 +264,7 @@ public Q_SLOTS:
   void focusSearchWidget();
 
 protected:
-  void resizeEvent(QResizeEvent* event);
+  void resizeEvent(QResizeEvent* event) override;
 
 private:
   void updateView(bool grid_view);


### PR DESCRIPTION
master:
<img width="340" height="882" alt="master" src="https://github.com/user-attachments/assets/2562ec2b-92b4-4c0e-a92c-63b765caa416" />

PR:
<img width="356" height="882" alt="pr" src="https://github.com/user-attachments/assets/7b9da96a-6d20-40ee-a891-8cc2bb7541bc" />
