### PR TITLE
CI: Bump `actions/checkout` to v5

### DIFF
--- a/.github/workflows/gamedb-lint.yml
+++ b/.github/workflows/gamedb-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/.github/workflows/linux-appimage-build.yml
+++ b/.github/workflows/linux-appimage-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/.github/workflows/linux-cross-appimage-build.yml
+++ b/.github/workflows/linux-cross-appimage-build.yml
@@ -18,7 +18,7 @@ jobs:
 
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/.github/workflows/linux-flatpak-build.yml
+++ b/.github/workflows/linux-flatpak-build.yml
@@ -27,7 +27,7 @@ jobs:
       options: --privileged
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         set-safe-directory: ${{ env.GITHUB_WORKSPACE }}

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,4 +98,3 @@ jobs:
             ./artifacts/linux-flatpak-x86_64/duckstation-x86_64.flatpak
             ./artifacts/linux-flatpak-aarch64/duckstation-aarch64.flatpak
             ./artifacts/macos/duckstation-mac-release.zip
-

--- a/.github/workflows/translation-lint.yml
+++ b/.github/workflows/translation-lint.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -26,5 +26,5 @@ jobs:
       shell: bash
       run: |
         for i in src/duckstation-qt/translations/*.ts; do
-          python scripts/verify_translation_placeholders.py "$i";
+          python scripts/verify_translation_placeholders.py "$i"
         done

--- a/.github/workflows/upload-caches.yml
+++ b/.github/workflows/upload-caches.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -198,7 +198,7 @@ jobs:
     runs-on: windows-2022
     timeout-minutes: 120
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         submodules: true


### PR DESCRIPTION
[Release notes](https://github.com/actions/checkout/releases/tag/v5.0.0)