### PR TITLE
Sharper icon scaling

### DIFF
--- a/src/duckstation-qt/qtutils.cpp
+++ b/src/duckstation-qt/qtutils.cpp
@@ -330,12 +330,12 @@ template<typename T>
 static void ResizeSharpBilinearT(T& pm, int size, int base_size)
 {
   // Sharp Bilinear scaling
-  // First, scale the icon by the largest integer size using nearest-neighbor...
-  const int integer_icon_size = static_cast<int>(size / base_size) * base_size;
+  // First, scale the icon by the next largest integer size using nearest-neighbor...
+  const int integer_icon_size = std::ceilf(static_cast<float>(size) / base_size) * base_size;
   pm = pm.scaled(integer_icon_size, integer_icon_size, Qt::IgnoreAspectRatio, Qt::FastTransformation);
 
-  // ...then scale any remainder using bilinear interpolation.
-  if (size - integer_icon_size > 0)
+  // ...then scale down any remainder using bilinear interpolation.
+  if (integer_icon_size - size > 0)
     pm = pm.scaled(size, size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 }
 


### PR DESCRIPTION
Rounding up the scale to the next largest integer size with nearest-neighbor then scaling down with bilinear interpolation can result in noticeably sharper scaling when at small scale factors (between 1x and 2x).

master (left) | PR (right)

<img width="109" height="731" alt="image" src="https://github.com/user-attachments/assets/c0605b58-8624-4976-abff-9e92681a5ee8" />
