### PR TITLE
CI: Drop unused input

### DIFF
--- a/.github/workflows/linux-appimage-build.yml
+++ b/.github/workflows/linux-appimage-build.yml
@@ -17,11 +17,9 @@ jobs:
         include:
           - name: "x64"
             asset: "DuckStation-x64.AppImage"
-            artifact: "linux-x64-appimage"
             cmakeoptions: ""
           - name: "x64 SSE2"
             asset: "DuckStation-x64-SSE2.AppImage"
-            artifact: "linux-x64-sse2-appimage"
             cmakeoptions: "-DDISABLE_SSE4=ON"
     steps:
     - uses: actions/checkout@v6
@@ -74,7 +72,6 @@ jobs:
     - name: Upload AppImage
       uses: actions/upload-artifact@v7
       with:
-        name: "${{ matrix.artifact }}"
         path: "${{ matrix.asset }}"
         archive: false
         if-no-files-found: error

--- a/.github/workflows/linux-cross-appimage-build.yml
+++ b/.github/workflows/linux-cross-appimage-build.yml
@@ -93,10 +93,9 @@ jobs:
         cmake --build build --parallel
         scripts/appimage/make-cross-appimage.sh "${{ matrix.arch }}" "$(realpath build)" "/${{ matrix.arch }}-chroot"
 
-    - name: Upload AppImages
+    - name: Upload AppImage
       uses: actions/upload-artifact@v7
       with:
-        name: "linux-${{ matrix.arch }}-appimage"
         path: "DuckStation-${{ matrix.arch }}.AppImage"
         archive: false
         if-no-files-found: error

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -68,7 +68,6 @@ jobs:
     - name: Upload MacOS .app
       uses: actions/upload-artifact@v7
       with:
-        name: "macos"
         path: "build/duckstation-mac-release.zip"
         archive: false
         if-no-files-found: error

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -117,7 +117,6 @@ jobs:
     - name: Upload ${{ matrix.name }} Symbols Archive
       uses: actions/upload-artifact@v7
       with:
-        name: "windows-${{ matrix.arch }}"
         path: "duckstation-windows-${{ matrix.arch }}-release-symbols.7z"
         archive: false
         if-no-files-found: error
@@ -142,7 +141,6 @@ jobs:
     - name: Upload ${{ matrix.name }} Release Archive
       uses: actions/upload-artifact@v7
       with:
-        name: "windows-${{ matrix.arch }}"
         path: "${{ matrix.assetname }}"
         archive: false
         if-no-files-found: error
@@ -157,7 +155,6 @@ jobs:
     - name: Upload ${{ matrix.name }} Installer Archive
       uses: actions/upload-artifact@v7
       with:
-        name: "windows-${{ matrix.arch }}"
         path: "${{ matrix.installerassetname }}"
         archive: false
         if-no-files-found: error


### PR DESCRIPTION
actions/upload-artifact ignores the `name` input when using `archive: false`.