### PR TITLE
Hybrid Bilinear scaling

### DIFF
--- a/src/core/gpu_presenter.cpp
+++ b/src/core/gpu_presenter.cpp
@@ -130,6 +130,9 @@ bool GPUPresenter::CompileDisplayPipelines(bool display, bool deinterlace, bool 
         case DisplayScalingMode::BilinearSharp:
           fs = shadergen.GenerateDisplaySharpBilinearFragmentShader();
           break;
+        case DisplayScalingMode::BilinearHybrid:
+          fs = shadergen.GenerateDisplayHybridBilinearFragmentShader();
+          break;
 
         case DisplayScalingMode::BilinearSmooth:
         case DisplayScalingMode::BilinearInteger:
@@ -717,6 +720,7 @@ void GPUPresenter::DrawDisplay(const GSVector2i target_size, const GSVector2i fi
     }
     break;
 
+    case DisplayScalingMode::BilinearHybrid:
     case DisplayScalingMode::BilinearSharp:
     {
       texture_filter_linear = true;

--- a/src/core/gpu_shadergen.h
+++ b/src/core/gpu_shadergen.h
@@ -13,6 +13,7 @@ public:
 
   std::string GenerateDisplayFragmentShader(bool clamp_uv, bool nearest) const;
   std::string GenerateDisplaySharpBilinearFragmentShader() const;
+  std::string GenerateDisplayHybridBilinearFragmentShader() const;
   std::string GenerateDisplayLanczosFragmentShader() const;
 
   std::string GenerateDeinterlaceWeaveFragmentShader() const;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -2032,12 +2032,13 @@ const char* Settings::GetForceVideoTimingDisplayName(ForceVideoTimingMode mode)
 }
 
 static constexpr const std::array s_display_scaling_names = {
-  "Nearest", "NearestInteger", "BilinearSmooth", "BilinearSharp", "BilinearInteger", "Lanczos",
+  "Nearest", "NearestInteger", "BilinearSmooth", "BilinearHybrid", "BilinearSharp", "BilinearInteger", "Lanczos",
 };
 static constexpr const std::array s_display_scaling_display_names = {
   TRANSLATE_DISAMBIG_NOOP("Settings", "Nearest-Neighbor", "DisplayScalingMode"),
   TRANSLATE_DISAMBIG_NOOP("Settings", "Nearest-Neighbor (Integer)", "DisplayScalingMode"),
   TRANSLATE_DISAMBIG_NOOP("Settings", "Bilinear (Smooth)", "DisplayScalingMode"),
+  TRANSLATE_DISAMBIG_NOOP("Settings", "Bilinear (Hybrid)", "DisplayScalingMode"),
   TRANSLATE_DISAMBIG_NOOP("Settings", "Bilinear (Sharp)", "DisplayScalingMode"),
   TRANSLATE_DISAMBIG_NOOP("Settings", "Bilinear (Integer)", "DisplayScalingMode"),
   TRANSLATE_DISAMBIG_NOOP("Settings", "Lanczos (Sharp)", "DisplayScalingMode"),

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -198,6 +198,7 @@ enum class DisplayScalingMode : u8
   Nearest,
   NearestInteger,
   BilinearSmooth,
+  BilinearHybrid,
   BilinearSharp,
   BilinearInteger,
   Lanczos,


### PR DESCRIPTION
This PR introduces a new scaling option: Hybrid Bilinear, a middle ground between Smooth Bilinear and Sharp Bilinear. It's smooth horizontally and sharp vertically like a raster scan on a CRT.

> [Analog television](https://en.wikipedia.org/wiki/Analog_television) has discrete scan lines (discrete vertical resolution), but does not have discrete pixels (horizontal resolution) – it instead varies the signal continuously over the scan line.
> --- [Raster scan - Wikipedia](https://en.wikipedia.org/wiki/Raster_scan#Scan_lines:~:text=Analog%20television%20has%20discrete%20scan%20lines%20(discrete%20vertical%20resolution)%2C%20but%20does%20not%20have%20discrete%20pixels%20(horizontal%20resolution)%20%E2%80%93%20it%20instead%20varies%20the%20signal%20continuously%20over%20the%20scan%20line.)

Based on: https://30fps.net/pages/pixelart-scaling/

This scaling method results in better blending for pixel art and pre-rendered graphics without blurring the image too much.

| Sharp Bilinear | Hybrid Bilinear | Smooth Bilinear |
|----------------|-----------------|-----------------|
|<img width="246" height="312" alt="SoTN - dracula - sharp bilinear" src="https://github.com/user-attachments/assets/4a00570a-7273-4267-b5d1-77cf325fa10b" />|<img width="246" height="312" alt="SoTN - dracula - hybrid bilinear" src="https://github.com/user-attachments/assets/913bbfc6-79e1-4adb-be94-33678cdfdae2" />|<img width="246" height="312" alt="SoTN - dracula - smooth bilinear" src="https://github.com/user-attachments/assets/bf8ba2b5-adae-4218-a9ba-9d1a911f89a5" />| 
|<img width="430" height="260" alt="RE2 - gun shop - sharp bilinear" src="https://github.com/user-attachments/assets/aa1840f1-bf7c-4fb7-ab3e-03e074fb3b1e" />|<img width="430" height="260" alt="RE2 - gun shop - hybrid bilinear" src="https://github.com/user-attachments/assets/9502a9c4-aa0b-41a3-8d38-e5194ca063fd" />|<img width="430" height="260" alt="RE2 - gun shop - smooth bilinear" src="https://github.com/user-attachments/assets/482c8321-bebb-40dd-95ed-88200da9e550" />|
|<img width="938" height="821" alt="1 - FF7 - mansion - bilinear sharp" src="https://github.com/user-attachments/assets/38f664f3-e44a-45b6-baed-e16d90dda51f" />|<img width="938" height="821" alt="2 - FF7 - mansion - bilinear hybrid" src="https://github.com/user-attachments/assets/e03f35b2-a535-4984-b8f2-3a585dd26416" />|<img width="938" height="821" alt="3 - FF7 - mansion - bilinear smooth" src="https://github.com/user-attachments/assets/aae6e86a-da09-45c6-95e9-5a97db5f863f" />|
