### PR TITLE
GameDB: Various fixes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -81,6 +81,7 @@ The following people have contributed to the project in some way, and are credit
 - @Overload86
 - @landcaster
 - @Sekai9
+- @Pesa
 
 ## Special Thanks
 


### PR DESCRIPTION
* Adjust display active offsets for Aconcagua, Echo Night, Persona 2, and Shin Megami Tensei
* Add sort titles to Persona games
* Drop `ForcePGXPCPUMode` from Persona 2 bonus disc since it's just FMVs
* Fix release date of Echo Night 2 and Policenauts
* Normalize spelling of "From Software"