### PR TITLE
Use DualSense Mic Mute LED for Analog Mode

### DIFF
--- a/src/core/analog_controller.cpp
+++ b/src/core/analog_controller.cpp
@@ -29,7 +29,10 @@ AnalogController::AnalogController(u32 index) : Controller(index)
   m_rumble_config.fill(0xFF);
 }
 
-AnalogController::~AnalogController() = default;
+AnalogController::~AnalogController()
+{
+  InputManager::SetGamepadAnalogLED(m_index, false);
+}
 
 ControllerType AnalogController::GetType() const
 {
@@ -334,6 +337,8 @@ void AnalogController::SetAnalogMode(bool enabled, bool show_message)
     return;
 
   m_analog_mode = enabled;
+
+  InputManager::SetGamepadAnalogLED(m_index, enabled);
 
   INFO_LOG("Controller {} switched to {} mode.", m_index + 1u, m_analog_mode ? "analog" : "digital");
   if (show_message)

--- a/src/core/analog_joystick.cpp
+++ b/src/core/analog_joystick.cpp
@@ -6,6 +6,7 @@
 #include "system.h"
 
 #include "util/imgui_manager.h"
+#include "util/input_manager.h"
 #include "util/state_wrapper.h"
 
 #include "common/bitutils.h"
@@ -25,7 +26,10 @@ AnalogJoystick::AnalogJoystick(u32 index) : Controller(index)
   Reset();
 }
 
