### PR TITLE
[CI] : Add Mini builds for x64 and x64 SSE2

### DIFF
--- a/.github/workflows/linux-appimage-build.yml
+++ b/.github/workflows/linux-appimage-build.yml
@@ -19,10 +19,17 @@ jobs:
             asset: "DuckStation-x64.AppImage"
             artifact: "linux-x64-appimage"
             cmakeoptions: ""
+            packagescript: "scripts/appimage/make-appimage.sh"
           - name: "x64 SSE2"
             asset: "DuckStation-x64-SSE2.AppImage"
             artifact: "linux-x64-sse2-appimage"
             cmakeoptions: "-DDISABLE_SSE4=ON"
+            packagescript: "scripts/appimage/make-appimage.sh"
+          - name: "x64 Mini"
+            asset: "DuckStation-Mini-x64.AppImage"
+            artifact: "linux-x64-mini-appimage"
+            cmakeoptions: "-DBUILD_QT_FRONTEND=OFF -DBUILD_MINI_FRONTEND=ON"
+            packagescript: "scripts/appimage/make-appimage-mini.sh"
     steps:
     - uses: actions/checkout@v6
       with:
@@ -68,7 +75,7 @@ jobs:
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmakeoptions }} -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_C_COMPILER=clang-19 -DCMAKE_CXX_COMPILER=clang++-19 -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" ..
         cmake --build . --parallel
         cd ..
-        scripts/appimage/make-appimage.sh $(realpath .) $(realpath ./build) "${{ matrix.asset }}"
+        ${{ matrix.packagescript }} $(realpath .) $(realpath ./build) "${{ matrix.asset }}"
 
     - name: Upload AppImage
       uses: actions/upload-artifact@v6

--- a/.github/workflows/linux-appimage-build.yml
+++ b/.github/workflows/linux-appimage-build.yml
@@ -30,6 +30,11 @@ jobs:
             artifact: "linux-x64-mini-appimage"
             cmakeoptions: "-DBUILD_QT_FRONTEND=OFF -DBUILD_MINI_FRONTEND=ON"
             packagescript: "scripts/appimage/make-appimage-mini.sh"
+          - name: "x64 Mini SSE2"
+            asset: "DuckStation-Mini-x64-SSE2.AppImage"
+            artifact: "linux-x64-mini-sse2-appimage"
+            cmakeoptions: "-DBUILD_QT_FRONTEND=OFF -DBUILD_MINI_FRONTEND=ON -DDISABLE_SSE4=ON"
+            packagescript: "scripts/appimage/make-appimage-mini.sh"
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
             ./artifacts/DuckStation-x64.AppImage
             ./artifacts/DuckStation-x64-SSE2.AppImage
             ./artifacts/DuckStation-Mini-x64.AppImage
+            ./artifacts/DuckStation-Mini-x64-SSE2.AppImage
             ./artifacts/DuckStation-arm64.AppImage
             ./artifacts/DuckStation-Mini-arm64.AppImage
             ./artifacts/DuckStation-armhf.AppImage
@@ -98,6 +99,7 @@ jobs:
             ./artifacts/DuckStation-x64.AppImage
             ./artifacts/DuckStation-x64-SSE2.AppImage
             ./artifacts/DuckStation-Mini-x64.AppImage
+            ./artifacts/DuckStation-Mini-x64-SSE2.AppImage
             ./artifacts/DuckStation-arm64.AppImage
             ./artifacts/DuckStation-Mini-arm64.AppImage
             ./artifacts/DuckStation-armhf.AppImage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,7 @@ jobs:
             ./artifacts/duckstation-windows-arm64-release-symbols.zip
             ./artifacts/DuckStation-x64.AppImage
             ./artifacts/DuckStation-x64-SSE2.AppImage
+            ./artifacts/DuckStation-Mini-x64.AppImage
             ./artifacts/DuckStation-arm64.AppImage
             ./artifacts/DuckStation-Mini-arm64.AppImage
             ./artifacts/DuckStation-armhf.AppImage
@@ -96,6 +97,7 @@ jobs:
             ./artifacts/duckstation-windows-arm64-release-symbols.zip
             ./artifacts/DuckStation-x64.AppImage
             ./artifacts/DuckStation-x64-SSE2.AppImage
