### PR TITLE
Qt: Fix keyboard navigation in game list after searching

### DIFF
--- a/src/duckstation-qt/gamelistwidget.cpp
+++ b/src/duckstation-qt/gamelistwidget.cpp
@@ -2165,8 +2165,7 @@ void GameListWidget::onSearchReturnPressed()
 
   QAbstractItemView* const target =
     isShowingGameGrid() ? static_cast<QAbstractItemView*>(m_grid_view) : static_cast<QAbstractItemView*>(m_list_view);
-  target->selectionModel()->select(m_sort_model->index(0, 0),
-                                   QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
+  target->setCurrentIndex(m_sort_model->index(0, 0));
   target->setFocus(Qt::ShortcutFocusReason);
 }
 


### PR DESCRIPTION
Keyboard navigation in a QAbstractItemView relies on the current index. `QItemSelectionModel::select()` changes the selection but not the current index. Thus, using the arrow keys to select the next row after searching could end up jumping to a random non-adjacent row instead, depending on the selection state of the view before searching.