### PR TITLE
Qt: View menu improvements

### DIFF
--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -529,26 +529,28 @@ void MainWindow::updateDisplayRelatedActions(bool has_surface, bool fullscreen)
   m_ui.actionFullscreen->setEnabled(has_surface && !s_system_starting);
   m_ui.actionFullscreen->setChecked(fullscreen);
 
-  updateGameListRelatedActions(has_surface);
+  updateGameListRelatedActions();
 }
 
-void MainWindow::updateGameListRelatedActions(bool running)
+void MainWindow::updateGameListRelatedActions()
 {
-  bool game_grid = m_game_list_widget->isShowingGameGrid();
-  bool game_list = m_game_list_widget->isShowingGameList();
-  bool has_background = Host::GetBaseStringSettingValue("UI", "GameListBackgroundPath") != "";
-  bool starting_or_running = (s_system_starting || running);
+  const bool running = !isShowingGameList();
+  const bool disable = (s_system_starting || (running && isRenderingToMain()));
 
-  m_ui.menuSortBy->setDisabled(starting_or_running);
-  m_ui.actionMergeDiscSets->setDisabled(starting_or_running);
-  m_ui.actionShowLocalizedTitles->setDisabled(starting_or_running);
-  m_ui.actionShowGameIcons->setDisabled(starting_or_running || !game_list);
-  m_ui.actionGridViewShowTitles->setDisabled(starting_or_running || !game_grid);
-  m_ui.actionViewZoomIn->setDisabled(starting_or_running);
-  m_ui.actionViewZoomOut->setDisabled(starting_or_running);
-  m_ui.actionGridViewRefreshCovers->setDisabled(starting_or_running || !game_grid);
-  m_ui.actionChangeGameListBackground->setDisabled(starting_or_running);
-  m_ui.actionClearGameListBackground->setDisabled(starting_or_running || !has_background);
+  const bool game_grid = m_game_list_widget->isShowingGameGrid();
+  const bool game_list = m_game_list_widget->isShowingGameList();
+  const bool has_background = Host::GetBaseStringSettingValue("UI", "GameListBackgroundPath") != "";
+
+  m_ui.menuSortBy->setDisabled(disable);
+  m_ui.actionMergeDiscSets->setDisabled(disable);
+  m_ui.actionShowLocalizedTitles->setDisabled(disable);
+  m_ui.actionShowGameIcons->setDisabled(disable || !game_list);
+  m_ui.actionGridViewShowTitles->setDisabled(disable || !game_grid);
+  m_ui.actionViewZoomIn->setDisabled(disable);
+  m_ui.actionViewZoomOut->setDisabled(disable);
+  m_ui.actionGridViewRefreshCovers->setDisabled(disable || !game_grid);
+  m_ui.actionChangeGameListBackground->setDisabled(disable);
+  m_ui.actionClearGameListBackground->setDisabled(disable || !has_background);
 }
 
 void MainWindow::focusDisplayWidget()
@@ -1462,14 +1464,14 @@ void MainWindow::onViewStatusBarActionToggled(bool checked)
 void MainWindow::onViewGameListActionTriggered()
 {
   m_game_list_widget->showGameList();
-  updateGameListRelatedActions(false);
+  updateGameListRelatedActions();
   switchToGameListView();
 }
 
 void MainWindow::onViewGameGridActionTriggered()
 {
   m_game_list_widget->showGameGrid();
-  updateGameListRelatedActions(false);
+  updateGameListRelatedActions();
   switchToGameListView();
 }
 

--- a/src/duckstation-qt/mainwindow.cpp
+++ b/src/duckstation-qt/mainwindow.cpp
@@ -528,6 +528,26 @@ void MainWindow::updateDisplayRelatedActions(bool has_surface, bool fullscreen)
   m_ui.menuWindowSize->setEnabled(s_system_valid && !s_system_starting && has_surface && !fullscreen);
   m_ui.actionFullscreen->setEnabled(has_surface && !s_system_starting);
   m_ui.actionFullscreen->setChecked(fullscreen);
