### PR TITLE
GameDB: Add HASH for Beyond the Beyond

### DIFF
--- a/data/resources/gamedb.yaml
+++ b/data/resources/gamedb.yaml
@@ -15983,6 +15983,9 @@ SCPS-10014:
   saveName: "Beyond the Beyond - Harukanaru Kanaan he (Japan)"
   controllers:
     - DigitalController
+  codes:
+    - SCPS-10014
+    - HASH-F5755D7F8AF0C3DE
   metadata:
     publisher: "SONY Computer Entertainment America Inc"
     developer: "CAMELOT Software Planning"


### PR DESCRIPTION
Added the HASH for Beyond the Beyond to GameDB.