### PR TITLE
MMPX :fix a transparent pixel bug & Adjusted floating-point tolerance

### DIFF
--- a/src/core/gpu_hw_shadergen.cpp
+++ b/src/core/gpu_hw_shadergen.cpp
@@ -836,10 +836,11 @@ void FilteredSampleFromVRAM(TEXPAGE_VALUE texpage, float2 coords, float4 uv_limi
   else if (texture_filter == GPUTextureFilter::MMPXEnhanced)
   {
     ss << R"(
+
 	#define srcf(xoffs,yoffs) \
 	  SampleFromVRAM(texpage, bcoords + float2(xoffs, yoffs), uv_limits) * \
-	  step(abs(bcoords.x + xoffs - clamp(bcoords.x + xoffs, uv_limits.x, uv_limits.z)), 0.001) * \
-	  step(abs(bcoords.y + yoffs - clamp(bcoords.y + yoffs, uv_limits.y, uv_limits.w)), 0.001)
+	  step(abs(bcoords.x + (xoffs) - clamp(bcoords.x + (xoffs), uv_limits.x, uv_limits.z)), 0.001) * \
+	  step(abs(bcoords.y + (yoffs) - clamp(bcoords.y + (yoffs), uv_limits.y, uv_limits.w)), 0.001)
 
 	#define src(xoffs,yoffs) packUnorm4x8(srcf(xoffs,yoffs))
 	)";
@@ -1051,10 +1052,11 @@ skiprest = skiprest||slope1||slope2||slope3||slope4||E==0u||B==0u||D==0u||F==0u|
   else if (texture_filter == GPUTextureFilter::MMPXAdvanced)
   {
     ss << R"(
+
 	#define srcf(xoffs,yoffs) \
 	  SampleFromVRAM(texpage, bcoords + float2(xoffs, yoffs), uv_limits) * \
-	  step(abs(bcoords.x + xoffs - clamp(bcoords.x + xoffs, uv_limits.x, uv_limits.z)), 0.001) * \
-	  step(abs(bcoords.y + yoffs - clamp(bcoords.y + yoffs, uv_limits.y, uv_limits.w)), 0.001)
+	  step(abs(bcoords.x + (xoffs) - clamp(bcoords.x + (xoffs), uv_limits.x, uv_limits.z)), 0.001) * \
+	  step(abs(bcoords.y + (yoffs) - clamp(bcoords.y + (yoffs), uv_limits.y, uv_limits.w)), 0.001)
 
 	#define src(xoffs,yoffs) packUnorm4x8(srcf(xoffs,yoffs))
 	)";
@@ -1342,8 +1344,6 @@ if (eq(E,A)) {
 		return mixXEoff;
 	}
 
-	if (E==0u && !Xisblack) return vX;
-
     eq_B_PC = eq(B,PC);
     eq_B_PA = eq(B,PA);
     eq_D_QG = eq(D,QG);
@@ -1353,6 +1353,7 @@ if (eq(E,A)) {
 	if ( comboE3 && comboA3 &&
 		(eq_B_PC || eq_D_QG) && eq_D_QA && eq_B_PA) {
 		mixFactor = mixFactor * (-0.618034) + 0.8541;
+		mixFactor = max(mixFactor, float(E==0u));	// xxx.alpha.duck
         return mixXEoff;
 	}
 
@@ -1362,6 +1363,7 @@ if (eq(E,A)) {
 		 && eq_E_H
 		) {
 		mixFactor = mixFactor * (-0.618034) + 0.8541;
+		mixFactor = max(mixFactor, float(E==0u));	// xxx.alpha.duck
         return mixXEoff;
 		}
 
@@ -1370,6 +1372,7 @@ if (eq(E,A)) {
 		 && eq_E_F
 		) {
 		mixFactor = mixFactor * (-0.618034) + 0.8541;
+		mixFactor = max(mixFactor, float(E==0u));	// xxx.alpha.duck
         return mixXEoff;
 		}
 
@@ -1413,13 +1416,15 @@ if (eq(E,A)) {
 
     En3 = eq_E_F && eq_E_H;
 
-	if ( scoreE<0.1 && mixFactor<0.1 && En4square && eq(E,S)==eq(E,SI) && eq(E,R)==eq(E,RI) ) return theEXIT;
+	if ( scoreE<0.01 && mixFactor<0.01 && En4square && eq(E,S)==eq(E,SI) && eq(E,R)==eq(E,RI) ) return theEXIT;
 
 
-	if ( scoreE<0.1 && !En3 && neq(E,I) ) {
+	if ( scoreE<0.01 && !En3 && neq(E,I) ) {
 		if ( B_wall && eq_E_F ) return theEXIT;
 		if ( D_wall && eq_E_H ) return theEXIT;
     }
+
+	if (E==0u && !Xisblack) return vX;	// xxx.alpha.duck
 
 	scoreE += float(B_slope && eq_A_P || D_slope && eq_A_Q);
 
@@ -1440,7 +1445,7 @@ if (eq(E,A)) {
 
 	if (eq(P,C)){
 		scoreB -= float(eq_A_AA);
-		scoreZ *= float(scoreE < 0.1);
+		scoreZ *= float(scoreE < 0.01);
 	}
 
 //*  D Zone
@@ -1451,15 +1456,15 @@ if (eq(E,A)) {
 
 	if (eq(G,Q)){
 		scoreD -= float(eq_A_AA);
-		scoreZ *= float(scoreE < 0.1);
+		scoreZ *= float(scoreE < 0.01);
 	}
 
     float scoreFinal = scoreE + scoreB + scoreD + scoreZ ;
 
-	scoreFinal += float(min(scoreB,scoreD) > -0.1 && (B_wall && D_tower || B_tower && D_wall)) *2.0;
+	scoreFinal += float(min(scoreB,scoreD) > -0.01 && (B_wall && D_tower || B_tower && D_wall)) *2.0;
 
-	mixFactor *= (1.0 - step(1.9, scoreFinal));
-	return mixXE + slopeBAD*(1.0 - step(0.9, scoreFinal));
+	mixFactor *= (1.0 - step(1.99, scoreFinal));
+	return mixXE + slopeBAD*(1.0 - step(0.99, scoreFinal));
 
 }	//* E == A
 
@@ -1531,7 +1536,7 @@ if (eq(E,A)) {
 
 	float E_lumDiff = mix(0.381966, 0.145898, max((El - 0.8541),0.0) * 6.8541);
 
-    if ( mixFactor<0.1 && !sim_EC && !sim_EG && neq(E,I) && abs(El-Fl)>E_lumDiff && abs(El-Hl)>E_lumDiff ) return slopeBAD;
+    if ( mixFactor<0.01 && !sim_EC && !sim_EG && neq(E,I) && abs(El-Fl)>E_lumDiff && abs(El-Hl)>E_lumDiff ) return slopeBAD;
 
 
 	eq_E_F = eq(E,F);
@@ -1556,7 +1561,7 @@ if (eq(E,A)) {
 
 	if ( En4square ) {
         if ( ( eq_B_C || eq_D_G) && eq_A_B) return theEXIT;
-        if ( ( eq_B_C || eq_D_G || mixFactor<0.1) && (eq(E,S) == eq(E, SI) && eq(E,R) == eq(E, RI)) ) return theEXIT;
+        if ( ( eq_B_C || eq_D_G || mixFactor<0.01) && (eq(E,S) == eq(E, SI) && eq(E,R) == eq(E, RI)) ) return theEXIT;
         return mixXEoff;
     }
 
@@ -1618,7 +1623,7 @@ float4 admixS( uint A, uint B, uint C, uint D, uint E, uint F, uint G, uint H, u
 
 	if ( sim_E_C && eq(E,D) && eq(B,C) ) return mixXE;
 
-	if ( (sim_E_C || mixFactor>0.1) && all_eq2(B,C,D) ) return mixXE;
+	if ( (sim_E_C || mixFactor>0.01) && all_eq2(B,C,D) ) return mixXE;
 
     return vE;
 }


### PR DESCRIPTION
Fixed a cross-case bug involving fully transparent pixels

Adjusted the floating-point tolerance from 0.1 to 0.01, purely to better telegraph

Enclose macro arguments in parentheses to ensure safe evaluation