### PR TITLE
Update qttranslations.inl

### DIFF
--- a/src/duckstation-qt/qttranslations.inl
+++ b/src/duckstation-qt/qttranslations.inl
@@ -5,7 +5,7 @@
 
 TRANSLATION_LIST_ENTRY("English", "en", "en-US", QLocale::English, QLocale::UnitedStates)
 TRANSLATION_LIST_ENTRY("Azərbaycanca", "az", "az-AZ", QLocale::Azerbaijani, QLocale::Azerbaijan)
-TRANSLATION_LIST_ENTRY("Español de Latinoamérica", "es", "es-ES", QLocale::Spanish, QLocale::LatinAmerica)
+TRANSLATION_LIST_ENTRY("Español de Hispanoamérica", "es", "es-ES", QLocale::Spanish, QLocale::LatinAmerica)
 TRANSLATION_LIST_ENTRY("Español de España", "es-ES", "es-ES", QLocale::Spanish, QLocale::Spain)
 TRANSLATION_LIST_ENTRY("Français", "fr", "fr-FR", QLocale::French, QLocale::France)
 TRANSLATION_LIST_ENTRY("Bahasa Indonesia", "id", "id-ID", QLocale::Indonesian, QLocale::Indonesia)


### PR DESCRIPTION
I changed the term Latinoamérica, which refers to the countries in the Americas whose language derives from Latin. Hispanoamérica is the correct term to refer to the countries that speak spanish.

https://es.wikipedia.org/wiki/Hispanoam%C3%A9rica