### PR TITLE
Qt: More accurate game list column width estimation

### DIFF
--- a/src/duckstation-qt/gamelistwidget.h
+++ b/src/duckstation-qt/gamelistwidget.h
@@ -161,14 +161,12 @@ public:
 
   void setAndSaveColumnHidden(int column, bool hidden);
 
-  void updateDynamicColumnWidths();
-
 private:
   void onHeaderSortIndicatorChanged(int, Qt::SortOrder);
   void onHeaderContextMenuRequested(const QPoint& point);
 
   void setFixedColumnWidth(int column, int width);
-  void setFixedColumnWidth(const QFontMetrics& fm, int column, int str_width, int padding);
+  void setFixedColumnWidth(const QFontMetrics& fm, int column, int str_width);
   void setFixedColumnWidths();
 
   void loadColumnVisibilitySettings();


### PR DESCRIPTION
Three main changes:

1. Use the pixel metrics of the style instead of hardcoded values.
1. Account for the potential sort indicator in the column header.
1. In the two "Size" columns, the largest numerical value does not necessarily result in the widest text string, so just use the value 8888.88 to estimate the width (we assume that 8 is the widest digit, which is true for many proportional fonts).