+
+  updateGameListRelatedActions(has_surface);
+}
+
+void MainWindow::updateGameListRelatedActions(bool running)
+{
+  bool game_grid = m_game_list_widget->isShowingGameGrid();
+  bool game_list = m_game_list_widget->isShowingGameList();
+  bool has_background = Host::GetBaseStringSettingValue("UI", "GameListBackgroundPath") != "";
+  bool starting_or_running = (s_system_starting || running);
+
+  m_ui.actionMergeDiscSets->setDisabled(starting_or_running);
+  m_ui.actionShowLocalizedTitles->setDisabled(starting_or_running);
+  m_ui.actionShowGameIcons->setDisabled(starting_or_running || !game_list);
+  m_ui.actionGridViewShowTitles->setDisabled(starting_or_running || !game_grid);
+  m_ui.actionViewZoomIn->setDisabled(starting_or_running);
+  m_ui.actionViewZoomOut->setDisabled(starting_or_running);
+  m_ui.actionGridViewRefreshCovers->setDisabled(starting_or_running || !game_grid);
+  m_ui.actionChangeGameListBackground->setDisabled(starting_or_running);
+  m_ui.actionClearGameListBackground->setDisabled(starting_or_running || !has_background);
 }
 
 void MainWindow::focusDisplayWidget()
@@ -1441,12 +1461,14 @@ void MainWindow::onViewStatusBarActionToggled(bool checked)
 void MainWindow::onViewGameListActionTriggered()
 {
   m_game_list_widget->showGameList();
+  updateGameListRelatedActions(false);
   switchToGameListView();
 }
 
 void MainWindow::onViewGameGridActionTriggered()
 {
   m_game_list_widget->showGameGrid();
+  updateGameListRelatedActions(false);
   switchToGameListView();
 }
 
@@ -2659,6 +2681,7 @@ void MainWindow::onViewChangeGameListBackgroundTriggered()
   Host::SetBaseStringSettingValue("UI", "GameListBackgroundPath", relative_path.c_str());
   Host::CommitBaseSettingChanges();
   m_game_list_widget->updateBackground(true);
+  m_ui.actionClearGameListBackground->setEnabled(true);
 }
 
 void MainWindow::onViewClearGameListBackgroundTriggered()
@@ -2666,6 +2689,7 @@ void MainWindow::onViewClearGameListBackgroundTriggered()
   Host::DeleteBaseSettingValue("UI", "GameListBackgroundPath");
   Host::CommitBaseSettingChanges();
   m_game_list_widget->updateBackground(true);
+  m_ui.actionClearGameListBackground->setEnabled(false);
 }
 
 void MainWindow::onSettingsTriggeredFromToolbar()

--- a/src/duckstation-qt/mainwindow.h
+++ b/src/duckstation-qt/mainwindow.h
@@ -274,7 +274,7 @@ private:
   void destroyDisplayWidget(bool show_game_list);
   void updateDisplayWidgetCursor();
   void updateDisplayRelatedActions(bool has_surface, bool fullscreen);
-  void updateGameListRelatedActions(bool running);
+  void updateGameListRelatedActions();
   void exitFullscreen(bool wait_for_completion);
 
   void doSettings(const char* category = nullptr);

--- a/src/duckstation-qt/mainwindow.h
+++ b/src/duckstation-qt/mainwindow.h
@@ -274,6 +274,7 @@ private:
   void destroyDisplayWidget(bool show_game_list);
   void updateDisplayWidgetCursor();
   void updateDisplayRelatedActions(bool has_surface, bool fullscreen);
+  void updateGameListRelatedActions(bool running);
   void exitFullscreen(bool wait_for_completion);
 
   void doSettings(const char* category = nullptr);

--- a/src/duckstation-qt/mainwindow.ui
+++ b/src/duckstation-qt/mainwindow.ui
@@ -37,6 +37,9 @@
     <property name="title">
      <string>&amp;System</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <widget class="QMenu" name="menuChangeDisc">
      <property name="title">
       <string>Change Disc</string>
@@ -93,6 +96,9 @@
     <property name="title">
      <string>S&amp;ettings</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <addaction name="actionViewGameProperties"/>
     <addaction name="separator"/>
     <addaction name="actionInterfaceSettings"/>
@@ -120,6 +126,9 @@
     <property name="title">
      <string>&amp;Help</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <addaction name="actionGitHubRepository"/>
     <addaction name="actionDiscordServer"/>
     <addaction name="separator"/>