-AnalogJoystick::~AnalogJoystick() = default;
+AnalogJoystick::~AnalogJoystick()
+{
+  InputManager::SetGamepadAnalogLED(m_index, false);
+}
 
 ControllerType AnalogJoystick::GetType() const
 {
@@ -40,6 +44,7 @@ bool AnalogJoystick::InAnalogMode() const
 void AnalogJoystick::Reset()
 {
   m_transfer_state = TransferState::Idle;
+  InputManager::SetGamepadAnalogLED(m_index, m_analog_mode);
 }
 
 bool AnalogJoystick::DoState(StateWrapper& sw, bool apply_input_state)
@@ -239,6 +244,8 @@ u16 AnalogJoystick::GetID() const
 void AnalogJoystick::ToggleAnalogMode()
 {
   m_analog_mode = !m_analog_mode;
+
+  InputManager::SetGamepadAnalogLED(m_index, m_analog_mode);
 
   INFO_LOG("Joystick {} switched to {} mode.", m_index + 1u, m_analog_mode ? "analog" : "digital");
   Host::AddIconOSDMessage(

--- a/src/core/fullscreen_ui.cpp
+++ b/src/core/fullscreen_ui.cpp
@@ -4862,6 +4862,10 @@ void FullscreenUI::DrawControllerSettingsPage()
                     FSUI_VSTR("Enable/Disable the Player LED on DualSense controllers."), "InputSources",
                     "SDLPS5PlayerLED", false, bsi->GetBoolValue("InputSources", "SDLControllerEnhancedMode", true),
                     false);
+  DrawToggleSetting(bsi, FSUI_ICONVSTR(ICON_FA_LIGHTBULB, "SDL DualSense Mic Mute LED for Analog Mode"),
+                    FSUI_VSTR("Enable/Disable using the DualSense controller's Mic Mute LED to indicate when Analog Mode is active."), "InputSources",
+                    "SDLPS5MicMuteLEDForAnalogMode", false, bsi->GetBoolValue("InputSources", "SDLControllerEnhancedMode", true),
+                    false);
 #ifdef _WIN32
   DrawToggleSetting(bsi, FSUI_ICONVSTR(ICON_FA_GEAR, "Enable XInput Input Source"),
                     FSUI_VSTR("Support for controllers that use the XInput protocol. XInput should only be used if you "
@@ -9684,6 +9688,7 @@ TRANSLATE_NOOP("FullscreenUI", "Enable VRAM Write Replacement");
 TRANSLATE_NOOP("FullscreenUI", "Enable XInput Input Source");
 TRANSLATE_NOOP("FullscreenUI", "Enable debugging when supported by the host's renderer API. Only for developer use.");
 TRANSLATE_NOOP("FullscreenUI", "Enable/Disable the Player LED on DualSense controllers.");
+TRANSLATE_NOOP("FullscreenUI", "Enable/Disable using the DualSense controller's Mic Mute LED to indicate when Analog Mode is active.");
 TRANSLATE_NOOP("FullscreenUI", "Enables alignment and bus exceptions. Not needed for any known games.");
 TRANSLATE_NOOP("FullscreenUI", "Enables an additional 6MB of RAM to obtain a total of 2+6 = 8MB, usually present on dev consoles.");
 TRANSLATE_NOOP("FullscreenUI", "Enables an additional three controller slots on each port. Not supported in all games.");
@@ -9972,6 +9977,7 @@ TRANSLATE_NOOP("FullscreenUI", "Runahead");
 TRANSLATE_NOOP("FullscreenUI", "Runahead/Rewind");
 TRANSLATE_NOOP("FullscreenUI", "Runs the software renderer in parallel for VRAM readbacks. On some systems, this may result in greater performance when using graphical enhancements with the hardware renderer.");
 TRANSLATE_NOOP("FullscreenUI", "SDL DualSense Player LED");
+TRANSLATE_NOOP("FullscreenUI", "SDL DualSense Mic Mute LED for Analog Mode");
 TRANSLATE_NOOP("FullscreenUI", "SDL DualShock 4 / DualSense Enhanced Mode");
 TRANSLATE_NOOP("FullscreenUI", "Safe Mode");
 TRANSLATE_NOOP("FullscreenUI", "Save Controller Preset");

--- a/src/core/jogcon.cpp
+++ b/src/core/jogcon.cpp
@@ -24,17 +24,32 @@ JogCon::JogCon(u32 index) : Controller(index)
 {
 }
 
-JogCon::~JogCon() = default;
+JogCon::~JogCon()
+{
+  InputManager::SetGamepadAnalogLED(m_index, false);
+}
 
 ControllerType JogCon::GetType() const
 {
   return ControllerType::JogCon;
 }
 
+bool JogCon::InAnalogMode() const
+{
+  // JogCon uses JogCon mode
+  return InJogConMode();
+}
+
+bool JogCon::InJogConMode() const
+{
+  return m_jogcon_mode;
+}
+
 void JogCon::Reset()
 {
   // Reset starts in jogcon mode?
   m_jogcon_mode = true;
+  InputManager::SetGamepadAnalogLED(m_index, m_jogcon_mode);
   ResetTransferState();
   ResetMotorConfig();
 }
@@ -183,6 +198,8 @@ void JogCon::SetJogConMode(bool enabled, bool show_message)
 
   m_jogcon_mode = enabled;
   m_configuration_mode = enabled && m_configuration_mode;
+
+  InputManager::SetGamepadAnalogLED(m_index, enabled);
 
   INFO_LOG("Controller {} switched to {} mode.", m_index + 1u, m_jogcon_mode ? "JogCon" : "Digital");
   if (show_message)

--- a/src/core/jogcon.h
+++ b/src/core/jogcon.h
@@ -49,6 +49,8 @@ public:
   static std::unique_ptr<JogCon> Create(u32 index);
 
   ControllerType GetType() const override;
+  bool InAnalogMode() const override;
+  bool InJogConMode() const;
 
   void Reset() override;
   bool DoState(StateWrapper& sw, bool apply_input_state) override;

--- a/src/core/negcon.cpp
+++ b/src/core/negcon.cpp
@@ -5,6 +5,7 @@
 #include "host.h"
 #include "system.h"
 
+#include "util/input_manager.h"
 #include "util/state_wrapper.h"
 
 #include "common/assert.h"
@@ -26,16 +27,26 @@ NeGcon::NeGcon(u32 index) : Controller(index)
   m_axis_state[static_cast<u8>(Axis::Steering)] = 0x80;
 }
 
-NeGcon::~NeGcon() = default;
+NeGcon::~NeGcon()
+{
+  InputManager::SetGamepadAnalogLED(m_index, false);
+}
 
 ControllerType NeGcon::GetType() const
 {
   return ControllerType::NeGcon;
 }
 
+bool NeGcon::InAnalogMode() const
+{
+  // NeGcon is always analog
+  return true;
+}
+
 void NeGcon::Reset()
 {
   m_transfer_state = TransferState::Idle;
+  InputManager::SetGamepadAnalogLED(m_index, true);
 }
 
 bool NeGcon::DoState(StateWrapper& sw, bool apply_input_state)

--- a/src/core/negcon.h
+++ b/src/core/negcon.h
@@ -87,6 +87,7 @@ public:
   static std::unique_ptr<NeGcon> Create(u32 index);
 
   ControllerType GetType() const override;
+  bool InAnalogMode() const override;
 
   void Reset() override;
   bool DoState(StateWrapper& sw, bool apply_input_state) override;

--- a/src/core/negcon_rumble.cpp
+++ b/src/core/negcon_rumble.cpp
@@ -36,7 +36,10 @@ NeGconRumble::NeGconRumble(u32 index) : Controller(index)
   m_rumble_config.fill(0xFF);
 }
 
-NeGconRumble::~NeGconRumble() = default;
+NeGconRumble::~NeGconRumble()
+{
+  InputManager::SetGamepadAnalogLED(m_index, false);
+}
 
 ControllerType NeGconRumble::GetType() const
 {
@@ -234,6 +237,8 @@ void NeGconRumble::SetAnalogMode(bool enabled, bool show_message)
 {
   if (m_analog_mode == enabled)
     return;
+
+  InputManager::SetGamepadAnalogLED(m_index, enabled);
 
   INFO_LOG("Controller {} switched to {} mode.", m_index + 1u, m_analog_mode ? "analog" : "digital");
   if (show_message)

--- a/src/duckstation-qt/controllerglobalsettingswidget.cpp
+++ b/src/duckstation-qt/controllerglobalsettingswidget.cpp
@@ -29,6 +29,8 @@ ControllerGlobalSettingsWidget::ControllerGlobalSettingsWidget(QWidget* parent, 
                                                               "SDLTouchpadAsPointer", false);
   ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.enableSDLPS5PlayerLED, "InputSources",
                                                               "SDLPS5PlayerLED", false);
+  ControllerSettingWidgetBinder::BindWidgetToInputProfileBool(sif, m_ui.enableSDLPS5MicMuteLEDForAnalogMode, "InputSources",
+                                                              "SDLPS5MicMuteLEDForAnalogMode", false);
   connect(m_ui.enableSDLSource, &QCheckBox::checkStateChanged, this,
           &ControllerGlobalSettingsWidget::updateSDLOptionsEnabled);
   connect(m_ui.ledSettings, &QToolButton::clicked, this, &ControllerGlobalSettingsWidget::ledSettingsClicked);
@@ -120,6 +122,8 @@ void ControllerGlobalSettingsWidget::updateSDLOptionsEnabled()
     m_ui.enableTouchPadAsPointer->setEnabled(enabled);
   if (m_ui.enableSDLPS5PlayerLED)
     m_ui.enableSDLPS5PlayerLED->setEnabled(enabled);
+  if (m_ui.enableSDLPS5MicMuteLEDForAnalogMode)
+    m_ui.enableSDLPS5MicMuteLEDForAnalogMode->setEnabled(enabled);
   if (m_ui.ledSettings)
     m_ui.ledSettings->setEnabled(enabled);
 }

--- a/src/duckstation-qt/controllerglobalsettingswidget.ui
+++ b/src/duckstation-qt/controllerglobalsettingswidget.ui
@@ -109,6 +109,13 @@
       <string>SDL Input Source</string>
      </property>
      <layout class="QGridLayout" name="sdlGridLayout">
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="enableSDLPS5MicMuteLEDForAnalogMode">
+        <property name="text">
+         <string>Use DualSense Mic Mute LED for Analog Mode</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>

--- a/src/util/input_manager.h
+++ b/src/util/input_manager.h
@@ -339,6 +339,9 @@ void RemoveHook();
 /// Returns true if there is an interception hook present.
 bool HasHook();
 
+void SetGamepadAnalogLED(u32 player_index, bool enabled);
+void SyncInputDeviceAnalogLEDOnConnection(std::string_view identifier);
+
 /// Internal method used by pads to dispatch vibration updates to input sources.
 /// Intensity is normalized from 0 to 1.
 void SetPadVibrationIntensity(u32 pad_index, float large_or_single_motor_intensity, float small_motor_intensity);

--- a/src/util/sdl_input_source.h
+++ b/src/util/sdl_input_source.h
@@ -52,6 +52,9 @@ public:
   static u32 GetRGBForPlayerId(const SettingsInterface& si, u32 player_id);
   static u32 ParseRGBForPlayerId(std::string_view str, u32 player_id);
 
+  static bool isPS5Controller(SDL_Gamepad* gp);
+  static void EnablePS5MicMuteLED(SDL_Gamepad* gp, bool enabled);
+
   static std::span<const SettingInfo> GetAdvancedSettingsInfo();
 
   static bool IsHandledInputEvent(const SDL_Event* ev);
@@ -117,6 +120,7 @@ private:
     {
       bool m_controller_enhanced_mode : 1;
       bool m_controller_ps5_player_led : 1;
+      bool m_controller_ps5_mic_mute_led_for_analog_mode : 1;
 
       bool m_joystick_xbox_hidapi : 1;
 


### PR DESCRIPTION
Provide an option to use the Mic Mute LED present in the DualSense and DualSense Edge controllers as an Analog Mode indicator similar to the Analog Mode LED on the DualAnalog/DualShock controllers.

<img width="877" height="162" alt="image" src="https://github.com/user-attachments/assets/bcf4719b-21f1-4c48-9853-565e8b2a7fba" />


|<img width="400" alt="image" src="https://static0.makeuseofimages.com/wordpress/wp-content/uploads/2021/02/PS5-Controller-Muted-Mic.jpg?q=50&fit=crop&w=825&dpr=1.5">|<img width="400" alt="image" src="https://www.the-nextlevel.com/features/hardware/dual-analog-pad/dual-analog-shock-lights.jpg">|
|-|-|