### PR TITLE
Qt: Fix overlapping widgets in game summary

### DIFF
--- a/src/duckstation-qt/gamesummarywidget.ui
+++ b/src/duckstation-qt/gamesummarywidget.ui
@@ -304,12 +304,6 @@
     <layout class="QHBoxLayout" name="verifyLayout" stretch="1,0">
      <item>
       <widget class="QLineEdit" name="revision">
-       <property name="minimumSize">
-        <size>
-         <width>300</width>
-         <height>0</height>
-        </size>
-       </property>
        <property name="readOnly">
         <bool>true</bool>
        </property>


### PR DESCRIPTION
I think we can remove `minimumSize` completely since QLineEdit uses the Expanding size policy by default and the parent layout will do the right thing.

Avoids the issue shown below:
<img width="1160" height="90" alt="overlap" src="https://github.com/user-attachments/assets/c86645cf-afc8-44ab-a21b-80dd4e3298f7" />