@@ -132,6 +141,9 @@
    <widget class="QMenu" name="menuDebug">
     <property name="title">
      <string>&amp;Debug</string>
+    </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
     </property>
     <widget class="QMenu" name="menuRenderer">
      <property name="title">
@@ -192,6 +204,9 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <widget class="QMenu" name="menuWindowSize">
      <property name="title">
       <string>&amp;Window Size</string>
@@ -226,6 +241,9 @@
    <widget class="QMenu" name="menu_Tools">
     <property name="title">
      <string>&amp;Tools</string>
+    </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
     </property>
     <addaction name="actionOpenDataDirectory"/>
     <addaction name="separator"/>

--- a/src/duckstation-qt/mainwindow.ui
+++ b/src/duckstation-qt/mainwindow.ui
@@ -212,6 +212,11 @@
       <string>&amp;Window Size</string>
      </property>
     </widget>
+    <widget class="QMenu" name="menuSortBy">
+     <property name="title">
+      <string>S&amp;ort By</string>
+     </property>
+    </widget>
     <addaction name="actionViewToolbar"/>
     <addaction name="actionViewLockToolbar"/>
     <addaction name="actionViewSmallToolbarIcons"/>
@@ -225,6 +230,8 @@
     <addaction name="separator"/>
     <addaction name="actionFullscreen"/>
     <addaction name="menuWindowSize"/>
+    <addaction name="separator"/>
+    <addaction name="menuSortBy"/>
     <addaction name="separator"/>
     <addaction name="actionMergeDiscSets"/>
     <addaction name="actionShowLocalizedTitles"/>

--- a/src/duckstation-qt/mainwindow.ui
+++ b/src/duckstation-qt/mainwindow.ui
@@ -37,9 +37,6 @@
     <property name="title">
      <string>&amp;System</string>
     </property>
-    <property name="toolTipsVisible">
-     <bool>true</bool>
-    </property>
     <widget class="QMenu" name="menuChangeDisc">
      <property name="title">
       <string>Change Disc</string>
@@ -96,9 +93,6 @@
     <property name="title">
      <string>S&amp;ettings</string>
     </property>
-    <property name="toolTipsVisible">
-     <bool>true</bool>
-    </property>
     <addaction name="actionViewGameProperties"/>
     <addaction name="separator"/>
     <addaction name="actionInterfaceSettings"/>
@@ -126,9 +120,6 @@
     <property name="title">
      <string>&amp;Help</string>
     </property>
-    <property name="toolTipsVisible">
-     <bool>true</bool>
-    </property>
     <addaction name="actionGitHubRepository"/>
     <addaction name="actionDiscordServer"/>
     <addaction name="separator"/>
@@ -141,9 +132,6 @@
    <widget class="QMenu" name="menuDebug">
     <property name="title">
      <string>&amp;Debug</string>
-    </property>
-    <property name="toolTipsVisible">
-     <bool>true</bool>
     </property>
     <widget class="QMenu" name="menuRenderer">
      <property name="title">
@@ -204,9 +192,6 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
-    <property name="toolTipsVisible">
-     <bool>true</bool>
-    </property>
     <widget class="QMenu" name="menuWindowSize">
      <property name="title">
       <string>&amp;Window Size</string>
@@ -248,9 +233,6 @@
    <widget class="QMenu" name="menu_Tools">
     <property name="title">
      <string>&amp;Tools</string>
-    </property>
-    <property name="toolTipsVisible">
-     <bool>true</bool>
     </property>
     <addaction name="actionOpenDataDirectory"/>
     <addaction name="separator"/>
@@ -754,6 +736,9 @@
     <string>Resume</string>
    </property>
    <property name="toolTip">
+    <string>Resumes the last save state created</string>
+   </property>
+   <property name="statusTip">
     <string>Resumes the last save state created</string>
    </property>
   </action>

--- a/src/duckstation-qt/mainwindow.ui
+++ b/src/duckstation-qt/mainwindow.ui
@@ -214,7 +214,7 @@
     </widget>
     <widget class="QMenu" name="menuSortBy">
      <property name="title">
-      <string>S&amp;ort By</string>
+      <string>Sort B&amp;y</string>
      </property>
     </widget>
     <addaction name="actionViewToolbar"/>
