### PR TITLE
Qt: Show tooltip when adjusting icon/cover scale

### DIFF
--- a/src/duckstation-qt/gamelistwidget.cpp
+++ b/src/duckstation-qt/gamelistwidget.cpp
@@ -1373,13 +1373,8 @@ void GameListWidget::initialize(QAction* actionGameList, QAction* actionGameGrid
   m_ui.showGridTitles->setDefaultAction(actionGridShowTitles);
   m_ui.showLocalizedTitles->setDefaultAction(actionShowLocalizedTitles);
 
-  // Configure scale slider for hover events
-  m_ui.scale->setAttribute(Qt::WA_Hover, true);
-  m_ui.scale->installEventFilter(this);
-
   connect(m_ui.scale, &QSlider::sliderPressed, this, &GameListWidget::showScaleToolTip);
   connect(m_ui.scale, &QSlider::valueChanged, this, &GameListWidget::onScaleSliderChanged);
-
   connect(m_ui.filterType, &QComboBox::currentIndexChanged, this, [this](int index) {
     m_sort_model->setFilterType((index == 0) ? GameList::EntryType::MaxCount :
                                                static_cast<GameList::EntryType>(index - 1));
@@ -1726,34 +1721,13 @@ void GameListWidget::setViewMode(int stack_index)
   }
 }
 
-// Handles scale slider hover events
-bool GameListWidget::eventFilter(QObject* obj, QEvent* ev)
-{
-  if (obj != m_ui.scale)
-    return false;
-
-  switch (ev->type())
-  {
-    case QEvent::HoverEnter:
-      showScaleToolTip();
-      return true;
-    case QEvent::HoverLeave:
-      QToolTip::hideText();
-      return true;
-    default:
-      return false;
-  }
-}
-
 void GameListWidget::showScaleToolTip()
 {
   const int value = m_ui.scale->value();
   if (isShowingGameGrid())
-    QToolTip::showText(QCursor::pos(),
-                       QString("Cover scale: %1%").arg(static_cast<float>(value) / DEFAULT_COVER_SCALE, 0, 'f', 0));
+    QToolTip::showText(QCursor::pos(), tr("Cover scale: %1%").arg(value));
   else if (isShowingGameList())
-    QToolTip::showText(QCursor::pos(),
-                       QString("Icon size: %1%").arg((value * 100) / ICON_SIZE_STEP));
+    QToolTip::showText(QCursor::pos(), tr("Icon size: %1%").arg((value * 100) / ICON_SIZE_STEP));
 }
 
 void GameListWidget::onScaleSliderChanged(int value)
@@ -2044,6 +2018,16 @@ void GameListListView::adjustIconSize(int delta)
 {
   const int new_size = std::clamp(m_model->getIconSize() + delta, MIN_ICON_SIZE, MAX_ICON_SIZE);
   m_model->setIconSize(new_size);
+}
+
+void GameListListView::zoomIn()
+{
+  adjustIconSize(ICON_SIZE_STEP);
+}
+
+void GameListListView::zoomOut()
+{
+  adjustIconSize(-ICON_SIZE_STEP);
 }
 
 GameListGridView::GameListGridView(GameListModel* model, GameListSortModel* sort_model, QWidget* parent)

--- a/src/duckstation-qt/gamelistwidget.h
+++ b/src/duckstation-qt/gamelistwidget.h
@@ -177,6 +177,10 @@ public:
   void setFixedColumnWidth(const QFontMetrics& fm, int column, int str_width);
   void setAndSaveColumnHidden(int column, bool hidden);
 
+public Q_SLOTS:
+  void zoomOut();
+  void zoomIn();
+
 protected:
   void wheelEvent(QWheelEvent* e) override;
 
@@ -265,7 +269,6 @@ private Q_SLOTS:
   void onRefreshProgress(const QString& status, int current, int total, int entry_count, float time);
   void onRefreshComplete();
 
-  bool eventFilter(QObject* obj, QEvent* ev) override;
   void showScaleToolTip();
   void onScaleSliderChanged(int value);
   void onScaleChanged();

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -1455,15 +1455,25 @@ void MainWindow::onViewSystemDisplayTriggered()
   switchToEmulationView();
 }
 
-void MainWindow::onViewGameGridZoomInActionTriggered()
+void MainWindow::onViewZoomInActionTriggered()
 {
-  if (isShowingGameList())
+  if (!isShowingGameList())
+    return;
+
+  if (m_game_list_widget->isShowingGameList())
+    m_game_list_widget->getListView()->zoomIn();
+  else if (m_game_list_widget->isShowingGameGrid())
     m_game_list_widget->getGridView()->zoomIn();
 }
 
-void MainWindow::onViewGameGridZoomOutActionTriggered()
+void MainWindow::onViewZoomOutActionTriggered()
 {
-  if (isShowingGameList())
+  if (!isShowingGameList())
+    return;
+
+  if (m_game_list_widget->isShowingGameList())
+    m_game_list_widget->getListView()->zoomOut();
+  else if (m_game_list_widget->isShowingGameGrid())
     m_game_list_widget->getGridView()->zoomOut();
 }
 
@@ -1826,10 +1836,10 @@ void MainWindow::setupAdditionalUi()
   m_shortcuts.game_list_search->setKeys(QKeySequence::keyBindings(QKeySequence::Find) +
                                         QKeySequence::keyBindings(QKeySequence::FindNext));
   connect(m_shortcuts.game_list_search, &QShortcut::activated, m_game_list_widget, &GameListWidget::focusSearchWidget);
