### PR TITLE
Qt: Use simpler text widgets in cover downloader and game summary

### DIFF
--- a/src/duckstation-qt/coverdownloadwindow.cpp
+++ b/src/duckstation-qt/coverdownloadwindow.cpp
@@ -25,7 +25,7 @@ CoverDownloadWindow::CoverDownloadWindow() : QWidget()
 
   connect(m_ui.start, &QPushButton::clicked, this, &CoverDownloadWindow::onStartClicked);
   connect(m_ui.close, &QPushButton::clicked, this, &CoverDownloadWindow::close);
-  connect(m_ui.urls, &QTextEdit::textChanged, this, &CoverDownloadWindow::updateEnabled);
+  connect(m_ui.urls, &QPlainTextEdit::textChanged, this, &CoverDownloadWindow::updateEnabled);
 
   const std::vector<std::string> urls = Core::GetBaseStringListSetting("UI", "CoverDownloaderURL");
   if (!urls.empty())

--- a/src/duckstation-qt/coverdownloadwindow.ui
+++ b/src/duckstation-qt/coverdownloadwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>720</width>
-    <height>506</height>
+    <height>551</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -59,7 +59,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTextEdit" name="urls"/>
+    <widget class="QPlainTextEdit" name="urls"/>
    </item>
    <item>
     <widget class="QLabel" name="label_2">

--- a/src/duckstation-qt/gamesummarywidget.cpp
+++ b/src/duckstation-qt/gamesummarywidget.cpp
@@ -27,7 +27,7 @@
 #include <QtCore/QSignalBlocker>
 #include <QtWidgets/QDialog>
 #include <QtWidgets/QDialogButtonBox>
-#include <QtWidgets/QTextBrowser>
+#include <QtWidgets/QTextEdit>
 
 #include "moc_gamesummarywidget.cpp"
 #include "ui_editgameserialdialog.h"
@@ -498,9 +498,10 @@ void GameSummaryWidget::onCompatibilityCommentsClicked()
 
   QVBoxLayout* layout = new QVBoxLayout(dlg);
 
-  QTextBrowser* tb = new QTextBrowser(dlg);
-  tb->setMarkdown(m_compatibility_comments);
-  layout->addWidget(tb, 1);
+  QTextEdit* text = new QTextEdit(dlg);
+  text->setMarkdown(m_compatibility_comments);
+  text->setReadOnly(true);
+  layout->addWidget(text, 1);
 
   QDialogButtonBox* bb = new QDialogButtonBox(QDialogButtonBox::Close, dlg);
   connect(bb, &QDialogButtonBox::rejected, dlg, &QDialog::accept);


### PR DESCRIPTION
We don't need (or want) rich text in the cover downloader, and we don't need the fancier/heavier QTextBrowser just to display markdown in the compatibility comments dialog.