### PR TITLE
Add missing include file to ThirdParty/SmallVector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@
 deps-build/
 /deps/
 
-# vs stuff
+# IDE stuff:
+# Visual Studio
 .vs
 ipch
 ipch/*
@@ -21,6 +22,8 @@ ipch/*
 *.VC.opendb
 *.VC.db
 /.vscode/
+# CLion
+/.idea/
 
 # cmake stuff
 CMakeCache.txt

--- a/src/common/thirdparty/SmallVector.h
+++ b/src/common/thirdparty/SmallVector.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>


### PR DESCRIPTION
This fixes compilation of duckstation on fedora 44 with clang-22
If this compiles in the GH CI then it will be good to go.