@@ -454,7 +454,7 @@
     <iconset theme="fullscreen-line"/>
    </property>
    <property name="text">
-    <string>Fullscreen</string>
+    <string>&amp;Fullscreen</string>
    </property>
   </action>
   <action name="actionResolution_Scale">
@@ -773,7 +773,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Lock Toolbar</string>
+    <string>Loc&amp;k Toolbar</string>
    </property>
   </action>
   <action name="actionViewSmallToolbarIcons">
@@ -781,7 +781,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Small Toolbar Icons</string>
+    <string>S&amp;mall Toolbar Icons</string>
    </property>
   </action>
   <action name="actionViewToolbarLabels">
@@ -789,7 +789,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Toolbar Labels</string>
+    <string>Toolbar L&amp;abels</string>
    </property>
   </action>
   <action name="actionViewToolbarLabelsBesideIcons">
@@ -797,7 +797,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Toolbar Labels Beside Icons</string>
+    <string>Toolbar Labels &amp;Beside Icons</string>
    </property>
   </action>
   <action name="actionViewStatusBar">
@@ -879,7 +879,7 @@
     <iconset theme="play-list-2-line"/>
    </property>
    <property name="text">
-    <string>Merge Multi-Disc Games</string>
+    <string>&amp;Merge Multi-Disc Games</string>
    </property>
   </action>
   <action name="actionGridViewShowTitles">
@@ -893,6 +893,9 @@
     <iconset theme="price-tag-3-line"/>
    </property>
    <property name="text">
+    <string>Show Titl&amp;es (Grid View)</string>
+   </property>
+   <property name="iconText">
     <string>Show Titles (Grid View)</string>
    </property>
    <property name="toolTip">
@@ -900,11 +903,17 @@
    </property>
   </action>
   <action name="actionViewZoomIn">
+   <property name="icon">
+    <iconset theme="zoom-in"/>
+   </property>
    <property name="text">
     <string>Zoom &amp;In</string>
    </property>
   </action>
   <action name="actionViewZoomOut">
+   <property name="icon">
+    <iconset theme="zoom-out"/>
+   </property>
    <property name="text">
     <string>Zoom &amp;Out</string>
    </property>
@@ -969,7 +978,7 @@
     <iconset theme="image-fill"/>
    </property>
    <property name="text">
-    <string>Show Game Icons (List View)</string>
+    <string>Show Game Ico&amp;ns (List View)</string>
    </property>
    <property name="toolTip">
     <string>Show Game Icons</string>
@@ -1066,12 +1075,12 @@
   </action>
   <action name="actionChangeGameListBackground">
    <property name="text">
-    <string>Change List Background...</string>
+    <string>&amp;Change List Background...</string>
    </property>
   </action>
   <action name="actionClearGameListBackground">
    <property name="text">
-    <string>Clear List Background</string>
+    <string>Clea&amp;r List Background</string>
    </property>
   </action>
   <action name="actionViewRefreshAchievementProgress">
@@ -1090,7 +1099,7 @@
     <iconset theme="language"/>
    </property>
    <property name="text">
-    <string>Show Localized Titles</string>
+    <string>Show Locali&amp;zed Titles</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
- Enable/Disable View menu items according to state
  - Disable all Game List/Grid related options while System Display is active.
    Reenable when switching back to List/Grid.
  - Disable Game List/Grid exclusive options when switching to the opposite view;
  - Disable "Clear List Background" when a background is not set;
  - Enable ~~tooltips~~ statustips for menu items;
- Added "View > Sort By" menu
  - Allows sorting by any column even when hidden
  - Allows sorting in grid view
- Added icons and mnemonics in View menu
  - Icons for Zoom In and Zoom Out
  - Adjusted and added missing mnemonics
- Keep Game List/Grid view options enabled if rendering to separate window

<img width="918" height="748" alt="image" src="https://github.com/user-attachments/assets/481dfd33-b384-4af5-8ce4-389f427c8c01" />

<img width="918" height="783" alt="image" src="https://github.com/user-attachments/assets/34fe3806-5283-4500-a65c-1ee2c6fe0e16" />

<img width="918" height="748" alt="image" src="https://github.com/user-attachments/assets/079b9b30-afd8-4850-8e9e-b589b86c87c5" />