+            ./artifacts/DuckStation-Mini-x64.AppImage
             ./artifacts/DuckStation-arm64.AppImage
             ./artifacts/DuckStation-Mini-arm64.AppImage
             ./artifacts/DuckStation-armhf.AppImage

--- a/scripts/appimage/make-appimage-mini.sh
+++ b/scripts/appimage/make-appimage-mini.sh
@@ -34,24 +34,17 @@ STRIP=strip
 
 declare -a MANUAL_LIBS=(
 	"libz.so.1"
-	"libbacktrace.so.0"
-	"libcpuinfo.so"
+	"libavcodec.so.62"
+	"libavformat.so.62"
+	"libavutil.so.60"
+	"libswscale.so.9"
+	"libswresample.so.6"
 	"libdiscord-rpc.so"
 	"libfreetype.so.6"
 	"libharfbuzz.so"
-	"libjpeg.so.62"
-	"libplutosvg.so.0"
-	"libpng16.so.16"
 	"libSDL3.so.0"
 	"libshaderc_shared.so"
-	"libsharpyuv.so.0"
-	"libsoundtouch.so.2"
 	"libspirv-cross-c-shared.so.0"
-	"libwebp.so.7"
-	"libwebpdemux.so.2"
-	"libwebpmux.so.3"
-	"libzip.so.5"
-	"libzstd.so.1"
 )
 
 set -e