-  m_shortcuts.game_grid_zoom_in =
-    new QShortcut(QKeySequence::ZoomIn, this, this, &MainWindow::onViewGameGridZoomInActionTriggered);
-  m_shortcuts.game_grid_zoom_out =
-    new QShortcut(QKeySequence::ZoomOut, this, this, &MainWindow::onViewGameGridZoomOutActionTriggered);
+  m_shortcuts.game_list_zoom_in =
+    new QShortcut(QKeySequence::ZoomIn, this, this, &MainWindow::onViewZoomInActionTriggered);
+  m_shortcuts.game_list_zoom_out =
+    new QShortcut(QKeySequence::ZoomOut, this, this, &MainWindow::onViewZoomOutActionTriggered);
 
   s_disable_window_rounded_corners = Host::GetBaseBoolSettingValue("Main", "DisableWindowRoundedCorners", false);
   if (s_disable_window_rounded_corners)
@@ -2096,8 +2106,8 @@ void MainWindow::updateShortcutActions(bool starting)
   m_shortcuts.open_file->setEnabled(!starting_or_running);
   m_shortcuts.game_list_refresh->setEnabled(is_showing_game_list);
   m_shortcuts.game_list_search->setEnabled(is_showing_game_list);
-  m_shortcuts.game_grid_zoom_in->setEnabled(is_showing_game_list);
-  m_shortcuts.game_grid_zoom_out->setEnabled(is_showing_game_list);
+  m_shortcuts.game_list_zoom_in->setEnabled(is_showing_game_list);
+  m_shortcuts.game_list_zoom_out->setEnabled(is_showing_game_list);
 }
 
 void MainWindow::updateStatusBarWidgetVisibility()
@@ -2368,8 +2378,8 @@ void MainWindow::connectSignals()
           &GameListWidget::setShowLocalizedTitles);
   connect(m_ui.actionShowGameIcons, &QAction::triggered, m_game_list_widget, &GameListWidget::setShowGameIcons);
   connect(m_ui.actionGridViewShowTitles, &QAction::triggered, m_game_list_widget, &GameListWidget::setShowCoverTitles);
-  connect(m_ui.actionGridViewZoomIn, &QAction::triggered, this, &MainWindow::onViewGameGridZoomInActionTriggered);
-  connect(m_ui.actionGridViewZoomOut, &QAction::triggered, this, &MainWindow::onViewGameGridZoomOutActionTriggered);
+  connect(m_ui.actionViewZoomIn, &QAction::triggered, this, &MainWindow::onViewZoomInActionTriggered);
+  connect(m_ui.actionViewZoomOut, &QAction::triggered, this, &MainWindow::onViewZoomOutActionTriggered);
   connect(m_ui.actionGridViewRefreshCovers, &QAction::triggered, m_game_list_widget,
           &GameListWidget::refreshGridCovers);
   connect(m_ui.actionViewRefreshAchievementProgress, &QAction::triggered, g_emu_thread,

--- a/src/duckstation-qt/mainwindow.h
+++ b/src/duckstation-qt/mainwindow.h
@@ -198,8 +198,8 @@ private Q_SLOTS:
   void onViewGameListActionTriggered();
   void onViewGameGridActionTriggered();
   void onViewSystemDisplayTriggered();
-  void onViewGameGridZoomInActionTriggered();
-  void onViewGameGridZoomOutActionTriggered();
+  void onViewZoomInActionTriggered();
+  void onViewZoomOutActionTriggered();
   void onGitHubRepositoryActionTriggered();
   void onIssueTrackerActionTriggered();
   void onDiscordServerActionTriggered();
@@ -328,8 +328,8 @@ private:
     QShortcut* open_file = nullptr;
     QShortcut* game_list_refresh = nullptr;
     QShortcut* game_list_search = nullptr;
-    QShortcut* game_grid_zoom_in = nullptr;
-    QShortcut* game_grid_zoom_out = nullptr;
+    QShortcut* game_list_zoom_in = nullptr;
+    QShortcut* game_list_zoom_out = nullptr;
   } m_shortcuts;
 
   SettingsWindow* m_settings_window = nullptr;

--- a/src/duckstation-qt/mainwindow.ui
+++ b/src/duckstation-qt/mainwindow.ui
@@ -215,8 +215,8 @@
     <addaction name="actionShowLocalizedTitles"/>
     <addaction name="actionShowGameIcons"/>
     <addaction name="actionGridViewShowTitles"/>
-    <addaction name="actionGridViewZoomIn"/>
-    <addaction name="actionGridViewZoomOut"/>
+    <addaction name="actionViewZoomIn"/>
+    <addaction name="actionViewZoomOut"/>
     <addaction name="actionGridViewRefreshCovers"/>
     <addaction name="actionViewRefreshAchievementProgress"/>
     <addaction name="separator"/>
@@ -874,14 +874,14 @@
     <string>Show Titles</string>
    </property>
   </action>
-  <action name="actionGridViewZoomIn">
+  <action name="actionViewZoomIn">
    <property name="text">
-    <string>Zoom &amp;In (Grid View)</string>
+    <string>Zoom &amp;In</string>
    </property>
   </action>
-  <action name="actionGridViewZoomOut">
+  <action name="actionViewZoomOut">
    <property name="text">
-    <string>Zoom &amp;Out (Grid View)</string>
+    <string>Zoom &amp;Out</string>
    </property>
   </action>
   <action name="actionGridViewRefreshCovers">


### PR DESCRIPTION
Display a tooltip with the current size when adjusting the scale slider for icons or covers.


https://github.com/user-attachments/assets/ae15548b-82ad-42d2-a512-8bf1fdc02400

