### PR TITLE
Qt: Disable tab key navigation on game list

### DIFF
--- a/src/duckstation-qt/gamelistwidget.cpp
+++ b/src/duckstation-qt/gamelistwidget.cpp
@@ -2410,6 +2410,7 @@ GameListListView::GameListListView(GameListModel* model, GameListSortModel* sort
   setContextMenuPolicy(Qt::CustomContextMenu);
   setAlternatingRowColors(true);
   setShowGrid(false);
+  setTabKeyNavigation(false);
 
   QHeaderView* const horizontal_header = horizontalHeader();
   horizontal_header->setHighlightSections(false);

--- a/src/duckstation-qt/postprocessingsettingswidget.h
+++ b/src/duckstation-qt/postprocessingsettingswidget.h
@@ -9,7 +9,7 @@
 
 #include "util/postprocessing.h"
 
-#include <QtWidgets/QTableWidget>
+#include <QtWidgets/QTabWidget>
 #include <QtWidgets/QWidget>
 
 class SettingsWindow;

--- a/src/duckstation-qt/qtutils.cpp
+++ b/src/duckstation-qt/qtutils.cpp
@@ -288,7 +288,7 @@ void QtUtils::SetWindowResizeable(QWidget* widget, bool resizeable)
       // Min/max numbers come from uic.
       widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
       widget->setMinimumSize(1, 1);
-      widget->setMaximumSize(16777215, 16777215);
+      widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
     }
     else
     {


### PR DESCRIPTION
Tab key navigation makes sense for cell-oriented "spreadsheet-like" table views, hence QTableView enables it by default. However, the game list (in list mode) is a row-oriented interface (it even uses `SelectRows` as selection behavior), which makes the default tab key navigation behavior not only unnecessary but also confusing, especially when using themes that don't have any visual indication of the currently focused cell (e.g., macOS).

Note that no functionality is lost, as you can still navigate the table/list view with the arrow keys, which is arguably more intuitive.

As a nice side effect, keyboard navigation is now consistent between list view and grid view.