--- a/scripts/appimage/make-appimage-mini.sh
+++ b/scripts/appimage/make-appimage-mini.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2019-2025 Connor McLaughlin <stenzek@gmail.com>
+# SPDX-License-Identifier: CC-BY-NC-ND-4.0
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+
+function retry_command {
+  # Package servers tend to be unreliable at times..
+  # Retry a bunch of times.
+  local RETRIES=10
+
+  for i in $(seq 1 "$RETRIES"); do
+    "$@" && break
+    if [ "$i" == "$RETRIES" ]; then
+      echo "Command \"$@\" failed after ${RETRIES} retries."
+      exit 1
+    fi
+  done
+}
+
+if [ "$#" -ne 3 ]; then
+    echo "Syntax: $0 <path to duckstation directory> <path to build directory> <output name>"
+    exit 1
+fi
+
+ROOTDIR=$1
+BUILDDIR=$2
+ASSETNAME=$3
+
+BINARY=duckstation-mini
+APPDIRNAME=DuckStation-Mini.AppDir
+STRIP=strip
+
+declare -a MANUAL_LIBS=(
+	"libz.so.1"
+	"libbacktrace.so.0"
+	"libcpuinfo.so"
+	"libdiscord-rpc.so"
+	"libfreetype.so.6"
+	"libharfbuzz.so"
+	"libjpeg.so.62"
+	"libplutosvg.so.0"
+	"libpng16.so.16"
+	"libSDL3.so.0"
+	"libshaderc_shared.so"
+	"libsharpyuv.so.0"
+	"libsoundtouch.so.2"
+	"libspirv-cross-c-shared.so.0"
+	"libwebp.so.7"
+	"libwebpdemux.so.2"
+	"libwebpmux.so.3"
+	"libzip.so.5"
+	"libzstd.so.1"
+)
+
+set -e
+
+DEPSDIR=$(realpath "$SCRIPTDIR/../../dep/prebuilt/linux-x64")
+LINUXDEPLOY=./linuxdeploy-x86_64
+APPIMAGETOOL=./appimagetool-x86_64
+APPIMAGERUNTIME=./runtime-x86_64
+PATCHELF=patchelf
+
+if [ ! -f "$LINUXDEPLOY" ]; then
+	retry_command wget -O "$LINUXDEPLOY" https://github.com/stenzek/duckstation-ext-qt-minimal/releases/download/linux/linuxdeploy-x86_64.AppImage
+	chmod +x "$LINUXDEPLOY"
+fi
+
+if [ ! -f "$APPIMAGETOOL" ]; then
+	retry_command wget -O "$APPIMAGETOOL" https://github.com/stenzek/duckstation-ext-qt-minimal/releases/download/linux/appimagetool-x86_64.AppImage
+	chmod +x "$APPIMAGETOOL"
+fi
+
+if [ ! -f "$APPIMAGERUNTIME" ]; then
+	retry_command wget -O "$APPIMAGERUNTIME" https://github.com/stenzek/type2-runtime/releases/download/continuous/runtime-x86_64
+fi
+
+OUTDIR=$(realpath "./$APPDIRNAME")
+rm -fr "$OUTDIR"
+
+echo "Locating extra libraries..."
+EXTRA_LIBS_ARGS=()
+for lib in "${MANUAL_LIBS[@]}"; do
+	srcpath=$(find "$DEPSDIR" -name "$lib")
+	if [ ! -f "$srcpath" ]; then
+		echo "Missing extra library $lib. Exiting."
+		exit 1
+	fi
+
+	echo "Found $lib at $srcpath."
+	EXTRA_LIBS_ARGS+=("--library=$srcpath")
+done
+
+# Why the nastyness? linuxdeploy strips our main binary, and there's no option to turn it off.
+# It also doesn't strip the Qt libs. We can't strip them after running linuxdeploy, because
+# patchelf corrupts the libraries (but they still work), but patchelf+strip makes them crash
+# on load. So, make a backup copy, strip the original (since that's where linuxdeploy finds
+# the libs to copy), then swap them back after we're done.
+
+rm -fr "$DEPSDIR.bak"
+cp -a "$DEPSDIR" "$DEPSDIR.bak"
+IFS="
+"
+for i in $(find "$DEPSDIR" -iname '*.so'); do
+  echo "Stripping deps library ${i}"
+  strip "$i"
+done
+
+echo "Running linuxdeploy to create AppDir..."
+NO_STRIP="1" \
+$LINUXDEPLOY --appdir="$OUTDIR" --executable="$BUILDDIR/bin/duckstation-mini" ${EXTRA_LIBS_ARGS[@]} \
+--desktop-file="$ROOTDIR/scripts/appimage/org.duckstation.DuckStation.Mini.desktop" \
+--icon-file="$ROOTDIR/scripts/appimage/org.duckstation.DuckStation.png" \
+
+echo "Copying resources into AppDir..."
+cp -a "$BUILDDIR/bin/resources" "$OUTDIR/usr/bin"
+
+# Restore unstripped deps (for cache).
+rm -fr "$DEPSDIR"
+mv "$DEPSDIR.bak" "$DEPSDIR"
+
+# Copy translations.
+cp -a "$BUILDDIR/bin/translations" "$OUTDIR/usr/bin"
+
+# Generate AppStream meta-info.
+echo "Generating AppStream metainfo..."
+mkdir -p "$OUTDIR/usr/share/metainfo"
+"$SCRIPTDIR/generate-metainfo.sh" "$OUTDIR/usr/share/metainfo"
+
+echo "Generating AppImage..."
+rm -f "$ASSETNAME"
+"$APPIMAGETOOL" -v --runtime-file "$APPIMAGERUNTIME" "$OUTDIR" "$ASSETNAME"

--- a/scripts/appimage/make-appimage-mini.sh
+++ b/scripts/appimage/make-appimage-mini.sh
@@ -113,8 +113,10 @@ cp -a "$BUILDDIR/bin/resources" "$OUTDIR/usr/bin"
 rm -fr "$DEPSDIR"
 mv "$DEPSDIR.bak" "$DEPSDIR"
 
-# Copy translations.
-cp -a "$BUILDDIR/bin/translations" "$OUTDIR/usr/bin"
+# Copy translations if present (only built with Qt frontend).
+if [ -d "$BUILDDIR/bin/translations" ]; then
+	cp -a "$BUILDDIR/bin/translations" "$OUTDIR/usr/bin"
+fi
 
 # Generate AppStream meta-info.
 echo "Generating AppStream metainfo..."

--- a/scripts/appimage/org.duckstation.DuckStation.Mini.desktop
+++ b/scripts/appimage/org.duckstation.DuckStation.Mini.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=DuckStation
+GenericName=PlayStation 1 Emulator
+Comment=Fast PlayStation 1 emulator
+Icon=org.duckstation.DuckStation
+TryExec=duckstation-mini
+Exec=duckstation-mini %f
+Categories=Game;Emulator;


### PR DESCRIPTION
This PR adds support for building DuckStation-Mini to x86_64 and x86_64 SSE2 targets.