### PR TITLE
l10n: update Swedish Qt translation

### DIFF
--- a/src/duckstation-qt/translations/duckstation-qt_sv.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_sv.ts
@@ -4,52 +4,42 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../aboutdialog.cpp" line="56"/>
         <source>License</source>
         <translation>Licens</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.ui" line="14"/>
         <source>About DuckStation</source>
         <translation>Om DuckStation</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.ui" line="53"/>
         <source>DuckStation</source>
         <translation>DuckStation</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="36"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="50"/>
         <source>DuckStation is a free simulator/emulator of the Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt; console, focusing on playability, speed, and long-term maintainability.</source>
         <translation>DuckStation är en fri simulator/emulator för konsolen Sony Playstation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt;, med fokus på spelbarhet, hastighet och långtidsunderhåll.</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="53"/>
         <source>Authors</source>
         <translation>Upphovspersoner</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="55"/>
         <source>Icon by</source>
         <translation>Ikon av</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="68"/>
         <source>DuckStation Third-Party Notices</source>
         <translation>Tredjepartsinformation för DuckStation</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="83"/>
         <source>Missing thirdparty.html file. You should request it from where-ever you obtained DuckStation.</source>
         <translation>Saknar filen thirdparty.html. Du bör begära den från var du fick tag på DuckStation.</translation>
     </message>
     <message>
-        <location filename="../aboutdialog.cpp" line="54"/>
         <source>and other contributors</source>
         <translation>och andra bidragsgivare</translation>
     </message>
@@ -57,54 +47,44 @@
 <context>
     <name>AchievementLoginDialog</name>
     <message>
-        <location filename="../achievementlogindialog.ui" line="26"/>
         <source>RetroAchievements Login</source>
         <comment>Window title</comment>
         <translation>Inloggning för RetroAchievements</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.ui" line="92"/>
         <source>RetroAchievements Login</source>
         <comment>Header text</comment>
         <translation>Inloggning för RetroAchievements</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.ui" line="107"/>
         <source>Please enter your user name and password for retroachievements.org below. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
         <translation>Ange ditt användarnamn och lösenord för RetroAchievements.org nedan. Ditt lösenord kommer inte att sparas i DuckStation, däremot kommer ett access token att genereras och användas.</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.ui" line="32"/>
         <source>User Name:</source>
         <translation>Användarnamn:</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.ui" line="39"/>
         <source>Password:</source>
         <translation>Lösenord:</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.ui" line="46"/>
         <source>Ready...</source>
         <translation>Redo...</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="38"/>
         <source>&amp;Login</source>
         <translation>&amp;Logga in</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="51"/>
         <source>Logging in...</source>
         <translation>Loggar in...</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="86"/>
         <source>Login Error</source>
         <translation>Inloggningsfel</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="87"/>
         <source>Login failed.
 Error: %1
 
@@ -115,17 +95,14 @@ Fel: %1
 Kontrollera ditt användarnamn och lösenord. Försök igen.</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="88"/>
         <source>Login failed.</source>
         <translation>Inloggningen misslyckades.</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="112"/>
         <source>Enable Achievements</source>
         <translation>Aktivera prestationer</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="113"/>
         <source>Achievement tracking is not currently enabled. Your login will have no effect until after tracking is enabled.
 
 Do you want to enable tracking now?</source>
@@ -134,12 +111,10 @@ Do you want to enable tracking now?</source>
 Vill du aktivera kontrollen nu?</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="135"/>
         <source>Enable Hardcore Mode</source>
         <translation>Aktivera hardcore-läge</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="136"/>
         <source>Hardcore mode is not currently enabled. Enabling hardcore mode allows you to set times, scores, and participate in game-specific leaderboards.
 
 However, hardcore mode also prevents the usage of save states, cheats and slowdown functionality.
@@ -152,17 +127,14 @@ Dock förhindrar även Hardcore-läget att man kan spara tillstånd, använda fu
 Vill du aktivera hardcore-läget?</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="159"/>
         <source>Restart Game</source>
         <translation>Starta om spelet</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="160"/>
         <source>Hardcore mode will not be enabled until the game is restarted. Do you want to restart the game now?</source>
         <translation>Hardcore-läget aktiveras inte förrän spelet har startats om. Vill du starta om spelet nu?</translation>
     </message>
     <message>
-        <location filename="../achievementlogindialog.cpp" line="33"/>
         <source>&lt;strong&gt;Your RetroAchievements login token is no longer valid.&lt;/strong&gt; You must re-enter your credentials for achievements to be tracked. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
         <translation>&lt;strong&gt;Din inloggningstoken för RetroAchievements är inte giltig längre.&lt;/strong&gt; Du måste ange dina inloggningsuppgifter igen för att kontrollera prestationer. Ditt lösenord kommer inte att sparas i DuckStation, istället kommer en accesstoken att genereras och användas.</translation>
     </message>
@@ -170,156 +142,110 @@ Vill du aktivera hardcore-läget?</translation>
 <context>
     <name>AchievementSettingsWidget</name>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="120"/>
-        <location filename="../achievementsettingswidget.cpp" line="76"/>
         <source>Enable Achievements</source>
         <translation>Aktivera prestationer</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="127"/>
-        <location filename="../achievementsettingswidget.cpp" line="78"/>
         <source>Enable Hardcore Mode</source>
         <translation>Aktivera hardcore-läge</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="86"/>
         <source>Test Unofficial Achievements</source>
         <translation>Testa inofficiella prestationer</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="275"/>
-        <location filename="../achievementsettingswidget.cpp" line="97"/>
         <source>Enable Sound Effects</source>
         <translation>Aktivera ljudeffekter</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="165"/>
         <source>Notifications</source>
         <translation>Aviseringar</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="205"/>
-        <location filename="../achievementsettingswidget.ui" line="251"/>
         <source>5 seconds</source>
         <translation>5 sekunder</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="89"/>
         <source>Login...</source>
         <translation>Logga in...</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="78"/>
         <source>View Profile...</source>
         <translation>Visa profil...</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="67"/>
         <source>Register</source>
         <translation>Registrera</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="114"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="134"/>
-        <location filename="../achievementsettingswidget.cpp" line="83"/>
         <source>Enable Spectator Mode</source>
         <translation>Aktivera åskådarläget</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="141"/>
-        <location filename="../achievementsettingswidget.cpp" line="81"/>
         <source>Enable Encore Mode</source>
         <translation>Aktivera Encore-läget</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="148"/>
         <source>Track Unofficial Achievements</source>
         <translation>Spåra inofficiella prestationer</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="155"/>
-        <location filename="../achievementsettingswidget.cpp" line="99"/>
         <source>Prefetch Badges</source>
         <translation>Förhämta märken</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="171"/>
-        <location filename="../achievementsettingswidget.cpp" line="89"/>
         <source>Show Achievement Notifications</source>
         <translation>Visa aviseringar om prestationer</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="217"/>
-        <location filename="../achievementsettingswidget.cpp" line="92"/>
         <source>Show Leaderboard Notifications</source>
         <translation>Visa aviseringar om ledartavlor</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="370"/>
         <source>Indicator Size:</source>
         <translation>Indikatorstorlek:</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="76"/>
-        <location filename="../achievementsettingswidget.cpp" line="78"/>
-        <location filename="../achievementsettingswidget.cpp" line="81"/>
-        <location filename="../achievementsettingswidget.cpp" line="83"/>
-        <location filename="../achievementsettingswidget.cpp" line="86"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="77"/>
         <source>When enabled and logged in, DuckStation will scan for achievements on startup.</source>
         <translation>När aktiverat och inloggad kommer DuckStation att söka efter prestationer vid uppstart.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="79"/>
         <source>&quot;Challenge&quot; mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions.</source>
         <translation>&quot;Challenge&quot;-läget för prestationer, inklusive koll på ledartavlor. Inaktiverar sparat tillstånd, fusk och funktioner för sakta körning.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="89"/>
-        <location filename="../achievementsettingswidget.cpp" line="92"/>
-        <location filename="../achievementsettingswidget.cpp" line="94"/>
-        <location filename="../achievementsettingswidget.cpp" line="97"/>
-        <location filename="../achievementsettingswidget.cpp" line="99"/>
-        <location filename="../achievementsettingswidget.cpp" line="121"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="98"/>
         <source>Plays sound effects for events such as achievement unlocks and leaderboard submissions.</source>
         <translation>Spelar upp ljudeffekter för händelser såsom en prestation låses upp och insändningar till ledartavlor.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="84"/>
         <source>When enabled, DuckStation will assume all achievements are locked and not send any unlock notifications to the server.</source>
         <translation>När aktiverad kommer DuckStation att anta att alla prestationer är låsta och inte skicka några upplåsniingsaviseringar till servern.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="90"/>
         <source>Displays popup messages on events such as achievement unlocks and game completion.</source>
         <translation>Visar popupmeddelanden vid händelser såsom en prestation låses upp och spel färdigställs.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="93"/>
         <source>Displays popup messages when starting, submitting, or failing a leaderboard challenge.</source>
         <translation>Visar popupmeddelanden vid start, insändning eller misslyckanden av en ledartavleutmaning.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="82"/>
         <source>When enabled, each session will behave as if no achievements have been unlocked.</source>
         <translation>När aktiverat kommer varje session att bete sig som att ingen prestation har låsts upp.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../achievementsettingswidget.cpp" line="283"/>
-        <location filename="../achievementsettingswidget.cpp" line="290"/>
         <source>%n seconds</source>
         <translation>
             <numerusform>%n second</numerusform>
@@ -327,210 +253,162 @@ Vill du aktivera hardcore-läget?</translation>
         </translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="100"/>
         <source>Logout</source>
         <translation>Logga ut</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="326"/>
         <source>Not Logged In.</source>
         <translation>Inte inloggad.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="263"/>
-        <location filename="../achievementsettingswidget.cpp" line="94"/>
         <source>Show Leaderboard Trackers</source>
         <translation>Visa ledartavlor</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="304"/>
         <source>Notification Size:</source>
         <translation>Aviseringsstorlek:</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="316"/>
-        <location filename="../achievementsettingswidget.ui" line="382"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="334"/>
         <source>Progress Tracking</source>
         <translation>Framstegsspårning</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="340"/>
         <source>Challenge Indicators:</source>
         <translation>Utmaningsindikatorer:</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="110"/>
         <source>Challenge Indicators</source>
         <translation>Utmaningsindikatorer</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="110"/>
         <source>Show Notifications</source>
         <translation>Visa aviseringar</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="294"/>
         <source>Notification Location:</source>
         <translation>Aviseringsplats:</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="350"/>
         <source>Progress Indicators:</source>
         <translation>Förloppsindikatorer:</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.ui" line="360"/>
         <source>Indicator Location:</source>
         <translation>Indikatorplats:</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="74"/>
         <source>(Customize)</source>
         <translation>(Anpassa)</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="87"/>
         <source>When enabled, DuckStation will track unofficial achievements. Unlocks will be saved locally and not sent to RetroAchievements.</source>
         <translation>När detta är aktiverat spårar DuckStation inofficiella prestationer. Upplåsningar sparas lokalt och skickas inte till RetroAchievements.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="95"/>
         <source>Shows a timer in the selected location when leaderboard challenges are active.</source>
         <translation>Visar en timer på vald plats när ledartavlans-utmaningar är aktiva.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="100"/>
         <source>Downloads all locked achievement badges while starting the game. This will reduce delays in the images being shown when unlocking achievements.</source>
         <translation>Hämtar alla låsta prestationsmärken när spelet startas. Det minskar fördröjningen när bilder visas vid upplåsning av prestationer.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="102"/>
         <source>Notification Location</source>
         <translation>Aviseringsplats</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="102"/>
         <source>Top Left</source>
         <translation>Överst till vänster</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="103"/>
         <source>Selects the screen location for achievement and leaderboard notifications.</source>
         <translation>Väljer skärmplatsen för aviseringar om prestationer och ledartavlor.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="104"/>
         <source>Notification Size</source>
         <translation>Aviseringsstorlek</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="104"/>
-        <location filename="../achievementsettingswidget.cpp" line="115"/>
-        <location filename="../achievementsettingswidget.cpp" line="169"/>
-        <location filename="../achievementsettingswidget.cpp" line="172"/>
         <source>Automatic</source>
         <translation>Automatisk</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="105"/>
         <source>Determines the size of achievement notification popups. Automatic will use the same scaling as the Big Picture UI.</source>
         <translation>Bestämmer storleken på prestationsaviseringar. Automatiskt använder samma skalning som storbildsgränssnittet.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="107"/>
         <source>Custom Notification Scale</source>
         <translation>Anpassad aviseringsskala</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="107"/>
-        <location filename="../achievementsettingswidget.cpp" line="118"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="108"/>
         <source>Sets the custom scale percentage for achievement notifications.</source>
         <translation>Anger den anpassade skalningsprocenten för prestationsaviseringar.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="111"/>
         <source>Shows a notification or icons in the selected location when a challenge/primed achievement is active.</source>
         <translation>Visar en avisering eller ikoner på vald plats när en utmatning/förberedd prestation är aktiv.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="113"/>
         <source>Indicator Location</source>
         <translation>Indikatorplats</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="113"/>
         <source>Bottom Right</source>
         <translation>Nederst till höger</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="114"/>
         <source>Selects the screen location for challenge/progress indicators, and leaderboard trackers.</source>
         <translation>Väljer skärmplatsen för utmaning/framstegsindikatorer samt följa ledartavlan.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="115"/>
         <source>Indicator Size</source>
         <translation>Indikatorstorlek</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="116"/>
         <source>Determines the size of challenge/progress indicators. Automatic will use the same scaling as the Big Picture UI.</source>
         <translation>Bestämmer storleken på utmanings- och förloppsindikatorer. Automatiskt använder samma skalning som storbildsgränssnittet.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="118"/>
         <source>Custom Indicator Scale</source>
         <translation>Anpassad indikatorskala</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="119"/>
         <source>Sets the custom scale percentage for challenge/progress indicators.</source>
         <translation>Anger den anpassade skalningsprocenten för utmanings- och förloppsindikatorer.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="121"/>
         <source>Progress Indicators</source>
         <translation>Förloppsindikatorer</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="122"/>
         <source>Shows a popup in the selected location when progress towards a measured achievement changes.</source>
         <translation>Visar ett popup-fönster på vald plats när framstegen mot en uppmätt prestation förändras.</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="169"/>
-        <location filename="../achievementsettingswidget.cpp" line="173"/>
         <source>Use OSD Scale</source>
         <translation>Använd OSD-skala</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="169"/>
-        <location filename="../achievementsettingswidget.cpp" line="174"/>
         <source>Custom</source>
         <translation>Anpassad</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="272"/>
         <source>Restart Game</source>
         <translation>Starta om spelet</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="273"/>
         <source>Hardcore mode will not be enabled until the game is restarted. Do you want to restart the game now?</source>
         <translation>Hardcore-läget aktiveras inte förrän spelet har startats om. Vill du starta om spelet nu?</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="320"/>
         <source>Logged in as %1
 Token generated %2</source>
         <translation>Inloggad som: %1
@@ -540,243 +418,178 @@ Token genererades %2</translation>
 <context>
     <name>AdvancedSettingsWidget</name>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="79"/>
-        <location filename="../advancedsettingswidget.cpp" line="82"/>
-        <location filename="../advancedsettingswidget.cpp" line="99"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="29"/>
         <source>Logging</source>
         <translation>Loggning</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="35"/>
         <source>Log Level:</source>
         <translation>Loggnivå:</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="52"/>
         <source>Log Channels</source>
         <translation>Loggkanaler</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="65"/>
-        <location filename="../advancedsettingswidget.cpp" line="67"/>
         <source>Log To System Console</source>
         <translation>Logga till systemkonsol</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="79"/>
-        <location filename="../advancedsettingswidget.cpp" line="71"/>
         <source>Log To Window</source>
         <translation>Logga till fönster</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="112"/>
         <source>Interface Settings</source>
         <translation>Gränssnittsinställningar</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="125"/>
-        <location filename="../advancedsettingswidget.cpp" line="82"/>
         <source>Rich Presence Monitor</source>
         <translation>Rich Presence-övervakare</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="132"/>
         <source>Enable RAIntegration</source>
         <translation>Aktivera RAIntegration</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="142"/>
-        <location filename="../advancedsettingswidget.cpp" line="85"/>
         <source>Cache Directory</source>
         <translation>Cachekatalog</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="148"/>
         <source>Used for storing compiled shaders and game list data.</source>
         <translation>Används för att lagra kompilerade shaders och data för spellistan.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="158"/>
-        <location filename="../advancedsettingswidget.ui" line="210"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="169"/>
-        <location filename="../advancedsettingswidget.ui" line="221"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="180"/>
-        <location filename="../advancedsettingswidget.ui" line="232"/>
         <source>Reset</source>
         <translation>Återställ</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="194"/>
-        <location filename="../advancedsettingswidget.cpp" line="87"/>
         <source>Covers Directory</source>
         <translation>Omslagskatalog</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="200"/>
         <source>Used for storing covers in the game grid/Big Picture UIs.</source>
         <translation>Används för att lagra omslag i spelrutnätet/Storbildsläge.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="246"/>
         <source>Web Cache</source>
         <translation>Webbcache</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="259"/>
         <source>Refresh</source>
         <translation>Uppdatera</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="270"/>
         <source>Clear</source>
         <translation>Töm</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="72"/>
-        <location filename="../advancedsettingswidget.cpp" line="69"/>
         <source>Log To Debug Console</source>
         <translation>Logga till felsökningskonsol</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="86"/>
-        <location filename="../advancedsettingswidget.cpp" line="73"/>
         <source>Log To File</source>
         <translation>Logga till fil</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="118"/>
-        <location filename="../advancedsettingswidget.cpp" line="79"/>
         <source>Show Debug Menu</source>
         <translation>Visa felsökningsmeny</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="54"/>
         <source>Select Cache Directory</source>
         <translation>Välj cachekatalog</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="57"/>
         <source>Select Covers Directory</source>
         <translation>Välj omslagskatalog</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="65"/>
         <source>Log Level</source>
         <translation>Loggnivå</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="65"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="66"/>
         <source>Sets the verbosity of messages logged. Higher levels will log more messages.</source>
         <translation>Ställer in nivån av meddelanden som loggas. Högre nivåer kommer logga fler meddelanden.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="67"/>
-        <location filename="../advancedsettingswidget.cpp" line="69"/>
-        <location filename="../advancedsettingswidget.cpp" line="71"/>
-        <location filename="../advancedsettingswidget.cpp" line="73"/>
-        <location filename="../advancedsettingswidget.cpp" line="75"/>
-        <location filename="../advancedsettingswidget.cpp" line="77"/>
         <source>User Preference</source>
         <translation>Användarinställningar</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="68"/>
         <source>Logs messages to the console window.</source>
         <translation>Loggar meddelanden till konsollfönstret.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="70"/>
         <source>Logs messages to the debug console where supported.</source>
         <translation>Loggar meddelanden till felsökningskonsollen där det stöds.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="72"/>
         <source>Logs messages to the window.</source>
         <translation>Loggar meddelanden till fönstret.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="74"/>
         <source>Logs messages to duckstation.log in the user directory.</source>
         <translation>Loggar meddelanden till duckstation.log i användarkatalogen.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="80"/>
         <source>Shows a debug menu bar with additional statistics and quick settings.</source>
         <translation>Visar en felsökningsmenyrad med ytterligare statistik och snabbinställningar.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="83"/>
         <source>Always displays the current RetroAchievements rich presence string in the indicator area.</source>
         <translation>Visar alltid den aktuella RetroAchievements Rich Presence-strängen i indikatorområdet.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="85"/>
-        <location filename="../advancedsettingswidget.cpp" line="87"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="86"/>
         <source>Specifies the directory where compiled shaders and game list data will be stored.</source>
         <translation>Anger katalogen där kompilerade shaders och data för spellistan ska lagras.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="88"/>
         <source>Specifies the directory where game cover images that are used in the game grid and Big Picture UI will be stored.</source>
         <translation>Anger katalogen där spelomslag som används i spelrutnätet och storbildsgränssnittet ska lagras.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="99"/>
         <source>Enable RAIntegration (Development Only)</source>
         <translation>Aktivera RAIntegration (endast för utveckling)</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="100"/>
         <source>When enabled, DuckStation will load the RAIntegration DLL which allows for achievement development.&lt;br&gt;The RA_Integration.dll file must be placed in the same directory as the DuckStation executable.</source>
         <translation>När den är aktiverad läser DuckStation in RAIntegration DLL vilket möjliggör utveckling av prestationer.&lt;br&gt;Filen RA_Integration.dll måste placeras i samma katalog som DuckStations-körbara fil.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="143"/>
         <source>Current Cache Size: %1 MB (%2 MB in %3 objects)</source>
         <translation>Aktuell cachestorlek: %1 MB (%2 MB i %3 objekt)</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="93"/>
-        <location filename="../advancedsettingswidget.cpp" line="75"/>
         <source>Log Timestamps</source>
         <translation>Logga tidsstämplar</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.ui" line="100"/>
-        <location filename="../advancedsettingswidget.cpp" line="77"/>
         <source>Log File Timestamps</source>
         <translation>Tidsstämplar för loggfil</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="76"/>
         <source>Includes the elapsed time since the application start in window and console logs.</source>
         <translation>Inkluderar den tid som har förflutit sedan applikationen startade i fönster- och konsolloggar.</translation>
     </message>
     <message>
-        <location filename="../advancedsettingswidget.cpp" line="78"/>
         <source>Includes the elapsed time since the application start in file logs.</source>
         <translation>Inkluderar den tid som förflutit sedan programmet startades i filloggarna.</translation>
     </message>
@@ -784,397 +597,282 @@ Token genererades %2</translation>
 <context>
     <name>AudioSettingsWidget</name>
     <message>
-        <location filename="../audiosettingswidget.ui" line="162"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="229"/>
         <source>Buffer Size:</source>
         <translation>Buffertstorlek:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="168"/>
         <source>Backend:</source>
         <translation>Bakände:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="266"/>
-        <location filename="../audiosettingswidget.ui" line="320"/>
-        <location filename="../audiosettingswidget.ui" line="390"/>
-        <location filename="../audiosettingswidget.ui" line="446"/>
-        <location filename="../audiosettingswidget.ui" line="502"/>
         <source>0 ms</source>
         <translation>0 ms</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="29"/>
         <source>Controls</source>
         <translation>Kontroller</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="35"/>
         <source>Output Volume:</source>
         <translation>Utmatningsvolym:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="67"/>
-        <location filename="../audiosettingswidget.ui" line="120"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="88"/>
         <source>Fast Forward Volume:</source>
         <translation>Volym för snabbspolning:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="143"/>
-        <location filename="../audiosettingswidget.cpp" line="114"/>
         <source>Mute All Sound</source>
         <translation>Tysta allt ljud</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="150"/>
-        <location filename="../audiosettingswidget.cpp" line="116"/>
         <source>Mute CD Audio</source>
         <translation>Tysta cd-ljud</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="286"/>
         <source>Output Latency:</source>
         <translation>Utmatningslatens:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="327"/>
         <source>Minimal</source>
         <translation>Minimal</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="212"/>
         <source>Stretch Mode:</source>
         <translation>Sträckläge:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="195"/>
         <source>Output Device:</source>
         <translation>Utmatningsenhet:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="193"/>
-        <location filename="../audiosettingswidget.cpp" line="240"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="105"/>
         <source>Output Latency</source>
         <translation>Utmatningslatens</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="349"/>
-        <location filename="../audiosettingswidget.cpp" line="350"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="123"/>
-        <location filename="../audiosettingswidget.cpp" line="126"/>
-        <location filename="../audiosettingswidget.cpp" line="149"/>
-        <location filename="../audiosettingswidget.cpp" line="152"/>
-        <location filename="../audiosettingswidget.cpp" line="155"/>
-        <location filename="../audiosettingswidget.cpp" line="283"/>
         <source>N/A</source>
         <translation>Inte tillgängligt</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="79"/>
-        <location filename="../audiosettingswidget.cpp" line="82"/>
-        <location filename="../audiosettingswidget.cpp" line="406"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="94"/>
         <source>Audio Backend</source>
         <translation>Ljudbakände</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="95"/>
         <source>The audio backend determines how frames produced by the emulator are submitted to the host. Cubeb provides the lowest latency, if you encounter issues, try the SDL backend. The null backend disables all host audio output.</source>
         <translation>Ljudbakänden bestämmer hur ljud produceras av emulatorn skickas till värden. Cubeb tillhandahåller lägsta latensen, om du påträffar problem, prova SDL-bakänden. Null-bakänden inaktiverar all ljudutmatning på värden.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="34"/>
-        <location filename="../audiosettingswidget.cpp" line="41"/>
-        <location filename="../audiosettingswidget.cpp" line="44"/>
-        <location filename="../audiosettingswidget.cpp" line="47"/>
-        <location filename="../audiosettingswidget.cpp" line="99"/>
-        <location filename="../audiosettingswidget.cpp" line="105"/>
-        <location filename="../audiosettingswidget.cpp" line="130"/>
-        <location filename="../audiosettingswidget.cpp" line="134"/>
-        <location filename="../audiosettingswidget.cpp" line="138"/>
-        <location filename="../audiosettingswidget.cpp" line="283"/>
-        <location filename="../audiosettingswidget.cpp" line="427"/>
-        <location filename="../audiosettingswidget.cpp" line="443"/>
-        <location filename="../audiosettingswidget.cpp" line="459"/>
-        <location filename="../audiosettingswidget.cpp" line="471"/>
         <source>%1 ms</source>
         <translation>%1 ms</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="100"/>
         <source>The buffer size determines the size of the chunks of audio which will be pulled by the host. Smaller values reduce the output latency, but may cause hitches if the emulation speed is inconsistent. Note that the Cubeb backend uses smaller chunks regardless of this value, so using a low value here may not significantly change latency.</source>
         <translation>Buffertstorleken bestämmer storleken på de ljudbitar som ska hämtas av värden. Mindre värden minskar utmatningslatensen, men kan orsaka problem om emuleringshastigheten är inkonsekvent. Observera att Cubeb-backend använder mindre bitar oavsett detta värde, så att använda ett lågt värde här kanske inte ändrar latensen nämnvärt.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="110"/>
         <source>Output Volume</source>
         <translation>Utmatningsvolym</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="111"/>
         <source>Controls the volume of the audio played on the host.</source>
         <translation>Styr volymen för ljudet som spelas på värden.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="112"/>
         <source>Fast Forward Volume</source>
         <translation>Snabbspolningsvolym</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="113"/>
         <source>Controls the volume of the audio played on the host when fast forwarding.</source>
         <translation>Styr volymen för ljudet som spelas på värden vid snabbspolning.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="108"/>
-        <location filename="../audiosettingswidget.cpp" line="114"/>
-        <location filename="../audiosettingswidget.cpp" line="116"/>
-        <location filename="../audiosettingswidget.cpp" line="142"/>
-        <location filename="../audiosettingswidget.cpp" line="146"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="115"/>
         <source>Prevents the emulator from producing any audible sound.</source>
         <translation>Förhindrar att emulatorn skapar någon form av ljud.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="117"/>
         <source>Forcibly mutes both CD-DA and XA audio from the CD-ROM. Can be used to disable background music in some games.</source>
         <translation>Tvingar både CD-DA och XA-ljud från cd-rom att vara tyst. Kan användas för att inaktivera bakgrundsmusik i vissa spel.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="120"/>
         <source>Stretch Mode</source>
         <translation>Sträckläge</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="349"/>
-        <location filename="../audiosettingswidget.cpp" line="120"/>
         <source>Time Stretching</source>
         <translation>Tidssträckning</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="121"/>
         <source>When running outside of 100% speed, adjusts the tempo on audio instead of dropping frames. Produces much nicer fast forward/slowdown audio at a small cost to performance.</source>
         <translation>Vid körning utanför 100% hastighet justeras tempot på ljudet istället för att släppa bildrutor. Ger mycket finare ljud vid snabbspolning framåt/hastighetssänkning till en liten bekostnad av prestandan.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="124"/>
-        <location filename="../audiosettingswidget.cpp" line="127"/>
         <source>Resets volume back to the global/inherited setting.</source>
         <translation>Nollställer volymen tillbaka till global/ärvd inställning.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="125"/>
-        <location filename="../audiosettingswidget.cpp" line="128"/>
         <source>Resets volume back to the default, i.e. full.</source>
         <translation>Nollställer volymen tillbaka till standard, t.ex full.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="123"/>
         <source>Reset Volume</source>
         <translation>Nollställ volym</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="130"/>
-        <location filename="../audiosettingswidget.cpp" line="126"/>
         <source>Reset Fast Forward Volume</source>
         <translation>Nollställ snabbspolningsvolym</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="324"/>
         <source>Maximum Latency: %1 ms (%2 ms buffer + %3 ms output)</source>
         <translation>Maximal latens: %1 ms (%2 ms buffert + %3 ms utdata)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="342"/>
         <source>Maximum Latency: %1 ms (minimum output latency unknown)</source>
         <translation>Maximal latens: %1 ms (minimum utdatalatens okänd)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="77"/>
         <source>Reset Output Volume</source>
         <translation>Återställ utmatningsvolym</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="99"/>
         <source>Buffer Size</source>
         <translation>Buffertstorlek</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="106"/>
         <source>Determines how much latency there is between the audio being picked up by the host API, and played through speakers.</source>
         <translation>Bestämmer hur stor fördröjning det är mellan det att ljudet plockas upp av värd-API:et och spelas upp i högtalarna.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="108"/>
         <source>Minimal Output Latency</source>
         <translation>Minimal utdatalatens</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="109"/>
         <source>When enabled, the minimum supported output latency will be used for the host API.</source>
         <translation>När den är aktiverad används den minsta stödda utmatningslatensen för värd-API:et.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="261"/>
         <source>%1 [Unavailable]</source>
         <translation>%1 [inte tillgänglig]</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="316"/>
         <source>Maximum Latency: %1 ms (%2 ms stretch + %3 ms buffer + %4 ms output)</source>
         <translation>Maximal latens: %1 ms (%2 ms utsträckning + %3 ms buffert + %4 ms utgång)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="335"/>
         <source>Maximum Latency: %1 ms (%2 ms stretch + %3 ms buffer, minimum output latency unknown)</source>
         <translation>Maximal latens: %1 ms (%2 ms utsträckning + %3 ms buffert, minsta utgångslatens okänd)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="273"/>
         <source>Reset Buffer Size</source>
         <translation>Återställ buffertstorlek</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="336"/>
         <source>Maximum Latency: 0 ms (0 ms stretch + 0 ms buffer + 0 ms output)</source>
         <translation>Maximal latens: 0 ms (0 ms utsträckning + 0 ms buffert + 0 ms utmatning)</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="355"/>
         <source>Sequence Length:</source>
         <translation>Sekvenslängd:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="400"/>
-        <location filename="../audiosettingswidget.cpp" line="149"/>
         <source>Reset Sequence Length</source>
         <translation>Återställ sekvenslängd</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="411"/>
         <source>Seek Window:</source>
         <translation>Spolningsfönster:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="456"/>
-        <location filename="../audiosettingswidget.cpp" line="152"/>
         <source>Reset Seek Window</source>
         <translation>Återställ spolningsfönster</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="467"/>
         <source>Overlap:</source>
         <translation>Överlappning:</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="512"/>
-        <location filename="../audiosettingswidget.cpp" line="155"/>
         <source>Reset Overlap</source>
         <translation>Återställ överlappning</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="525"/>
         <source>Use Quick Seek</source>
         <translation>Använd snabbspolning</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.ui" line="532"/>
         <source>Use Anti-Aliasing Filter</source>
         <translation>Använd kantutjämningsfilter</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="129"/>
         <source>Stretch Sequence Length</source>
         <translation>Sträck ut sekvenslängd</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="131"/>
         <source>Determines how long individual sequences are when the time-stretch algorithm chops the audio. Longer sequences can improve quality but increase latency.</source>
         <translation>Bestämmer hur långa enskilda sekvenser är när tidssträckningsalgoritmen delar upp ljudet. Längre sekvenser kan förbättra kvaliteten men öka latensen.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="134"/>
         <source>Stretch Seek Window</source>
         <translation>Sträck ut spolningsfönster</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="135"/>
         <source>Controls how wide a window the algorithm searches for the best overlap position when joining consecutive sequences. Larger windows may yield better joins at the cost of increased CPU work.</source>
         <translation>Styr hur stort ett fönster är som algoritmen söker efter den bästa överlappningspositionen när den sammanfogar på varandra följande sekvenser. Större fönster kan ge bättre sammanfogningar, men kräver mer CPU-kraft.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="137"/>
         <source>Stretch Overlap Length</source>
         <translation>Sträck ut överlappningslängd</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="139"/>
         <source>Specifies how long two consecutive sequences are overlapped when mixed back together. Greater overlap can make transitions smoother but increases latency.</source>
         <translation>Anger hur länge två på varandra följande sekvenser överlappar varandra när de blandas ihop igen. Större överlappning kan göra övergångarna mjukare men ökar latensen.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="141"/>
         <source>Enable Quick Seek</source>
         <translation>Aktivera snabbspolning</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="142"/>
-        <location filename="../audiosettingswidget.cpp" line="146"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="143"/>
         <source>Enables the quick seeking algorithm in the time-stretch routine. Reduces CPU usage at a minor cost to audio quality.</source>
         <translation>Aktiverar algoritmen för snabb sökning i tidssträckningsrutinen. Minskar CPU-användningen till en mindre kostnad för ljudkvaliteten.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="145"/>
         <source>Enable Anti-Alias Filter</source>
         <translation>Använd kantutjämningsfilter</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="147"/>
         <source>Enables an anti-aliasing filter used by the pitch transposer. Disabling it may reduce quality when pitch shifting but can slightly reduce CPU usage.</source>
         <translation>Aktiverar ett kantutjämningsfilter som används av tonhöjdstransponeraren. Om du inaktiverar det kan kvaliteten försämras vid tonhöjdsförskjutning, men CPU-användningen kan minska något.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="150"/>
-        <location filename="../audiosettingswidget.cpp" line="153"/>
-        <location filename="../audiosettingswidget.cpp" line="156"/>
         <source>Resets value back to the global/inherited setting.</source>
         <translation>Återställer värdet till den globala/ärvda inställningen.</translation>
     </message>
     <message>
-        <location filename="../audiosettingswidget.cpp" line="151"/>
-        <location filename="../audiosettingswidget.cpp" line="154"/>
-        <location filename="../audiosettingswidget.cpp" line="157"/>
         <source>Resets value back to the default.</source>
         <translation>Återställer värdet tillbaka till standard.</translation>
     </message>
@@ -1182,53 +880,42 @@ Token genererades %2</translation>
 <context>
     <name>AutoUpdaterDialog</name>
     <message>
-        <location filename="../autoupdaterdialog.ui" line="14"/>
-        <location filename="../autoupdaterdialog.cpp" line="393"/>
         <source>Automatic Updater</source>
         <translation>Automatisk uppdatering</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.ui" line="58"/>
         <source>Update Available</source>
         <translation>Uppdatering tillgänglig</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.ui" line="77"/>
         <source>Current Version: </source>
         <translation>Aktuell version: </translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.ui" line="92"/>
         <source>New Version: </source>
         <translation>Ny version: </translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.ui" line="107"/>
         <source>Download Size:</source>
         <translation>Hämtningsstorlek:</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.ui" line="144"/>
         <source>Download and Install...</source>
         <translation>Hämta och installera...</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.ui" line="151"/>
         <source>Skip This Update</source>
         <translation>Hoppa över denna uppdatering</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.ui" line="158"/>
         <source>Remind Me Later</source>
         <translation>Påminn mig senare</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="192"/>
         <source>Do not show again</source>
         <translation>Visa inte igen</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="297"/>
         <source>Failed to retrieve or download update:
 
 %1
@@ -1241,66 +928,52 @@ You can manually update DuckStation by re-downloading the latest release. Do you
 Du kan uppdatera DuckStation manuellt genom att hämta ner den senaste utgåvan igen. Vill du öppna hämtningssidan nu?</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="300"/>
-        <location filename="../autoupdaterdialog.cpp" line="844"/>
         <source>Updater Error</source>
         <translation>Fel vid uppdatering</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="394"/>
         <source>No updates are currently available. Please try again later.</source>
         <translation>Inga uppdateringar finns för närvarande tillgängliga. Försök igen senare.</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="464"/>
-        <location filename="../autoupdaterdialog.cpp" line="468"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="471"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="474"/>
         <source>Loading...</source>
         <translation>Läser in...</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="521"/>
         <source>&lt;h2&gt;Changes:&lt;/h2&gt;</source>
         <translation>&lt;h2&gt;Ändringar:&lt;/h2&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="550"/>
         <source>&lt;h2&gt;Save State Warning&lt;/h2&gt;&lt;p&gt;Installing this update will make your save states &lt;b&gt;incompatible&lt;/b&gt;. Please ensure you have saved your games to memory card before installing this update or you will lose progress.&lt;/p&gt;</source>
         <translation>&lt;h2&gt;Varning för sparade tillstånd&lt;/h2&gt;&lt;p&gt;Installation av denna uppdatering kommer att göra dina sparade tillstånd &lt;b&gt;inkompatibla&lt;/b&gt;. Försäkra dig om att du har sparat dina spel till minneskort innan du installerar denna uppdatering annars kommer du förlora dem.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="741"/>
         <source>&lt;h1&gt;Inconsistent Application State&lt;/h1&gt;&lt;h3&gt;The update zip is missing the current executable:&lt;/h3&gt;&lt;div align=&quot;center&quot;&gt;&lt;pre&gt;%1&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;&lt;strong&gt;This is usually a result of manually renaming the file.&lt;/strong&gt; Continuing to install this update may result in a broken installation if the renamed executable is used. The DuckStation executable should be named:&lt;/p&gt;&lt;div align=&quot;center&quot;&gt;&lt;pre&gt;%2&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Do you want to continue anyway?&lt;/p&gt;</source>
         <translation>&lt;h1&gt;Inkonsekvent programtillstånd&lt;/h1&gt;&lt;h3&gt;Den aktuella körbara filen saknas i uppdateringens zip-fil:&lt;/h3&gt;&lt;div align=&quot;center&quot;&gt;&lt;pre&gt;%1&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;&lt;strong&gt;Detta beror vanligtvis på att filen har bytt namn manuellt.&lt;/strong&gt; Om du fortsätter att installera uppdateringen kan installationen sluta fungera om filen med det ändrade namnet används. DuckStations körbara fil ska heta:&lt;/p&gt;&lt;div align=&quot;center&quot;&gt;&lt;pre&gt;%2&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Vill du fortsätta ändå?&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="740"/>
         <source>Updater Warning</source>
         <translation>Uppdateringsvarning</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="845"/>
         <source>Failed to remove updater exe after update:
 %1</source>
         <translation>Misslyckades med att ta bort uppdateringsfil efter uppdatering:
 %1</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="107"/>
         <source>Stable Releases</source>
         <translation>Stabila utgåvor</translation>
     </message>
     <message>
-        <location filename="../autoupdaterdialog.cpp" line="108"/>
         <source>Preview Releases</source>
         <translation>Förhandsvisningar</translation>
     </message>
@@ -1308,226 +981,174 @@ Du kan uppdatera DuckStation manuellt genom att hämta ner den senaste utgåvan 
 <context>
     <name>BIOSSettingsWidget</name>
     <message>
-        <location filename="../biossettingswidget.ui" line="89"/>
         <source>BIOS Directory</source>
         <translation>BIOS-katalog</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="136"/>
-        <location filename="../biossettingswidget.ui" line="207"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="29"/>
         <source>BIOS Selection</source>
         <translation>Val av BIOS</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="69"/>
         <source>PAL (Europe, Australia):</source>
         <translation>PAL (Europa, Australien):</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="35"/>
         <source>NTSC-J (Japan):</source>
         <translation>NTSC-J (Japan):</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="52"/>
         <source>NTSC-U/C (US/Canada):</source>
         <translation>NTSC-U/C (US, Kanada):</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="95"/>
         <source>DuckStation will search for BIOS images in this directory.</source>
         <translation>DuckStation kommer att söka efter BIOS-avbilder i denna katalog.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="107"/>
-        <location filename="../biossettingswidget.cpp" line="111"/>
         <source>Install BIOS</source>
         <translation>Installera BIOS</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="118"/>
-        <location filename="../biossettingswidget.cpp" line="109"/>
         <source>Refresh List</source>
         <translation>Uppdatera lista</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="147"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="158"/>
         <source>Reset</source>
         <translation>Nollställ</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="245"/>
-        <location filename="../biossettingswidget.cpp" line="126"/>
         <source>Enable TTY Logging</source>
         <translation>Aktivera TTY-loggning</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="174"/>
         <source>Parallel Port</source>
         <translation>Parallellport</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="180"/>
         <source>Device Type:</source>
         <translation>Enhetstyp:</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="197"/>
         <source>Image Path:</source>
         <translation>Avbildssökväg:</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="220"/>
-        <location filename="../biossettingswidget.cpp" line="119"/>
         <source>Cartridge Switch On</source>
         <translation>Cartridge-brytaren på</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="227"/>
-        <location filename="../biossettingswidget.cpp" line="123"/>
         <source>Allow Image Writes</source>
         <translation>Tillåt avbildsskrivningar</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="123"/>
-        <location filename="../biossettingswidget.cpp" line="126"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="127"/>
         <source>Logs BIOS calls to printf(). Not all games contain debugging messages.</source>
         <translation>Loggar BIOS-anrop till printf(). Inte alla spel innehåller felsökningsmeddelanden.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="114"/>
         <source>Device Type</source>
         <translation>Enhetstyp</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="110"/>
         <source>Refreshes the list of BIOS images that can be selected.</source>
         <translation>Uppdaterar listan över BIOS-avbilder som kan väljas.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="112"/>
         <source>Installs a new BIOS image into the emulator&apos;s BIOS directory.</source>
         <translation>Installerar en ny BIOS-avbild i emulatorns BIOS-katalog.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="114"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="115"/>
         <source>Simulates a device plugged into the console&apos;s parallel port. Usually these are flash cartridges, and require some sort of image dump to function.</source>
         <translation>Simulerar en enhet ansluten till konsollens parallellport. Oftast är dessa flash-cartridge och kräver någon form av avbildsdump för att fungera.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="117"/>
         <source>Image Path</source>
         <translation>Avbildssökväg</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="117"/>
         <source>Empty</source>
         <translation>Tom</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="118"/>
         <source>Sets the path to the image used for flash cartridges.</source>
         <translation>Anger sökvägen till avbilden som används för flash-cartridge.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="119"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="120"/>
         <source>Simulates the position of the switch on the cartridge. Most cartridges require the switch to be on for it to activate on startup.</source>
         <translation>Simulerar positionen för brytaren på cartridgen. De flesta cartridge kräver att brytaren är på för att aktivera den vid uppstart.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="124"/>
         <source>Stores any images made to the cartridge&apos;s flash storage back to the host&apos;s file system. &lt;strong&gt;This will overwrite your cartridge dump,&lt;/strong&gt; you should ensure you have a backup first.</source>
         <translation>Lagrar alla avbilder gjorda på cartridgens flash-lagring tillbaka till värdens filsystem. &lt;strong&gt;Detta kommer att skriva över din cartridge-dump,&lt;/strong&gt; du bör försäkra dig om att ha en säkerhetskopia först.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="89"/>
         <source>Select BIOS Directory</source>
         <translation>Välj BIOS-katalog</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="134"/>
         <source>Select BIOS Image</source>
         <translation>Välj BIOS-avbild</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="143"/>
-        <location filename="../biossettingswidget.cpp" line="170"/>
         <source>BIOS Install Error</source>
         <translation>Fel vid BIOS-installation</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="157"/>
         <source>BIOS Already Installed</source>
         <translation>BIOS redan installerad</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="158"/>
         <source>The BIOS file &apos;%1&apos; is already installed. Do you want to overwrite it?</source>
         <translation>BIOS-filen &apos;%1&apos; är redan installerad. Vill du skriva över den?</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="176"/>
         <source>BIOS Installed</source>
         <translation>BIOS installerad</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="177"/>
         <source>BIOS &apos;%1&apos; installed as &apos;%2&apos;.</source>
         <translation>BIOS &apos;%1&apos; installerad som &apos;%2&apos;.</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="206"/>
         <source>Use Global Setting</source>
         <translation>Använd global inställning</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="208"/>
         <source>Auto-Detect</source>
         <translation>Identifiera automatiskt</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="178"/>
-        <location filename="../biossettingswidget.cpp" line="225"/>
         <source>Unknown</source>
         <translation>Okänd</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="250"/>
         <source>%1 (Missing)</source>
         <translation>%1 (saknas)</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.cpp" line="275"/>
         <source>Select PIO Image</source>
         <translation>VÄLJ PIO-avbild</translation>
     </message>
     <message>
-        <location filename="../biossettingswidget.ui" line="239"/>
         <source>Options</source>
         <translation>Alternativ</translation>
     </message>
@@ -1535,340 +1156,251 @@ Du kan uppdatera DuckStation manuellt genom att hämta ner den senaste utgåvan 
 <context>
     <name>CaptureSettingsWidget</name>
     <message>
-        <location filename="../capturesettingswidget.ui" line="29"/>
         <source>Screenshots</source>
         <translation>Skärmbilder</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="35"/>
         <source>Screenshot Size:</source>
         <translation>Storlek för skärmbild:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="50"/>
         <source>Quality:</source>
         <translation>Kvalitet:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="57"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="72"/>
-        <location filename="../capturesettingswidget.ui" line="148"/>
         <source>File Name Format:</source>
         <translation>Filnamnsformat:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="82"/>
-        <location filename="../capturesettingswidget.ui" line="158"/>
         <source>Save Location:</source>
         <translation>Lagringsplats:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="94"/>
-        <location filename="../capturesettingswidget.ui" line="170"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="105"/>
-        <location filename="../capturesettingswidget.ui" line="181"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="116"/>
-        <location filename="../capturesettingswidget.ui" line="192"/>
         <source>Reset</source>
         <translation>Återställ</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="132"/>
         <source>Media Capture</source>
         <translation>Mediafångst</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="138"/>
         <source>Backend:</source>
         <translation>Bakände:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="228"/>
-        <location filename="../capturesettingswidget.ui" line="359"/>
         <source>Container:</source>
         <translation>Container:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="238"/>
-        <location filename="../capturesettingswidget.ui" line="369"/>
         <source>Codec:</source>
         <translation>Kodek:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="248"/>
-        <location filename="../capturesettingswidget.ui" line="379"/>
         <source>Bitrate:</source>
         <translation>Bitfrekvens:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="255"/>
-        <location filename="../capturesettingswidget.ui" line="386"/>
         <source> kbps</source>
         <extracomment>Unit that will appear next to a number. Alter the space or whatever is needed before the text depending on your language.</extracomment>
         <translation> kbps</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="274"/>
         <source>Resolution:</source>
         <translation>Upplösning:</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="299"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="322"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.ui" line="331"/>
-        <location filename="../capturesettingswidget.ui" line="405"/>
         <source>Extra Arguments</source>
         <translation>Extra argument</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="65"/>
         <source>Select Screenshots Directory</source>
         <translation>Välj katalog för skärmbilder</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="69"/>
         <source>Select Media Capture Directory</source>
         <translation>Välj katalog för mediafångst</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="119"/>
         <source>Screenshot Size</source>
         <translation>Skärmbildsstorlek</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="119"/>
         <source>Screen Resolution</source>
         <translation>Skärmupplösning</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="120"/>
         <source>Determines the resolution at which screenshots will be saved. Internal resolutions preserve more detail at the cost of file size.</source>
         <translation>Bestämmer vilken upplösning som skärmbilderna ska sparas med. Interna upplösningar bevarar fler detaljer på bekostnad av filstorleken.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="122"/>
-        <location filename="../capturesettingswidget.cpp" line="141"/>
         <source>Save Location</source>
         <translation>Lagringsplats</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="122"/>
-        <location filename="../capturesettingswidget.cpp" line="141"/>
-        <location filename="../capturesettingswidget.cpp" line="152"/>
-        <location filename="../capturesettingswidget.cpp" line="173"/>
-        <location filename="../capturesettingswidget.cpp" line="247"/>
-        <location filename="../capturesettingswidget.cpp" line="296"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="123"/>
         <source>Specifies the directory where screenshots will be saved.</source>
         <translation>Anger katalogen där skärmbilder ska sparas.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="125"/>
-        <location filename="../capturesettingswidget.cpp" line="144"/>
         <source>Save Name</source>
         <translation>Sparningsnamn</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="127"/>
-        <location filename="../capturesettingswidget.cpp" line="146"/>
         <source>Determines the format of the filename used when saving screenshots, and whether a subdirectory is created per-game.</source>
         <translation>Bestämmer filnamnsformatet för sparade skärmbilder och om en underkatalog skapas för varje spel.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="130"/>
         <source>Screenshot Format</source>
         <translation>Skärmbildsformat</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="132"/>
         <source>Selects the format which will be used to save screenshots. JPEG produces smaller files, but loses detail.</source>
         <translation>Väljer det format som ska användas för att spara skärmbilder. JPEG ger mindre filer, men förlorar detaljer.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="133"/>
         <source>Screenshot Quality</source>
         <translation>Skärmbildskvalitet</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="135"/>
         <source>Selects the quality at which screenshots will be compressed. Higher values preserve more detail for JPEG, and reduce file size for PNG.</source>
         <translation>Väljer den kvalitet med vilken skärmbilder komprimeras. Högre värden bevarar fler detaljer för JPEG och minskar filstorleken för PNG.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="138"/>
         <source>Backend</source>
         <translation>Bakände</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="140"/>
         <source>Selects the framework that is used to encode video/audio.</source>
         <translation>Väljer det ramverk som används för att koda video/ljud.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="148"/>
-        <location filename="../capturesettingswidget.cpp" line="169"/>
         <source>Container</source>
         <translation>Container</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="150"/>
         <source>Determines the file format used to contain the captured video.</source>
         <translation>Bestämmer filformatet för den inspelade videon.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="171"/>
         <source>Determines the file format used to contain the captured audio.</source>
         <translation>Bestämmer filformatet för det inspelade ljudet.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="259"/>
-        <location filename="../capturesettingswidget.cpp" line="308"/>
         <source>%1 (Unknown)</source>
         <translation>%1 (Okänd)</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="142"/>
         <source>Specifies the directory where media capture (video/audio) will be saved.</source>
         <translation>Anger katalogen där mediafångster (video/ljud) ska sparas.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="152"/>
         <source>Video Codec</source>
         <translation>Videokodek</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="153"/>
         <source>Selects which Video Codec to be used for media capture. &lt;b&gt;If unsure, leave it on default.&lt;/b&gt;</source>
         <translation>Väljer videokodeken som ska användas för mediafångst. &lt;b&gt;Lämna standardvärdet om du är osäker.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="154"/>
         <source>Video Bitrate</source>
         <translation>Bitfrekvens för video</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="155"/>
-        <location filename="../capturesettingswidget.cpp" line="176"/>
         <source>%1 kbps</source>
         <translation>%1 kbps</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="156"/>
         <source>Sets the video bitrate to be used. Larger bitrate generally yields better video quality at the cost of larger resulting file size.</source>
         <translation>Ställer in den videobitfrekvens som ska användas. Högre bitfrekvens ger i allmänhet bättre videokvalitet till priset av större filstorlek.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="159"/>
         <source>Automatic Resolution</source>
         <translation>Automatisk upplösning</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="159"/>
-        <location filename="../capturesettingswidget.cpp" line="163"/>
-        <location filename="../capturesettingswidget.cpp" line="178"/>
         <source>Unchecked</source>
         <translation>Avmarkerad</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="160"/>
         <source>When checked, the video capture resolution will follows the internal resolution of the running game. &lt;b&gt;Be careful when using this setting especially when you are upscaling, as higher internal resolutions (above 4x) can cause system slowdown.&lt;/b&gt;</source>
         <translation>När detta är markerat kommer videoinspelningens upplösning att följa den interna upplösningen i det spel som körs. &lt;b&gt;Var försiktig när du använder den här inställningen, särskilt när du uppskalar, eftersom högre interna upplösningar (över 4x) kan göra att systemet saktar ner.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="163"/>
         <source>Enable Extra Video Arguments</source>
         <translation>Aktivera extra videoargument</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="164"/>
         <source>Allows you to pass arguments to the selected video codec.</source>
         <translation>Gör det möjligt att skicka argument till den valda videokodeken.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="166"/>
         <source>Extra Video Arguments</source>
         <translation>Extra videoargument</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="166"/>
-        <location filename="../capturesettingswidget.cpp" line="181"/>
         <source>Empty</source>
         <translation>Tom</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="167"/>
         <source>Parameters passed to the selected video codec.&lt;br&gt;&lt;b&gt;You must use &apos;=&apos; to separate key from value and &apos;:&apos; to separate two pairs from each other.&lt;/b&gt;&lt;br&gt;For example: &quot;crf = 21 : preset = veryfast&quot;</source>
         <translation>Parametrar som skickas till den valda videokodeken.&lt;br&gt;&lt;b&gt;Du måste använda &apos;=&apos; för att skilja nyckel från värde och &apos;:&apos; för att skilja två par från varandra.&lt;/b&gt;&lt;br&gt;Till exempel: &quot;crf = 21 : preset = veryfast&quot;</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="173"/>
         <source>Audio Codec</source>
         <translation>Ljudkodek</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="174"/>
         <source>Selects which Audio Codec to be used for media capture. &lt;b&gt;If unsure, leave it on default.&lt;/b&gt;</source>
         <translation>Väljer ljudkodeken som ska användas för mediafångst. &lt;b&gt;Lämna standardvärdet om du är osäker.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="175"/>
         <source>Audio Bitrate</source>
         <translation>Bitfrekvens för ljud</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="177"/>
         <source>Sets the audio bitrate to be used.</source>
         <translation>Ställer in ljudbitfrekvensen att använda.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="178"/>
         <source>Enable Extra Audio Arguments</source>
         <translation>Aktivera extra ljudargument</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="179"/>
         <source>Allows you to pass arguments to the selected audio codec.</source>
         <translation>Gör det möjligt att skicka argument till den valda ljudkodeken.</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="181"/>
         <source>Extra Audio Arguments</source>
         <translation>Extra ljudargument</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="182"/>
         <source>Parameters passed to the selected audio codec.&lt;br&gt;&lt;b&gt;You must use &apos;=&apos; to separate key from value and &apos;:&apos; to separate two pairs from each other.&lt;/b&gt;&lt;br&gt;For example: &quot;compression_level = 4 : joint_stereo = 1&quot;</source>
         <translation>Parametrar som skickas till den valda ljudkodeken.&lt;br&gt;&lt;b&gt;Du måste använda &apos;=&apos; för att skilja nyckel från värde och &apos;:&apos; för att skilja två par från varandra.&lt;/b&gt;&lt;br&gt;Till exempel: &quot;compression_level = 4 : joint_stereo = 1&quot;</translation>
     </message>
     <message>
-        <location filename="../capturesettingswidget.cpp" line="208"/>
-        <location filename="../capturesettingswidget.cpp" line="214"/>
-        <location filename="../capturesettingswidget.cpp" line="252"/>
-        <location filename="../capturesettingswidget.cpp" line="301"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
@@ -1876,58 +1408,44 @@ Du kan uppdatera DuckStation manuellt genom att hämta ner den senaste utgåvan 
 <context>
     <name>CheatCodeEditorDialog</name>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="831"/>
         <source>Enter Group Name</source>
         <translation>Ange gruppnamn</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="831"/>
         <source>Enter name for the code group. Using backslashes (\) will create sub-trees.</source>
         <translation>Ange namn för kodgruppen. Använd bakstreck (\) för att skapa underträd.</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="859"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="866"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="878"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="898"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="939"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="859"/>
         <source>Name cannot be empty.</source>
         <translation>Namnet får inte vara tomt.</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="866"/>
         <source>Instructions cannot be empty.</source>
         <translation>Instruktioner får inte vara tomma.</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="899"/>
         <source>A code with the name &apos;%1&apos; already exists.</source>
         <translation>En kod med namnet &apos;%1&apos; finns redan.</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="940"/>
         <source>Failed to save cheat code:
 %1</source>
         <translation>Misslyckades med att spara fuskkod:
 %1</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="988"/>
         <source>Ungrouped</source>
         <translation>Inte grupperad</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="993"/>
         <source>New...</source>
         <translation>Ny...</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="879"/>
         <source>The entered cheat code is not valid:
 
 %1
@@ -1943,7 +1461,6 @@ Om du försöker använda denna fuskkod kommer den inte att fungera som förvän
 <context>
     <name>ColorPickerButton</name>
     <message>
-        <location filename="../colorpickerbutton.cpp" line="74"/>
         <source>Select LED Color</source>
         <translation>Välj LED-färg</translation>
     </message>
@@ -1951,251 +1468,186 @@ Om du försöker använda denna fuskkod kommer den inte att fungera som förvän
 <context>
     <name>ConsoleSettingsWidget</name>
     <message>
-        <location filename="../consolesettingswidget.ui" line="29"/>
         <source>Console</source>
         <translation>Konsol</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="35"/>
         <source>Region:</source>
         <translation>Region:</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="78"/>
-        <location filename="../consolesettingswidget.cpp" line="96"/>
         <source>Enable 8MB RAM (Dev Console)</source>
         <translation>Aktivera 8MB RAM (Utvecklarkonsol)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="90"/>
         <source>CPU Emulation</source>
         <translation>CPU-emulering</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="96"/>
         <source>Execution Mode:</source>
         <translation>Körningsläge:</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="108"/>
-        <location filename="../consolesettingswidget.cpp" line="105"/>
         <source>Enable Clock Speed Control (Overclocking/Underclocking)</source>
         <translation>Aktivera klockfrekvenskontroll (överklockning/underklockning)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="168"/>
-        <location filename="../consolesettingswidget.cpp" line="109"/>
         <source>Enable Recompiler ICache</source>
         <translation>Aktivera ICache för omkompilerare</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="178"/>
         <source>CD-ROM Emulation</source>
         <translation>Cd-rom-emulering</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="184"/>
         <source>Read Speedup:</source>
         <translation>Högre läshastighet:</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="192"/>
-        <location filename="../consolesettingswidget.cpp" line="115"/>
         <source>None (Double Speed)</source>
         <translation>Ingen (dubbel hastighet)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="197"/>
         <source>2x (Quad Speed)</source>
         <translation>2x (fyrdubbel hastighet)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="202"/>
         <source>3x (6x Speed)</source>
         <translation>3x (6x hastighet)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="207"/>
         <source>4x (8x Speed)</source>
         <translation>4x (8x hastighet)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="212"/>
         <source>5x (10x Speed)</source>
         <translation>5x (10x hastighet)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="217"/>
         <source>6x (12x Speed)</source>
         <translation>6x (12x hastighet)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="230"/>
         <source>Seek Speedup:</source>
         <translation>Sök snabbare:</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="237"/>
-        <location filename="../consolesettingswidget.ui" line="241"/>
-        <location filename="../consolesettingswidget.cpp" line="119"/>
         <source>None (Normal Speed)</source>
         <translation>Ingen (normal hastighet)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="246"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="251"/>
         <source>3x</source>
         <translation>3x</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="256"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="261"/>
         <source>5x</source>
         <translation>5x</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="266"/>
         <source>6x</source>
         <translation>6x</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="295"/>
-        <location filename="../consolesettingswidget.cpp" line="126"/>
         <source>Apply Image Patches</source>
         <translation>Verkställ bildpatchar</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="288"/>
-        <location filename="../consolesettingswidget.cpp" line="134"/>
         <source>Ignore Drive Subcode</source>
         <translation>Ignorera enhetens underkod</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="79"/>
         <source>Region</source>
         <translation>Region</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="79"/>
-        <location filename="../consolesettingswidget.cpp" line="82"/>
         <source>Auto-Detect</source>
         <translation>Identifiera automatiskt</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="80"/>
         <source>Determines the emulated hardware type.</source>
         <translation>Bestämmer emulerad hårdvarutyp.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="102"/>
         <source>Execution Mode</source>
         <translation>Körningsläge</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="102"/>
         <source>Recompiler (Fastest)</source>
         <translation>Omkompilerare (snabbaste)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="103"/>
         <source>Determines how the emulated CPU executes instructions.</source>
         <translation>Fastställer hur den emulerade CPUn kör instruktioner.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="87"/>
-        <location filename="../consolesettingswidget.cpp" line="89"/>
-        <location filename="../consolesettingswidget.cpp" line="92"/>
-        <location filename="../consolesettingswidget.cpp" line="96"/>
-        <location filename="../consolesettingswidget.cpp" line="105"/>
-        <location filename="../consolesettingswidget.cpp" line="109"/>
-        <location filename="../consolesettingswidget.cpp" line="123"/>
-        <location filename="../consolesettingswidget.cpp" line="126"/>
-        <location filename="../consolesettingswidget.cpp" line="130"/>
-        <location filename="../consolesettingswidget.cpp" line="134"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="106"/>
         <source>When this option is chosen, the clock speed set below will be used.</source>
         <translation>När detta alternativ väljs så kommer klockfrekvensen som anges nedan att användas.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="107"/>
         <source>Overclocking Percentage</source>
         <translation>Överklockningsprocent</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="107"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="108"/>
         <source>Selects the percentage of the normal clock speed the emulated hardware will run at.</source>
         <translation>Väljer den procentandel av den normala klockfrekvensen som den emulerade maskinvaran ska köras med.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="110"/>
         <source>Simulates stalls in the recompilers when the emulated CPU would have to fetch instructions into its cache. Makes games run closer to their console framerate, at a small cost to performance. Interpreter mode always simulates the instruction cache.</source>
         <translation>Simulerar uppehåll i omkompilerarna när den emulerade processorn måste hämta instruktioner i cacheminnet. Gör att spelen körs närmare konsolens bildfrekvens, till en liten bekostnad av prestanda. I tolkningsläget simuleras alltid instruktionscachen.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="97"/>
         <source>Enables an additional 6MB of RAM to obtain a total of 2+6 = 8MB, usually present on dev consoles. Games have to use a larger heap size for this additional RAM to be usable. Titles which rely on memory mirrors may break, so it should only be used with compatible mods.</source>
         <translation>Möjliggör ytterligare 6 MB RAM för att få totalt 2+6 = 8 MB, vilket vanligtvis finns på utvecklingskonsoler. Spel måste använda en större heap-storlek för att detta extra RAM-minne ska kunna användas. Titlar som förlitar sig på minnesspeglar kan gå sönder, så det bör endast användas med kompatibla moddar.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="281"/>
-        <location filename="../consolesettingswidget.cpp" line="123"/>
         <source>Preload Image to RAM</source>
         <translation>Förinläs avbild till RAM</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="124"/>
         <source>Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some cases also eliminates stutter when games initiate audio track playback.</source>
         <translation>Läser in spelavbildningen till RAM-minnet. Användbart för nätverkssökvägar som kan bli otillförlitliga under spelets gång. I vissa fall elimineras även hack när spel initierar uppspelning av ljudspår.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="115"/>
         <source>CD-ROM Read Speedup</source>
         <translation>Ökad läshastighet för CD-ROM</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="116"/>
         <source>Speeds up CD-ROM reads by the specified factor. Only applies to double-speed reads, and is ignored when audio is playing. May improve loading speeds in some games, at the cost of breaking others.</source>
         <translation>Ökar hastigheten på CD-ROM-läsningen med den angivna faktorn. Gäller endast för dubbelsnabb läsning och ignoreras när ljud spelas upp. Kan förbättra inläsningshastigheten i vissa spel, på bekostnad av att andra går sönder.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="119"/>
         <source>CD-ROM Seek Speedup</source>
         <translation>Snabbare CD-ROM-sökning</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="120"/>
         <source>Reduces the simulated time for the CD-ROM sled to move to different areas of the disc. Can improve loading times, but crash games which do not expect the CD-ROM to operate faster.</source>
         <translation>Förkortar den simulerade tiden för CD-ROM-släden att förflytta sig till olika områden på skivan. Kan förbättra inläsningstiderna, men kraschar spel som inte förväntar sig att CD-ROM-skivan ska arbeta snabbare.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="127"/>
         <source>Automatically applies patches to disc images when they are present in the same directory. Currently only PPF patches are supported with this option.</source>
         <translation>Tillämpar automatiskt patchar på skivavbildningar när de finns i samma katalog. För närvarande stöds endast PPF-patchar med detta alternativ.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="135"/>
         <source>Ignores the subchannel provided by the drive when using physical discs, instead always generating subchannel data. Won&apos;t work with libcrypt games, but can improve read reliability on some drives.</source>
         <translation>Ignorerar den underkanal som tillhandahålls av enheten vid användning av fysiska skivor, och genererar istället alltid underkanaldata. Fungerar inte med libcrypt-spel, men kan förbättra lästillförlitligheten på vissa enheter.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="192"/>
         <source>Enabling CPU overclocking will break games, cause bugs, reduce performance and can significantly increase system requirements.
 
 By enabling this option you are agreeing to not create any bug reports unless you have confirmed the bug also occurs with overclocking disabled.
@@ -2208,92 +1660,70 @@ Genom att aktivera det här alternativet samtycker du till att inte skapa några
 Den här varningen visas bara en gång.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="196"/>
         <source>CPU Overclocking Warning</source>
         <translation>Varning för CPU-överklockning</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="199"/>
         <source>Yes, I will confirm bugs without overclocking before reporting.</source>
         <translation>Ja, jag kommer bekräfta buggar utan överklockning innan rapportering.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="200"/>
         <source>No, take me back to safety.</source>
         <translation>Nej, ta mig tillbaka till säkerhet.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="242"/>
         <source>%1% (%2MHz)</source>
         <translation>%1% (%2MHz)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="57"/>
-        <location filename="../consolesettingswidget.cpp" line="87"/>
         <source>Fast Boot</source>
         <translation>Snabb uppstart</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="71"/>
-        <location filename="../consolesettingswidget.cpp" line="89"/>
         <source>Fast Forward Boot</source>
         <translation>Snabbspolad uppstart</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="64"/>
-        <location filename="../consolesettingswidget.cpp" line="92"/>
         <source>Fast Forward Memory Card Access</source>
         <translation>Snabbspolning av minneskort</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="88"/>
         <source>Skips the boot animation. Safe to enable.</source>
         <translation>Hoppar över uppstartsanimationen. Säkert att aktivera.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="90"/>
         <source>Fast forwards through the early loading process when fast booting, saving time. Results may vary between games.</source>
         <translation>Snabbspolar igenom den tidiga inläsningsprocessen vid snabb uppstart, vilket sparar tid. Resultaten kan variera mellan spel.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="93"/>
         <source>Fast forwards through memory card access, both loading and saving. Can reduce waiting times in games that frequently access memory cards.</source>
         <translation>Snabbspolar genom minneskortsåtkomst, både inläsning och lagring. Kan minska väntetiderna i spel som ofta använder minneskort.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="45"/>
         <source>Frame Rate:</source>
         <translation>Bildfrekvens:</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="83"/>
         <source>Utilizes the chosen frame timing regardless of the active region. This feature can be used to force PAL games to run at 60Hz and NTSC games to run at 50Hz. For most games which have a speed tied to the framerate, this will result in the game running approximately 17% faster or slower. For variable frame rate games, it may not affect the speed.</source>
         <translation>Använder den valda bildtimingen oavsett vilken region som är aktiv. Denna funktion kan användas för att tvinga PAL-spel att köras med 60 Hz och NTSC-spel att köras med 50 Hz. För de flesta spel som har en hastighet som är knuten till bildfrekvensen kommer detta att resultera i att spelet körs ungefär 17% snabbare eller långsammare. För spel med variabel bildfrekvens kanske det inte påverkar hastigheten.</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="302"/>
-        <location filename="../consolesettingswidget.cpp" line="130"/>
         <source>Switch to Next Disc on Stop</source>
         <translation>Växla till nästa skiva vid stopp</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="131"/>
         <source>Automatically switches to the next disc in the game when the game stops the CD-ROM motor. No switch will occur if the last disc in the game is already selected. &lt;strong&gt;Does not work for all games.&lt;/strong&gt;</source>
         <translation>Växlar automatiskt till nästa skiva i spelet när spelet stoppar CD-ROM-motorn. Ingen växling sker om den sista skivan i spelet redan är vald. &lt;strong&gt;Fungerar inte för alla spel.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.cpp" line="82"/>
         <source>Frame Rate</source>
         <translation>Bildfrekvens</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="222"/>
-        <location filename="../consolesettingswidget.ui" line="271"/>
         <source>Maximum (Safer)</source>
         <translation>Maximalt (Säkrare)</translation>
     </message>
     <message>
-        <location filename="../consolesettingswidget.ui" line="128"/>
         <source>100% (33.87MHz)</source>
         <translation>100% (33.87MHz)</translation>
     </message>
@@ -2301,73 +1731,58 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget</name>
     <message>
-        <location filename="../controllerbindingwidget.ui" line="40"/>
         <source>Bindings</source>
         <translation>Bindningar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget.ui" line="60"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget.ui" line="80"/>
         <source>Macros</source>
         <translation>Makron</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget.ui" line="117"/>
         <source>Automatic Mapping</source>
         <translation>Automatisk mappning</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget.ui" line="128"/>
-        <location filename="../controllerbindingwidgets.cpp" line="307"/>
         <source>Clear Mapping</source>
         <translation>Töm mappning</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="292"/>
         <source>Multiple devices...</source>
         <translation>Flera enheter...</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="297"/>
         <source>No devices available</source>
         <translation>Inga enheter tillgängliga</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="308"/>
         <source>Are you sure you want to clear all mappings for this controller? This action cannot be undone.</source>
         <translation>Är du säker på att du vill tömma alla mappningar för denna handkontroller? Denna åtgärd går inte att ångra.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="517"/>
         <source>Controller %1 %2</source>
         <translation>Handkontroll %1 %2</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="427"/>
         <source>Axes</source>
         <translation>Axlar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="458"/>
         <source>Buttons</source>
         <translation>Knappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="362"/>
         <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
         <translation>Inga generiska bindningar genererades för enheten &apos;%1&apos;. Handkontrollern/källan kanske inte har stöd för automatisk mappning.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget.ui" line="29"/>
         <source>Controller Type</source>
         <translation>Handkontrollertyp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="361"/>
         <source>Automatic Mapping Failed</source>
         <translation>Automatisk mappning misslyckades</translation>
     </message>
@@ -2375,130 +1790,98 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_AnalogController</name>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="43"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="49"/>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="206"/>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="795"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="86"/>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="243"/>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="758"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="123"/>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="280"/>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="869"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="160"/>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="317"/>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="832"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="200"/>
         <source>Left Analog</source>
         <translation>Vänster analog</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="357"/>
         <source>Large Motor</source>
         <translation>Stor motor</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="405"/>
         <source>R2</source>
         <translation>R2</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="436"/>
         <source>Select</source>
         <translation>Välj</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="467"/>
         <source>L2</source>
         <translation>L2</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="498"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="529"/>
         <source>R1</source>
         <translation>R1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="560"/>
         <source>L1</source>
         <translation>L1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="595"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="601"/>
         <source>Cross</source>
         <translation>Kryss</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="638"/>
         <source>Square</source>
         <translation>Fyrkant</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="675"/>
         <source>Triangle</source>
         <translation>Triangel</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="712"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="752"/>
         <source>Right Analog</source>
         <translation>Höger analog</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="909"/>
         <source>Small Motor</source>
         <translation>Liten motor</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="1071"/>
         <source>R3</source>
         <translation>R3</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="1040"/>
         <source>Analog</source>
         <translation>Analog</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="1009"/>
         <source>L3</source>
         <translation>L3</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_controller.ui" line="1102"/>
         <source>Analog LED</source>
         <translation>Analog LED</translation>
     </message>
@@ -2506,115 +1889,86 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_AnalogJoystick</name>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="43"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="49"/>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="206"/>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="764"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="86"/>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="243"/>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="727"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="123"/>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="280"/>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="838"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="160"/>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="317"/>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="801"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="200"/>
         <source>Left Analog</source>
         <translation>Vänster analog</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="374"/>
         <source>R1</source>
         <translation>R1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="405"/>
         <source>L1</source>
         <translation>L1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="436"/>
         <source>L2</source>
         <translation>L2</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="467"/>
         <source>R2</source>
         <translation>R2</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="498"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="529"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="564"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="570"/>
         <source>Cross</source>
         <translation>Kryss</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="607"/>
         <source>Square</source>
         <translation>Fyrkant</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="644"/>
         <source>Triangle</source>
         <translation>Triangel</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="681"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="721"/>
         <source>Right Analog</source>
         <translation>Höger analog</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="947"/>
         <source>R3</source>
         <translation>R3</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="984"/>
         <source>L3</source>
         <translation>L3</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_analog_joystick.ui" line="1034"/>
         <source>Mode</source>
         <translation>Läge</translation>
     </message>
@@ -2622,82 +1976,66 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_DigitalController</name>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="43"/>
         <source>L1</source>
         <translation>L1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="74"/>
         <source>L2</source>
         <translation>L2</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="105"/>
         <source>R2</source>
         <translation>R2</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="136"/>
         <source>R1</source>
         <translation>R1</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="184"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="190"/>
         <source>Cross</source>
         <translation>Kryss</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="227"/>
         <source>Square</source>
         <translation>Fyrkant</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="264"/>
         <source>Triangle</source>
         <translation>Triangel</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="301"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="440"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="446"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="483"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="520"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="557"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="614"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_digital_controller.ui" line="645"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
@@ -2705,73 +2043,59 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_GunCon</name>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="43"/>
         <source>Pointer Setup</source>
         <translation>Konfigurera pekare</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="49"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, lightguns will use the mouse pointer. To use the mouse, you &lt;span style=&quot; font-weight:700;&quot;&gt;do not&lt;/span&gt; need to configure any bindings apart from the trigger and buttons. Aiming only needs to be set when you want to use multiple mice.&lt;/p&gt;&lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;span style=&quot; font-weight:700;&quot;&gt;left unbound&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE: &lt;/span&gt;Mouse mapping must be enabled in Global Settings to bind your PC&apos;s mouse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Som standard använder ljuspistoler muspekaren. För att använda musen behöver du &lt;span style=&quot; font-weight:700;&quot;&gt;inte&lt;/span&gt; konfigurera några bindningar utöver avtryckaren och knapparna. Siktet behöver endast ställas in om du vill använda flera möss.&lt;/p&gt;&lt;p&gt;Om du vill använda en handkontroll eller en ljuspistol som simulerar en handkontroll i stället för en mus ska den bindas till relativ siktning. Annars ska relativ siktning &lt;span style=&quot; font-weight:700;&quot;&gt;lämnas obunden&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;OBS! &lt;/span&gt;Musmappning måste aktiveras i globala inställningar för att datorns mus ska kunna bindas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="65"/>
         <source>Relative Aiming</source>
         <extracomment>Try to use Sony&apos;s official terminology for this. A good place to start would be in the console or the DualShock 2&apos;s manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.</extracomment>
         <translation>Relative Aiming</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="71"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="108"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="145"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="182"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="330"/>
         <source>Aiming</source>
         <translation>Sikte</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="367"/>
         <source>Trigger</source>
         <translation>Skjutknapp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="373"/>
         <source>Fire Offscreen</source>
         <translation>Skjut utanför skärm</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="410"/>
         <source>Fire</source>
         <translation>Skjut</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="450"/>
         <source>Side Buttons</source>
         <translation>Sidoknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="456"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_guncon.ui" line="493"/>
         <source>A</source>
         <translation>A</translation>
     </message>
@@ -2779,73 +2103,59 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_Justifier</name>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="43"/>
         <source>Pointer Setup</source>
         <translation>Konfigurera pekare</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="49"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, lightguns will use the mouse pointer. To use the mouse, you &lt;span style=&quot; font-weight:700;&quot;&gt;do not&lt;/span&gt; need to configure any bindings apart from the trigger and buttons. Aiming only needs to be set when you want to use multiple mice.&lt;/p&gt;&lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;span style=&quot; font-weight:700;&quot;&gt;left unbound&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE: &lt;/span&gt;Mouse mapping must be enabled in Global Settings to bind your PC&apos;s mouse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Som standard använder ljuspistoler muspekaren. För att använda musen behöver du &lt;span style=&quot; font-weight:700;&quot;&gt;inte&lt;/span&gt; konfigurera några bindningar utöver avtryckaren och knapparna. Siktet behöver endast ställas in om du vill använda flera möss.&lt;/p&gt;&lt;p&gt;Om du vill använda en handkontroll eller en ljuspistol som simulerar en handkontroll i stället för en mus ska den bindas till relativ siktning. Annars ska relativ siktning &lt;span style=&quot; font-weight:700;&quot;&gt;lämnas obunden&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;OBS! &lt;/span&gt;Musmappning måste aktiveras i globala inställningar för att datorns mus ska kunna bindas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="65"/>
         <source>Relative Aiming</source>
         <extracomment>Try to use Sony&apos;s official terminology for this. A good place to start would be in the console or the DualShock 2&apos;s manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.</extracomment>
         <translation>Relative Aiming</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="71"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="108"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="145"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="182"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="330"/>
         <source>Aiming</source>
         <translation>Sikte</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="367"/>
         <source>Trigger</source>
         <translation>Skjutknapp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="373"/>
         <source>Fire Offscreen</source>
         <translation>Skjut utanför skärm</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="410"/>
         <source>Fire</source>
         <translation>Skjut</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="450"/>
         <source>Side Buttons</source>
         <translation>Sidoknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="456"/>
         <source>Back</source>
         <translation>Bakåt</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_justifier.ui" line="493"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
@@ -2853,27 +2163,22 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_Mouse</name>
     <message>
-        <location filename="../controllerbindingwidget_mouse.ui" line="62"/>
         <source>Pointer</source>
         <translation>Pekare</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_mouse.ui" line="53"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE: &lt;/span&gt;Mouse mapping must be enabled in Global Settings to bind your PC&apos;s mouse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;OBS! &lt;/span&gt;Musmappning måste aktiveras i globala inställningar för att datorns mus ska kunna bindas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_mouse.ui" line="113"/>
         <source>Buttons</source>
         <translation>Knappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_mouse.ui" line="119"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_mouse.ui" line="156"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
@@ -2881,74 +2186,58 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_NeGcon</name>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="56"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="62"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="99"/>
-        <location filename="../controllerbindingwidget_negcon.ui" line="609"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="136"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="173"/>
-        <location filename="../controllerbindingwidget_negcon.ui" line="572"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="213"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="261"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="292"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="340"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="346"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="383"/>
         <source>II</source>
         <translation>II</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="420"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="457"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negcon.ui" line="566"/>
         <source>Steering/Twist</source>
         <translation>Styrning/Twist</translation>
     </message>
@@ -2956,89 +2245,70 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_NeGconRumble</name>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="56"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="62"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="99"/>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="609"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="136"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="173"/>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="572"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="213"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="261"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="292"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="340"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="346"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="383"/>
         <source>II</source>
         <translation>II</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="420"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="457"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="566"/>
         <source>Steering/Twist</source>
         <translation>Styrning/Twist</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="662"/>
         <source>Analog</source>
         <translation>Analog</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="681"/>
         <source>Large Motor</source>
         <translation>Stor motor</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidget_negconrumble.ui" line="718"/>
         <source>Small Motor</source>
         <translation>Liten motor</translation>
     </message>
@@ -3046,17 +2316,14 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerCustomSettingsWidget</name>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="978"/>
         <source>Restore Default Settings</source>
         <translation>Återställ standardinställningar</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="862"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="867"/>
         <source>Select File</source>
         <translation>Välj fil</translation>
     </message>
@@ -3064,230 +2331,184 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerGlobalSettingsWidget</name>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="31"/>
         <source>SDL Input Source</source>
         <translation>Källa för SDL-inmatning</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="77"/>
         <source>Enable SDL Input Source</source>
         <translation>Aktivera källa för SDL-inmatning</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="107"/>
         <source>Enable Touchpad</source>
         <translation>Aktivera pekplatta</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="48"/>
         <source>Enable DualSense Player LED</source>
         <translation>Aktivera Player LED för DualSense</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="117"/>
         <source>XInput Source</source>
         <translation>XInput-källa</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="298"/>
         <source>Using raw input improves precision when you bind controller sticks to the mouse pointer. Also enables multiple mice to be used.</source>
         <translation>Användning av rå inmatning förbättrar precisionen när du binder kontrollerspakar till muspekaren. Gör också att flera möss kan användas.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="175"/>
         <source>Horizontal Sensitivity:</source>
         <translation>Horisontell känslighet:</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="104"/>
         <source>Allows use of the touchpad for DualShock 4 / DualSense controllers as a pointer, for use with lightguns.</source>
         <translation>Gör det möjligt att använda styrplattan på DualShock 4-/DualSense-handkontroller som pekare för ljuspistoler.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="221"/>
-        <location filename="../controllerglobalsettingswidget.ui" line="276"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="230"/>
         <source>Vertical Sensitivity:</source>
         <translation>Vertikal känslighet:</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="288"/>
         <source>Use Raw Input</source>
         <translation>Använd rå inmatning</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="366"/>
         <source>Multitap Mode:</source>
         <translation>Multitap-läge:</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="379"/>
         <source>Profile Settings</source>
         <translation>Profilinställningar</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.cpp" line="221"/>
         <source>Controller LED Settings</source>
         <translation>LED-inställningar för handkontroller</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="350"/>
         <source>Controller Multitap</source>
         <translation>Multitap för handkontroller</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="356"/>
         <source>The multitap enables up to 8 controllers to be connected to the console. Each multitap provides 4 ports. Multitap is not supported by all games.</source>
         <translation>Multitap (eller flerspelaradapter) gör att upp till 8 handkontrollrar kan anslutas till konsollen. Varje multitap ger 4 portar. Multitap stöds inte av alla spel.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="169"/>
         <source>Mouse/Pointer Source</source>
         <translation>Källa för mus/pekare</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="330"/>
         <source>Enable Mouse Mapping</source>
         <translation>Aktivera musmappning</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="427"/>
         <source>Detected Devices</source>
         <translation>Identifierade enheter</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="123"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The XInput source provides support for controllers that use the XInput protocol. This source should &lt;span style=&quot; font-weight:700;&quot;&gt;only&lt;/span&gt; be used if you are using a XInput wrapper library.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;XInput-källan ger stöd för styrenheter som använder XInput-protokollet. Denna källa bör &lt;span style=&quot; font-weight:700;&quot;&gt;endast&lt;/span&gt; användas om du använder ett XInput-wrapperbibliotek.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.cpp" line="186"/>
         <source>Advanced SDL Options</source>
         <translation>Avancerade SDL-alternativ</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.cpp" line="215"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.cpp" line="215"/>
         <source>No SDL devices are currently connected.</source>
         <translation>Inga SDL-enheter är för närvarande anslutna.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.cpp" line="231"/>
         <source>&lt;strong&gt;Controller LED Settings&lt;/strong&gt;&lt;br&gt;
 The &quot;alternate&quot; color is used when analog mode is active.</source>
         <translation>&lt;strong&gt;Inställningar för kontrollerns LED-lampor&lt;/strong&gt;&lt;br&gt;
 Den ”alternativa” färgen används när analogt läge är aktivt.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.cpp" line="259"/>
         <source>Alternate Mode:</source>
         <translation>Alternativt läge:</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.cpp" line="259"/>
         <source>Normal Mode:</source>
         <translation>Normalt läge:</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="45"/>
         <source>Enables the player LED on DualSense controllers.</source>
         <translation>Aktiverar spelarens LED på DualSense-kontroller.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="61"/>
         <source>Adjusts LED settings for controllers with configurable LEDs.</source>
         <translation>Justerar LED-inställningar för kontroller med konfigurerbar LED.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="74"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the SDL input source and detection of controllers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aktiverar SDL-ingångskällan och detektering av styrenheter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="84"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows rumble and LED effects for DualShock 4 / DualSense controllers in Bluetooth mode. This option is not required for wired connections.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Enabling enhanced reports may result in your controller being unusable in other applications until it is turned off and on again.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tillåter vibrationer och LED-effekter för DualShock 4-/DualSense-kontroller i Bluetooth-läge. Det här alternativet krävs inte för kabelanslutningar. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Om du aktiverar förbättrade rapporter kan det hända att din kontroller inte går att använda i andra program förrän du stänger av och slår på den igen.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="87"/>
         <source>DualShock 4 / DualSense Enhanced Mode (Bluetooth Only)</source>
         <translation>DualShock 4 / DualSense förbättrat läge (endast Bluetooth)</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="94"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The SDL input source supports most controllers, and is the preferred option. Enhanced mode may be required for the Vibration/LED functionality of DualShock 4 / DualSense pads in Bluetooth mode. You can also edit &lt;a href=&quot;ADVANCED_SDL_OPTIONS&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#99ebff;&quot;&gt;advanced options&lt;/span&gt;&lt;/a&gt; which control device-specific behavior.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;SDL-ingångskällan stöder de flesta kontroller och är det rekommenderade alternativet. Förbättrat läge kan krävas för vibrations-/LED-funktionen hos DualShock 4-/DualSense-kontroller i Bluetooth-läge. Du kan också redigera &lt;a href=&quot;ADVANCED_SDL_OPTIONS&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#99ebff;&quot;&gt;avancerade alternativ&lt;/span&gt;&lt;/a&gt; som styr enhetsspecifikt beteende.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="133"/>
         <source>Enable XInput Source</source>
         <translation>Aktivera XInput-källa</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="143"/>
         <source>DirectInput Source</source>
         <translation>DirectInput-källa</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="149"/>
         <source>The DirectInput source provides support for legacy controllers which do not support XInput. Accessing these controllers via SDL is recommended instead.</source>
         <translation>DirectInput-källan ger stöd för äldre kontroller som inte stöder XInput. Istället rekommenderas att du använder SDL för att komma åt dessa kontroller.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="159"/>
         <source>Enable DirectInput Source</source>
         <translation>Aktivera DirectInput-källa</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="311"/>
         <source>Mapping Settings</source>
         <translation>Mappningsinställningar</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="317"/>
         <source>By default, mapping mouse movement and device sensors is disabled to avoid accidential bindings when manually mapping.</source>
         <translation>Som standard är mappning av musrörelser och enhetssensorer inaktiverad för att undvika oavsiktliga bindningar vid manuell mappning.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="327"/>
         <source>Allows the mouse to be mapped to emulated controls. By default movement of the mouse will be ignored.</source>
         <translation>Gör det möjligt att mappa musen till emulerade kontroller. Som standard ignoreras musens rörelser.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="285"/>
         <source>Uses raw input for mice input. Enable if you wish to use multiple mice/lightguns.</source>
         <translation>Använder rå inmatning för musinmatning. Aktivera om du vill använda flera möss/ljuspistoler.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="337"/>
         <source>Allows sensors such as accelerometers to be mapped to emulated controls. By default sensors will be ignored.</source>
         <translation>Gör det möjligt att mappa sensorer, exempelvis accelerometrar, till emulerade kontroller. Sensorer ignoreras som standard.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="340"/>
         <source>Enable Sensor Mapping</source>
         <translation>Aktivera sensormappning</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="385"/>
         <source>When these options are enabled, input sources and hotkeys can be set in this input profile, and will be used instead of the global source/hotkey configuration. By default, sources and hotkeys are always shared between all profiles.</source>
         <translation>När dessa alternativ är aktiverade kan inmatningskällor och snabbtangenter ställas in i denna inmatningsprofil och kommer att användas istället för den globala käll-/snabbtangentkonfigurationen. Som standard delas källor och snabbtangenter alltid mellan alla profiler.</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="395"/>
         <source>Use Profile Input Sources</source>
         <translation>Använd profilens inmatningskällor</translation>
     </message>
     <message>
-        <location filename="../controllerglobalsettingswidget.ui" line="402"/>
         <source>Use Profile Hotkeys</source>
         <translation>Använd profilens snabbtangenter</translation>
     </message>
@@ -3295,94 +2516,74 @@ Den ”alternativa” färgen används när analogt läge är aktivt.</translati
 <context>
     <name>ControllerMacroEditWidget</name>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="29"/>
         <source>Binds/Buttons</source>
         <translation>Bindningar/Knappar</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="35"/>
         <source>Select the buttons which you want to trigger with this macro. All buttons are activated concurrently.</source>
         <translation>Välj knapparna som du vill utlösa med detta makro. Alla knappar är aktiverade samtidigt.</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="51"/>
         <source>Pressure</source>
         <translation>Tryckkänslighet</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="57"/>
         <source>For buttons which are pressure sensitive, this slider controls how much force will be simulated when the macro is active.</source>
         <translation>För knappar som är tryckkänsliga så kontrollerar denna draglist hur mycket kraft som ska simuleras när makrot är aktivt.</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="91"/>
-        <location filename="../controllermacroeditwidget.ui" line="171"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="103"/>
         <source>Trigger</source>
         <translation>Utlösare</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="111"/>
         <source>Select the trigger to activate this macro. This can be a single button, or combination of buttons (chord). Shift-click for multiple triggers.</source>
         <translation>Välj utlösaren för att aktivera detta makro. Detta kan vara en enda knapp eller en kombination av knappar (ackord). Skift-klicka för flera utlösare.</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="124"/>
         <source>Press To Toggle</source>
         <translation>Tryck för att växla</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="142"/>
         <source>Deadzone:</source>
         <translation>Dödläge:</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="183"/>
         <source>Frequency</source>
         <translation>Frekvens</translation>
     </message>
     <message>
-        <location filename="../controllermacroeditwidget.ui" line="191"/>
         <source>Macro will toggle every N frames.</source>
         <translation>Makrot kommer växla var N bildruta.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="636"/>
         <source>Controller %1 Macro %2</source>
         <translation>Handkontroll %1 makro %2</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="655"/>
         <source>Not Configured</source>
         <translation>Inte konfigurerad</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="660"/>
-        <location filename="../controllerbindingwidgets.cpp" line="665"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="671"/>
         <source>Set Frequency</source>
         <translation>Ställ in frekvens</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="671"/>
         <source>Frequency: </source>
         <translation>Frekvens: </translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="700"/>
         <source>Macro will not repeat.</source>
         <translation>Makrot kommer inte upprepas.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../controllerbindingwidgets.cpp" line="702"/>
         <source>Macro will toggle buttons every %n frame(s).</source>
         <translation>
             <numerusform>Makrot kommer att växla knappar var %n bildruta.</numerusform>
@@ -3393,12 +2594,10 @@ Den ”alternativa” färgen används när analogt läge är aktivt.</translati
 <context>
     <name>ControllerMacroWidget</name>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="529"/>
         <source>Controller Port %1 Macros</source>
         <translation>Kontrollerport %1-makron</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="539"/>
         <source>Macro %1
 %2</source>
         <translation>Makro %1
@@ -3408,85 +2607,66 @@ Den ”alternativa” färgen används när analogt läge är aktivt.</translati
 <context>
     <name>ControllerSettingsWindow</name>
     <message>
-        <location filename="../controllersettingswindow.ui" line="78"/>
         <source>Editing Preset:</source>
         <translation>Redigerar förval:</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.ui" line="95"/>
         <source>New Preset</source>
         <translation>Nytt förval</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.ui" line="106"/>
         <source>Apply Preset</source>
         <translation>Tillämpa förval</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.ui" line="117"/>
         <source>Delete Preset</source>
         <translation>Ta bort förval</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.ui" line="128"/>
         <source>Copy Global Settings</source>
         <translation>Kopiera globala inställningar</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="298"/>
         <source>Restore Defaults</source>
         <translation>Återställ standardvärden</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="184"/>
-        <location filename="../controllersettingswindow.cpp" line="582"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="327"/>
         <source>Per-game controller configuration reset to global settings.</source>
         <translation>Handkontrollerkonfiguration för per-spel nollställdes till globala inställningar.</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="76"/>
         <source>DuckStation Controller Presets</source>
         <translation>Handkontrollerförval för DuckStation</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="175"/>
-        <location filename="../controllersettingswindow.cpp" line="190"/>
-        <location filename="../controllersettingswindow.cpp" line="204"/>
         <source>Create Controller Preset</source>
         <translation>Skapa handkontrollerförval</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="175"/>
         <source>Enter the name for the new controller preset:</source>
         <translation>Ange namnet för det nya handkontrollerförvalet:</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="185"/>
         <source>A preset with the name &apos;%1&apos; already exists.</source>
         <translation>Ett förval med namnet &quot;%1&quot; finns redan.</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="191"/>
         <source>Do you want to copy all bindings from the currently-selected preset to the new preset? Selecting No will create a completely empty preset.</source>
         <translation>Vill du kopiera alla bindningar från aktuellt valt förval till det nya förvalet? Väljer du Nej så kommer en helt tomt förval att skapas.</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="205"/>
         <source>Do you want to copy the current hotkey bindings from global settings to the new controller preset?</source>
         <translation>Vill du kopiera de aktuella snabbtangentsbindningarna från globala inställningar till det nya handkontrollerförvalet?</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="248"/>
         <source>Load Controller Preset</source>
         <translation>Läs in handkontrollerförval</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="249"/>
         <source>Are you sure you want to apply the controller preset named &apos;%1&apos;?
 
 All current global bindings will be removed, and the preset bindings loaded.
@@ -3499,12 +2679,10 @@ Alla aktuella globala bindningar kommer att tas bort och förvalsbindningarna at
 Du kan inte ångra denna åtgärd.</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="275"/>
         <source>Delete Controller Preset</source>
         <translation>Ta bort handkontrollerförval</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="276"/>
         <source>Are you sure you want to delete the controller preset named &apos;%1&apos;?
 
 You cannot undo this action.</source>
@@ -3513,7 +2691,6 @@ You cannot undo this action.</source>
 Du kan inte ångra denna åtgärd.</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="299"/>
         <source>Are you sure you want to restore the default controller configuration?
 
 All bindings and configuration will be lost. You cannot undo this action.</source>
@@ -3522,36 +2699,28 @@ All bindings and configuration will be lost. You cannot undo this action.</sourc
 Alla bindningar och konfigurationen kommer att förloras . Du kan inte ångra denna åtgärd.</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="328"/>
         <source>Controller preset reset to global settings.</source>
         <translation>Handkontrollerförval nollställdes till globala inställningar.</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="438"/>
         <source>Global Settings</source>
         <translation>Globala inställningar</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="464"/>
-        <location filename="../controllersettingswindow.cpp" line="515"/>
         <source>Controller Port %1
 %2</source>
         <translation>Kontrollerport %1
 %2</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="477"/>
         <source>Hotkeys</source>
         <translation>Snabbtangenter</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.cpp" line="583"/>
         <source>The controller preset named &apos;%1&apos; cannot be found.</source>
         <translation>Handkontrollerförvalet med namnet &apos;%1&apos; kan inte hittas.</translation>
     </message>
     <message>
-        <location filename="../controllersettingswindow.ui" line="20"/>
-        <location filename="../controllersettingswindow.cpp" line="326"/>
         <source>DuckStation Controller Settings</source>
         <translation>Handkontrollerinställningar för DuckStation</translation>
     </message>
@@ -3559,37 +2728,26 @@ Alla bindningar och konfigurationen kommer att förloras . Du kan inte ångra de
 <context>
     <name>CoreThread</name>
     <message>
-        <location filename="../qthost.cpp" line="3136"/>
         <source>%1x%2</source>
         <translation>%1x%2</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1140"/>
-        <location filename="../qthost.cpp" line="1165"/>
-        <location filename="../qthost.cpp" line="1536"/>
-        <location filename="../qthost.cpp" line="1650"/>
-        <location filename="../qthost.cpp" line="1681"/>
-        <location filename="../qthost.cpp" line="1793"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1140"/>
         <source>Cannot change GPU dump state without restarting the system.</source>
         <translation>GPU-dumpens tillstånd kan inte ändras utan att systemet startas om.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1166"/>
         <source>Failed to load state: %1</source>
         <translation>Misslyckades med att läsa in tillstånd: %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1414"/>
         <source>Memory Card Busy</source>
         <translation>Minneskortet är upptaget</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1415"/>
         <source>WARNING: Your game is still saving to the memory card. Continuing to %1 may IRREVERSIBLY DESTROY YOUR MEMORY CARD. We recommend resuming your game and waiting 5 seconds for it to finish saving.
 
 Do you want to %1 anyway?</source>
@@ -3598,12 +2756,10 @@ Do you want to %1 anyway?</source>
 Vill du %1 ändå?</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1424"/>
         <source>Achievement Unlocks Unconfirmed</source>
         <translation>Prestationsupplåsningar är obekräftade</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1425"/>
         <source>%1 achievement unlocks have not been confirmed by the server. Continuing to %2 will result in loss of these unlocks. Once network connectivity has been re-established, these unlocks will be confirmed automatically.
 
 Do you want to %2 anyway?</source>
@@ -3612,32 +2768,26 @@ Do you want to %2 anyway?</source>
 Vill du %2 ändå?</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1451"/>
         <source>shut down</source>
         <translation>stäng av</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1473"/>
         <source>reset</source>
         <translation>starta om</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1505"/>
         <source>change disc</source>
         <translation>byt skiva</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1536"/>
         <source>Failed to switch to subimage %1</source>
         <translation>Misslyckades med att växla till underbild %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1640"/>
         <source>Confirm Download</source>
         <translation>Bekräfta hämtning</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1641"/>
         <source>Your DuckStation installation does not have the padtest application available.
 
 This file is approximately 206KB, do you want to download it now?</source>
@@ -3646,32 +2796,26 @@ This file is approximately 206KB, do you want to download it now?</source>
 Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1793"/>
         <source>Failed to save state: %1</source>
         <translation>Misslyckades med att spara tillstånd: %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="3136"/>
         <source>No Image</source>
         <translation>Ingen bild</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="3146"/>
         <source>Game: %1 FPS</source>
         <translation>Spel: %1 bilder/s</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="3155"/>
         <source>Video: %1 FPS (%2%)</source>
         <translation>Video: %1 bilder/s (%2%)</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1791"/>
         <source>State saved to %1.</source>
         <translation>Tillstånd sparades till %1.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1651"/>
         <source>Failed to download padtest application: %1</source>
         <translation>Misslyckades med att hämta applikationen padtest: %1</translation>
     </message>
@@ -3679,53 +2823,42 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>CoverDownloadWindow</name>
     <message>
-        <location filename="../coverdownloadwindow.ui" line="14"/>
         <source>Download Covers</source>
         <translation>Hämta omslagsbilder</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.ui" line="36"/>
         <source>DuckStation can automatically download covers for games which do not currently have a cover set. We do not host any cover images, the user must provide their own source for images.</source>
         <translation>DuckStation kan automatiskt hämta omslagsbilder för spel som du för närvarande inte har ett omslag för. Vi tillhandahåller inte några omslagsbilder och användaren måste tillhandahålla sin egna källa för bilder.</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.ui" line="54"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Depending on your jurisdiction, &lt;span style=&quot; font-weight:700;&quot;&gt;game covers may be copyrighted&lt;/span&gt;. You are only authorized to use this tool with &lt;span style=&quot; font-weight:700;&quot;&gt;your own servers and images&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;In the box below, specify the URLs to download covers from, with one template URL per line. The following variables are available:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${title}:&lt;/span&gt; Title of the game.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${savetitle}:&lt;/span&gt; Title of the game including the region.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${localizedtitle}:&lt;/span&gt; Localized (native language) title of the game.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${filetitle}:&lt;/span&gt; Name component of the game&apos;s filename.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${serial}:&lt;/span&gt; Serial of the game.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Example:&lt;/span&gt; https://www.example-not-a-real-domain.com/covers/${serial}.jpg&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Beroende på din jurisdiktion kan &lt;span style=&quot; font-weight:700;&quot;&gt;spelomslag vara upphovsrättsskyddade&lt;/span&gt;. Du får endast använda verktyget med &lt;span style=&quot; font-weight:700;&quot;&gt;dina egna servrar och bilder&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;Ange webbadresserna som omslag ska hämtas från i rutan nedan, med en malladress per rad. Följande variabler är tillgängliga:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${title}:&lt;/span&gt; Spelets titel.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${savetitle}:&lt;/span&gt; Spelets titel inklusive region.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${localizedtitle}:&lt;/span&gt; Lokaliserad titel (originalspråk).&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${filetitle}:&lt;/span&gt; Titeldelen av spelets filnamn.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${serial}:&lt;/span&gt; Spelets serienummer.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Exempel:&lt;/span&gt; https://www.example-not-a-real-domain.com/covers/${serial}.jpg&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.ui" line="73"/>
         <source>By default, the downloaded covers will be saved with the game&apos;s title. If this is not desired, you can check the &quot;Use Serial File Names&quot; box below. Using serials instead of game titles will prevent conflicts when multiple regions of the same game are used.</source>
         <translation>Som standard kommer hämtade omslagsbilder att sparas med spelets titel. Om detta inte är önskvärt så kan du välja &quot;Använd filnamn för serienummer&quot; nedan. Använda serienummer istället för speltitlar förhindrar konflikter när flera regioner av samma spel används.</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.ui" line="83"/>
         <source>Use Serial File Names</source>
         <translation>Använd filnamn för serienummer</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.ui" line="90"/>
         <source>Waiting to start...</source>
         <translation>Väntar på att starta...</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.ui" line="105"/>
-        <location filename="../coverdownloadwindow.cpp" line="107"/>
         <source>Start</source>
         <translation>Starta</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.ui" line="119"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.cpp" line="93"/>
         <source>Download complete.</source>
         <translation>Hämtningen är färdig.</translation>
     </message>
     <message>
-        <location filename="../coverdownloadwindow.cpp" line="107"/>
         <source>Stop</source>
         <translation>Stoppa</translation>
     </message>
@@ -3733,32 +2866,26 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>DebuggerAddBreakpointDialog</name>
     <message>
-        <location filename="../debuggeraddbreakpointdialog.ui" line="14"/>
         <source>Add Breakpoint</source>
         <translation>Lägg till brytpunkt</translation>
     </message>
     <message>
-        <location filename="../debuggeraddbreakpointdialog.ui" line="20"/>
         <source>Address:</source>
         <translation>Adress:</translation>
     </message>
     <message>
-        <location filename="../debuggeraddbreakpointdialog.ui" line="30"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../debuggeraddbreakpointdialog.ui" line="42"/>
         <source>Execute</source>
         <translation>Kör</translation>
     </message>
     <message>
-        <location filename="../debuggeraddbreakpointdialog.ui" line="52"/>
         <source>Read</source>
         <translation>Läs</translation>
     </message>
     <message>
-        <location filename="../debuggeraddbreakpointdialog.ui" line="59"/>
         <source>Write</source>
         <translation>Skriv</translation>
     </message>
@@ -3766,12 +2893,10 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>DebuggerCallStackModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="253"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="255"/>
         <source>Frame</source>
         <translation>Bildruta</translation>
     </message>
@@ -3779,12 +2904,10 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>DebuggerRegistersModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="100"/>
         <source>Register</source>
         <translation>Register</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="102"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
@@ -3792,17 +2915,14 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>DebuggerStackModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="158"/>
         <source>&lt;invalid&gt;</source>
         <translation>&lt;ogiltig&gt;</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="174"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="176"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
@@ -3810,12 +2930,10 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>DebuggerThreadsModel</name>
     <message>
-        <location filename="../debuggermodels.cpp" line="397"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="399"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
@@ -3823,425 +2941,336 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>DebuggerWindow</name>
     <message>
-        <location filename="../debuggerwindow.ui" line="382"/>
         <source>Step Into</source>
         <translation>Stega in i</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="385"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="397"/>
         <source>Step Over</source>
         <translation>Stega över</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="400"/>
         <source>F10</source>
         <translation>F10</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="436"/>
         <source>Step Out</source>
         <translation>Stega ut</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="14"/>
         <source>CPU Debugger</source>
         <translation>CPU-felsökare</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="34"/>
         <source>&amp;Debug</source>
         <translation>&amp;Felsök</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="53"/>
-        <location filename="../debuggerwindow.ui" line="258"/>
         <source>Breakpoints</source>
         <translation>Brytpunkter</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="65"/>
         <source>toolBar</source>
         <translation>verktygsrad</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="95"/>
         <source>Disassembly</source>
         <translation>Disassembler</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="114"/>
         <source>Registers</source>
         <translation>Register</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="145"/>
         <source>Memory</source>
         <translation>Minne</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="167"/>
         <source>RAM</source>
         <translation>RAM</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="177"/>
         <source>Scratchpad</source>
         <translation>Skissblock</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="184"/>
         <source>EXP1</source>
         <translation>EXP1</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="191"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="198"/>
         <source>VRAM</source>
         <translation>VRAM</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="205"/>
         <source>SPU RAM</source>
         <translation>SPU-RAM</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="230"/>
         <source>Search</source>
         <translation>Sök</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="278"/>
         <source>#</source>
         <translation>#</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="283"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="288"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="293"/>
         <source>Hit Count</source>
         <translation>Antal träffar</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="303"/>
         <source>Stack</source>
         <translation>Stapel</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="322"/>
         <source>Threads</source>
         <translation>Trådar</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="341"/>
         <source>Call Stack</source>
         <translation>Anropsstack</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="364"/>
         <source>&amp;Pause/Continue</source>
         <translation>&amp;Paus/Fortsätt</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="367"/>
         <source>Pause/Continue</source>
         <translation>Paus/Fortsätt</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="370"/>
         <source>F5</source>
         <translation>F5</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="379"/>
         <source>&amp;Step Into</source>
         <translation>&amp;Stega in i</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="394"/>
         <source>Step &amp;Over</source>
         <translation>Stega ö&amp;ver</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="409"/>
-        <location filename="../debuggerwindow.cpp" line="349"/>
         <source>Toggle &amp;Breakpoint</source>
         <translation>Växla &amp;brytpunkt</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="412"/>
         <source>Toggle Breakpoint</source>
         <translation>Växla brytpunkt</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="415"/>
         <source>F9</source>
         <translation>F9</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="424"/>
         <source>&amp;Close</source>
         <translation>S&amp;täng</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="433"/>
         <source>Step O&amp;ut</source>
         <translation>Stega &amp;ut</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="439"/>
         <source>Ctrl+F11</source>
         <translation>Ctrl+F11</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="448"/>
-        <location filename="../debuggerwindow.cpp" line="352"/>
         <source>&amp;Run To Cursor</source>
         <translation>&amp;Kör till markör</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="451"/>
         <source>Run To Cursor</source>
         <translation>Kör till markör</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="454"/>
         <source>Ctrl+F10</source>
         <translation>Ctrl+F10</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="463"/>
         <source>&amp;Clear Breakpoints</source>
         <translation>&amp;Töm brytpunkter</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="466"/>
         <source>Clear Breakpoints</source>
         <translation>Töm brytpunkter</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="469"/>
         <source>Ctrl+Del</source>
         <translation>Ctrl+Del</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="478"/>
         <source>&amp;Add Breakpoint</source>
         <translation>&amp;Lägg till brytpunkt</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="481"/>
         <source>Add Breakpoint</source>
         <translation>Lägg till brytpunkt</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="484"/>
         <source>Ctrl+F9</source>
         <translation>Ctrl+F9</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="493"/>
         <source>&amp;Go To PC</source>
         <translation>&amp;Gå till PC</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="496"/>
         <source>Go To PC</source>
         <translation>Gå till PC</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="499"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="508"/>
         <source>Go To &amp;Address</source>
         <translation>Gå till &amp;adress</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="511"/>
         <source>Go To Address</source>
         <translation>Gå till adress</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="514"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="523"/>
         <source>&amp;Dump Address</source>
         <translation>&amp;Dumpa adress</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="526"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="535"/>
         <source>&amp;Trace</source>
         <translation>S&amp;påra</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="538"/>
         <source>Trace</source>
         <translation>Spåra</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.ui" line="541"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../debuggermodels.cpp" line="530"/>
-        <location filename="../qtutils.cpp" line="220"/>
         <source>Invalid address. It should be in hex (0x12345678 or 12345678)</source>
         <translation>Ogiltig adress. Den bör anges i hex (0x12345678 eller 12345678)</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="168"/>
         <source>No address selected.</source>
         <translation>Ingen adress vald.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="184"/>
         <source>Enter code address:</source>
         <translation>Ange kodadress:</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="194"/>
-        <location filename="../qtutils.cpp" line="203"/>
         <source>Enter memory address:</source>
         <translation>Ange minnesadress:</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="218"/>
         <source>Trace logging started to cpu_log.txt.
 This file can be several gigabytes, so be aware of SSD wear.</source>
         <translation>Spårloggning startad till cpu_log.txt.
 Denna fil kan bli flera gigabytes så tänk på diskutrymmet.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="223"/>
         <source>Trace logging to cpu_log.txt stopped.</source>
         <translation>Spårloggning till cpu_log.txt stoppad.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="262"/>
         <source>&amp;Remove</source>
         <translation>&amp;Ta bort</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="314"/>
         <source>Debugger</source>
         <translation>Felsökare</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="315"/>
         <source>Failed to add step-out breakpoint, are you in a valid function?</source>
         <translation>Misslyckades med att stega ut ur brytpunkt. Är du i en giltig funktion?</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="363"/>
         <source>&amp;Patch Instruction</source>
         <translation>&amp;Patcha instruktion</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="367"/>
         <source>&amp;Nop Instruction</source>
         <translation>&amp;Noppa instruktion</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="372"/>
         <source>View in &amp;Dump</source>
         <translation>Visa i &amp;dump</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="375"/>
         <source>&amp;Follow Load/Store</source>
         <translation>&amp;Följ läs in/Lagra</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="417"/>
         <source>Failed to read the instruction at 0x%1.</source>
         <translation>Det gick inte att läsa instruktionen vid 0x%1.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="428"/>
         <source>Patch Instruction</source>
         <translation>Patcha instruktion</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="429"/>
         <source>Enter replacement instruction for 0x%1:</source>
         <translation>Ange ersättningsinstruktion för 0x%1:</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="444"/>
         <source>Invalid Instruction</source>
         <translation>Ogiltig instruktion</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="463"/>
         <source>Failed to write patched instruction to 0x%1.</source>
         <translation>Det gick inte att skriva den patchade instruktionen till 0x%1.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="469"/>
         <source>Patched instruction at 0x%1.</source>
         <translation>Patchade instruktionen vid 0x%1.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="520"/>
-        <location filename="../debuggerwindow.cpp" line="547"/>
         <source>Invalid search pattern. It should contain hex digits or question marks.</source>
         <translation>Ogiltigt sökmönster. Det bör innehålla hexadecimala siffror eller frågetecken.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="559"/>
         <source>Pattern not found.</source>
         <translation>Mönstret hittades inte.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="575"/>
         <source>Pattern found at 0x%1 (passed the end of memory).</source>
         <translation>Mönster hittades vid 0x%1 (passerat minnets slut).</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="581"/>
         <source>Pattern found at 0x%1.</source>
         <translation>Mönster hittades på 0x%1.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="911"/>
         <source>Failed to add breakpoint. A breakpoint may already exist at this address.</source>
         <translation>Misslyckades med att lägga till brytpunkt. En brytpunkt kanske redan finns på denna adress.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="931"/>
         <source>Failed to remove breakpoint. This breakpoint may not exist.</source>
         <translation>Misslyckades med att ta bort brytpunkt. Denna brytpunkt kanske inte finns.</translation>
     </message>
     <message>
-        <location filename="../debuggerwindow.cpp" line="1043"/>
         <source>Loaded %1 saved breakpoints.</source>
         <translation>Läste in %1 sparade brytpunkter.</translation>
     </message>
@@ -4249,206 +3278,162 @@ Denna fil kan bli flera gigabytes så tänk på diskutrymmet.</translation>
 <context>
     <name>DebuggingSettingsWidget</name>
     <message>
-        <location filename="../debuggingsettingswidget.ui" line="51"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Changing these settings may cause games to become unstable or crash.&lt;/span&gt; Do not change any settings on this page if you do not know what you are doing, or understand what the impact of the change will be.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Om du ändrar dessa inställningar kan spel bli instabila eller krascha.&lt;/span&gt; Ändra inte inställningarna på den här sidan om du inte vet vad du gör eller förstår vilka konsekvenser ändringen får.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.ui" line="64"/>
         <source>Reset To Default</source>
         <translation>Återställ till standard</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.ui" line="85"/>
         <source>Option</source>
         <translation>Alternativ</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.ui" line="90"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="145"/>
         <source>Select folder for %1</source>
         <translation>Välj mapp för %1</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="184"/>
         <source>Apply Game Settings</source>
         <translation>Tillämpa spelinställningar</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="188"/>
         <source>Apply Compatibility Settings</source>
         <translation>Tillämpa kompatibilitetsinställningar</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="190"/>
         <source>Load Devices From Save States</source>
         <translation>Läs in enheter från sparade tillstånd</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="192"/>
         <source>Pause On Start</source>
         <translation>Pausa vid start</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="193"/>
         <source>Save State Compression</source>
         <translation>Komprimering för sparat tillstånd</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="201"/>
         <source>Display Active Start Offset</source>
         <translation>Visa aktiv startoffset</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="203"/>
         <source>Display Active End Offset</source>
         <translation>Visa aktiv slutoffset</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="205"/>
         <source>Display Line Start Offset</source>
         <translation>Offset för visningsradens början</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="207"/>
         <source>Display Line End Offset</source>
         <translation>Offset för visning av linjens slut</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="211"/>
         <source>DMA Max Slice Ticks</source>
         <translation>DMA Max Slice Ticks</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="212"/>
-        <location filename="../debuggingsettingswidget.cpp" line="214"/>
-        <location filename="../debuggingsettingswidget.cpp" line="218"/>
-        <location filename="../debuggingsettingswidget.cpp" line="237"/>
-        <location filename="../debuggingsettingswidget.cpp" line="240"/>
         <source> cycles</source>
         <translation> cykler</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="213"/>
         <source>DMA Halt Ticks</source>
         <translation>DMA Halt Ticks</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="215"/>
         <source>GPU FIFO Size</source>
         <translation>GPU FIFO-storlek</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="216"/>
         <source> words</source>
         <translation> ord</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="217"/>
         <source>GPU Max Runahead</source>
         <translation>GPU Max Runahead</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="220"/>
         <source>Enable Recompiler Memory Exceptions</source>
         <translation>Aktivera minnesundantag för omkompilerare</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="222"/>
         <source>Enable Recompiler Block Linking</source>
         <translation>Aktivera blocklänkning för omkompilerare</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="224"/>
         <source>Enable Recompiler Fast Memory Access</source>
         <translation>Aktivera snabb minnesåtkomst för omkompilerare</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="229"/>
         <source>CD-ROM Mechacon Version</source>
         <translation>CD-ROM Mechacon-version</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="233"/>
         <source>CD-ROM Readahead Sectors</source>
         <translation>CD-ROM Readahead-sektorer</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="234"/>
         <source> sectors</source>
         <translation> sektorer</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="235"/>
         <source>CD-ROM Max Read Speedup Cycles</source>
         <translation>Maximalt antal accelerationscykler för CD-ROM-läsning</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="238"/>
         <source>CD-ROM Max Seek Speedup Cycles</source>
         <translation>Maximalt antal accelerationscykler för CD-ROM-sökning</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="241"/>
         <source>CD-ROM Disable Speedup on MDEC</source>
         <translation>Inaktivera CD-ROM-hastighetsökning på MDEC</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="243"/>
         <source>CD-ROM Region Check</source>
         <translation>Regionskontroll för CD-ROM</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="244"/>
         <source>CD-ROM SubQ Skew</source>
         <translation>CD-ROM SubQ Skew</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="245"/>
         <source>Allow Booting Without SBI File</source>
         <translation>Tillåt uppstarter utan SBI-fil</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="248"/>
         <source>Enable GDB Server</source>
         <translation>Aktivera GDB-server</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="249"/>
         <source>GDB Server Port</source>
         <translation>GDB-serverport</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="252"/>
         <source>Enable PCSX Expansion Region</source>
         <translation>Aktivera PCSX-expansionsområde</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="254"/>
         <source>Export Shared Memory</source>
         <translation>Exportera delat minne</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="256"/>
         <source>Redirect SIO to TTY</source>
         <translation>Omdirigera SIO till TTY</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="257"/>
         <source>Enable PCDrv</source>
         <translation>Aktivera PCDrv</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="258"/>
         <source>Enable PCDrv Writes</source>
         <translation>Aktivera PCDrv-skrivningar</translation>
     </message>
     <message>
-        <location filename="../debuggingsettingswidget.cpp" line="259"/>
         <source>PCDrv Root Directory</source>
         <translation>Rotkatalog för PCDrv</translation>
     </message>
@@ -4456,12 +3441,10 @@ Denna fil kan bli flera gigabytes så tänk på diskutrymmet.</translation>
 <context>
     <name>EditGameSerialDialog</name>
     <message>
-        <location filename="../editgameserialdialog.ui" line="14"/>
         <source>Edit Game Serial</source>
         <translation>Redigera spelets serienummer</translation>
     </message>
     <message>
-        <location filename="../editgameserialdialog.ui" line="53"/>
         <source>Changing the serial for a game will make it appear as a different game, and will not share save data or settings with the original game.
 
 Clicking Reset will restore the serial back to the value scanned from in the disc image.</source>
@@ -4470,17 +3453,14 @@ Clicking Reset will restore the serial back to the value scanned from in the dis
 Om du klickar på Återställ återställs serienumret till värdet som lästes från skivavbilden.</translation>
     </message>
     <message>
-        <location filename="../editgameserialdialog.ui" line="73"/>
         <source>Path:</source>
         <translation>Sökväg:</translation>
     </message>
     <message>
-        <location filename="../editgameserialdialog.ui" line="87"/>
         <source>New Serial:</source>
         <translation>Nytt serienummer:</translation>
     </message>
     <message>
-        <location filename="../editgameserialdialog.ui" line="97"/>
         <source>This game currently has a custom serial set.</source>
         <translation>Spelet har för närvarande ett anpassat serienummer.</translation>
     </message>
@@ -4488,17 +3468,14 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
 <context>
     <name>EmptyGameListWidget</name>
     <message>
-        <location filename="../emptygamelistwidget.ui" line="82"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;No games in supported formats were found.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please add a directory with games to begin.&lt;/p&gt;&lt;p&gt;Game dumps in the following formats will be scanned and listed:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Inga spel i format som stöds hittades.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Lägg till en katalog med spel för att börja.&lt;/p&gt;&lt;p&gt;Speldumpar i följande format kommer att sökas igenom och listas:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../emptygamelistwidget.ui" line="114"/>
         <source>Add Game Directory...</source>
         <translation>Lägg till spelkatalog...</translation>
     </message>
     <message>
-        <location filename="../emptygamelistwidget.ui" line="155"/>
         <source>Scan For New Games</source>
         <translation>Sök efter nya spel</translation>
     </message>
@@ -4506,359 +3483,270 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
 <context>
     <name>EmulationSettingsWidget</name>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="29"/>
         <source>Speed Control</source>
         <translation>Hastighetskontroll</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="42"/>
         <source>Fast Forward Speed:</source>
         <translation>Hastighet för snabbspolning:</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="49"/>
         <source>Turbo Speed:</source>
         <translation>Turbohastighet:</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="164"/>
         <source>Latency Control</source>
         <translation>Latenskontroll</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="191"/>
-        <location filename="../emulationsettingswidget.cpp" line="197"/>
         <source>Reduce Input Latency</source>
         <translation>Reducera inmatningslatens</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="177"/>
-        <location filename="../emulationsettingswidget.cpp" line="184"/>
         <source>Sync To Host Refresh Rate</source>
         <translation>Synka till värdens uppdateringsfrekvens</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="198"/>
-        <location filename="../emulationsettingswidget.cpp" line="206"/>
         <source>Skip Duplicate Frame Display</source>
         <translation>Hoppa över dubblett bildvisning</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="213"/>
         <source>Frame Time Buffer:</source>
         <translation>Bildtidsbuffert:</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="220"/>
         <source> Milliseconds</source>
         <translation> millisekunder</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="291"/>
         <source>Enable Rewinding</source>
         <translation>Aktivera tillbakaspolning</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="244"/>
         <source>Rewind Save Frequency:</source>
         <translation>Frekvens för sparande av tillbakaspolning:</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="278"/>
         <source> Seconds</source>
         <translation> sekunder</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="271"/>
         <source>Rewind Buffer Size:</source>
         <translation>Buffertstorlek för tillbakaspolning:</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="35"/>
         <source>Normal Speed:</source>
         <translation>Normal hastighet:</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="58"/>
-        <location filename="../emulationsettingswidget.ui" line="93"/>
-        <location filename="../emulationsettingswidget.ui" line="128"/>
-        <location filename="../emulationsettingswidget.cpp" line="73"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="78"/>
         <source>Reset Normal Speed</source>
         <translation>Återställ normal hastighet</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="113"/>
         <source>Reset Fast Forward Speed</source>
         <translation>Återställ snabbspolningshastighet</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="148"/>
         <source>Reset Turbo Speed</source>
         <translation>Återställ turbohastighet</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="251"/>
         <source> Frames</source>
         <translation> bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="314"/>
         <source>Runahead:</source>
         <translation>Runahead:</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="327"/>
         <source>1 Frame</source>
         <translation>1 bildruta</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="337"/>
         <source>3 Frames</source>
         <translation>3 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="342"/>
         <source>4 Frames</source>
         <translation>4 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="347"/>
         <source>5 Frames</source>
         <translation>5 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="352"/>
         <source>6 Frames</source>
         <translation>6 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="357"/>
         <source>7 Frames</source>
         <translation>7 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="362"/>
         <source>8 Frames</source>
         <translation>8 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="367"/>
         <source>9 Frames</source>
         <translation>9 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="372"/>
         <source>10 Frames</source>
         <translation>10 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="322"/>
-        <location filename="../emulationsettingswidget.cpp" line="224"/>
         <source>Disabled</source>
         <translation>Inaktiverad</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="184"/>
-        <location filename="../emulationsettingswidget.cpp" line="191"/>
         <source>Optimal Frame Pacing</source>
         <translation>Optimal bildrytm</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="170"/>
-        <location filename="../emulationsettingswidget.cpp" line="179"/>
         <source>Vertical Sync (VSync)</source>
         <translation>Vertikal sync (VSync)</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="63"/>
         <source>N/A</source>
         <translation>Inte tillgängligt</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="72"/>
         <source>% (Normal Speed)</source>
         <translation>% (normal hastighet)</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="169"/>
         <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached, and if not, the emulator will run as fast as it can manage.</source>
         <translation>Ställer in målhastigheten för emuleringen. Det är inte säkert att denna hastighet uppnås, och om så inte är fallet körs emulatorn så snabbt som den klarar av.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="172"/>
         <source>Fast Forward Speed</source>
         <translation>Hastighet för snabbspolning</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="172"/>
-        <location filename="../emulationsettingswidget.cpp" line="175"/>
         <source>User Preference</source>
         <translation>Användarinställningar</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="173"/>
         <source>Sets the fast forward speed. This speed will be used when the fast forward hotkey is pressed/toggled.</source>
         <translation>Ställer in hastigheten för snabbspolning framåt. Denna hastighet används när snabbtangenten för snabbspolning trycks in/växlas.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="175"/>
         <source>Turbo Speed</source>
         <translation>Turbohastighet</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="176"/>
         <source>Sets the turbo speed. This speed will be used when the turbo hotkey is pressed/toggled. Turboing will take priority over fast forwarding if both hotkeys are pressed/toggled.</source>
         <translation>Ställer in turbo-hastigheten. Denna hastighet används när snabbtangenten för turbo trycks in/växlas. Turbo prioriteras framför snabbspolning framåt om båda snabbknapparna är nedtryckta/växlade.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="180"/>
         <source>Synchronizes presentation of the console&apos;s frames to the host. Enabling may result in smoother animations, at the cost of increased input lag. &lt;strong&gt;GSync/FreeSync users should enable Optimal Frame Pacing instead.&lt;/strong&gt;</source>
         <translation>Synkroniserar presentationen av konsolens bildrutor till värden. Aktivering kan resultera i mjukare animeringar, men till priset av ökad input lag. &lt;strong&gt;GSync/FreeSync-användare bör aktivera Optimal bildrytm istället.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="185"/>
         <source>Adjusts the emulation speed so the console&apos;s refresh rate matches the host&apos;s refresh rate when VSync is enabled. This results in the smoothest animations possible, at the cost of potentially increasing the emulation speed by less than 1%. Sync To Host Refresh Rate will not take effect if the console&apos;s refresh rate is too far from the host&apos;s refresh rate. Users with variable refresh rate displays should disable this option.</source>
         <translation>Justerar emuleringshastigheten så att konsolens uppdateringsfrekvens matchar värdens uppdateringsfrekvens när VSync är aktiverat. Detta ger så mjuka animeringar som möjligt, till priset av en potentiell ökning av emuleringshastigheten med mindre än 1%. Synkronisering med värddatorns uppdateringsfrekvens fungerar inte om konsolens uppdateringsfrekvens ligger för långt från värddatorns uppdateringsfrekvens. Användare med skärmar med variabel uppdateringsfrekvens bör inaktivera det här alternativet.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="192"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="193"/>
         <source>Enabling this option will ensure every frame the console renders is displayed to the screen, at a consistent rate, for optimal frame pacing. If you have a GSync/FreeSync display, enable this option. If you are having difficulties maintaining full speed, or are getting audio glitches, try disabling this option.</source>
         <translation>Om du aktiverar det här alternativet kommer varje bildruta som konsolen renderar att visas på skärmen med en jämn hastighet, vilket ger optimal bildrytm. Om du har en GSync/FreeSync-skärm ska du aktivera det här alternativet. Om du har svårt att hålla full hastighet eller om du får ljudstörningar kan du försöka inaktivera det här alternativet.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="198"/>
         <source>Reduces input latency by delaying the start of frame until closer to the presentation time. This may cause dropped frames on slower systems with higher frame time variance, if the buffer size is not sufficient.</source>
         <translation>Minskar inmatningslatensen genom att fördröja starten av bildrutan till närmare presentationstiden. Detta kan orsaka tappade bildrutor på långsammare system med högre bildtidsvarians, om buffertstorleken inte är tillräcklig.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="200"/>
         <source>Frame Time Buffer</source>
         <translation>Bildtidsbuffert</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="201"/>
         <source>%1 ms</source>
         <translation>%1 ms</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="202"/>
         <source>Specifies the amount of buffer time added, which reduces the additional sleep time introduced. Higher values increase input latency, but decrease the risk of overrun, or missed frames. Lower values require faster hardware.</source>
         <translation>Anger hur mycket bufferttid som läggs till, vilket minskar den extra sömntid som införs. Högre värden ökar inmatningslatensen, men minskar risken för överkörning eller missade bilder. Lägre värden kräver snabbare hårdvara.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="207"/>
         <source>Skips the presentation/display of frames that are not unique. Can be combined with driver-level frame generation to increase perceptible frame rate. Can result in worse frame pacing, and is not compatible with syncing to host refresh.</source>
         <translation>Hoppar över presentation/visning av bildrutor som inte är unika. Kan kombineras med bildgenerering på drivrutinsnivå för att öka den märkbara bildfrekvensen. Kan resultera i sämre bildrytm och är inte kompatibel med synkronisering med host refresh.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="211"/>
         <source>Rewinding</source>
         <translation>Tillbakaspolning</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="212"/>
         <source>&lt;b&gt;Enable Rewinding:&lt;/b&gt; Saves state periodically so you can rewind any mistakes while playing.&lt;br&gt; &lt;b&gt;Rewind Save Frequency:&lt;/b&gt; How often a rewind state will be created. Higher frequencies have greater system requirements.&lt;br&gt; &lt;b&gt;Rewind Buffer Size:&lt;/b&gt; How many saves will be kept for rewinding. Higher values have greater memory requirements.</source>
         <translation>&lt;b&gt;Aktivera tillbakaspolning:&lt;/b&gt; Sparar tillståndet regelbundet så att du kan spola tillbaka om du gör fel under spelningen.&lt;br&gt; &lt;b&gt;Frekvens för sparande av tillbakaspolning:&lt;/b&gt; Hur ofta ett tillbakaspolningstillstånd skapas. Högre frekvenser har högre systemkrav.&lt;br&gt; &lt;b&gt;Buffertstorlek för återspolning:&lt;/b&gt; Hur många sparningar som behålls för tillbakaspolning. Högre värden kräver mer minne.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="308"/>
-        <location filename="../emulationsettingswidget.cpp" line="224"/>
         <source>Runahead</source>
         <translation>Runahead</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="225"/>
         <source>Simulates the system ahead of time and rolls back/replays to reduce input lag. Very high system requirements.</source>
         <translation>Simulerar systemet i förväg och rullar tillbaka/spelar upp för att minska fördröjningen. Mycket höga systemkrav.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="43"/>
         <source>Use Global Setting [Unlimited]</source>
         <translation>Använd global inställning  [obegränsat]</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="302"/>
         <source>Rewind is disabled because runahead is enabled. Runahead will significantly increase system requirements.</source>
         <translation>Tillbakaspolning är inaktiverad eftersom runahead är aktiverat. Runahead kommer att öka systemkraven avsevärt.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="308"/>
         <source>Rewind is not enabled. Please note that enabling rewind may significantly increase system requirements.</source>
         <translation>Tillbakaspolning är inte aktiverad. Observera att aktivera tillbakaspolning kan öka systemkraven mycket.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="179"/>
-        <location filename="../emulationsettingswidget.cpp" line="184"/>
-        <location filename="../emulationsettingswidget.cpp" line="192"/>
-        <location filename="../emulationsettingswidget.cpp" line="197"/>
-        <location filename="../emulationsettingswidget.cpp" line="206"/>
-        <location filename="../emulationsettingswidget.cpp" line="211"/>
-        <location filename="../emulationsettingswidget.cpp" line="218"/>
-        <location filename="../emulationsettingswidget.cpp" line="228"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="332"/>
         <source>2 Frames</source>
         <translation>2 bildrutor</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="44"/>
         <source>Use Global Setting [%1%]</source>
         <translation>Använd global inställning [%1%]</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="71"/>
-        <location filename="../emulationsettingswidget.ui" line="106"/>
-        <location filename="../emulationsettingswidget.ui" line="141"/>
         <source>Unlimited</source>
         <translation>Obegränsat</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="168"/>
         <source>Emulation Speed</source>
         <translation>Emuleringshastighet</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="238"/>
         <source>Rewind</source>
         <translation>Spola tillbaka</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="380"/>
-        <location filename="../emulationsettingswidget.cpp" line="228"/>
         <source>Enable for Analog Input</source>
         <translation>Aktivera för analog inmatning</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="229"/>
         <source>Activates runahead when analog input changes, which significantly increases system requirements.</source>
         <translation>Aktiverar runahead när analog inmatning ändras, vilket avsevärt ökar systemkraven.</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.ui" line="298"/>
-        <location filename="../emulationsettingswidget.cpp" line="217"/>
         <source>Use Software Renderer (Low VRAM Mode)</source>
         <translation>Använd programvarurenderare (lågt VRAM-läge)</translation>
     </message>
     <message>
-        <location filename="../emulationsettingswidget.cpp" line="219"/>
         <source>Uses the software renderer when creating rewind states to prevent additional VRAM usage. Especially useful when upscaling, as this will significantly reduce the system requirements for rewinding.</source>
         <translation>Använder programvarurenderaren när tillbakaspolningstillstånd skapas för att förhindra ytterligare VRAM-användning. Särskilt användbart vid uppskalning, eftersom detta avsevärt minskar systemkraven för tillbakaspolning.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../emulationsettingswidget.cpp" line="288"/>
         <source>Rewind for %n frame(s), lasting %1 second(s) will require %2MB of RAM and %3MB of VRAM.</source>
         <translation>
             <numerusform>Spola tillbaka %n bildruta, varaktighet %1 sekund(er) kommer kräva %2MB RAM och %3MB VRAM.</numerusform>
@@ -4866,7 +3754,6 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../emulationsettingswidget.cpp" line="292"/>
         <source>Rewind for %n frame(s), lasting %1 second(s) will require %2MB of RAM.</source>
         <translation>
             <numerusform>Spola tillbaka %n bildruta, varaktighet %1 sekund(er) kräver %2MB RAM.</numerusform>
@@ -4877,49 +3764,38 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
 <context>
     <name>GameCheatCodeChoiceEditorDialog</name>
     <message>
-        <location filename="../gamecheatcodechoiceeditordialog.ui" line="14"/>
         <source>Cheat Choice Editor</source>
         <translation>Redigera fuskval</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodechoiceeditordialog.ui" line="21"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodechoiceeditordialog.ui" line="26"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodechoiceeditordialog.ui" line="42"/>
         <source>Add Cheat</source>
         <translation>Lägg till fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodechoiceeditordialog.ui" line="59"/>
         <source>Remove Cheat</source>
         <translation>Ta bort fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="1087"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="1102"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="1112"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="1087"/>
         <source>At least one option must be defined.</source>
         <translation>Minst ett alternativ måste definieras.</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="1103"/>
         <source>The option &apos;%1&apos; is defined twice.</source>
         <translation>Alternativet &apos;%1&apos; är definierat två gånger.</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="1113"/>
         <source>The option &apos;%1&apos; does not have a valid value. It must be a number.</source>
         <translation>Alternativet &apos;%1&apos; saknar giltigt värde. Det måste vara ett tal.</translation>
     </message>
@@ -4927,57 +3803,46 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
 <context>
     <name>GameCheatCodeEditorDialog</name>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="14"/>
         <source>Cheat Code Editor</source>
         <translation>Redigera fuskkoder</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="23"/>
         <source>Name:</source>
         <translation>Namn:</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="33"/>
         <source>Description:</source>
         <translation>Beskrivning:</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="56"/>
         <source>Group:</source>
         <translation>Grupp:</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="66"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="76"/>
         <source>Activation:</source>
         <translation>Aktivering:</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="86"/>
         <source>Options:</source>
         <translation>Alternativ:</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="96"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="101"/>
         <source>Choice</source>
         <translation>Val</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="106"/>
         <source>Range</source>
         <translation>Omfång</translation>
     </message>
     <message>
-        <location filename="../gamecheatcodeeditordialog.ui" line="128"/>
         <source>Edit Choices...</source>
         <translation>Redigera val...</translation>
     </message>
@@ -4985,135 +3850,102 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
 <context>
     <name>GameCheatSettingsWidget</name>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="31"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="424"/>
         <source>Enable Cheats</source>
         <translation>Aktivera fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="55"/>
         <source>Sort Alphabetically</source>
         <translation>Sortera alfabetiskt</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="69"/>
         <source>Add Cheat</source>
         <translation>Lägg till fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="80"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="359"/>
         <source>Remove Cheat</source>
         <translation>Ta bort fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="91"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="364"/>
         <source>Disable All Cheats</source>
         <translation>Inaktivera alla fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="145"/>
         <source>Load Database Cheats</source>
         <translation>Läs in databasfusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="171"/>
         <source>Clear List</source>
         <translation>Töm listan</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="182"/>
         <source>Import...</source>
         <translation>Importera...</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="193"/>
         <source>Export...</source>
         <translation>Exportera...</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.ui" line="102"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="367"/>
         <source>Reload Cheats</source>
         <translation>Läs om fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="352"/>
         <source>Add Cheat...</source>
         <translation>Lägg till fusk...</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="355"/>
         <source>Edit Cheat...</source>
         <translation>Redigera fusk...</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="408"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="429"/>
         <source>Do not show again</source>
         <translation>Visa inte igen</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="564"/>
         <source>From File...</source>
         <translation>Från fil...</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="566"/>
         <source>From Text...</source>
         <translation>Från text...</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="573"/>
         <source>PCSXR/Libretro Cheat Files (*.cht *.txt);;All Files (*.*)</source>
         <translation>PCSXR/Libretro-fuskfiler (*.cht *.txt);;Alla filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="575"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="593"/>
         <source>Import Cheats</source>
         <translation>Importera fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="583"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="663"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="685"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="705"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="584"/>
         <source>Failed to read file:
 %1</source>
         <translation>Misslyckades med att läsa fil:
 %1</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="593"/>
         <source>Cheat File Text:</source>
         <translation>Text för fuskfil:</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="686"/>
         <source>Failed to save file:
 %1</source>
         <translation>Misslyckades med att spara fil:
 %1</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="664"/>
         <source>This code is from the built-in cheat database, and cannot be removed. To hide this code, uncheck the &quot;Load Database Cheats&quot; option.</source>
         <translation>Denna kod är från den inbyggda fuskdatabasen och kan inte tas bort. För att dölja denna kod, avmarkera alternativet &quot;Läs in databasfusk&quot;.</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="403"/>
         <source>Enable Game Settings</source>
         <translation>Aktivera spelinställningar</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="404"/>
         <source>Game settings are currently disabled. This is NOT the default. Enabling this cheat will not have any effect until game settings are enabled.
 
 Do you want to enable game settings now?</source>
@@ -5122,7 +3954,6 @@ Do you want to enable game settings now?</source>
 Vill du aktivera spelinställningarna nu?</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="425"/>
         <source>Cheats are not currently enabled for this game. Enabling this cheat will not have any effect until cheats are enabled for this game.
 
 Do you want to enable cheats now?</source>
@@ -5131,35 +3962,28 @@ Do you want to enable cheats now?</source>
 Vill du aktivera fusk nu?</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="670"/>
-        <location filename="../gamecheatsettingswidget.cpp" line="713"/>
         <source>Confirm Removal</source>
         <translation>Bekräfta borttagning</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="671"/>
         <source>You are removing the code named &apos;%1&apos;. You cannot undo this action, are you sure you wish to delete this code?</source>
         <translation>Du tar bort koden som namnet &apos;%1&apos;. Du kan inte ångra denna åtgärd. Är du säker på att du vill ta bort denna kod?</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="696"/>
         <source>PCSXR Cheat Files (*.cht);;All Files (*.*)</source>
         <translation>PCSXR-fuskfiler (*.cht);;Alla filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="698"/>
         <source>Export Cheats</source>
         <translation>Exportera fusk</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="706"/>
         <source>Failed to save cheat file:
 %1</source>
         <translation>Misslyckades med att spara fuskfil:
 %1</translation>
     </message>
     <message>
-        <location filename="../gamecheatsettingswidget.cpp" line="714"/>
         <source>You are removing all cheats manually added for this game. This action cannot be reversed.
 
 Any database cheats will still be loaded and present unless you uncheck the &quot;Load Database Cheats&quot; option.
@@ -5175,7 +3999,6 @@ Alla databasfusk kommer fortfarande att läsas in och synas såvida inte du avma
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../gamelistwidget.cpp" line="222"/>
         <source>Unknown</source>
         <translation>Okänt</translation>
     </message>
@@ -5183,97 +4006,78 @@ Alla databasfusk kommer fortfarande att läsas in och synas såvida inte du avma
 <context>
     <name>GameListModel</name>
     <message>
-        <location filename="../gamelistwidget.cpp" line="89"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="90"/>
         <source>File Title</source>
         <translation>Filtitel</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="96"/>
         <source>Time Played</source>
         <translation>Tid spelat</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="97"/>
         <source>Last Played</source>
         <translation>Senast spelat</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="98"/>
         <source>Size</source>
         <translation>Storlek</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="100"/>
         <source>Region</source>
         <translation>Region</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="102"/>
         <source>Compatibility</source>
         <translation>Kompatibilitet</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="87"/>
         <source>Icon</source>
         <translation>Ikon</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="88"/>
         <source>Serial</source>
         <translation>Serienummer</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="91"/>
         <source>Developer</source>
         <translation>Utvecklare</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="92"/>
         <source>Publisher</source>
         <translation>Utgivare</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="93"/>
         <source>Genre</source>
         <translation>Genre</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="94"/>
         <source>Year</source>
         <translation>År</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="95"/>
         <source>Players</source>
         <translation>Spelare</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="101"/>
         <source>Achievements</source>
         <translation>Prestationer</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="1088"/>
         <source>No Achievements</source>
         <translation>Inga prestationer</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="1090"/>
         <source>%1/%2 achievements unlocked</source>
         <translation>%1/%2 prestationer upplåsta</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="1094"/>
         <source>%1 unlocked in hardcore mode</source>
         <translation>%1 upplåst i hardcore-läget</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="99"/>
         <source>Data Size</source>
         <translation>Datastorlek</translation>
     </message>
@@ -5281,12 +4085,10 @@ Alla databasfusk kommer fortfarande att läsas in och synas såvida inte du avma
 <context>
     <name>GameListSearchDirectoriesModel</name>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="80"/>
         <source>Search Directory</source>
         <translation>Sökkatalog</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="82"/>
         <source>Scan Recursively</source>
         <translation>Sök  rekursivt</translation>
     </message>
@@ -5294,64 +4096,50 @@ Alla databasfusk kommer fortfarande att läsas in och synas såvida inte du avma
 <context>
     <name>GameListSettingsWidget</name>
     <message>
-        <location filename="../gamelistsettingswidget.ui" line="31"/>
         <source>Search Directories (will be scanned for games)</source>
         <translation>Sökkataloger (kommer att genomsökas efter spel)</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.ui" line="57"/>
         <source>Add</source>
         <translation>Lägg till</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.ui" line="74"/>
-        <location filename="../gamelistsettingswidget.ui" line="174"/>
-        <location filename="../gamelistsettingswidget.cpp" line="291"/>
         <source>Remove</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.ui" line="114"/>
         <source>Excluded Paths (will not be scanned)</source>
         <translation>Exkluderade sökvägar (kommer inte sökas igenom)</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.ui" line="157"/>
         <source>Folder...</source>
         <translation>Mapp...</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.ui" line="140"/>
         <source>File...</source>
         <translation>Fil...</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.ui" line="218"/>
         <source>Scan For New Games</source>
         <translation>Leta efter nya spel</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.ui" line="235"/>
         <source>Rescan All Games</source>
         <translation>Sök igenom alla spel igen</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="294"/>
         <source>Open Directory...</source>
         <translation>Öppna katalog...</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="302"/>
         <source>Select Search Directory</source>
         <translation>Välj sökkatalog</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="308"/>
         <source>Scan Recursively?</source>
         <translation>Sök igenom rekursivt?</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="309"/>
         <source>Would you like to scan the directory &quot;%1&quot; recursively?
 
 Scanning recursively takes more time, but will identify files in subdirectories.</source>
@@ -5360,12 +4148,10 @@ Scanning recursively takes more time, but will identify files in subdirectories.
 Söka igenom den rekursivt tar längre tid men identifierar filer i underkataloger.</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="336"/>
         <source>Select Path</source>
         <translation>Välj sökväg</translation>
     </message>
     <message>
-        <location filename="../gamelistsettingswidget.cpp" line="346"/>
         <source>Select Directory</source>
         <translation>Välj katalog</translation>
     </message>
@@ -5373,47 +4159,38 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GameListWidget</name>
     <message>
-        <location filename="../gamelistwidget.ui" line="55"/>
         <source>Game List</source>
         <translation>Spellista</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.ui" line="74"/>
         <source>Game Grid</source>
         <translation>Spelrutnät</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.ui" line="93"/>
         <source>Merge Multi-Disc Games</source>
         <translation>Slå ihop spel på flera skivor</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.ui" line="112"/>
         <source>Show Localized Titles</source>
         <translation>Visa lokalanpassade titlar</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.ui" line="150"/>
         <source>Show Titles</source>
         <translation>Visa titlar</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.ui" line="205"/>
         <source>All Types</source>
         <translation>Alla typer</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.ui" line="218"/>
         <source>All Regions</source>
         <translation>Alla regioner</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.ui" line="131"/>
         <source>Show Game Icons</source>
         <translation>Visa spelikoner</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="78"/>
         <source>.cue (Cue Sheets)
 .iso (Single Track Image)
 .ecm (Error Code Modeling Image)
@@ -5430,12 +4207,10 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 .pbp (PlayStation Portable, endast dekrypterad)</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="2338"/>
         <source>Cover scale: %1%</source>
         <translation>Omslagsskala: %1%</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="2340"/>
         <source>Icon size: %1%</source>
         <translation>Ikonstorlek: %1%</translation>
     </message>
@@ -5443,37 +4218,30 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GamePatchDetailsWidget</name>
     <message>
-        <location filename="../gamepatchdetailswidget.ui" line="67"/>
         <source>Patch Title</source>
         <translation>Patchtitel</translation>
     </message>
     <message>
-        <location filename="../gamepatchdetailswidget.ui" line="29"/>
         <source>Enabled</source>
         <translation>Aktiverad</translation>
     </message>
     <message>
-        <location filename="../gamepatchdetailswidget.ui" line="48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Author: &lt;/span&gt;Patch Author&lt;/p&gt;&lt;p&gt;Description would go here&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Upphovsperson: &lt;/span&gt;Patch Author&lt;/p&gt;&lt;p&gt;Beskrivning anges här&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../gamepatchsettingswidget.cpp" line="34"/>
         <source>Unknown</source>
         <translation>Okänt</translation>
     </message>
     <message>
-        <location filename="../gamepatchsettingswidget.cpp" line="37"/>
         <source>No description provided.</source>
         <translation>Ingen beskrivning angavs.</translation>
     </message>
     <message>
-        <location filename="../gamepatchsettingswidget.cpp" line="33"/>
         <source>&lt;strong&gt;Author: &lt;/strong&gt;%1%2&lt;br&gt;%3</source>
         <translation>&lt;strong&gt;Upphovsperson:  &lt;/strong&gt;%1%2&lt;br&gt;%3</translation>
     </message>
     <message>
-        <location filename="../gamepatchsettingswidget.cpp" line="35"/>
         <source>&lt;br&gt;&lt;strong&gt;Not permitted in RetroAchievements hardcore mode.&lt;/strong&gt;</source>
         <translation>&lt;br&gt;&lt;strong&gt;Inte tillåtet i RetroAchievements hardcore-läge.&lt;/strong&gt;</translation>
     </message>
@@ -5481,17 +4249,14 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GamePatchSettingsWidget</name>
     <message>
-        <location filename="../gamepatchsettingswidget.ui" line="71"/>
         <source>Reload Patches</source>
         <translation>Läs om patchar</translation>
     </message>
     <message>
-        <location filename="../gamepatchsettingswidget.ui" line="47"/>
         <source>Disable All Patches</source>
         <translation>Inaktivera alla patchar</translation>
     </message>
     <message>
-        <location filename="../gamepatchsettingswidget.cpp" line="126"/>
         <source>No patches are available for this game.</source>
         <translation>Det finns inga patchar tillgängliga för detta spel.</translation>
     </message>
@@ -5499,248 +4264,194 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GameSummaryWidget</name>
     <message>
-        <location filename="../gamesummarywidget.ui" line="43"/>
         <source>Title:</source>
         <translation>Titel:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="29"/>
         <source>Image Path:</source>
         <translation>Avbildssökväg:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="352"/>
         <source>Length</source>
         <translation>Längd</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="357"/>
         <source>Hash</source>
         <translation>Kontrollsumma</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="260"/>
         <source>Controllers:</source>
         <translation>Handkontroller:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="274"/>
         <source>Controller Preset:</source>
         <translation>Handkontrollerförval:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="246"/>
         <source>Release Info:</source>
         <translation>Utgivet den:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="147"/>
         <source>Languages:</source>
         <translation>Språk:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="206"/>
         <source>Uses separate game settings for each disc of multi-disc games. Can only be set on the first/main disc.</source>
         <translation>Använder separata spelinställningar för varje skiva i flerskivsspel. Kan endast ställas in på första/huvudskivan.</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="209"/>
         <source>Use Separate Disc Settings</source>
         <translation>Använd separata skivinställningar</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="286"/>
         <source>Edit...</source>
         <translation>Redigera...</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="91"/>
         <source>Serial:</source>
         <translation>Serienummer:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="190"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="116"/>
         <source>Region:</source>
         <translation>Region:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="105"/>
         <source>Change Serial</source>
         <translation>Ändra serienummer</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="168"/>
         <source>Compatibility:</source>
         <translation>Kompatibilitet:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="218"/>
         <source>Hashes:</source>
         <translation>Kontrollsummor:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="232"/>
         <source>Metadata:</source>
         <translation>Metadata:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="311"/>
         <source>Verify</source>
         <translation>Verifiera</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="337"/>
         <source>#</source>
         <translation>#</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="342"/>
         <source>Mode</source>
         <translation>Läge</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="347"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="362"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="502"/>
         <source>&lt;not computed&gt;</source>
         <translation>&lt;inte beräknad&gt;</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="65"/>
         <source>Show Default Flag</source>
         <translation>Visa standardflagga</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="142"/>
         <source>%1 (Custom)</source>
         <translation>%1 (anpassad)</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="143"/>
-        <location filename="../gamesummarywidget.cpp" line="215"/>
-        <location filename="../gamesummarywidget.cpp" line="245"/>
-        <location filename="../gamesummarywidget.cpp" line="263"/>
-        <location filename="../gamesummarywidget.cpp" line="270"/>
-        <location filename="../gamesummarywidget.cpp" line="271"/>
-        <location filename="../gamesummarywidget.cpp" line="272"/>
         <source>Unknown</source>
         <translation>Okänt</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="195"/>
         <source> by </source>
         <translation> av </translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="196"/>
         <source>%1 (published by %2)</source>
         <translation>%1 (utgivet av %2)</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="210"/>
         <source>published by %1</source>
         <translation>utgivet av %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="697"/>
         <source>Search on redump.info</source>
         <translation>Sök på redump.info</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="222"/>
         <source>Released %1</source>
         <translation>Utgivet %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="229"/>
         <source>%1-%2 players</source>
         <translation>%1-%2 spelare</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="238"/>
         <source>%1-%2 memory card blocks</source>
         <translation>%1-%2 minneskortsblock</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="299"/>
         <source>Use Global Settings</source>
         <translation>Använd globala inställningar</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="301"/>
         <source>Game Specific Configuration</source>
         <translation>Spelspecifik konfiguration</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="308"/>
         <source>Game ID: %1</source>
         <translation>Spel-ID: %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="498"/>
         <source>Track %1</source>
         <translation>Spår %1</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="542"/>
         <source>Compatibility Report</source>
         <translation>Kompatibilitetsrapport</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="584"/>
         <source>Per-game controller configuration initialized with global settings.</source>
         <translation>Kontrollerkonfiguration per-spel initierades med globala inställningar.</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="151"/>
         <source>N/A</source>
         <translation>Inte tillgängligt</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="56"/>
         <source>Restore Title</source>
         <translation>Återställ titel</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="136"/>
         <source>Restore Region</source>
         <translation>Återställ region</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="654"/>
         <source>Hash Calculation Failed</source>
         <translation>Beräkning av kontrollsumma misslyckades</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.cpp" line="529"/>
         <source>This game was not scanned by DuckStation. Some functionality is not available.</source>
         <translation>Detta spel har inte sökts igenom av DuckStation. Viss funktionalitet är inte tillgänglig.</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="67"/>
         <source>Disc Set Title:</source>
         <translation>Titel för skivuppsättning:</translation>
     </message>
     <message>
-        <location filename="../gamesummarywidget.ui" line="80"/>
         <source>Restore Disc Set Title</source>
         <translation>Återställ titel för skivuppsättning</translation>
     </message>
     <message numerus="yes">
-        <location filename="../gamesummarywidget.cpp" line="231"/>
         <source>%n player(s)</source>
         <translation>
             <numerusform>%n spelare</numerusform>
@@ -5748,7 +4459,6 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../gamesummarywidget.cpp" line="240"/>
         <source>%n memory card block(s)</source>
         <translation>
             <numerusform>%n minneskortsblock</numerusform>
@@ -5759,1143 +4469,842 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GraphicsSettingsWidget</name>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="35"/>
         <source>Renderer:</source>
         <translation>Renderare:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="45"/>
         <source>Adapter:</source>
         <translation>Adapter:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="137"/>
         <source>Down-Sampling:</source>
         <translation>Nersampling:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="226"/>
         <source>:</source>
         <translation>:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="255"/>
         <source>Scaling:</source>
         <translation>Skalning:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="305"/>
-        <location filename="../graphicssettingswidget.cpp" line="400"/>
         <source>Widescreen Rendering</source>
         <translation>Bredbildsrendering</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="291"/>
-        <location filename="../graphicssettingswidget.cpp" line="412"/>
         <source>Force 4:3 For FMVs</source>
         <translation>Tvinga 4:3 för FMVs</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="298"/>
-        <location filename="../graphicssettingswidget.cpp" line="414"/>
         <source>FMV Chroma Smoothing</source>
         <translation>FMV Chroma-utjämning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="277"/>
-        <location filename="../graphicssettingswidget.cpp" line="404"/>
         <source>PGXP Geometry Correction</source>
         <translation>Korrigering av PGXP-geometri</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="284"/>
         <source>PGXP Depth Buffer (Low Compatibility)</source>
         <translation>PGXP djupbuffert (låg kompatibilitet)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="174"/>
         <source>Sprite Texture Filtering:</source>
         <translation>Filtrering av sprite-textur:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="356"/>
         <source>Display Options</source>
         <translation>Skärmalternativ</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="362"/>
         <source>Exclusive Fullscreen:</source>
         <translation>Exklusiv helskärm:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="379"/>
         <source>Screen Position:</source>
         <translation>Skärmposition:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="539"/>
-        <location filename="../graphicssettingswidget.ui" line="1016"/>
         <source>Rendering Options</source>
         <translation>Renderingsalternativ</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="545"/>
         <source>Multi-Sampling:</source>
         <translation>Multisampling:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="555"/>
         <source>Line Detection:</source>
         <translation>Linjedetektering:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="312"/>
-        <location filename="../graphicssettingswidget.cpp" line="417"/>
         <source>Round Upscaled Texture Coordinates</source>
         <translation>Avrunda uppskalade texturkoordinater</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="606"/>
-        <location filename="../graphicssettingswidget.cpp" line="465"/>
         <source>Software Renderer Readbacks</source>
         <translation>Återläsning för programvarurenderare</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="576"/>
         <source>Max Queued Frames:</source>
         <translation>Max köade bildrutor:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="632"/>
         <source>PGXP</source>
         <translation>PGXP</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="656"/>
         <source>Geometry Tolerance:</source>
         <translation>Geometritolerans:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="700"/>
         <source>Depth Clear Threshold:</source>
         <translation>Tröskelvärde för djuptömning:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="738"/>
-        <location filename="../graphicssettingswidget.cpp" line="483"/>
         <source>Perspective Correct Colors</source>
         <translation>Korrekta färger för perspektiv</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="766"/>
-        <location filename="../graphicssettingswidget.cpp" line="496"/>
         <source>Vertex Cache</source>
         <translation>Vertex-cache</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="731"/>
-        <location filename="../graphicssettingswidget.cpp" line="479"/>
         <source>Perspective Correct Textures</source>
         <translation>Korrekta texturer för perspektiv</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="759"/>
-        <location filename="../graphicssettingswidget.cpp" line="492"/>
         <source>CPU Mode</source>
         <translation>CPU-läge</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="752"/>
-        <location filename="../graphicssettingswidget.cpp" line="490"/>
         <source>Preserve Projection Precision</source>
         <translation>Bevara projektionens precision</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="745"/>
-        <location filename="../graphicssettingswidget.cpp" line="486"/>
         <source>Culling Correction</source>
         <translation>Rensningskorrigering</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="773"/>
-        <location filename="../graphicssettingswidget.cpp" line="499"/>
         <source>Disable on 2D Polygons</source>
         <translation>Inaktivera för 2D-polygoner</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="780"/>
-        <location filename="../graphicssettingswidget.cpp" line="503"/>
         <source>Depth Test Transparent Polygons</source>
         <translation>Transparenta polygoner för djuptest</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="824"/>
         <source>General Settings</source>
         <translation>Allmänna inställningar</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="830"/>
-        <location filename="../graphicssettingswidget.cpp" line="510"/>
         <source>Enable Texture Cache</source>
         <translation>Aktivera texturcache</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="922"/>
-        <location filename="../graphicssettingswidget.cpp" line="533"/>
         <source>Use Old MDEC Routines</source>
         <translation>Använd gamla MDEC-rutiner</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1162"/>
-        <location filename="../graphicssettingswidget.cpp" line="579"/>
         <source>Disable Compute Shaders</source>
         <translation>Inaktivera beräkningsshaders</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1113"/>
-        <location filename="../graphicssettingswidget.cpp" line="582"/>
         <source>Disable Compressed Textures</source>
         <translation>Inaktivera komprimerade texturer</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="516"/>
         <source>Enable Texture Replacements</source>
         <translation>Aktivera texturersättningar</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="837"/>
-        <location filename="../graphicssettingswidget.cpp" line="513"/>
         <source>Preload Texture Replacements</source>
         <translation>Förinläs texturersättningar</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="862"/>
-        <location filename="../graphicssettingswidget.cpp" line="524"/>
         <source>Enable Texture Dumping</source>
         <translation>Aktivera texturdumpning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="892"/>
-        <location filename="../graphicssettingswidget.cpp" line="526"/>
         <source>Dump Replaced Textures</source>
         <translation>Dumpa ersatta texturer</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="885"/>
-        <location filename="../graphicssettingswidget.cpp" line="519"/>
         <source>Always Track Uploads</source>
         <translation>Spåra alltid uppladdningar</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="902"/>
         <source>VRAM Write (Background) Replacement</source>
         <translation>Ersättning för VRAM-skrivning (bakgrund)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="908"/>
-        <location filename="../graphicssettingswidget.cpp" line="529"/>
         <source>Enable VRAM Write Replacement</source>
         <translation>Aktivera VRAM-skrivningsersättning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="915"/>
-        <location filename="../graphicssettingswidget.cpp" line="531"/>
         <source>Enable VRAM Write Dumping</source>
         <translation>Aktivera VRAM-skrivdumpning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="932"/>
         <source>Textures Directory</source>
         <translation>Texturkatalog</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="938"/>
         <source>Directory to load replacement textures from, and save dumps to.</source>
         <translation>Katalog att läsa in ersättande texturer från och spara dumpar till.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="998"/>
         <source>Debugging</source>
         <translation>Felsökning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1022"/>
         <source>Wireframe Mode:</source>
         <translation>Wireframe-läge:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="567"/>
-        <location filename="../graphicssettingswidget.cpp" line="454"/>
         <source>Threaded Rendering</source>
         <translation>Trådad rendering</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1034"/>
-        <location filename="../graphicssettingswidget.cpp" line="543"/>
         <source>Disable Textures</source>
         <translation>Inaktivera texturer</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1041"/>
-        <location filename="../graphicssettingswidget.cpp" line="546"/>
         <source>Disable Vertex Lighting</source>
         <translation>Inaktivera hörnbelysning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1053"/>
         <source>GPU Dump Recording/Playback</source>
         <translation>Inspelning/Uppspelning av GPU-dump</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1059"/>
         <source>Dump Compression Mode:</source>
         <translation>Komprimeringsläge för dump:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1069"/>
         <source>Fast Dump Playback</source>
         <translation>Snabb dumpuppspelning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1079"/>
         <source>Device Options</source>
         <translation>Enhetsalternativ</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1141"/>
         <source>Disable Texture Copy To Self</source>
         <translation>Inaktivera texturkopia till själv</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1120"/>
-        <location filename="../graphicssettingswidget.cpp" line="560"/>
         <source>Disable Dual-Source Blending</source>
         <translation>Inaktivera blandning med dubbla källor</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1134"/>
-        <location filename="../graphicssettingswidget.cpp" line="567"/>
         <source>Disable Texture Buffers</source>
         <translation>Inaktivera texturbuffertar</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1148"/>
-        <location filename="../graphicssettingswidget.cpp" line="573"/>
         <source>Disable Memory Import</source>
         <translation>Inaktivera minnesimport</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1155"/>
-        <location filename="../graphicssettingswidget.cpp" line="576"/>
         <source>Disable Rasterizer Order Views</source>
         <translation>Inaktivera vyer för rastrerarordning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="204"/>
         <source>Aspect Ratio:</source>
         <translation>Bildförhållande:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="394"/>
-        <location filename="../graphicssettingswidget.cpp" line="397"/>
         <source>Bilinear (Smooth)</source>
         <translation>Bilinjär (mjuk)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="245"/>
         <source>Crop:</source>
         <translation>Beskär:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="443"/>
-        <location filename="../graphicssettingswidget.ui" line="463"/>
-        <location filename="../graphicssettingswidget.ui" line="483"/>
-        <location filename="../graphicssettingswidget.ui" line="503"/>
-        <location filename="../graphicssettingswidget.ui" line="668"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="349"/>
         <source>Internal Resolution</source>
         <translation>Intern upplösning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="65"/>
         <source>Rendering</source>
         <translation>Rendering</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="106"/>
         <source>Internal Resolution:</source>
         <translation>Intern upplösning:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="164"/>
         <source>Texture Filtering:</source>
         <translation>Texturfiltrering:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="194"/>
         <source>Deinterlacing:</source>
         <translation>Deinterlacing:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="687"/>
         <source>Reset Geometry Tolerance</source>
         <translation>Återställ geometritolerans</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="716"/>
         <source>Reset Depth Clear Threshold</source>
         <translation>Återställ tröskelvärde för djupnollställning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="806"/>
-        <location filename="../graphicssettingswidget.ui" line="847"/>
         <source>Texture Replacement</source>
         <translation>Texturersättning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="853"/>
         <source>Enable Texture Replacement</source>
         <translation>Aktivera texturersättningar</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="948"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="959"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="970"/>
         <source>Reset</source>
         <translation>Nollställ</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="520"/>
-        <location filename="../graphicssettingswidget.cpp" line="435"/>
         <source>Disable Mailbox Presentation</source>
         <translation>Inaktivera presentation av brevlåda</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1106"/>
-        <location filename="../graphicssettingswidget.cpp" line="558"/>
         <source>Disable Shader Cache</source>
         <translation>Inaktivera shadercache</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="149"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="338"/>
         <source>Advanced</source>
         <translation>Avancerat</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="527"/>
-        <location filename="../graphicssettingswidget.cpp" line="439"/>
         <source>Use Blit Swap Chain</source>
         <translation>Använd blit-växlingskedja</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1085"/>
-        <location filename="../graphicssettingswidget.cpp" line="549"/>
         <source>Use Debug Device</source>
         <translation>Använd felsökningsenhet</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1127"/>
-        <location filename="../graphicssettingswidget.cpp" line="563"/>
         <source>Disable Framebuffer Fetch</source>
         <translation>Inaktivera framebuffer-hämtning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="400"/>
-        <location filename="../graphicssettingswidget.cpp" line="404"/>
-        <location filename="../graphicssettingswidget.cpp" line="408"/>
-        <location filename="../graphicssettingswidget.cpp" line="412"/>
-        <location filename="../graphicssettingswidget.cpp" line="414"/>
-        <location filename="../graphicssettingswidget.cpp" line="417"/>
-        <location filename="../graphicssettingswidget.cpp" line="435"/>
-        <location filename="../graphicssettingswidget.cpp" line="439"/>
-        <location filename="../graphicssettingswidget.cpp" line="458"/>
-        <location filename="../graphicssettingswidget.cpp" line="465"/>
-        <location filename="../graphicssettingswidget.cpp" line="483"/>
-        <location filename="../graphicssettingswidget.cpp" line="490"/>
-        <location filename="../graphicssettingswidget.cpp" line="492"/>
-        <location filename="../graphicssettingswidget.cpp" line="496"/>
-        <location filename="../graphicssettingswidget.cpp" line="499"/>
-        <location filename="../graphicssettingswidget.cpp" line="503"/>
-        <location filename="../graphicssettingswidget.cpp" line="510"/>
-        <location filename="../graphicssettingswidget.cpp" line="513"/>
-        <location filename="../graphicssettingswidget.cpp" line="516"/>
-        <location filename="../graphicssettingswidget.cpp" line="519"/>
-        <location filename="../graphicssettingswidget.cpp" line="524"/>
-        <location filename="../graphicssettingswidget.cpp" line="526"/>
-        <location filename="../graphicssettingswidget.cpp" line="529"/>
-        <location filename="../graphicssettingswidget.cpp" line="531"/>
-        <location filename="../graphicssettingswidget.cpp" line="533"/>
-        <location filename="../graphicssettingswidget.cpp" line="543"/>
-        <location filename="../graphicssettingswidget.cpp" line="546"/>
-        <location filename="../graphicssettingswidget.cpp" line="549"/>
-        <location filename="../graphicssettingswidget.cpp" line="552"/>
-        <location filename="../graphicssettingswidget.cpp" line="555"/>
-        <location filename="../graphicssettingswidget.cpp" line="558"/>
-        <location filename="../graphicssettingswidget.cpp" line="560"/>
-        <location filename="../graphicssettingswidget.cpp" line="563"/>
-        <location filename="../graphicssettingswidget.cpp" line="567"/>
-        <location filename="../graphicssettingswidget.cpp" line="570"/>
-        <location filename="../graphicssettingswidget.cpp" line="573"/>
-        <location filename="../graphicssettingswidget.cpp" line="576"/>
-        <location filename="../graphicssettingswidget.cpp" line="579"/>
-        <location filename="../graphicssettingswidget.cpp" line="582"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="354"/>
-        <location filename="../graphicssettingswidget.cpp" line="451"/>
-        <location filename="../graphicssettingswidget.cpp" line="539"/>
-        <location filename="../graphicssettingswidget.cpp" line="789"/>
         <source>Disabled</source>
         <translation>Inaktiverad</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="511"/>
         <source>Enables caching of guest textures, required for texture replacement. &lt;strong&gt;The texture cache is currently experimental, and may cause rendering errors in some games.&lt;/strong&gt;</source>
         <translation>Aktiverar cachelagring av gästtexturer, vilket krävs för texturersättningar. &lt;strong&gt;Texturcachen är för närvarande experimentell och kan orsaka renderingsfel i vissa spel.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="520"/>
         <source>Forces texture upload tracking to be enabled regardless of whether it is needed. Reduces performance, but allows toggling replacements on and off. &lt;strong&gt;Not required for replacements to load, &lt;/strong&gt;normally tracking is automatically enabled when needed.</source>
         <translation>Tvingar spårning av texturuppladdning att aktiveras oavsett om det behövs eller inte. Minskar prestandan, men gör det möjligt att växla mellan på- och avstängning av ersättningar. &lt;strong&gt;Krävs inte för att ersättningar ska läsas in &lt;/strong&gt;, normalt aktiveras spårning automatiskt när det behövs.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="862"/>
         <source>%1x Native</source>
         <translation>%1x inbyggd</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="454"/>
-        <location filename="../graphicssettingswidget.cpp" line="461"/>
-        <location filename="../graphicssettingswidget.cpp" line="479"/>
-        <location filename="../graphicssettingswidget.cpp" line="486"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="378"/>
         <source>Aspect Ratio</source>
         <translation>Bildförhållande</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="383"/>
         <source>Deinterlacing</source>
         <translation>Deinterlacing</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="423"/>
         <source>Fullscreen Mode</source>
         <translation>Helskärmsläge</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="423"/>
-        <location filename="../graphicssettingswidget.cpp" line="741"/>
         <source>Borderless Fullscreen</source>
         <translation>Ramfri helskärm</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="424"/>
         <source>Chooses the fullscreen resolution and frequency.</source>
         <translation>Väljer helskärmsupplösningen och frekvens.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="361"/>
         <source>Texture Filtering</source>
         <translation>Texturfiltrering</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="440"/>
         <source>Uses a blit presentation model instead of flipping when using the Direct3D 11 renderer. This usually results in slower performance, but may be required for some streaming applications, or to uncap framerates on some systems.</source>
         <translation>Använder en blit-presentationsmodell istället för flipping när Direct3D 11-renderaren används. Detta resulterar vanligtvis i långsammare prestanda, men kan vara nödvändigt för vissa strömningsprogram eller för att frigöra bildfrekvenser på vissa system.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="700"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="436"/>
         <source>Forces the use of FIFO over Mailbox presentation, i.e. double buffering instead of triple buffering. Usually results in worse frame pacing.</source>
         <translation>Tvingar fram användning av FIFO i stället för brevlådepresentation, dvs. dubbelbuffring i stället för trippelbuffring. Detta resulterar vanligen i sämre bildrytm.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="264"/>
         <source>Select Textures Directory</source>
         <translation>Välj texturkatalog</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="339"/>
         <source>Renderer</source>
         <translation>Renderare</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="344"/>
         <source>Adapter</source>
         <translation>Adapter</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="344"/>
         <source>(Default)</source>
         <translation>(standard)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="345"/>
         <source>If your system contains multiple GPUs or adapters, you can select which GPU you wish to use for the hardware renderers. &lt;br&gt;This option is only supported in Direct3D and Vulkan. OpenGL will always use the default device.</source>
         <translation>Om ditt system innehåller flera GPU:er eller adaptrar kan du välja vilken GPU du vill använda för hårdvarurenderingarna. &lt;br&gt;Det här alternativet stöds endast i Direct3D och Vulkan. OpenGL kommer alltid att använda standardenheten.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="350"/>
         <source>Setting this beyond 1x will enhance the resolution of rendered 3D polygons and lines. Only applies to the hardware backends. &lt;br&gt;This option is usually safe, with most games looking fine at higher resolutions. Higher resolutions require a more powerful GPU.</source>
         <translation>Om du ställer in detta värde till mer än 1x förbättras upplösningen för renderade 3D-polygoner och linjer. Gäller endast för hårdvarubakändar. &lt;br&gt;Det här alternativet är vanligtvis säkert, och de flesta spel ser bra ut i högre upplösningar. Högre upplösningar kräver en kraftfullare GPU.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="354"/>
         <source>Down-Sampling</source>
         <translation>Nersampling</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="355"/>
         <source>Downsamples the rendered image prior to displaying it. Can improve overall image quality in mixed 2D/3D games, but should be disabled for pure 3D games.</source>
         <translation>Samplar ner den renderade bilden innan den visas. Kan förbättra den övergripande bildkvaliteten i blandade 2D/3D-spel, men bör inaktiveras för rena 3D-spel.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="357"/>
         <source>Down-Sampling Display Scale</source>
         <translation>Skala för skärmnedsampling</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="357"/>
         <source>1x</source>
         <translation>1x</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="358"/>
         <source>Selects the resolution scale that will be applied to the final image. 1x will downsample to the original console resolution.</source>
         <translation>Väljer den upplösningsskala som ska tillämpas på den slutliga bilden. 1x innebär nedskalning till den ursprungliga konsolupplösningen.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="363"/>
         <source>Smooths out the blockiness of magnified textures on 3D objects by using filtering. &lt;br&gt;Will have a greater effect on higher resolution scales.</source>
         <translation>Utjämnar blockigheten i förstorade texturer på 3D-objekt med hjälp av filtrering. &lt;br&gt;Effekten blir större på skalor med högre upplösning.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="366"/>
         <source>Sprite Texture Filtering</source>
         <translation>Filtrering av sprite-textur</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="368"/>
         <source>Smooths out the blockiness of magnified textures on 2D objects by using filtering. This filter only applies to sprites and other 2D elements, such as the HUD.</source>
         <translation>Utjämnar blockigheten i förstorade texturer på 2D-objekt med hjälp av filtrering. Detta filter gäller endast sprites och andra 2D-element, t.ex. HUD.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="380"/>
         <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is Auto (Game Native) which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era.</source>
         <translation>Ändrar det bildförhållande som används för att visa konsolens utdata på skärmen. Standardinställningen är Automatiskt (spelets inbyggda) som automatiskt justerar bildförhållandet så att det motsvarar hur ett spel skulle visas på en typisk TV för den tiden.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="385"/>
         <source>Determines which algorithm is used to convert interlaced frames to progressive for display on your system. Using progressive rendering provides the best quality output, but some games require interlaced rendering.</source>
         <translation>Bestämmer vilken algoritm som används för att konvertera sammanflätade (interlaced) bildrutor till progressiva för visning på ditt system. Progressiv rendering ger den bästa kvaliteten, men vissa spel kräver interlaced rendering.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="388"/>
         <source>Crop</source>
         <translation>Beskär</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="390"/>
         <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide. Some games display content in the overscan area, or use it for screen effects. May not display correctly with the &quot;All Borders&quot; setting. &quot;Only Overscan&quot; offers a good compromise between stability and hiding black borders.</source>
         <translation>Bestämmer hur stor del av det område som normalt inte syns på en konsument-TV-apparat som ska beskäras/döljas. Vissa spel visar innehåll i overscan-området eller använder det för skärmeffekter. Visas kanske inte korrekt med inställningen &quot;Alla kanter&quot;. &quot;Endast överskanning&quot; är en bra kompromiss mellan stabilitet och att dölja svarta kanter.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="394"/>
         <source>Scaling</source>
         <translation>Skalning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="395"/>
         <source>Determines how the emulated console&apos;s output is upscaled or downscaled to your monitor&apos;s resolution.</source>
         <translation>Bestämmer hur den emulerade konsolens utdata ska upp- eller nedskalas till din bildskärms upplösning.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="401"/>
         <source>Scales vertex positions in screen-space to a widescreen aspect ratio, essentially increasing the field of view from 4:3 to the chosen display aspect ratio in 3D games. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Skalar vertexpositioner i skärmrymden till ett bredbildsförhållande, vilket i princip ökar synfältet från 4:3 till det valda bildförhållandet i 3D-spel. &lt;b&gt;&lt;u&gt;Kanske inte kompatibel med alla spel.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="405"/>
         <source>Reduces &quot;wobbly&quot; polygons and &quot;warping&quot; textures that are common in PS1 games. &lt;strong&gt;May not be compatible with all games.&lt;/strong&gt;</source>
         <translation>Reducerar &quot;vingliga&quot; polygoner och &quot;skeva&quot; texturer som är vanliga i PS1-spel. &lt;strong&gt;Kanske inte kompatibel med alla spel.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="408"/>
         <source>PGXP Depth Buffer</source>
         <translation>PGXP-djupbuffert</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="409"/>
         <source>Attempts to reduce polygon Z-fighting by testing pixels against the depth values from PGXP. Low compatibility, but can work well in some games. Other games may need a threshold adjustment.</source>
         <translation>Försöker minska polygonernas Z-fighting genom att testa bildpunkter mot djupvärdena från PGXP. Låg kompatibilitet, men kan fungera bra i vissa spel. Andra spel kan behöva en tröskeljustering.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="413"/>
         <source>Switches back to 4:3 display aspect ratio when displaying 24-bit content, usually FMVs.</source>
         <translation>Växlar tillbaka till bildförhållandet 4:3 vid visning av 24-bitars innehåll, vanligtvis FMV.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="415"/>
         <source>Smooths out blockyness between colour transitions in 24-bit content, usually FMVs.</source>
         <translation>Utjämnar blockighet mellan färgövergångar i 24-bitars innehåll, vanligtvis FMV.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="425"/>
         <source>Exclusive Fullscreen Control</source>
         <translation>Exklusiv helskärmskontroll</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="425"/>
         <source>Automatic</source>
         <translation>Automatisk</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="426"/>
         <source>Controls whether exclusive fullscreen can be utilized by Vulkan drivers.</source>
         <translation>Kontrollerar om exklusiv helskärm kan användas av Vulkan-drivrutiner.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="428"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="430"/>
         <source>Determines the position on the screen when black borders must be added.</source>
         <translation>Bestämmer positionen på skärmen när svarta sorgkanter måste läggas till.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="446"/>
         <source>Line Detection</source>
         <translation>Linjedetektion</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="448"/>
         <source>Attempts to detect one pixel high/wide lines that rely on non-upscaled rasterization behavior, filling in gaps introduced by upscaling.</source>
         <translation>Försök att upptäcka en bildpunkt höga/breda linjer som förlitar sig på icke-uppskalad rastrering och fyller i luckor som uppstått genom uppskalning.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="451"/>
         <source>Multi-Sampling</source>
         <translation>Multi-sampling</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="452"/>
         <source>Uses multi-sampled anti-aliasing when rendering 3D polygons. Can improve visuals with a lower performance requirement compared to upscaling, &lt;strong&gt;but often introduces rendering errors.&lt;/strong&gt;</source>
         <translation>Använder multi-samplad anti-aliasing vid rendering av 3D-polygoner. Kan förbättra grafiken med ett lägre prestandakrav jämfört med uppskalning, &lt;strong&gt;men ger ofta upphov till renderingsfel.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="455"/>
         <source>Uses a second thread for drawing graphics. Provides a significant speed improvement particularly with the software renderer, and is safe to use.</source>
         <translation>Använder en andra tråd för att rita grafik. Ger en betydande hastighetsförbättring, särskilt med programvarurenderaren och är säker att använda.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="466"/>
         <source>Runs the software renderer in parallel for VRAM readbacks. On some systems, this may result in greater performance when using graphical enhancements with the hardware renderer.</source>
         <translation>Kör programvarurenderingen parallellt för VRAM-återläsningar. På vissa system kan detta resultera i bättre prestanda när du använder grafiska förbättringar med maskinvarurenderingen.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="418"/>
         <source>Rounds texture coordinates instead of flooring when upscaling. Can fix misaligned textures in some games, but break others, and is incompatible with texture filtering.</source>
         <translation>Avrundar texturkoordinater istället för flooring vid uppskalning. Kan fixa feljusterade texturer i vissa spel, men förstöra andra, och är inkompatibel med texturfiltrering.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="472"/>
         <source>Geometry Tolerance</source>
         <translation>Geometritolerans</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="472"/>
         <source>-1.00px (Disabled)</source>
         <translation>-1.00px (Inaktiverad)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="473"/>
         <source>Discards precise geometry when it is found to be offset past the specified threshold. This can help with games that have vertices significantly moved by PGXP, but is still a hack/workaround.</source>
         <translation>Kasserar exakt geometri när det upptäcks att den är förskjuten över det angivna tröskelvärdet. Detta kan hjälpa till med spel där hörnpunkter flyttas avsevärt av PGXP, men det är fortfarande ett hack/temporärlösning.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="475"/>
         <source>Depth Clear Threshold</source>
         <translation>Tröskelvärde för djuptömning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="477"/>
         <source>Determines the increase in depth that will result in the depth buffer being cleared. Can help with depth issues in some games, but is still a hack/workaround.</source>
         <translation>Bestämmer den ökning av djupet som leder till att djupbufferten rensas. Kan hjälpa till med djupproblem i vissa spel, men är fortfarande ett hack/temporärlösning.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="480"/>
         <source>Uses perspective-correct interpolation for texture coordinates, straightening out warped textures. Requires geometry correction enabled.</source>
         <translation>Använder perspektivkorrigerad interpolering för texturkoordinater, vilket rätar ut skeva texturer. Kräver att geometrikorrigering är aktiverad.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="484"/>
         <source>Uses perspective-correct interpolation for vertex colors, which can improve visuals in some games, but cause rendering errors in others. Requires geometry correction enabled.</source>
         <translation>Använder perspektivkorrigerad interpolering för vertexfärger, vilket kan förbättra grafiken i vissa spel, men orsaka renderingsfel i andra. Kräver att geometrikorrigering är aktiverad.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="487"/>
         <source>Increases the precision of polygon culling, reducing the number of holes in geometry. Requires geometry correction enabled.</source>
         <translation>Ökar precisionen i polygonutrensningen, vilket minskar antalet hål i geometrin. Kräver att geometrikorrigering är aktiverad.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="491"/>
         <source>Adds additional precision to PGXP data post-projection. May improve visuals in some games.</source>
         <translation>Lägger till ytterligare precision till PGXP-data efterprojicering. Kan förbättra grafiken i vissa spel.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="493"/>
         <source>Uses PGXP for all instructions, not just memory operations. Required for PGXP to correct wobble in some games, but has a high performance cost.</source>
         <translation>Använder PGXP för alla instruktioner, inte bara minnesoperationer. Krävs för att PGXP ska korrigera wobble i vissa spel, men har en hög prestandakostnad.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="497"/>
         <source>Uses screen-space vertex positions to obtain precise positions, instead of tracking memory accesses. Can provide PGXP compatibility for some games, but &lt;strong&gt;generally provides no benefit.&lt;/strong&gt;</source>
         <translation>Använder vertexpositioner i skärmrymden för att få exakta positioner, istället för att spåra minnesåtkomst. Kan ge PGXP-kompatibilitet för vissa spel, men &lt;strong&gt;ger i allmänhet inga fördelar.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="500"/>
         <source>Uses native resolution coordinates for 2D polygons, instead of precise coordinates. Can fix misaligned UI in some games, but otherwise should be left disabled. The game database will enable this automatically when needed.</source>
         <translation>Använder koordinater med inbyggd upplösning för 2D-polygoner, istället för exakta koordinater. Kan åtgärda felriktat användargränssnitt i vissa spel, men bör annars lämnas inaktiverat. Speldatabasen kommer att aktivera detta automatiskt när det behövs.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="534"/>
         <source>Enables the older, less accurate MDEC decoding routines. May be required for old replacement backgrounds to match/load.</source>
         <translation>Aktiverar de äldre, mindre exakta MDEC-avkodningsrutinerna. Kan krävas för att gamla ersättningsbakgrunder ska matcha/läsas in.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="517"/>
         <source>Enables loading of replacement textures. Not compatible with all games.</source>
         <translation>Aktiverar inläsning av ersättningstexturer. Inte kompatibelt med alla spel.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="514"/>
         <source>Loads all replacement texture to RAM, reducing stuttering at runtime.</source>
         <translation>Läser in alla ersättningstexturer till RAM-minnet, vilket gör att det går snabbare att köra.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="525"/>
         <source>Enables dumping of textures to image files, which can be replaced. Not compatible with all games.</source>
         <translation>Aktiverar dumpning av texturer till bildfiler, som kan ersättas. Inte kompatibel med alla spel.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="527"/>
         <source>Dumps textures that have replacements already loaded.</source>
         <translation>Dumpar texturer som har ersättningar redan inlästa.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="530"/>
         <source>Enables the replacement of background textures in supported games.</source>
         <translation>Aktiverar ersättning av bakgrundstexturer i spel som stöds.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="532"/>
         <source>Writes backgrounds that can be replaced to the dump directory.</source>
         <translation>Skriver bakgrunder som kan ersättas till dumpkatalogen.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="539"/>
         <source>Wireframe Mode</source>
         <translation>Ramverksläge</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="540"/>
         <source>Draws a wireframe outline of the triangles rendered by the console&apos;s GPU, either as a replacement or an overlay.</source>
         <translation>Ritar en wireframe-kontur av de trianglar som renderas av konsolens GPU, antingen som en ersättning eller ett överlägg.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="544"/>
         <source>Disables texture emulation in the GPU, forcing all primitives to only show vertex colours.</source>
         <translation>Inaktiverar texturemulering i grafikprocessorn och tvingar alla primitiver att endast visa hörnfärger.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="547"/>
         <source>Disables vertex lighting in the GPU, forcing all primitives to only show raw texture colours.</source>
         <translation>Inaktiverar hörnbelysning i grafikprocessorn och tvingar alla primitiver att endast visa råa texturfärger.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="550"/>
         <source>Enable debugging when supported by the host&apos;s renderer API. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Aktivera felsökning när detta stöds av värdens API för rendering. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="559"/>
         <source>Forces shaders to be compiled for every run of the program. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Tvingar shaders att kompileras för varje körning av programmet. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="561"/>
         <source>Prevents dual-source blending from being used. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Förhindrar att blandning med dubbla källor används. Användbar för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="564"/>
         <source>Prevents the framebuffer fetch extensions from being used. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Förhindrar att tilläggen för hämtning av framebufferten används. Användbart för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="568"/>
         <source>Forces VRAM updates through texture updates, instead of texture buffers and draws. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Tvingar VRAM-uppdateringar genom texturuppdateringar, istället för texturbuffertar och draws. Användbart för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="570"/>
         <source>Disable Texture Copies To Self</source>
         <translation>Inaktivera texturkopior till själv</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="571"/>
         <source>Disables the use of self-copy updates for the VRAM texture. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användning av självkopieuppdateringar för VRAM-texturen. Användbar för tester av trasiga grafikdrivrutiner. &lt;strong&gt;Endast för utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="574"/>
         <source>Disables the use of host memory importing. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användning av värdminnesimport. Användbar för tester av trasiga grafikdrivrutiner. &lt;strong&gt;Endast för utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="577"/>
         <source>Disables the use of rasterizer order views. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användning av rasterizer order views. Användbar för tester av trasiga grafikdrivrutiner. &lt;strong&gt;Endast för utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="580"/>
         <source>Disables the use of compute shaders. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användningen av compute shaders. Användbart för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="583"/>
         <source>Disables the use of compressed textures. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användningen av komprimerade texturer. Användbar för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="725"/>
         <source>%1 [Unavailable]</source>
         <translation>%1 [inte tillgänglig]</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="843"/>
         <source>PGXP is not enabled. Increasing the resolution without enabling PGXP will result in visible polygon glitches.</source>
         <translation>PGXP är inte aktiverat. Om upplösningen höjs utan att PGXP aktiveras uppstår synliga polygonfel.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="850"/>
         <source>Automatic (Based on Window Size)</source>
         <translation>Automatisk (baserat på fönsterstorlek)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="851"/>
         <source>1x Native (Default)</source>
         <translation>1x inbyggd (Standard)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="852"/>
         <source>3x Native (for 720p)</source>
         <translation>3x inbyggd (för 720p)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="853"/>
         <source>5x Native (for 1080p)</source>
         <translation>5x inbyggd (för 1080p)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="854"/>
         <source>6x Native (for 1440p)</source>
         <translation>6x inbyggd (för 1440p)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="855"/>
         <source>9x Native (for 4K)</source>
         <translation>9x inbyggd (för 4K)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="1046"/>
         <source>&lt;h3&gt;Changing the renderer is not recommended!&lt;/h3&gt;&lt;p&gt;The &lt;strong&gt;Automatic&lt;/strong&gt; option provides the best experience, selecting the optimal renderer for your graphics adapter. There is &lt;strong&gt;no visual or performance advantage&lt;/strong&gt; to using a different renderer, and you risk the application breaking due to driver bugs.&lt;br&gt;&lt;br&gt;If you continue with changing the renderer, &lt;strong&gt;do not ask for support&lt;/strong&gt;.&lt;br&gt;&lt;br&gt;Are you sure you want to change the renderer?&lt;/p&gt;</source>
         <translation>&lt;h3&gt;Det rekommenderas inte att byta renderare!&lt;/h3&gt;&lt;p&gt;Alternativet &lt;strong&gt;Automatisk&lt;/strong&gt; ger den bästa upplevelsen genom att välja den optimala renderaren för ditt grafikkort. Det finns &lt;strong&gt;ingen visuell eller prestandamässig fördel&lt;/strong&gt; med att använda en annan renderare, och drivrutinsfel kan få programmet att sluta fungera.&lt;br&gt;&lt;br&gt;Om du fortsätter att byta renderare ska du &lt;strong&gt;inte be om support&lt;/strong&gt;.&lt;br&gt;&lt;br&gt;Är du säker på att du vill byta renderare?&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="786"/>
         <source>Use Global Setting</source>
         <translation>Använd global inställning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="791"/>
         <source>%1x MSAA</source>
         <translation>%1x MSAA</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="793"/>
         <source>%1x SSAA</source>
         <translation>%1x SSAA</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="184"/>
         <source>Dithering:</source>
         <translation>Dithering:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="599"/>
-        <location filename="../graphicssettingswidget.cpp" line="461"/>
         <source>Scaled Interlacing</source>
         <translation>Skalad interlacing</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1092"/>
-        <location filename="../graphicssettingswidget.cpp" line="552"/>
         <source>Use GPU-Based Validation</source>
         <translation>Använd GPU-baserad validering</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="340"/>
         <source>Selects the backend to use for rendering the console/game visuals. &lt;br&gt;Depending on your system and hardware, Direct3D 11 and OpenGL hardware backends may be available. &lt;br&gt;The software renderer offers the best compatibility, but is the slowest and does not offer any enhancements.</source>
         <translation>Väljer den bakände som ska användas för att rendera konsol- och spelgrafiken. &lt;br&gt;Beroende på system och maskinvara kan Direct3D 11- och OpenGL-hårdvarubakändar finnas tillgängliga. &lt;br&gt;Programvarurenderingen erbjuder den bästa kompatibiliteten, men är långsammast och erbjuder inga förbättringar.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="371"/>
         <source>Dithering</source>
         <translation>Dithering</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="373"/>
         <source>Controls how dithering is applied in the emulated GPU. True Color disables dithering and produces the nicest looking gradients. Scaled options make the dither pattern less noticeable at higher resolutions. Shader Blending options perform blending in software, and are more accurate but have a &lt;strong&gt;significant&lt;/strong&gt; performance penalty.</source>
         <translation>Kontrollerar hur dithering tillämpas i den emulerade GPU:n. True Color inaktiverar dithering och ger de snyggaste gradienterna. Med skalade alternativ blir dithermönstret mindre märkbart i högre upplösningar. Alternativet Shader-blandning utför blandning i programvara och är mer exakt, men har en &lt;strong&gt;betydande&lt;/strong&gt; prestandaförlust.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="462"/>
         <source>Scales line skipping in interlaced rendering to the internal resolution. This makes the combing less obvious at higher resolutions. Usually safe to enable.</source>
         <translation>Skalar linjeöverhoppning vid interlaced-rendering till den interna upplösningen. Detta gör kamningen mindre uppenbar i högre upplösningar. Vanligtvis säkert att aktivera.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="553"/>
         <source>Enable GPU-based validation when supported by the renderer API. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Aktivera GPU-baserad validering när detta stöds av renderarens API. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="504"/>
         <source>Enables depth testing for semi-transparent polygons. Usually these include shadows, and tend to clip through the ground when depth testing is enabled. Depth writes for semi-transparent polygons are disabled regardless of this setting.</source>
         <translation>Aktiverar djupkontroll för halvtransparenta polygoner. Dessa inkluderar vanligtvis skuggor och tenderar att klippa igenom marken när djupkontroll är aktiverat. Djupskrivningar för halvtransparenta polygoner är inaktiverade oavsett denna inställning.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="265"/>
         <source>FMV Scaling:</source>
         <translation>FMV-skalning:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="1099"/>
-        <location filename="../graphicssettingswidget.cpp" line="555"/>
         <source>Prefer OpenGL ES Context</source>
         <translation>Föredra OpenGL ES Context</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="397"/>
         <source>FMV Scaling</source>
         <translation>FMV-skalning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="398"/>
         <source>Determines the scaling algorithm used when 24-bit content is active, typically FMVs.</source>
         <translation>Bestämmer skalningsalgoritmen som används när 24-bitarsinnehåll är aktivt, vanligtvis FMV.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="556"/>
         <source>Uses OpenGL ES even when desktop OpenGL is supported. May improve performance on some SBC drivers.</source>
         <translation>Använder OpenGL ES även när OpenGL för stationära datorer stöds. Kan förbättra prestandan på vissa SBC-drivrutiner.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="897"/>
         <source>Custom</source>
         <translation>Anpassad</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="396"/>
         <source>Fine Crop Mode:</source>
         <translation>Läget för finjusterad beskäring:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="414"/>
         <source>Reset Fine Cropping</source>
         <translation>Återställ finjusterad beskäring</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="427"/>
         <source>Fine Crop Size:</source>
         <translation>Storlek för finjusterad beskäring:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="436"/>
         <source>Left:</source>
         <translation>Vänster:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="456"/>
         <source>Top:</source>
         <translation>Överst:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="476"/>
         <source>Right:</source>
         <translation>Höger:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="496"/>
         <source>Bottom:</source>
         <translation>Nederst:</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.ui" line="592"/>
         <source>Texture Modulation Cropping (&quot;Old/v0 GPU&quot;)</source>
         <translation>Beskäring av texturmodulation (&quot;Old/v0&quot; GPU)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="431"/>
         <source>Fine Crop Mode</source>
         <translation>Läget för finjusterad beskäring</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="431"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="432"/>
         <source>Enables manual fine cropping of the display area, while preserving the aspect ratio of the image. Useful for removing black borders in certain games.</source>
         <translation>Aktiverar manuell finjustering av visningsområdet, samtidigt som bildens bildförhållande bibehålls. Användbart för att ta bort svarta kanter i vissa spel.</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="458"/>
         <source>Texture Modulation Cropping (&quot;Old/v0&quot; GPU)</source>
         <translation>Beskäring av texturmodulation (&quot;Old/v0&quot; GPU)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="459"/>
         <source>Crops vertex colours to 5:5:5 before modulating with the texture colour, which typically results in more visible banding. This is a characteristic of the &quot;old&quot; GPUs found in early model consoles.</source>
         <translation>Beskär vertexfärgerna till 5:5:5 innan de moduleras med texturfärgen, vilket vanligtvis resulterar i mer synliga band. Detta är ett kännetecken för de ”gamla” GPU:erna som finns i tidiga konsolmodeller.</translation>
     </message>
@@ -6903,7 +5312,6 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>Host</name>
     <message numerus="yes">
-        <location filename="../gamelistwidget.cpp" line="2511"/>
         <source>%n seconds</source>
         <translation>
             <numerusform>%n sekund</numerusform>
@@ -6911,7 +5319,6 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../gamelistwidget.cpp" line="2512"/>
         <source>%n minutes</source>
         <translation>
             <numerusform>%n minut</numerusform>
@@ -6919,7 +5326,6 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../gamelistwidget.cpp" line="2513"/>
         <source>%n hours</source>
         <translation>
             <numerusform>%n timme</numerusform>
@@ -6927,17 +5333,14 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
         </translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="2518"/>
         <source>Today</source>
         <translation>Idag</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="2519"/>
         <source>Yesterday</source>
         <translation>Igår</translation>
     </message>
     <message>
-        <location filename="../gamelistwidget.cpp" line="2520"/>
         <source>Never</source>
         <translation>Aldrig</translation>
     </message>
@@ -6945,98 +5348,78 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>ISOBrowserWindow</name>
     <message>
-        <location filename="../isobrowserwindow.ui" line="14"/>
         <source>ISO Browser</source>
         <translation>ISO-bläddrare</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="26"/>
         <source>File:</source>
         <translation>Fil:</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="64"/>
-        <location filename="../isobrowserwindow.ui" line="80"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="85"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="90"/>
         <source>Size</source>
         <translation>Storlek</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="114"/>
         <source>Extract</source>
         <translation>Extrahera</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="121"/>
         <source>Extract (XA)</source>
         <translation>Extrahera (XA)</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="128"/>
         <source>Extract (Raw)</source>
         <translation>Extrahera (Raw)</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="135"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="83"/>
         <source>ISO Browser - %1</source>
         <translation>ISO-bläddrare - %1</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="93"/>
         <source>Select File</source>
         <translation>Välj fil</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="168"/>
         <source>&amp;Open</source>
         <translation>Ö&amp;ppna</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="173"/>
         <source>&amp;Extract</source>
         <translation>&amp;Extrahera</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="175"/>
         <source>Extract (&amp;XA)</source>
         <translation>Extrahera (&amp;XA)</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="177"/>
         <source>Extract (&amp;Raw)</source>
         <translation>Extrahera (&amp;Raw)</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="189"/>
         <source>Extract File</source>
         <translation>Extrahera fil</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="337"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.cpp" line="345"/>
         <source>&lt;Parent Directory&gt;</source>
         <translation>&lt;föräldrakatalog&gt;</translation>
     </message>
     <message>
-        <location filename="../isobrowserwindow.ui" line="40"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
@@ -7044,70 +5427,54 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>InputBindingDialog</name>
     <message>
-        <location filename="../inputbindingdialog.ui" line="14"/>
         <source>Edit Bindings</source>
         <translation>Redigera bindningar</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="20"/>
         <source>Bindings for Controller0/ButtonCircle</source>
         <translation>Bindningar för Kontroller0/ButtonCircle</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="74"/>
         <source>Sensitivity:</source>
         <translation>Känslighet:</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="87"/>
-        <location filename="../inputbindingdialog.ui" line="107"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="94"/>
         <source>Deadzone:</source>
         <translation>Dödläge:</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="148"/>
         <source>Add Binding</source>
         <translation>Lägg till bindning</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="159"/>
         <source>Remove Binding</source>
         <translation>Ta bort bindning</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="170"/>
         <source>Clear Bindings</source>
         <translation>Töm bindningar</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.cpp" line="33"/>
         <source>Bindings for %1:</source>
         <translation>Bindningar för %1:</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.cpp" line="176"/>
-        <location filename="../inputbindingdialog.cpp" line="193"/>
         <source>Push Button/Axis... [%1]</source>
         <translation>Tryckknapp/Axlar... [%1]</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.cpp" line="362"/>
-        <location filename="../inputbindingdialog.cpp" line="386"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="114"/>
         <source>Reset Sensitivity</source>
         <translation>Nollställ känslighet</translation>
     </message>
     <message>
-        <location filename="../inputbindingdialog.ui" line="125"/>
         <source>Reset Deadzone</source>
         <translation>Nollställ dödzon</translation>
     </message>
@@ -7115,24 +5482,20 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>InputBindingWidget</name>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="116"/>
         <source>Left-click to change binding.
 Shift-click to set multiple bindings.</source>
         <translation>Vänsterklicka för att ändra bindning.
 Skift-klicka för att ställa in flera bindningar.</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="117"/>
         <source>Right-click to remove binding.</source>
         <translation>Högerklicka för att ta bort bindning.</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="123"/>
         <source>No binding set.</source>
         <translation>Ingen bindning inställd.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../inputbindingwidgets.cpp" line="145"/>
         <source>%n bindings</source>
         <translation>
             <numerusform>%n bindning</numerusform>
@@ -7140,28 +5503,22 @@ Skift-klicka för att ställa in flera bindningar.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="361"/>
-        <location filename="../inputbindingwidgets.cpp" line="378"/>
         <source>Push Button/Axis... [%1]</source>
         <translation>Tryckknapp/Axlar... [%1]</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="499"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="501"/>
         <source>No devices with vibration motors were detected.</source>
         <translation>Inga enheter med vibrationsmotorer hittades.</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="502"/>
         <source>No devices with LEDs were detected.</source>
         <translation>Inga enheter med LED hittades.</translation>
     </message>
     <message>
-        <location filename="../inputbindingwidgets.cpp" line="519"/>
         <source>&lt;strong&gt;%1&lt;/strong&gt;&lt;br&gt;Select the device and effect to map this bind to.</source>
         <translation>&lt;strong&gt;%1&lt;/strong&gt;&lt;br&gt;Välj enheten och effekten som denna bindning ska mappas till.</translation>
     </message>
@@ -7169,347 +5526,246 @@ Skift-klicka för att ställa in flera bindningar.</translation>
 <context>
     <name>InterfaceSettingsWidget</name>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="29"/>
         <source>Behavior</source>
         <translation>Beteende</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="63"/>
-        <location filename="../interfacesettingswidget.cpp" line="171"/>
         <source>Pause On Focus Loss</source>
         <translation>Pausa när fokus tappas</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="49"/>
-        <location filename="../interfacesettingswidget.cpp" line="167"/>
         <source>Inhibit Screensaver</source>
         <translation>Förhindra skärmsläckare</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="84"/>
-        <location filename="../interfacesettingswidget.cpp" line="179"/>
         <source>Enable Discord Presence</source>
         <translation>Aktivera Discord-närvaro</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="56"/>
-        <location filename="../interfacesettingswidget.cpp" line="174"/>
         <source>Pause On Controller Disconnection</source>
         <translation>Pausa när handkontroller kopplas från</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="77"/>
-        <location filename="../interfacesettingswidget.cpp" line="177"/>
         <source>Start In Big Picture Mode</source>
         <translation>Starta i storbildsläge</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="94"/>
         <source>Game Display</source>
         <translation>Spelskärm</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="100"/>
-        <location filename="../interfacesettingswidget.cpp" line="182"/>
         <source>Start Fullscreen</source>
         <translation>Starta helskärm</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="107"/>
-        <location filename="../interfacesettingswidget.cpp" line="184"/>
         <source>Double-Click Toggles Fullscreen</source>
         <translation>Dubbelklick växlar helskärm</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="114"/>
-        <location filename="../interfacesettingswidget.cpp" line="187"/>
         <source>Render To Separate Window</source>
         <translation>Renderera till separat fönster</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="128"/>
-        <location filename="../interfacesettingswidget.cpp" line="193"/>
         <source>Hide Main Window When Running</source>
         <translation>Dölj huvudmenyn vid körning</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="142"/>
-        <location filename="../interfacesettingswidget.cpp" line="197"/>
         <source>Disable Window Resizing</source>
         <translation>Inaktivera ändring av fönsterstorlek</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="121"/>
-        <location filename="../interfacesettingswidget.cpp" line="190"/>
         <source>Hide Cursor In Fullscreen</source>
         <translation>Dölj markör i helskärm</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="159"/>
         <source>Appearance</source>
         <translation>Utseende</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="188"/>
         <source>Updates</source>
         <translation>Uppdateringar</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="165"/>
         <source>Language:</source>
         <translation>Språk:</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="175"/>
         <source>Theme:</source>
         <translation>Tema:</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="194"/>
         <source>Update Channel:</source>
         <translation>Uppdateringskanal:</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="204"/>
         <source>Current Version:</source>
         <translation>Aktuell version:</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="220"/>
-        <location filename="../interfacesettingswidget.cpp" line="238"/>
         <source>Enable Automatic Update Check</source>
         <translation>Aktivera automatisk uppdateringskontroll</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="240"/>
         <source>Check for Updates...</source>
         <translation>Leta efter uppdateringar...</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="161"/>
-        <location filename="../interfacesettingswidget.cpp" line="163"/>
-        <location filename="../interfacesettingswidget.cpp" line="167"/>
-        <location filename="../interfacesettingswidget.cpp" line="184"/>
-        <location filename="../interfacesettingswidget.cpp" line="187"/>
-        <location filename="../interfacesettingswidget.cpp" line="190"/>
-        <location filename="../interfacesettingswidget.cpp" line="238"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="188"/>
         <source>Renders the display of the simulated console to the main window of the application, over the game list. If checked, the display will render in a separate window.</source>
         <translation>Renderar skärmen för den simulerade konsolen till huvudfönstret för programmet, över spellistan. Om markerad kommer skärmen att rendera i ett separat fönster.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="239"/>
         <source>Automatically checks for updates to the program on startup. Updates can be deferred until later or skipped entirely.</source>
         <translation>Letar automatiskt efter uppdateringar till programmet vid uppstart. Uppdateringar kan fördröjas till senare eller hoppas över helt.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="133"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="168"/>
         <source>Prevents the screen saver from activating and the host from sleeping while emulation is running.</source>
         <translation>Förhindrar att skärmsläckaren aktiveras och att värden går in i viloläge när emulatorn körs.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="176"/>
         <source>Pauses the emulator when a controller with bindings is disconnected.</source>
         <translation>Pausar emulatorn när en handkontoller med bindningar kopplas från.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="110"/>
-        <location filename="../interfacesettingswidget.cpp" line="119"/>
-        <location filename="../interfacesettingswidget.cpp" line="169"/>
-        <location filename="../interfacesettingswidget.cpp" line="171"/>
-        <location filename="../interfacesettingswidget.cpp" line="175"/>
-        <location filename="../interfacesettingswidget.cpp" line="177"/>
-        <location filename="../interfacesettingswidget.cpp" line="179"/>
-        <location filename="../interfacesettingswidget.cpp" line="182"/>
-        <location filename="../interfacesettingswidget.cpp" line="193"/>
-        <location filename="../interfacesettingswidget.cpp" line="195"/>
-        <location filename="../interfacesettingswidget.cpp" line="197"/>
-        <location filename="../interfacesettingswidget.cpp" line="199"/>
-        <location filename="../interfacesettingswidget.cpp" line="205"/>
-        <location filename="../interfacesettingswidget.cpp" line="210"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="172"/>
         <source>Pauses the emulator when you minimize the window or switch to another application, and unpauses when you switch back.</source>
         <translation>Pausar emulatorn när du minimerar fönstret eller byter till ett annat program samt avpausar när du växlar tillbaka.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="183"/>
         <source>Automatically switches to fullscreen mode when a game is started.</source>
         <translation>Ändrar automatiskt till fullskärm när spelet startar.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="191"/>
         <source>Hides the mouse pointer/cursor when the emulator is in fullscreen mode.</source>
         <translation>Döljer muspekaren/markören när emulatorn är i helskärmsläge.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="180"/>
         <source>Shows the game you are currently playing as part of your profile in Discord.</source>
         <translation>Visar spelet som du för närvarande spelar som en del av din profil i Discord.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="35"/>
-        <location filename="../interfacesettingswidget.cpp" line="161"/>
         <source>Confirm Game Close</source>
         <translation>Bekräfta spelavstängning</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="42"/>
-        <location filename="../interfacesettingswidget.cpp" line="163"/>
         <source>Save State On Game Close</source>
         <translation>Spara tillstånd vid spelavstängning</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="162"/>
         <source>Determines whether a prompt will be displayed to confirm closing the game.</source>
         <translation>Bestämmer huruvid en prompt kommer att visas för att bekräfta avstängning av spelet.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="164"/>
         <source>Automatically saves the system state when closing the game or exiting. You can then resume directly from where you left off next time.</source>
         <translation>Sparar automatiskt systemets tillstånd  när du stänger spelet eller stänger av applikationen. Du kan sedan fortsätta direkt där du slutade nästa gång.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="178"/>
         <source>Starts the application in Big Picture Mode instead of the desktop interface.</source>
         <translation>Startar programmet i storbildsläge i stället för skrivbordsgränssnittet.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="185"/>
         <source>Switches between full screen and windowed when the window is double-clicked.</source>
         <translation>Växlar mellan helskärm och fönsterläge när fönstret dubbelklickas.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="194"/>
         <source>Hides the main window of the application while the game is displayed in a separate window.</source>
         <translation>Döljer programmets huvudfönster medan spelet visas i ett separat fönster.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="198"/>
         <source>Prevents resizing of the window while a game is running.</source>
         <translation>Förhindrar storleksändring av fönstret medan ett spel körs.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="216"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="216"/>
         <source>System Language</source>
         <translation>Systemspråk</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="217"/>
         <source>Selects the language for the application. Please note that not all parts of the application may be translated for a given language.</source>
         <translation>Väljer språk för applikationen. Observera att inte alla delar av applikationen kanske är översatta till ett visst språk.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="230"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="231"/>
         <source>Selects the theme for the application.</source>
         <translation>Väljer temat för applikationen.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="233"/>
         <source>Update Channel</source>
         <translation>Uppdateringskanal</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="235"/>
         <source>Selects the channel that will be checked for updates to the application. The &lt;strong&gt;preview&lt;/strong&gt; channel contains the latest changes, and may be unstable. The &lt;strong&gt;latest&lt;/strong&gt; channel tracks the latest release.</source>
         <translation>Väljer den kanal som ska kontrolleras för uppdateringar av applikationen. Kanalen &lt;strong&gt;preview&lt;/strong&gt; innehåller de senaste ändringarna och kan vara instabil. Kanalen &lt;strong&gt;latest&lt;/strong&gt; följer den senaste versionen.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="135"/>
-        <location filename="../interfacesettingswidget.cpp" line="195"/>
         <source>Display System Log In Main Window</source>
         <translation>Visa systemlogg i huvudfönstret</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="149"/>
-        <location filename="../interfacesettingswidget.cpp" line="199"/>
         <source>Automatically Resize Window</source>
         <translation>Storleksändra fönstret automatiskt</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="79"/>
-        <location filename="../interfacesettingswidget.cpp" line="205"/>
         <source>Disable Window Rounded Corners</source>
         <translation>Inaktivera fönster med rundade hörn</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="85"/>
-        <location filename="../interfacesettingswidget.cpp" line="210"/>
         <source>Use Fractional Window Scale</source>
         <translation>Använd fraktionell fönsterskalning</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="104"/>
-        <location filename="../interfacesettingswidget.cpp" line="110"/>
         <source>Use System Font</source>
         <translation>Använd systemteckensnitt</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="111"/>
         <source>Uses the system font for the interface, instead of the bundled Roboto font. Enabling this option may cause some UI elements to not fit within windows.</source>
         <translation>Använder systemets teckensnitt i gränssnittet i stället för det medföljande Roboto-teckensnittet. Alternativet kan göra att vissa gränssnittselement inte ryms i fönstren.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="115"/>
-        <location filename="../interfacesettingswidget.cpp" line="119"/>
         <source>Disable Style Sheets</source>
         <translation>Inaktivera stilmallar</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="120"/>
         <source>Disables the use of style sheets in the application, reverting to the original &apos;Fusion&apos; style but retaining the color scheme.</source>
         <translation>Inaktiverar stilmallar i programmet och återgår till den ursprungliga Fusion-stilen, men behåller färgschemat.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="196"/>
         <source>Displays the log in the main window of the application while a game is running.</source>
         <translation>Visar loggen i huvudfönstret för applikationen när ett spel körs.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="200"/>
         <source>Automatically resizes the window to match the internal resolution. &lt;strong&gt;For high internal resolutions, this will create very large windows.&lt;/strong&gt;</source>
         <translation>Ändrar automatiskt storlek på fönstret så att det matchar den interna upplösningen. &lt;strong&gt;För höga interna upplösningar kommer detta att skapa mycket stora fönster.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="206"/>
         <source>Disables the rounding of windows automatically applied in Windows 11, which may obscure parts of the content.</source>
         <translation>Inaktiverar den automatiska avrundningen av fönster i Windows 11, som kan dölja delar av innehållet.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="211"/>
         <source>Calculates the true scaling factor for your display, avoiding the downsampling applied by MacOS.</source>
         <translation>Beräknar den verkliga skalningsfaktorn för din skärm och undviker den nedsampling som tillämpas av MacOS.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.ui" line="70"/>
-        <location filename="../interfacesettingswidget.cpp" line="169"/>
         <source>Disable Background Input</source>
         <translation>Inaktivera bakgrundsinmatning</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="170"/>
         <source>Prevents inputs from being processed when another application is active.</source>
         <translation>Förhindrar att inmatningar behandlas när en annan applikation är aktiv.</translation>
     </message>
@@ -7517,7 +5773,6 @@ Skift-klicka för att ställa in flera bindningar.</translation>
 <context>
     <name>LogWidget</name>
     <message>
-        <location filename="../logwindow.cpp" line="64"/>
         <source>Dropped %1 log messages, please use file or system console logging.
 </source>
         <translation>Släppte %1 loggmeddelanden, använd loggning till fil eller systemkonsol.
@@ -7527,77 +5782,62 @@ Skift-klicka för att ställa in flera bindningar.</translation>
 <context>
     <name>LogWindow</name>
     <message>
-        <location filename="../logwindow.cpp" line="301"/>
         <source>Log Window - %1 [%2]</source>
         <translation>Loggfönster - %1 [%2]</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="305"/>
         <source>Log Window</source>
         <translation>Loggfönster</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="328"/>
         <source>&amp;Clear</source>
         <translation>&amp;Töm</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="330"/>
         <source>&amp;Save...</source>
         <translation>&amp;Spara...</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="333"/>
         <source>&amp;Settings</source>
         <translation>I&amp;nställningar</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="336"/>
         <source>Log To &amp;System Console</source>
         <translation>Logga till &amp;systemkonsoll</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="340"/>
         <source>Log To &amp;Debug Console</source>
         <translation>Logga till &amp;felsökningskonsoll</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="344"/>
         <source>Log To &amp;File</source>
         <translation>Logga till &amp;fil</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="350"/>
         <source>Attach To &amp;Main Window</source>
         <translation>Fäst till &amp;huvudfönstret</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="354"/>
         <source>Show &amp;Timestamps</source>
         <translation>Visa &amp;tidsstämplar</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="360"/>
         <source>&amp;Log Level</source>
         <translation>&amp;Loggnivå</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="370"/>
         <source>&amp;Channels</source>
         <translation>&amp;Kanaler</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="413"/>
         <source>Select Log File</source>
         <translation>Välj loggfil</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="413"/>
         <source>Log Files (*.txt)</source>
         <translation>Loggfiler (*.txt)</translation>
     </message>
     <message>
-        <location filename="../logwindow.cpp" line="429"/>
         <source>Log was written to %1.
 </source>
         <translation>Loggen skrevs till %1.
@@ -7607,37 +5847,30 @@ Skift-klicka för att ställa in flera bindningar.</translation>
 <context>
     <name>MAC_APPLICATION_MENU</name>
     <message>
-        <location filename="../qthost.cpp" line="95"/>
         <source>Services</source>
         <translation>Tjänster</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="96"/>
         <source>Hide %1</source>
         <translation>Dölj %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="97"/>
         <source>Hide Others</source>
         <translation>Dölj övriga</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="98"/>
         <source>Show All</source>
         <translation>Visa alla</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="99"/>
         <source>Preferences...</source>
         <translation>Inställningar...</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="100"/>
         <source>Quit %1</source>
         <translation>Avsluta %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="101"/>
         <source>About %1</source>
         <translation>Om %1</translation>
     </message>
@@ -7645,689 +5878,526 @@ Skift-klicka för att ställa in flera bindningar.</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.ui" line="23"/>
         <source>&amp;System</source>
         <translation>&amp;System</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="671"/>
-        <location filename="../mainwindow.cpp" line="1392"/>
-        <location filename="../mainwindow.cpp" line="1759"/>
         <source>Change Disc</source>
         <translation>Byt skiva</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="683"/>
         <source>Cheats</source>
         <translation>Fusk</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="897"/>
-        <location filename="../mainwindow.cpp" line="1252"/>
         <source>Load State</source>
         <translation>Läs in tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="83"/>
         <source>S&amp;ettings</source>
         <translation>&amp;Inställningar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="112"/>
         <source>&amp;Help</source>
         <translation>&amp;Hjälp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="125"/>
         <source>&amp;Debug</source>
         <translation>Fe&amp;lsök</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="129"/>
         <source>Switch GPU Renderer</source>
         <translation>Byt GPU-renderare</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="134"/>
         <source>Switch CPU Emulation Mode</source>
         <translation>Byt CPU-emuleringsläge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="139"/>
         <source>Switch Crop Mode</source>
         <translation>Byt beskäringsläge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="144"/>
         <source>Log Level</source>
         <translation>Loggnivå</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="149"/>
         <source>Log Channels</source>
         <translation>Loggkanaler</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="45"/>
-        <location filename="../mainwindow.ui" line="438"/>
         <source>&amp;Load State</source>
         <translation>&amp;Läs in tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="450"/>
         <source>&amp;Save State</source>
         <translation>&amp;Spara tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="486"/>
         <source>C&amp;onsole</source>
         <translation>K&amp;onsol</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="633"/>
         <source>View Third-Party Notices...</source>
         <translation>Tredjepartslicenser...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="656"/>
         <source>&amp;About DuckStation...</source>
         <translation>&amp;Om DuckStation...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="731"/>
         <source>&amp;Interface</source>
         <translation>&amp;Gränssnitt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="840"/>
         <source>Show VRAM</source>
         <translation>Visa VRAM</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="848"/>
         <source>Dump CPU to VRAM Copies</source>
         <translation>Dumpa CPU till VRAM-kopior</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="856"/>
         <source>Dump VRAM to CPU Copies</source>
         <translation>Dumpa VRAM till CPU-kopior</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="869"/>
         <source>Dump RAM...</source>
         <translation>Dumpa RAM...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="874"/>
         <source>Dump VRAM...</source>
         <translation>Dumpa VRAM...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="879"/>
         <source>Dump SPU RAM...</source>
         <translation>Dumpa SPU RAM...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="887"/>
         <source>Show GPU State</source>
         <translation>Visa GPU-tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="895"/>
         <source>Show CD-ROM State</source>
         <translation>Visa cd-rom-tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="903"/>
         <source>Show SPU State</source>
         <translation>Visa SPU-tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="911"/>
         <source>Show Timers State</source>
         <translation>Visa tillstånd för timers</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="919"/>
         <source>Show MDEC State</source>
         <translation>Visa MDEC-tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="927"/>
         <source>Show DMA State</source>
         <translation>Visa DMA-tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="894"/>
         <source>Resume</source>
         <translation>Återuppta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="963"/>
         <source>Resumes the last save state created.</source>
         <translation>Återupptar senaste sparade tillståndet som skapats.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1089"/>
         <source>Memory &amp;Card Editor</source>
         <translation>Minneskorts&amp;redigerare</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1101"/>
         <source>CPU D&amp;ebugger</source>
         <translation>CPU-felsöka&amp;re</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1242"/>
-        <location filename="../mainwindow.cpp" line="1462"/>
         <source>Big Picture</source>
         <translation>Storbild</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1266"/>
         <source>Memory &amp;Scanner</source>
         <translation>Minness&amp;kanner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1299"/>
         <source>Media Ca&amp;pture</source>
         <translation>Mediafångs&amp;t</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="193"/>
         <source>&amp;View</source>
         <translation>&amp;Visa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="154"/>
         <source>CD-ROM Lid Control</source>
         <translation>Styrning av CD-ROM-lucka</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="197"/>
         <source>&amp;Window Size</source>
         <translation>&amp;Fönsterstorlek</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="253"/>
         <source>&amp;Tools</source>
         <translation>Ver&amp;ktyg</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="330"/>
         <source>Start &amp;File...</source>
         <translation>Starta &amp;fil...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="342"/>
         <source>Start &amp;Disc...</source>
         <translation>Starta s&amp;kiva...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="357"/>
         <source>Start &amp;BIOS</source>
         <translation>Starta &amp;BIOS</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="381"/>
         <source>&amp;Rescan All Games</source>
         <translation>Sök ig&amp;enom alla spel igen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="426"/>
         <source>&amp;Pause</source>
         <translation>&amp;Paus</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="462"/>
         <source>E&amp;xit</source>
         <translation>Avs&amp;luta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="510"/>
         <source>&amp;Controllers</source>
         <translation>Handko&amp;ntroller</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="534"/>
         <source>&amp;Graphics</source>
         <translation>&amp;Grafik</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="597"/>
         <source>&amp;GitHub Repository...</source>
         <translation>&amp;GitHub-förråd...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="609"/>
         <source>&amp;Discord Server...</source>
         <translation>&amp;Discord-server...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="621"/>
         <source>Check for &amp;Updates...</source>
         <translation>Leta e&amp;fter uppdateringar...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="645"/>
         <source>About &amp;Qt...</source>
         <translation>Om &amp;Qt...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="779"/>
-        <location filename="../mainwindow.ui" line="794"/>
         <source>&amp;Settings</source>
         <translation>I&amp;nställningar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="805"/>
         <source>From File...</source>
         <translation>Från fil...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="813"/>
         <source>From Device...</source>
         <translation>Från enhet...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="821"/>
         <source>From Game List...</source>
         <translation>Från spellista...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="829"/>
         <source>Remove Disc</source>
         <translation>Ta bort skiva</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="936"/>
         <source>&amp;Screenshot</source>
         <translation>&amp;Skärmbild</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="948"/>
         <source>&amp;Memory Cards</source>
         <translation>Minn&amp;eskort</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="215"/>
         <source>&amp;Toolbar</source>
         <translation>Ve&amp;rktygsrad</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2167"/>
         <source>Lock Toolbar</source>
         <translation>Lås verktygsrad</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1029"/>
         <source>&amp;Status Bar</source>
         <translation>Statusra&amp;d</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="719"/>
-        <location filename="../mainwindow.ui" line="1044"/>
         <source>Game &amp;List</source>
         <translation>Spellis&amp;ta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1062"/>
         <source>System &amp;Display</source>
         <translation>Systemskä&amp;rm</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1077"/>
         <source>Game &amp;Properties</source>
         <translation>Spele&amp;genskaper</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1116"/>
         <source>Game &amp;Grid</source>
         <translation>Spelr&amp;utnät</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1155"/>
         <source>Show Titles (Grid View)</source>
         <translation>Visa titlar (rutnätsvy)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1349"/>
         <source>Log Timestamps</source>
         <translation>Logga tidsstämplar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1365"/>
         <source>Log To System Console</source>
         <translation>Logga till systemkonsol</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1373"/>
         <source>Log To Window</source>
         <translation>Logga till fönster</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1381"/>
         <source>Log To File</source>
         <translation>Logga till fil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1461"/>
         <source>Start Big Picture Mode</source>
         <translation>Starta storbildsläge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1993"/>
         <source>%1x Scale</source>
         <translation>%1x skala</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3482"/>
         <source>No containers are available for the current backend.</source>
         <translation>Inga containrar är tillgängliga för den aktuella bakänden.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3499"/>
         <source>%1 Files (*.%2)</source>
         <translation>%1 filer (*.%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3164"/>
         <source>Save State For Resume</source>
         <translation>Spara tillstånd för att återuppta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1182"/>
-        <location filename="../mainwindow.cpp" line="1271"/>
-        <location filename="../mainwindow.cpp" line="1367"/>
-        <location filename="../mainwindow.cpp" line="1657"/>
-        <location filename="../mainwindow.cpp" line="3430"/>
-        <location filename="../mainwindow.cpp" line="3447"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="111"/>
         <source>All File Types (*.bin *.img *.iso *.cue *.chd *.cpe *.ecm *.mds *.pbp *.ccd *.elf *.exe *.psexe *.ps-exe *.psx *.psf *.minipsf *.m3u *.psxgpu);;Single-Track Raw Images (*.bin *.img *.iso);;Cue Sheets (*.cue);;MAME CHD Images (*.chd);;Error Code Modeler Images (*.ecm);;Media Descriptor Sidecar Images (*.mds);;CloneCD Images (*.ccd);;PlayStation EBOOTs (*.pbp *.PBP);;PlayStation Executables (*.cpe *.elf *.exe *.psexe *.ps-exe, *.psx);;Portable Sound Format Files (*.psf *.minipsf);;Playlists (*.m3u);;PSX GPU Dumps (*.psxgpu *.psxgpu.zst *.psxgpu.xz)</source>
         <translation>Alla filtyper (*.bin *.img *.iso *.cue *.chd *.cpe *.ecm *.mds *.pbp *.ccd *.elf *.exe *.psexe *.ps-exe *.psx *.psf *.minipsf *.m3u *.psxgpu);;Råa enkelspårsavbilder (*.bin *.img *.iso);;Cue-ark (*.cue);;MAME CHD-avbilder (*.chd);;Error Code Modeler-avbilder (*.ecm);;Media Descriptor-sidofiler (*.mds);;CloneCD-avbilder (*.ccd);;PlayStation EBOOT-filer (*.pbp *.PBP);;Körbara PlayStation-filer (*.cpe *.elf *.exe *.psexe *.ps-exe, *.psx);;Portable Sound Format-filer (*.psf *.minipsf);;Spellistor (*.m3u);;PSX GPU-dumpar (*.psxgpu *.psxgpu.zst *.psxgpu.xz)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="723"/>
         <source>Could not find any CD-ROM devices. Please ensure you have a CD-ROM drive connected and sufficient permissions to access it.</source>
         <translation>Kunde inte hitta några cd-rom-enheter. Försäkra dig om att du har en cd-rom-enhet ansluten och tillräckliga rättigheter att komma åt den.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="737"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="913"/>
         <source>Resume (%1)</source>
         <translation>Återuppta (%1)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="920"/>
-        <location filename="../mainwindow.cpp" line="1009"/>
-        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Game Save %1 (%2)</source>
         <translation>Sparat spel %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="932"/>
         <source>Edit Memory Cards...</source>
         <translation>Redigera minneskort...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="955"/>
         <source>Confirm Save State Deletion</source>
         <translation>Bekräfta borttagning av sparat tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="990"/>
-        <location filename="../mainwindow.cpp" line="1043"/>
         <source>Save States (*.sav)</source>
         <translation>Sparade tillstånd (*.sav)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1009"/>
-        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Game Save %1 (Empty)</source>
         <translation>Sparat spel %1 (Tom)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1018"/>
-        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Global Save %1 (%2)</source>
         <translation>Globalt sparat spel %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1018"/>
-        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Global Save %1 (Empty)</source>
         <translation>Globalt sparat spel %1 (Tom)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1071"/>
         <source>Select Cheats...</source>
         <translation>Välj fusk...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1090"/>
         <source>Cheats are not enabled.</source>
         <translation>Fusk har inte aktiverats.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
         <source>&amp;Apply Cheat</source>
         <translation>Tilläm&amp;pa fusk</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1219"/>
         <source>Save was created %1.</source>
         <translation>Sparningen skapades %1.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1462"/>
         <source>Exit Big Picture</source>
         <translation>Avsluta storbildsläge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1657"/>
         <source>You must select a disc to change discs.</source>
         <translation>Du måste välja en skiva för att byta skivor.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1687"/>
-        <location filename="../mainwindow.cpp" line="1768"/>
         <source>Properties...</source>
         <translation>Egenskaper...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1697"/>
         <source>Open Containing Directory...</source>
         <translation>Öppna överliggande katalog...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1704"/>
         <source>Browse ISO...</source>
         <translation>Bläddra ISO...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1715"/>
-        <location filename="../mainwindow.cpp" line="1776"/>
         <source>Set Cover Image...</source>
         <translation>Ange omslagsbild...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1796"/>
         <source>Exclude From List</source>
         <translation>Exkludera från lista</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1801"/>
         <source>Reset Play Time</source>
         <translation>Nollställ spelad tid</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2734"/>
-        <location filename="../mainwindow.cpp" line="2742"/>
-        <location filename="../mainwindow.cpp" line="2750"/>
         <source>Destination File</source>
         <translation>Målfil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2734"/>
-        <location filename="../mainwindow.cpp" line="2750"/>
         <source>Binary Files (*.bin)</source>
         <translation>Binärfiler (*.bin)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2742"/>
         <source>Binary Files (*.bin);;PNG Images (*.png)</source>
         <translation>Binärfiler (*.bin);;PNG-bilder (*.png)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3270"/>
-        <location filename="../mainwindow.cpp" line="3281"/>
-        <location filename="../mainwindow.cpp" line="3305"/>
-        <location filename="../mainwindow.cpp" line="3314"/>
         <source>Memory Card Not Found</source>
         <translation>Minneskortet hittades inte</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3271"/>
         <source>Memory card &apos;%1&apos; does not exist. Do you want to create an empty memory card?</source>
         <translation>Minneskortet &apos;%1&apos; finns inte. Vill du skapa ett tomt minneskort?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3282"/>
         <source>Failed to create memory card &apos;%1&apos;: %2</source>
         <translation>Misslyckades med att skapa minneskort &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3306"/>
-        <location filename="../mainwindow.cpp" line="3315"/>
         <source>Memory card &apos;%1&apos; could not be found. Try starting the game and saving to create it.</source>
         <translation>Minneskortet &apos;%1&apos; kunde inte hittas. Prova att starta spelet och spara för att skapa det.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3332"/>
         <source>RA: Logged in as %1 (%2 points, %3 casual). %4 unread messages.</source>
         <translation>RA: Inloggad som %1 (%2 poäng, %3 avslappnat). %4 olästa meddelanden.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3432"/>
         <source>RA: Updated achievement game database.</source>
         <translation>RA: Prestationsdatabasen har uppdaterats.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3511"/>
         <source>Media Capture</source>
         <translation>Mediafångst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1729"/>
         <source>Default Boot</source>
         <translation>Standarduppstart</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1733"/>
         <source>Fast Boot</source>
         <translation>Snabb uppstart</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1739"/>
         <source>Full Boot</source>
         <translation>Fullständig uppstart</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1747"/>
         <source>Boot and Debug</source>
         <translation>Uppstart och felsökning</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1814"/>
         <source>Add Search Directory...</source>
         <translation>Lägg till sökkatalog...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="345"/>
-        <location filename="../mainwindow.cpp" line="1352"/>
         <source>Start Disc</source>
         <translation>Starta skiva</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="709"/>
-        <location filename="../mainwindow.cpp" line="1377"/>
         <source>Select Disc Image</source>
         <translation>Välj skivavbild</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="618"/>
         <source>Paused</source>
         <translation>Pausad</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1461"/>
         <source>Stop Big Picture Mode</source>
         <translation>Stoppa storbildsläge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="741"/>
         <source>Select disc drive:</source>
         <translation>Välj skivenhet:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1823"/>
         <source>Select Cover Image</source>
         <translation>Välj skivomslag</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1842"/>
         <source>Cover Already Exists</source>
         <translation>Omslaget finns redan</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1843"/>
         <source>A cover image for this game already exists, do you wish to replace it?</source>
         <translation>En omslagsbild för detta spel finns redan. Vill du ersätta den?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1837"/>
-        <location filename="../mainwindow.cpp" line="1852"/>
-        <location filename="../mainwindow.cpp" line="1858"/>
-        <location filename="../mainwindow.cpp" line="1864"/>
         <source>Copy Error</source>
         <translation>Kopieringsfel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1853"/>
         <source>Failed to remove existing cover &apos;%1&apos;</source>
         <translation>Misslyckades med att ta bort befintligt omslag &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1859"/>
         <source>Failed to copy &apos;%1&apos; to &apos;%2&apos;</source>
         <translation>Misslyckades med att kopiera &apos;%1&apos; till &apos;%2&apos;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1865"/>
         <source>Failed to remove &apos;%1&apos;</source>
         <translation>Misslyckades med att ta bort &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1875"/>
         <source>Confirm Reset</source>
         <translation>Bekräfta omstart</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1838"/>
         <source>You must select a different file to the current cover image.</source>
         <translation>Du måste välja en annan fil för den aktuella omslagsbilden.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1876"/>
         <source>Are you sure you want to reset the play time for &apos;%1&apos;?
 
 This action cannot be undone.</source>
@@ -8336,47 +6406,34 @@ This action cannot be undone.</source>
 Denna åtgärd kan inte ångras.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
-        <location filename="../mainwindow.cpp" line="1199"/>
         <source>Load Resume State</source>
         <translation>Läs in återställt tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1170"/>
-        <location filename="../mainwindow.cpp" line="1253"/>
         <source>Fresh Boot</source>
         <translation>Fräsch uppstart</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1171"/>
-        <location filename="../mainwindow.cpp" line="1254"/>
         <source>Delete And Boot</source>
         <translation>Ta bort och starta upp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1183"/>
-        <location filename="../mainwindow.cpp" line="1272"/>
         <source>Failed to delete save state file &apos;%1&apos;.</source>
         <translation>Misslyckades med att ta bort sparad tillståndfil: &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="988"/>
         <source>Load From File...</source>
         <translation>Läs in från fil...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="990"/>
-        <location filename="../mainwindow.cpp" line="1043"/>
         <source>Select Save State File</source>
         <translation>Välj fil för sparat tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1000"/>
         <source>Undo Load State</source>
         <translation>Ångra inläst tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="956"/>
         <source>Are you sure you want to delete all save states for %1?
 
 The saves will not be recoverable.</source>
@@ -8385,122 +6442,98 @@ The saves will not be recoverable.</source>
 Detta går inte att ångra.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1038"/>
         <source>Save To File...</source>
         <translation>Spara till fil...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1327"/>
         <source>Confirm Disc Change</source>
         <translation>Bekräfta skivbyte</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1331"/>
         <source>Swap Disc</source>
         <translation>Växla skiva</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="22"/>
         <source>Native</source>
         <translation>Inbyggd</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="24"/>
         <source>Classic Windows</source>
         <translation>Classic Windows</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="26"/>
         <source>Fusion</source>
         <translation>Fusion</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="27"/>
         <source>Dark Fusion (Gray)</source>
         <translation>Dark Fusion (Grå)</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="28"/>
         <source>Dark Fusion (Blue)</source>
         <translation>Dark Fusion (Blå)</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="31"/>
         <source>Cobalt Sky</source>
         <translation>Cobalt Sky</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="32"/>
         <source>Grey Matter</source>
         <translation>Grey Matter</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="35"/>
         <source>Dark Ocean</source>
         <translation>Mörkt hav</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="36"/>
         <source>Dark Ruby</source>
         <translation>Dark Ruby</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="37"/>
         <source>Purple Rain</source>
         <translation>Purple Rain</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="38"/>
         <source>QDarkStyle</source>
         <translation>QDarkStyle</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="34"/>
         <source>Pinky Pals</source>
         <translation>Pinky Pals</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="30"/>
         <source>AMOLED</source>
         <translation>AMOLED</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="33"/>
         <source>Green Giant</source>
         <translation>Gröna jätten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="119"/>
         <source>Images (*.jpg *.jpeg *.png *.webp)</source>
         <translation>Bilder (*.jpg *.jpeg *.png *.webp)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2931"/>
         <source>Select Background Image</source>
         <translation>Välj bakgrundsbild</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1468"/>
         <source>Refresh Achievement &amp;Progress</source>
         <translation>Uppdatera prestationsfra&amp;msteg</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3449"/>
         <source>RA: Updated achievement progress database.</source>
         <translation>RA: Framstegsdatabasen för prestationer uppdaterades.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="949"/>
         <source>Delete Save States</source>
         <translation>Ta bort sparade tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="997"/>
         <source>Undo Load State (%1)</source>
         <translation>Ångra inläsning av tillstånd (%1)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1165"/>
         <source>A resume save state was found for this game, but it is corrupted and cannot be loaded:
 
 %1
@@ -8513,866 +6546,690 @@ Do you want to delete the save state and boot the game anyway?</source>
 Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1328"/>
         <source>Do you want to swap discs or boot the new image via system restart?</source>
         <translation>Vill du byta skiva eller starta den nya avbilden genom att starta om systemet?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1367"/>
         <source>No resume save state found.</source>
         <translation>Inget återupptagningsbart sparat tillstånd hittades.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1791"/>
         <source>Select Disc...</source>
         <translation>Välj skiva...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2172"/>
         <source>Small Icons</source>
         <translation>Små ikoner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2177"/>
         <source>Show Labels</source>
         <translation>Visa etiketter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2182"/>
         <source>Labels Beside Icons</source>
         <translation>Etiketter bredvid ikoner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1357"/>
         <source>Log File Timestamps</source>
         <translation>Tidsstämplar för loggfil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="71"/>
         <source>Top</source>
         <translation>Överst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="72"/>
         <source>Bottom</source>
         <translation>Nederst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="73"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="74"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="2188"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1167"/>
         <source>Zoom &amp;In</source>
         <translation>Zooma &amp;in</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1179"/>
         <source>Zoom &amp;Out</source>
         <translation>Zooma &amp;ut</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="206"/>
         <source>Sort B&amp;y</source>
         <translation>Sortera e&amp;fter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="27"/>
         <source>Cha&amp;nge Disc</source>
         <translation>&amp;Byt skiva</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="36"/>
         <source>&amp;Cheats</source>
         <translation>&amp;Fusk</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="54"/>
         <source>Sa&amp;ve State</source>
         <translation>Spara &amp;tillstånd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="257"/>
         <source>Allows you to record audio and/or video from the content.</source>
         <translation>Gör det möjligt att spela in ljud och/eller video från innehållet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="260"/>
         <source>Media Capt&amp;ure</source>
         <translation>Mediafån&amp;gst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="333"/>
         <source>Starts a new session using the selected file.</source>
         <translation>Startar en ny session med den valda filen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="348"/>
         <source>Starts a new session from a physical disc.</source>
         <translation>Startar en ny session från en fysisk skiva.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="360"/>
         <source>Starts a new session without any disc inserted.</source>
         <translation>Startar en ny session utan att någon skiva är isatt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="369"/>
         <source>Scan &amp;For New Games</source>
         <translation>Sök &amp;efter nya spel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="372"/>
         <source>Searches for new games added since the last refresh.</source>
         <translation>Söker efter nya spel som lagts till sedan senaste uppdateringen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="384"/>
         <source>Rescans all games, discarding any cached information.</source>
         <translation>Söker igenom alla spel igen och raderar all cachad information.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="399"/>
         <source>Ends the current session.</source>
         <translation>Avslutar den aktuella sessionen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="408"/>
         <source>&amp;Restart Game</source>
         <translation>&amp;Starta om spelet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="411"/>
-        <location filename="../mainwindow.cpp" line="1332"/>
         <source>Restart</source>
         <translation>Starta om</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="414"/>
         <source>Restarts the emulated system.</source>
         <translation>Startar om det emulerade systemet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="429"/>
         <source>Pauses/resumes the session.</source>
         <translation>Pausar/återupptar sessionen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="441"/>
         <source>Restores the session state from the selected slot.</source>
         <translation>Återställer sessionens tillstånd från den valda platsen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="465"/>
         <source>Exits the application.</source>
         <translation>Avslutar applikationen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="474"/>
         <source>&amp;BIOS</source>
         <translation>&amp;BIOS</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="477"/>
         <source>Configures where the system firmware is located.</source>
         <translation>Konfigurerar var systemets fasta programvara finns.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="489"/>
         <source>Configures options related to the simulated console.</source>
         <translation>Konfigurerar alternativ relaterade till den simulerade konsolen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="498"/>
         <source>&amp;Emulation</source>
         <translation>&amp;Emulering</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="501"/>
         <source>Configures options related to the simulation.</source>
         <translation>Konfigurerar alternativ relaterade till simuleringen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="513"/>
         <source>Configures options and bindings for the emulated controllers.</source>
         <translation>Konfigurerar alternativ och bindningar för de emulerade kontrollerna.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="522"/>
         <source>Hot&amp;keys</source>
         <translation>Snabb&amp;tangenter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="525"/>
         <source>Configures shortcut keys for actions related to the session.</source>
         <translation>Konfigurerar genvägstangenter för åtgärder relaterade till sessionen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="537"/>
         <source>Configures options related to how the session content is displayed.</source>
         <translation>Konfigurerar alternativ relaterade till hur sessionens innehåll visas.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="546"/>
         <source>Post-Processi&amp;ng</source>
         <translation>Efterbehandli&amp;ng</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="549"/>
         <source>Configures post-processing effects applied after rendering the content.</source>
         <translation>Konfigurerar efterbearbetningseffekter som tillämpas efter rendering av innehållet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="558"/>
         <source>On-&amp;Screen Display</source>
         <translation>&amp;Skärmvisning</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="561"/>
         <source>These options determine the behavior of the messages that are displayed while content is running.</source>
         <translation>Dessa alternativ bestämmer hur meddelanden som visas medan innehåll körs ska fungera.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="570"/>
         <source>Capt&amp;ure</source>
         <translation>Fån&amp;ga</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="573"/>
         <source>These options determine how screenshots and videos are captured by the application.</source>
         <translation>Dessa alternativ bestämmer hur programmet tar skärmbilder och spelar in video.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="585"/>
         <source>&amp;Fullscreen</source>
         <translation>&amp;Helskärm</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="588"/>
         <source>Switches between fullscreen and windowed modes.</source>
         <translation>Växlar mellan helskärm och fönsterlägen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="600"/>
         <source>Opens a link to the GitHub repository for the application.</source>
         <translation>Öppnar en länk till GitHub-arkivet för applikationen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="612"/>
         <source>Opens a link to the Discord server for the application.</source>
         <translation>Öppnar en länk till Discord-servern för applikationen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="624"/>
         <source>Checks if any application updates are available for download.</source>
         <translation>Kontrollerar om det finns några programuppdateringar tillgängliga att hämta ner.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="636"/>
         <source>Shows copyright and license notices for third-party libraries included with the application.</source>
         <translation>Visar upphovsrätts- och licensmeddelanden för tredjepartsbibliotek som ingår i applikationen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="648"/>
         <source>Displays copyright and license notices for Qt.</source>
         <translation>Visar upphovsrätts- och licensmeddelanden för Qt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="659"/>
         <source>Displays copyright and license notices for the application.</source>
         <translation>Visar upphovsrätts- och licensmeddelanden för applikationen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="674"/>
         <source>Swaps the currently-inserted disc with another disc or game.</source>
         <translation>Byter ut den skiva som för närvarande är isatt mot en annan skiva eller ett annat spel.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="686"/>
         <source>Shows the list of cheats available for this game.</source>
         <translation>Visar listan över fusk tillgängliga för detta spel.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="695"/>
         <source>&amp;Audio</source>
         <translation>&amp;Ljud</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="698"/>
         <source>Configures options related to how audio from the content is played.</source>
         <translation>Konfigurerar alternativ relaterade till hur ljud från innehållet spelas upp.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="707"/>
         <source>Ac&amp;hievements</source>
         <translation>Pres&amp;tationer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="710"/>
         <source>Configures options related to RetroAchievements.</source>
         <translation>Konfigurerar alternativ relaterade till RetroAchievements.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="722"/>
         <source>Configures the locations where the application will search for game files.</source>
         <translation>Konfigurerar de platser där programmet ska söka efter spelfiler.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="734"/>
         <source>Configures options related to the apperance and behavior of the application.</source>
         <translation>Konfigurerar alternativ relaterade till applikationens utseende och beteende.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="746"/>
         <source>Configures advanced options for the application.</source>
         <translation>Konfigurerar avancerade alternativ för applikationen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="758"/>
         <source>Configures internal options for the application.</source>
         <translation>Konfigurerar programmets interna alternativ.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="767"/>
         <source>Add Game Director&amp;y...</source>
         <translation>Lägg till spel&amp;katalog...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="770"/>
         <source>Adds a new directory that will be searched for game files.</source>
         <translation>Lägger till en ny katalog som kommer att sökas igenom efter spelfiler.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="782"/>
-        <location filename="../mainwindow.ui" line="797"/>
         <source>Opens the settings window.</source>
         <translation>Öppnar inställningsfönstret.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="808"/>
         <source>Manually selects the disc image file to switch to.</source>
         <translation>Väljer manuellt den skivavbildningsfil som ska växlas till.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="816"/>
         <source>Switches to a physical disc.</source>
         <translation>Växlar till en fysisk skiva.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="824"/>
         <source>Switches to a disc in the game list.</source>
         <translation>Växlar till en skiva i spellistan.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="832"/>
         <source>Removes the disc from the emulated system.</source>
         <translation>Tar bort skivan från det emulerade systemet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="939"/>
         <source>Takes a screenshot of the current content.</source>
         <translation>Tar en skärmbild på aktuellt innehåll.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="951"/>
         <source>Configures options related to the emulated memory cards.</source>
         <translation>Konfigurerar alternativ relaterade till emulerade minneskort.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="974"/>
         <source>Controls whether the toolbar is visible.</source>
         <translation>Kontrollerar om verktygsfältet ska visas.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="982"/>
         <source>Loc&amp;k Toolbar</source>
         <translation>Lå&amp;s verktygsrad</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="985"/>
         <source>Controls whether the toolbar can be moved.</source>
         <translation>Kontrollerar om verktygsfältet kan flyttas.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="996"/>
         <source>Controls whether the smaller toolbar icons are displayed.</source>
         <translation>Kontrollerar om de mindre verktygsfältikonerna visas.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1007"/>
         <source>Controls whether labels are displayed alongside toolbar icons.</source>
         <translation>Kontrollerar om etiketter visas bredvid verktygsfältets ikoner.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1018"/>
         <source>Controls whether labels are displayed next to or under toolbar icons.</source>
         <translation>Kontrollerar om etiketter visas bredvid eller under verktygsfältets ikoner.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1032"/>
         <source>Controls whether the status bar is visible.</source>
         <translation>Kontrollerar om statusfältet är synligt.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1047"/>
         <source>Switches to the list of available games in table view.</source>
         <translation>Växlar till listan över tillgängliga spel i tabellvy.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1065"/>
         <source>Switches back to the game currently running.</source>
         <translation>Växlar tillbaka till det spel som för närvarande körs.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1080"/>
         <source>Opens the configuration for the game currently running.</source>
         <translation>Öppnar konfigurationen för spelet som körs för närvarande.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1092"/>
         <source>Opens the memory card editor.</source>
         <translation>Öppnar minneskortsredigeraren.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1104"/>
         <source>Opens the debugger for the emulated CPU.</source>
         <translation>Öppnar felsökaren för den emulerade CPU:n.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1119"/>
         <source>Switches to the list of available games in grid/cover view.</source>
         <translation>Växlar till listan över tillgängliga spel i rutnät-/omslagsvy.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1134"/>
         <source>&amp;Merge Multi-Disc Games</source>
         <translation>Slå samman spel &amp;på flera skivor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1137"/>
         <source>Merges multiple discs that belong to the same game into a single item in the game list.</source>
         <translation>Slår samman flera skivor som tillhör samma spel till ett enda objekt i spellistan.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1453"/>
         <source>Clear List Backgro&amp;und</source>
         <translation>Töm listbakgr&amp;und</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1483"/>
         <source>Refresh &amp;Achievement Database</source>
         <translation>Uppdatera &amp;prestationsdatabas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1528"/>
         <source>&amp;Animate Game Icons</source>
         <translation>&amp;Animera spelikoner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1543"/>
         <source>Prefer Ac&amp;hievement Icons</source>
         <translation>Föredra prestations&amp;ikoner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1561"/>
         <source>Syst&amp;em Log</source>
         <translation>System&amp;logg</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1573"/>
         <source>Start &amp;Capture</source>
         <translation>Starta &amp;fångst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1576"/>
         <source>Starts recording audio and video.</source>
         <translation>Startar inspelning av ljud och video.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1585"/>
         <source>Stop &amp;Capture</source>
         <translation>Stoppa &amp;fångst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1597"/>
         <source>Start &amp;Video-Only Capture</source>
         <translation>Starta &amp;videofångst (endast video)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1600"/>
         <source>Starts a video-only recording.</source>
         <translation>Startar en inspelning med endast video.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1612"/>
         <source>Start &amp;Audio-Only Capture</source>
         <translation>Starta &amp;ljudfångst (endast ljud)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1615"/>
         <source>Starts an audio-only recording.</source>
         <translation>Startar en inspelning med endast ljud.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1627"/>
         <source>Automatic</source>
         <translation>Automatisk</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1635"/>
         <source>Closed</source>
         <translation>Stängd</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1643"/>
         <source>Open</source>
         <translation>Öppen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1158"/>
         <source>Shows captions under the game cover in grid view.</source>
         <translation>Visar bildtexter under spelomslaget i rutnätvy.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="743"/>
         <source>Ad&amp;vanced</source>
         <translation>Avance&amp;rat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="755"/>
         <source>&amp;Debugging</source>
         <translation>&amp;Felsökning</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="864"/>
         <source>Enable &amp;Safe Mode</source>
         <translation>Aktivera &amp;säkert läge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="960"/>
         <source>Res&amp;ume</source>
         <translation>Återup&amp;pta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="971"/>
         <source>&amp;Show Toolbar</source>
         <translation>&amp;Visa verktygsrad</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="993"/>
         <source>S&amp;mall Icons</source>
         <translation>S&amp;må ikoner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1004"/>
         <source>Show &amp;Labels</source>
         <translation>Visa &amp;etiketter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1015"/>
         <source>Show Labels &amp;Beside Icons</source>
         <translation>Visa etiketter &amp;bredvid ikoner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1152"/>
         <source>Show Grid Ca&amp;ptions</source>
         <translation>Visa rutnätste&amp;xter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1170"/>
         <source>Increases the size of game icons or covers.</source>
         <translation>Ökar storleken på spelikonerna eller omslag.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1182"/>
         <source>Decreases the size of game icons or covers.</source>
         <translation>Minskar storleken på spelikonerna eller omslag.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1191"/>
         <source>&amp;Refresh Grid Covers</source>
         <translation>&amp;Uppdatera rutnätsomslag</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1194"/>
         <source>Invalidates the cache of game covers, allowing new images to be discovered.</source>
         <translation>Invaliderar cachen för spelomslag, vilket gör det möjligt att upptäcka nya bilder.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1203"/>
         <source>&amp;Open Data Directory...</source>
         <translation>&amp;Öppna datakatalog...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1206"/>
         <source>Opens the directory containing application data in your file browser.</source>
         <translation>Öppnar katalogen som innehåller programdata i din filbläddrare.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1221"/>
         <source>Ends the current session without the option to save state.</source>
         <translation>Avslutar den aktuella sessionen utan möjlighet att spara tillståndet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1230"/>
         <source>Start Bi&amp;g Picture Mode</source>
         <translation>Starta s&amp;torbildsläge</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1233"/>
-        <location filename="../mainwindow.ui" line="1245"/>
         <source>Opens or closes the controller-based &quot;big picture&quot; mode.</source>
         <translation>Öppnar eller stänger det kontrollerbaserade ”storbildsläget”.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1254"/>
         <source>Cover &amp;Downloader</source>
         <translation>Hämta &amp;omslagsbilder</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1257"/>
         <source>Opens the cover downloader window.</source>
         <translation>Öppnar fönstret för hämtningar av omslag.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1272"/>
         <source>Opens the memory scanner window.</source>
         <translation>Öppnar fönstret för minnesskanner.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1290"/>
         <source>Shows icons from the memory card of each game in list view.</source>
         <translation>Visar ikoner från minneskortet för varje spel i listvy.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1305"/>
         <source>Starts or stops capture of video and audio from the content.</source>
         <translation>Startar eller stoppar inspelning av video och ljud från innehållet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1314"/>
         <source>Open Te&amp;xture Directory...</source>
         <translation>Öppna te&amp;xturkatalog...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1317"/>
         <source>Opens the directory used to store texture replacements.</source>
         <translation>Öppnar katalogen som används för att lagra texturersättningar.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1326"/>
         <source>&amp;Reload Texture Replacements</source>
         <translation>&amp;Läs om texturersättningar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1329"/>
         <source>Invalidates the cache of available replacement textures.</source>
         <translation>Invaliderar cachen med tillgängliga ersättningstexturer.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1338"/>
         <source>Capture &amp;GPU Frame</source>
         <translation>Fånga &amp;GPU-bildruta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1341"/>
         <source>Saves the emulated GPU commands to a file that can be later replayed.</source>
         <translation>Sparar emulerade GPU-kommandona i en fil som senare kan spelas upp igen.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1390"/>
         <source>&amp;ISO Browser</source>
         <translation>&amp;ISO-bläddrare</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1393"/>
         <source>Opens the ISO browser window.</source>
         <translation>Öppnar fönstret för ISO-bläddraren.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1405"/>
         <source>&amp;Free Camera</source>
         <translation>&amp;Fri kamera</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1408"/>
         <source>Allows you to freely move the camera in supported games.</source>
         <translation>Gör det möjligt att fritt flytta kameran i spel som stöder denna funktion.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1417"/>
         <source>Controller &amp;Test</source>
         <translation>Handkontroller&amp;test</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1420"/>
         <source>Allows you to test emulated controller mappings.</source>
         <translation>Gör det möjligt att testa emulerade kontrollermappningar.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1429"/>
         <source>Controller Prese&amp;ts</source>
         <translation>Handkontrollsför&amp;val</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1432"/>
         <source>Creates or edits controller presets that can be applied to games.</source>
         <translation>Skapar eller redigerar förval för kontroller som kan användas i spel.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1441"/>
         <source>&amp;Change List Background...</source>
         <translation>Ä&amp;ndra listbakgrund...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1444"/>
         <source>Changes the background image shown in the game list/grid.</source>
         <translation>Ändrar bakgrundsbilden som visas i spellistan/rutnätet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1456"/>
         <source>Removes the background image shown in the game list/grid.</source>
         <translation>Tar bort bakgrundsbilden som visas i spellistan/rutnätet.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1471"/>
         <source>Refreshes the list of unlocked achievements.</source>
         <translation>Uppdaterar listan över upplåsta prestationer.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1486"/>
         <source>Updates the database for achievements shown in the game list.</source>
         <translation>Uppdaterar databasen för prestationer som visas i spellistan.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1498"/>
         <source>Show Locali&amp;zed Titles</source>
         <translation>Visa lokalan&amp;passade titlar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1501"/>
         <source>Shows titles for games in their native language.</source>
         <translation>Visar titlar på spel på deras ursprungliga språk.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1974"/>
         <source>&amp;Ascending</source>
         <translation>S&amp;tigande</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1982"/>
         <source>&amp;Descending</source>
         <translation>&amp;Fallande</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="453"/>
         <source>Saves the session state to the selected slot.</source>
         <translation>Sparar sessionstillståndet till vald plats.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1510"/>
         <source>Memory &amp;Editor</source>
         <translation>Minnesr&amp;edigerare</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1516"/>
         <source>Opens the memory editor window.</source>
         <translation>Öppnar fönstret för minnesredigeraren.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1531"/>
         <source>Animates icons in the list view when selected.</source>
         <translation>Animerar ikoner i listvyn när de väljs.</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="29"/>
         <source>Darker Fusion</source>
         <translation>Darker Fusion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1213"/>
         <source>&lt;strong&gt;Resume Game&lt;/strong&gt;&lt;br&gt;Do you want to load this state, or start from a fresh boot?</source>
         <translation>&lt;strong&gt;Återuppta spel&lt;/strong&gt;&lt;br&gt;Vill du läsa  in detta tillstånd eller starta om från början?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="393"/>
         <source>Cl&amp;ose Game</source>
         <translation>S&amp;täng spel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="396"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1215"/>
         <source>Close Game &amp;Without Saving</source>
         <translation>Stäng spelet &amp;utan att spara</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1218"/>
         <source>Close (No Save)</source>
         <translation>Stäng (spara inte)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1287"/>
         <source>Show Game Ico&amp;ns</source>
         <translation>Visa speliko&amp;ner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1546"/>
         <source>Prioritizes the games badges used for RetroAchievements over memory card icons.</source>
         <translation>Prioriterar spelmärken som används för RetroAchievements istället för minneskortsikoner.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3159"/>
         <source>Confirm Exit</source>
         <translation>Bekräfta avslut</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3159"/>
         <source>Confirm Close</source>
         <translation>Bekräfta stängning</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3160"/>
         <source>Are you sure you want to exit the application?</source>
         <translation>Är du säker på att du vill avsluta applikationen?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="3161"/>
         <source>Are you sure you want to close the current game?</source>
         <translation>Är du säker på att du vill stänga det aktuella spelet?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1269"/>
         <source>Scanner</source>
         <translation>Skanner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1302"/>
         <source>Capture</source>
         <translation>Fånga</translation>
     </message>
     <message>
-        <location filename="../mainwindow.ui" line="1513"/>
         <source>Editor</source>
         <translation>Redigerare</translation>
     </message>
     <message>
-        <location filename="../interfacesettingswidget.cpp" line="312"/>
-        <location filename="../mainwindow.cpp" line="3616"/>
         <source>Checking for updates...</source>
         <translation>Letar efter uppdateringar...</translation>
     </message>
@@ -9380,59 +7237,42 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>MemoryCardEditorDialog</name>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="14"/>
         <source>Memory Card Editor</source>
         <translation>Redigera minneskort</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="48"/>
-        <location filename="../memorycardeditorwindow.ui" line="248"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="53"/>
-        <location filename="../memorycardeditorwindow.ui" line="253"/>
         <source>File Name</source>
         <translation>Filnamn</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="58"/>
-        <location filename="../memorycardeditorwindow.ui" line="258"/>
         <source>Blocks</source>
         <translation>Block</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="82"/>
-        <location filename="../memorycardeditorwindow.ui" line="200"/>
         <source>New...</source>
         <translation>Ny...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="93"/>
-        <location filename="../memorycardeditorwindow.ui" line="211"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="43"/>
-        <location filename="../memorycardeditorwindow.ui" line="243"/>
         <source>Icon</source>
         <translation>Ikon</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="68"/>
         <source>Memory Card 2:</source>
         <translation>Minneskort 2:</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="190"/>
         <source>Memory Card 1:</source>
         <translation>Minneskort 1:</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.ui" line="129"/>
-        <location filename="../memorycardeditorwindow.ui" line="170"/>
         <source>Card Modified</source>
         <translation>Kortet ändrat</translation>
     </message>
@@ -9440,225 +7280,168 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>MemoryCardEditorWindow</name>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="40"/>
         <source>Single Save Files (*.mcs);;All Files (*.*)</source>
         <translation>Enstaka sparade filer (*.mcs);;Alla filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="142"/>
-        <location filename="../memorycardeditorwindow.cpp" line="941"/>
         <source>Delete File</source>
         <translation>Ta bort fil</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="144"/>
-        <location filename="../memorycardeditorwindow.cpp" line="944"/>
         <source>Undelete File</source>
         <translation>Ångra filborttagning</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="146"/>
-        <location filename="../memorycardeditorwindow.cpp" line="947"/>
         <source>Rename File</source>
         <translation>Byt namn på fil</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="148"/>
-        <location filename="../memorycardeditorwindow.cpp" line="950"/>
         <source>Export File</source>
         <translation>Exportera fil</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="193"/>
         <source>New Card...</source>
         <translation>Nytt kort...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="194"/>
         <source>Open Card...</source>
         <translation>Öppna kort...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="275"/>
         <source>Format Card</source>
         <translation>Formatera kort</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="274"/>
         <source>Save</source>
         <translation>Spara</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="559"/>
-        <location filename="../memorycardeditorwindow.cpp" line="628"/>
-        <location filename="../memorycardeditorwindow.cpp" line="638"/>
-        <location filename="../memorycardeditorwindow.cpp" line="701"/>
-        <location filename="../memorycardeditorwindow.cpp" line="766"/>
-        <location filename="../memorycardeditorwindow.cpp" line="797"/>
-        <location filename="../memorycardeditorwindow.cpp" line="825"/>
-        <location filename="../memorycardeditorwindow.cpp" line="865"/>
-        <location filename="../memorycardeditorwindow.cpp" line="917"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="560"/>
         <source>Failed to load memory card: %1</source>
         <translation>Misslyckades med att läsa in minneskort: %1</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="434"/>
         <source> (Deleted)</source>
         <translation> (borttaget)</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="42"/>
         <source>PNG Images (*.png);;JPEG Images (*.jpg *.jpeg);;WebP Images (*.webp)</source>
         <translation>PNG-bilder (*.png);;JPEG-bilder (*.jpg *.jpeg);;WebP-bilder (*.webp)</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="44"/>
         <source>Animated PNG Images (*.png)</source>
         <translation>Animerade PNG-bilder (*.png)</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="150"/>
-        <location filename="../memorycardeditorwindow.cpp" line="740"/>
-        <location filename="../memorycardeditorwindow.cpp" line="755"/>
-        <location filename="../memorycardeditorwindow.cpp" line="953"/>
         <source>Extract Icon</source>
         <translation>Extrahera ikon</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="276"/>
         <source>Import...</source>
         <translation>Importera...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="525"/>
-        <location filename="../memorycardeditorwindow.cpp" line="552"/>
         <source>Select Memory Card</source>
         <translation>Välj minneskort</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="605"/>
         <source>Save memory card?</source>
         <translation>Spara minneskort?</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="606"/>
         <source>Memory card &apos;%1&apos; is not saved, do you want to save before closing?</source>
         <translation>Minneskortet &apos;%1&apos; har inte sparats. Vill du spara det innan du stänger?</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="629"/>
         <source>Destination memory card already contains a save file with the same name (%1) as the one you are attempting to copy. Please delete this file from the destination memory card before copying.</source>
         <translation>Minneskortsmålet innehåller redan en sparad fil med samma namn (%1) som den som du försöker att kopiera. Ta bort denna fil från minneskortsmålet innan du kopierar.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="639"/>
         <source>Insufficient blocks, this file needs %1 but only %2 are available.</source>
         <translation>Otillräckliga block, denna fil behöver %1 men endast %2 finns tillgängliga.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="702"/>
         <source>Failed to undelete file %1. The file may have been partially overwritten by another save.</source>
         <translation>Misslyckades med att återställa borttagna filen %1. Filen kan delvis ha skrivits över av en annan sparning.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="717"/>
         <source>Select Single Save File</source>
         <translation>Välj en enskild sparfil</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="742"/>
-        <location filename="../memorycardeditorwindow.cpp" line="781"/>
-        <location filename="../memorycardeditorwindow.cpp" line="956"/>
         <source>Extract Animated Icon</source>
         <translation>Extrahera animerad ikon</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="767"/>
         <source>Failed to extract icon from save file %1:
 %2</source>
         <translation>Misslyckades med att extrahera ikon från sparfilen %1:
 %2</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="798"/>
         <source>Failed to extract animated icon from save file %1:
 %2</source>
         <translation>Misslyckades med att extrahera animerad ikon från sparfilen %1:
 %2</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="826"/>
         <source>Failed to rename save file %1:
 %2</source>
         <translation>Misslyckades med att byta namn på sparade filen %1:
 %2</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="845"/>
         <source>Import Single Save File...</source>
         <translation>Importera en enskild sparfil...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="847"/>
         <source>Import Entire Memory Card...</source>
         <translation>Importera hela minneskortet...</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="857"/>
         <source>Select Import File</source>
         <translation>Välj importfil</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="866"/>
         <source>Failed to import memory card from %1:
 %2</source>
         <translation>Misslyckades med att importa minneskort från %1:
 %2</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="887"/>
         <source>Format memory card?</source>
         <translation>Formatera minneskort?</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="888"/>
         <source>Formatting the memory card will destroy all saves, and they will not be recoverable. The memory card which will be formatted is located at &apos;%1&apos;.</source>
         <translation>Formatering av minneskortet kommer att förstöra alla sparningar och det går inte att ångra. Minneskortet som kommer att formateras finns på &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="909"/>
         <source>Select Save File</source>
         <translation>Välj sparad fil</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="918"/>
         <source>Failed to import save from %1:
 %2</source>
         <translation>Misslyckades med att importera sparning från %1:
 %2</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="959"/>
         <source>Copy File</source>
         <translation>Kopiera fil</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="35"/>
         <source>DuckStation Memory Card (*.mcd)</source>
         <translation>DuckStation-minneskort (*.mcd)</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="36"/>
         <source>All Importable Memory Card Types (*.mcd *.mcr *.mc *.gme *.srm *.psm *.ps *.ddf *.mem *.vgs *.psx)</source>
         <translation>Alla importerbara minneskortstyper (*.mcd *.mcr *.mc *.gme *.srm *.psm *.ps *.ddf *.mem *.vgs *.psx)</translation>
     </message>
     <message numerus="yes">
-        <location filename="../memorycardeditorwindow.cpp" line="502"/>
         <source>%n block(s) free</source>
         <translation>
             <numerusform>%n block ledigt</numerusform>
@@ -9669,42 +7452,34 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>MemoryCardRenameFileDialog</name>
     <message>
-        <location filename="../memorycardrenamefiledialog.ui" line="14"/>
         <source>Rename Memory Card File</source>
         <translation>Byt namn på minneskortsfilen</translation>
     </message>
     <message>
-        <location filename="../memorycardrenamefiledialog.ui" line="44"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;WARNING: &lt;/span&gt;Renaming memory card files may result in saves becoming inaccessible or corrupted. Be sure to make backups first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;VARNING: &lt;/span&gt;Byta namn på minneskortsfiler kan orsaka att sparningar inte blir nåbara eller skadade. Försäkra dig om att göra säkerhetskopior först.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../memorycardrenamefiledialog.ui" line="62"/>
         <source>Original Name:</source>
         <translation>Ursprungligt namn:</translation>
     </message>
     <message>
-        <location filename="../memorycardrenamefiledialog.ui" line="76"/>
         <source>Region:</source>
         <translation>Region:</translation>
     </message>
     <message>
-        <location filename="../memorycardrenamefiledialog.ui" line="86"/>
         <source>Serial:</source>
         <translation>Serienummer:</translation>
     </message>
     <message>
-        <location filename="../memorycardrenamefiledialog.ui" line="96"/>
         <source>File Name:</source>
         <translation>Filnamn:</translation>
     </message>
     <message>
-        <location filename="../memorycardrenamefiledialog.ui" line="106"/>
         <source>Full File Name:</source>
         <translation>Fullständigt filnamn:</translation>
     </message>
     <message>
-        <location filename="../memorycardeditorwindow.cpp" line="1075"/>
         <source>Unknown (%1)</source>
         <translation>Okänt (%1)</translation>
     </message>
@@ -9712,130 +7487,98 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>MemoryCardSettingsWidget</name>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="84"/>
-        <location filename="../memorycardsettingswidget.cpp" line="112"/>
-        <location filename="../memorycardsettingswidget.cpp" line="254"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="87"/>
-        <location filename="../memorycardsettingswidget.cpp" line="115"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="61"/>
         <source>The number of memory cards that can be used is dependent on multitap and game support.</source>
         <translation>Antalet minneskort som kan användas beror på multitap- och spelstöd.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="74"/>
         <source>Save Locations</source>
         <translation>Lagringsplatser</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="80"/>
         <source>Memory Cards:</source>
         <translation>Minneskort:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="102"/>
         <source>Memory Cards Location</source>
         <translation>Minneskortens lagringsplats</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="102"/>
-        <location filename="../memorycardsettingswidget.cpp" line="130"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="103"/>
         <source>Specifies the directory where memory cards will be saved.</source>
         <translation>Anger katalogen där minneskort ska sparas.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="108"/>
         <source>Save States:</source>
         <translation>Sparade tillstånd:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="127"/>
         <source>Select Save States Directory</source>
         <translation>Välj katalog för sparade tillstånd</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="130"/>
         <source>Save States Location</source>
         <translation>Lagringsplats för sparade tillstånd</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="131"/>
         <source>Specifies the directory where save states will be saved.</source>
         <translation>Anger katalogen där sparade tillstånd ska sparas.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="136"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="140"/>
-        <location filename="../memorycardsettingswidget.cpp" line="145"/>
         <source>Create Save State Backups</source>
         <translation>Skapa säkerhetskopior av sparade tillstånd</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="146"/>
         <source>Backs up any previous save state when creating a new save state, with a .bak extension.</source>
         <translation>Säkerhetskopierar alla tidigare sparade tillstånd när ett nytt sparat tillstånd skapas, med filändelsen .bak.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="148"/>
-        <location filename="../memorycardsettingswidget.cpp" line="152"/>
         <source>Enable Global Save States</source>
         <translation>Aktivera globala sparade tillstånd</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="152"/>
         <source>Unchecked</source>
         <translation>Avmarkerad</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="153"/>
         <source>When enabled, the legacy global save state slots will be available. These slots are independent of the current game.</source>
         <translation>När detta är aktiverat blir de äldre globala platserna för sparade tillstånd tillgängliga. Platserna är oberoende av det aktuella spelet.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="156"/>
-        <location filename="../memorycardsettingswidget.cpp" line="161"/>
         <source>Use Single Card For Multi-Disc Games</source>
         <translation>Använd ett kort för flerskivsspel</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="162"/>
         <source>When playing a multi-disc game and using per-game (title) memory cards, a single memory card will be used for all discs. If unchecked, a separate card will be used for each disc.</source>
         <translation>När du spelar ett spel på flera skivor och använder minneskort per-spel (titel) kommer ett enstaka minneskort att användas för alla skivor. Om avmarkerad kommer ett enstaka kort att användas för varje skiva.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="167"/>
-        <location filename="../memorycardsettingswidget.cpp" line="178"/>
         <source>Memory Card Editor</source>
         <translation>Redigera minneskort</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="172"/>
         <source>The memory card editor enables you to move saves between cards, as well as import cards of other formats.</source>
         <translation>Redigeraren för minneskort låter dig att flytta sparningar mellan kort såväl som att importera kort av andra format.</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="210"/>
         <source>Port %1</source>
         <translation>Port %1</translation>
     </message>
     <message numerus="yes">
-        <location filename="../memorycardsettingswidget.cpp" line="215"/>
         <source>Current Multitap Mode: %1 (%n Cards)</source>
         <comment>Card Count</comment>
         <translation>
@@ -9844,33 +7587,26 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
         </translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="99"/>
         <source>Select Memory Card Directory</source>
         <translation>Välj katalog för minneskort</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="238"/>
         <source>Memory Card Type:</source>
         <translation>Minneskortstyp:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="266"/>
         <source>Shared Memory Card Path:</source>
         <translation>Sökväg för delat minneskort:</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="290"/>
         <source>Select path to memory card image</source>
         <translation>Välj sökväg till minneskortsavbild</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="145"/>
-        <location filename="../memorycardsettingswidget.cpp" line="161"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
-        <location filename="../memorycardsettingswidget.cpp" line="36"/>
         <source>All Memory Card Types (*.mcd *.mcr *.mc)</source>
         <translation>Alla minneskortstyper (*.mcd *.mcr *.mc)</translation>
     </message>
@@ -9878,164 +7614,130 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>MemoryEditorWindow</name>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="14"/>
         <source>Memory Editor</source>
         <translation>Minnesredigerare</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="28"/>
-        <location filename="../memoryeditorwindow.ui" line="344"/>
         <source>Address:</source>
         <translation>Adress:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="52"/>
         <source>RAM</source>
         <translation>RAM</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="65"/>
         <source>Scratchpad</source>
         <translation>Skissblock</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="75"/>
         <source>EXP1</source>
         <translation>EXP1</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="85"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="95"/>
         <source>VRAM</source>
         <translation>VRAM</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="105"/>
         <source>SPU RAM</source>
         <translation>SPU-RAM</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="131"/>
         <source>Search</source>
         <translation>Sök</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="142"/>
         <source>Data Inspector</source>
         <translation>Datainspekterare</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="148"/>
         <source>ASCII Character:</source>
         <translation>ASCII-tecken:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="176"/>
         <source>Signed Byte:</source>
         <translation>Signerad byte:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="192"/>
         <source>Decimal</source>
         <translation>Decimal</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="202"/>
         <source>Hexadecimal</source>
         <translation>Hexadecimal</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="212"/>
         <source>Octal</source>
         <translation>Oktal</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="237"/>
         <source>Unsigned Byte:</source>
         <translation>Osignerad byte:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="246"/>
         <source>Little Endian</source>
         <translation>Little Endian</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="256"/>
         <source>Big Endian</source>
         <translation>Big Endian</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="281"/>
         <source>Unsigned Halfword:</source>
         <translation>Osignerad halfword:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="288"/>
         <source>32-Bit Float:</source>
         <translation>32-bitars flyttal:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="309"/>
         <source>Unsigned Doubleword:</source>
         <translation>Osignerad doubleword:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="358"/>
         <source>UTF-8 String:</source>
         <translation>UTF-8-sträng:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="365"/>
         <source>64-Bit Float:</source>
         <translation>64-bitars flyttal:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="379"/>
         <source>Unsigned Word:</source>
         <translation>Osignerad word:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="386"/>
         <source>Signed Word:</source>
         <translation>Signerad word:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="406"/>
         <source>Signed Halfword:</source>
         <translation>Signerad halfword:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.ui" line="413"/>
         <source>Signed Doubleword:</source>
         <translation>Signerad doubleword:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.cpp" line="95"/>
         <source>Enter memory address:</source>
         <translation>Ange minnesadress:</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.cpp" line="172"/>
-        <location filename="../memoryeditorwindow.cpp" line="199"/>
         <source>Invalid search pattern. It should contain hex digits or question marks.</source>
         <translation>Ogiltigt sökmönster. Det bör innehålla hexadecimala siffror eller frågetecken.</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.cpp" line="211"/>
         <source>Pattern not found in memory.</source>
         <translation>Mönstret hittades inte i minnet.</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.cpp" line="228"/>
         <source>Pattern found at 0x%1 (passed the end of memory).</source>
         <translation>Mönster hittades vid 0x%1 (passerat minnets slut).</translation>
     </message>
     <message>
-        <location filename="../memoryeditorwindow.cpp" line="235"/>
         <source>Pattern found at 0x%1.</source>
         <translation>Mönster hittades vid 0x%1.</translation>
     </message>
@@ -10043,289 +7745,230 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>MemoryScannerWindow</name>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="14"/>
         <source>Memory Scanner</source>
         <translation>Minnesskanner</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="46"/>
-        <location filename="../memoryscannerwindow.ui" line="389"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="51"/>
-        <location filename="../memoryscannerwindow.ui" line="399"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="56"/>
         <source>Previous Value</source>
         <translation>Föregående värde</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="69"/>
         <source>Search Parameters</source>
         <translation>Sökparametrar</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="75"/>
         <source>Value:</source>
         <translation>Värde:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="91"/>
         <source>Signed</source>
         <translation>Signerad</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="96"/>
         <source>Unsigned</source>
         <translation>Osignerad</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="108"/>
         <source>Decimal</source>
         <translation>Decimal</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="113"/>
         <source>Hex</source>
         <translation>Hex</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="123"/>
         <source>Data Size:</source>
         <translation>Datastorlek:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="134"/>
         <source>Byte (1 byte)</source>
         <translation>Byte (1 byte)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="139"/>
         <source>Halfword (2 bytes)</source>
         <translation>Halvord (2 byte)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="144"/>
         <source>Word (4 bytes)</source>
         <translation>Ord (4 byte)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="152"/>
         <source>Operator:</source>
         <translation>Operator:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="160"/>
         <source>Any Value (&apos;New Search&apos; or &apos;Reset Result Value&apos;)</source>
         <translation>Valfritt värde (&quot;Ny sökning&quot; eller &quot;Återställ resultatvärde&quot;)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="165"/>
         <source>Less Than Previous Result</source>
         <translation>Mindre än tidigare resultat</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="170"/>
         <source>Less or Equal to Previous Result</source>
         <translation>Mindre eller lika med föregående resultat</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="175"/>
         <source>Greater Than Previous Result</source>
         <translation>Större än tidigare resultat</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="180"/>
         <source>Greater or Equal to Previous Result</source>
         <translation>Större eller lika med föregående resultat</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="185"/>
         <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Inte lika med föregående resultat (ändrat värde)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="190"/>
         <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Lika med föregående resultat (oförändrat värde)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="195"/>
         <source>Decreased By Value</source>
         <translation>Minskas med värde</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="200"/>
         <source>Increased By Value</source>
         <translation>Ökas med värde</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="205"/>
         <source>Changed By Value</source>
         <translation>Ändras med värde</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="210"/>
         <source>Equal to Value</source>
         <translation>Lika med värdet</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="215"/>
         <source>Not Equal to Value</source>
         <translation>Inte lika med värdet</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="220"/>
         <source>Less Than Value</source>
         <translation>Mindre än värdet</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="225"/>
         <source>Less or Equal to Value</source>
         <translation>Mindre än eller lika med värdet</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="230"/>
         <source>Greater Than Value</source>
         <translation>Större än värdet</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="235"/>
         <source>Greater or Equal to Value</source>
         <translation>Större än eller lika med värdet</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="243"/>
         <source>Start Address:</source>
         <translation>Startadress:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="253"/>
         <source>End Address:</source>
         <translation>Slutadress:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="263"/>
         <source>Preset Range:</source>
         <translation>Förvalsintervall:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="271"/>
         <source>RAM</source>
         <translation>RAM</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="276"/>
         <source>Scratchpad</source>
         <translation>Skissblock</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="281"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="289"/>
         <source>Result Count:</source>
         <translation>Resultatantal:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="296"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="305"/>
         <source>New Search</source>
         <translation>Ny sökning</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="315"/>
         <source>Search Again</source>
         <translation>Sök igen</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="325"/>
         <source>Clear Results</source>
         <translation>Töm resultat</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="337"/>
         <source>Add Selected Results To Watch List</source>
         <translation>Lägg till valda resultat i bevakningslistan</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="384"/>
         <source>Simple Cheat Code or Description</source>
         <translation>Enkel fuskkod eller Beskrivning</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="394"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="404"/>
         <source>Freeze</source>
         <translation>Frys</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="420"/>
         <source>Load Watch</source>
         <translation>Lägg till bevakning</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="433"/>
         <source>Save Watch</source>
         <translation>Spara bevakning</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="440"/>
         <source>Add Manual Address</source>
         <translation>Lägg till manuell adress</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="450"/>
         <source>Freeze Selected Entries</source>
         <translation>Frys valda poster</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="460"/>
         <source>Remove Selected Entries</source>
         <translation>Ta bort markerade poster</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.cpp" line="98"/>
         <source>Address of RAM for HxD Usage: 0x%1</source>
         <translation>Adress till RAM för HxD-användning: 0x%1</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.cpp" line="331"/>
         <source>Enter manual address:</source>
         <translation>Ange manuell adress:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.cpp" line="341"/>
         <source>Select data size:</source>
         <translation>Välj datastorlek:</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.cpp" line="560"/>
         <source>%1 (only showing first %2)</source>
         <translation>%1 (visar endast första %2)</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.ui" line="61"/>
         <source>First Value</source>
         <translation>Första värdet</translation>
     </message>
     <message>
-        <location filename="../memoryscannerwindow.cpp" line="406"/>
         <source>Failed to open memory editor at specified address.</source>
         <translation>Misslyckades med att öppna minnesredigeraren vid angiven adress.</translation>
     </message>
@@ -10333,23 +7976,18 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>MultipleDeviceAutobindDialog</name>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="1031"/>
         <source>Select the devices from the list below that you want to bind to this controller.</source>
         <translation>Välj de enheter i listan nedan som du vill binda till den här kontrollern.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="1081"/>
-        <location filename="../controllerbindingwidgets.cpp" line="1096"/>
         <source>Automatic Mapping Failed</source>
         <translation>Automatisk mappning misslyckades</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="1082"/>
         <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
         <translation>Inga generiska bindningar genererades för enheten &apos;%1&apos;. Handkontrollern/källan kanske inte har stöd för automatisk mappning.</translation>
     </message>
     <message>
-        <location filename="../controllerbindingwidgets.cpp" line="1097"/>
         <source>No devices were selected.</source>
         <translation>Inga enheter valdes.</translation>
     </message>
@@ -10357,326 +7995,238 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>OSDSettingsWidget</name>
     <message>
-        <location filename="../osdsettingswidget.ui" line="29"/>
         <source>Display</source>
         <translation>Skärm</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="35"/>
         <source>Display Scale:</source>
         <translation>Visningsskala:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="42"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="55"/>
         <source>Display Margins:</source>
         <translation>Visningsmarginaler:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="62"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="72"/>
         <source>Theme:</source>
         <translation>Tema:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="82"/>
         <source>Font:</source>
         <translation>Teckensnitt:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="92"/>
         <source>Overlay Font:</source>
         <translation>Överläggsteckensnitt:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="105"/>
         <source>Messages</source>
         <translation>Meddelanden</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="111"/>
-        <location filename="../osdsettingswidget.cpp" line="117"/>
         <source>Show Messages</source>
         <translation>Visa meddelanden</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="118"/>
-        <location filename="../osdsettingswidget.cpp" line="120"/>
         <source>Show Status Indicators</source>
         <translation>Visa statusindikatorer</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="125"/>
-        <location filename="../osdsettingswidget.cpp" line="123"/>
         <source>Animate Messages</source>
         <translation>Animera meddelanden</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="132"/>
-        <location filename="../osdsettingswidget.cpp" line="126"/>
         <source>Blur Message Backgrounds</source>
         <translation>Gör meddelandebakgrunder oskarpa</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="139"/>
         <source>Error Duration:</source>
         <translation>Fellängd:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="146"/>
-        <location filename="../osdsettingswidget.ui" line="172"/>
-        <location filename="../osdsettingswidget.ui" line="198"/>
-        <location filename="../osdsettingswidget.ui" line="224"/>
         <source> seconds</source>
         <translation> sekunder</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="165"/>
         <source>Warning Duration:</source>
         <translation>Varningslängd:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="191"/>
         <source>Information Duration:</source>
         <translation>Informationslängd:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="217"/>
         <source>Action Duration:</source>
         <translation>Åtgärdslängd:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="243"/>
         <source>Display Location:</source>
         <translation>Visningsplats:</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="256"/>
         <source>Overlays</source>
         <translation>Överlägg</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="267"/>
-        <location filename="../osdsettingswidget.cpp" line="137"/>
         <source>Show FPS</source>
         <translation>Visa bilder/s</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="274"/>
-        <location filename="../osdsettingswidget.cpp" line="135"/>
         <source>Show Emulation Speed</source>
         <translation>Visa emuleringshastighet</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="281"/>
-        <location filename="../osdsettingswidget.cpp" line="140"/>
         <source>Show CPU Usage</source>
         <translation>Visa CPU-användning</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="288"/>
-        <location filename="../osdsettingswidget.cpp" line="142"/>
         <source>Show GPU Usage</source>
         <translation>Visa GPU-användning</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="295"/>
-        <location filename="../osdsettingswidget.cpp" line="132"/>
         <source>Show Resolution</source>
         <translation>Visa upplösning</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="302"/>
-        <location filename="../osdsettingswidget.cpp" line="144"/>
         <source>Show GPU Statistics</source>
         <translation>Visa GPU-statistik</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="309"/>
-        <location filename="../osdsettingswidget.cpp" line="150"/>
         <source>Show Frame Times</source>
         <translation>Visa bildrutetider</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="316"/>
-        <location filename="../osdsettingswidget.cpp" line="147"/>
         <source>Show Latency Statistics</source>
         <translation>Visa latensstatistik</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="323"/>
-        <location filename="../osdsettingswidget.cpp" line="153"/>
         <source>Show Controller Input</source>
         <translation>Visa kontrollerinmatning</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.ui" line="330"/>
-        <location filename="../osdsettingswidget.cpp" line="155"/>
         <source>Show Settings</source>
         <translation>Visa inställningar</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="97"/>
         <source>Display Scale</source>
         <translation>Visningsskala</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="98"/>
         <source>Changes the size at which on-screen elements, including status and messages are displayed.</source>
         <translation>Ändrar storleken för vilken OSD-element, inklusive status och meddelanden, visas med.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="99"/>
         <source>Display Margins</source>
         <translation>Visningsmarginaler</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="101"/>
         <source>Determines the margin between the edge of the screen and on-screen messages.</source>
         <translation>Bestämmer marginalen mellan skärmkanten och skärmmeddelanden.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="104"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="104"/>
         <source>Automatic</source>
         <translation>Automatisk</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="105"/>
         <source>Determines the theme to use for on-screen display elements and the Big Picture UI.</source>
         <translation>Bestämmer vilket tema som ska användas för visningselement på skärmen och storbildsgränssnittet.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="107"/>
         <source>Font</source>
         <translation>Teckensnitt</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="109"/>
         <source>Determines the font to use for on-screen display elements and the Big Picture UI.</source>
         <translation>Bestämmer teckensnittet för skärmvisningselement och storbildsgränssnittet.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="111"/>
         <source>Overlay Font</source>
         <translation>Överläggsteckensnitt</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="114"/>
         <source>Determines the font to use for the performance overlay.</source>
         <translation>Bestämmer teckensnittet för prestandaöverlägget.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="117"/>
-        <location filename="../osdsettingswidget.cpp" line="120"/>
-        <location filename="../osdsettingswidget.cpp" line="123"/>
-        <location filename="../osdsettingswidget.cpp" line="126"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="118"/>
         <source>Shows on-screen-display messages when events occur such as save states being created/loaded, screenshots being taken, etc. Errors and warnings are still displayed regardless of this setting.</source>
         <translation>Visar meddelanden på skärmen när händelser inträffar, till exempel när spartillstånd skapas/läses in, skärmbilder fångas osv. Fel och varningar visas fortfarande oavsett denna inställning.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="121"/>
         <source>Shows indicators on screen when the system is not running in its &quot;normal&quot; state. For example, fast forwarding, or being paused.</source>
         <translation>Visar indikatorer på skärmen när systemet inte körs i sitt &quot;normala&quot; tillstånd. Till exempel snabbspolning framåt eller vid paus.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="124"/>
         <source>Enables animation for on-screen messages when they appear and disappear.</source>
         <translation>Animerar skärmmeddelanden när de visas och försvinner.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="127"/>
         <source>Enables a blur effect on the background behind on-screen messages to improve readability.</source>
         <translation>Aktiverar oskärpa i bakgrunden bakom skärmmeddelanden för bättre läsbarhet.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="129"/>
         <source>Message Location</source>
         <translation>Meddelandeplats</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="131"/>
         <source>Selects which location on the screen messages are displayed.</source>
         <translation>Väljer vilken plats på skärmen som meddelanden ska visas.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="132"/>
-        <location filename="../osdsettingswidget.cpp" line="135"/>
-        <location filename="../osdsettingswidget.cpp" line="137"/>
-        <location filename="../osdsettingswidget.cpp" line="140"/>
-        <location filename="../osdsettingswidget.cpp" line="142"/>
-        <location filename="../osdsettingswidget.cpp" line="144"/>
-        <location filename="../osdsettingswidget.cpp" line="147"/>
-        <location filename="../osdsettingswidget.cpp" line="150"/>
-        <location filename="../osdsettingswidget.cpp" line="153"/>
-        <location filename="../osdsettingswidget.cpp" line="155"/>
         <source>Unchecked</source>
         <translation>Avmarkerad</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="133"/>
         <source>Shows the resolution of the game in the top-right corner of the display.</source>
         <translation>Visar spelets upplösning längst upp i högra hörnet av skärmen.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="136"/>
         <source>Shows the current emulation speed of the system in the top-right corner of the display as a percentage.</source>
         <translation>Visar aktuell emuleringshastighet för systemet i övre högra hörnet av skärmen som ett procenttal.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="138"/>
         <source>Shows the internal frame rate of the game in the top-right corner of the display.</source>
         <translation>Visar den interna bildfrekvensen för spelet i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="141"/>
         <source>Shows the host&apos;s CPU usage of each system thread in the top-right corner of the display.</source>
         <translation>Visar värdens CPU-användning för varje systemtråd i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="143"/>
         <source>Shows the host&apos;s GPU usage in the top-right corner of the display.</source>
         <translation>Visar värdens GPU-användning i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="145"/>
         <source>Shows information about the emulated GPU in the top-right corner of the display.</source>
         <translation>Visar information om emulerad GPU i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="148"/>
         <source>Shows information about input and audio latency in the top-right corner of the display.</source>
         <translation>Visar information om inmatnings- och ljudlatens i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="151"/>
         <source>Shows the history of frame rendering times as a graph in the top-right corner of the display.</source>
         <translation>Visar historiken för bildrenderingstider som en graf i det övre högra hörnet av skärmen.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="154"/>
         <source>Shows the current controller state of the system in the bottom-left corner of the display.</source>
         <translation>Visar aktuellt tillstånd för handkontroller för systemet i nedre vänstra hörnet av skärmen.</translation>
     </message>
     <message>
-        <location filename="../osdsettingswidget.cpp" line="156"/>
         <source>Shows a summary of current settings in the bottom-right corner of the display.</source>
         <translation>Visar ett sammandrag av aktuella inställningar i nedre högra hörnet av skärmen.</translation>
     </message>
@@ -10684,57 +8234,46 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>PostProcessingChainConfigWidget</name>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="31"/>
         <source>Enable Post Processing</source>
         <translation>Aktivera efterbehandling</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="62"/>
         <source>&amp;Reload Shaders</source>
         <translation>&amp;Uppdatera shaders</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="75"/>
         <source>Post Processing Chain</source>
         <translation>Efterbehandlingskedja</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="103"/>
         <source>Add</source>
         <translation>Lägg till</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="120"/>
         <source>Remove</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="137"/>
         <source>Clear</source>
         <translation>Töm</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="154"/>
         <source>Move Up</source>
         <translation>Flytta upp</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="171"/>
         <source>Move Down</source>
         <translation>Flytta ner</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="242"/>
         <source>Are you sure you want to clear all shader stages?</source>
         <translation>Är du säker på att du vill tömma alla shader stages?</translation>
     </message>
     <message>
-        <location filename="../postprocessingchainconfigwidget.ui" line="51"/>
         <source>Open Directory</source>
         <translation>Öppna katalog</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="241"/>
         <source>Clear Shader Stages</source>
         <translation>Töm shader-steg</translation>
     </message>
@@ -10742,166 +8281,126 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>PostProcessingOverlayConfigWidget</name>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="29"/>
         <source>Basic Configuration</source>
         <translation>Grundinställning</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="45"/>
         <source>Selected Preset:</source>
         <translation>Valt förval:</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="35"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A border overlay is an image that is drawn around the system display. Border overlays are applied after post-processing. You can choose from the border list below, or manually configure a custom border.&lt;/p&gt;&lt;p&gt;Additional preset borders can be added to the &lt;span style=&quot; font-weight:700;&quot;&gt;resources\overlays&lt;/span&gt; folder within in the data directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ett kantöverlägg är en bild som ritas runt systemskärmen. Kantöverlägg appliceras efter efterbearbetning. Du kan välja från listan nedan eller manuellt konfigurera en anpassad kant.&lt;/p&gt;&lt;p&gt;Fler förval för kanter kan läggas till i mappen &lt;span style=&quot; font-weight:700;&quot;&gt;resources\overlays&lt;/span&gt; i datakatalogen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="61"/>
         <source>Refresh Overlay List</source>
         <translation>Uppdatera överläggslista</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="75"/>
         <source>Custom Configuration</source>
         <translation>Anpassad konfiguration</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="81"/>
         <source>Image Path:</source>
         <translation>Bildsökväg:</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="93"/>
         <source>Browse...</source>
         <translation>Bläddra…</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="106"/>
         <source>Display Start:</source>
         <translation>Skärmstart:</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="115"/>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="160"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="122"/>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="139"/>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="167"/>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="184"/>
         <source> pixels</source>
         <translation> pixlar</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="132"/>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="177"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="198"/>
-        <location filename="../postprocessingsettingswidget.cpp" line="595"/>
         <source>Destination Alpha Blending</source>
         <translation>Alfablandning för destination</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="205"/>
-        <location filename="../postprocessingsettingswidget.cpp" line="592"/>
         <source>Alpha Blending</source>
         <translation>Alfa-blandning</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="227"/>
         <source>Export...</source>
         <translation>Exportera...</translation>
     </message>
     <message>
-        <location filename="../postprocessingoverlayconfigwidget.ui" line="151"/>
         <source>Display End:</source>
         <translation>Skärmslut:</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="607"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="608"/>
         <source>Custom...</source>
         <translation>Anpassad...</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="582"/>
         <source>Image Path</source>
         <translation>Sökväg till bild</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="582"/>
-        <location filename="../postprocessingsettingswidget.cpp" line="585"/>
         <source>Unspecified</source>
         <translation>Ospecificerad</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="583"/>
         <source>Defines the path of the custom overlay image that will be loaded.</source>
         <translation>Definierar sökvägen för den anpassade överlagringsbild som ska läsas in.</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="584"/>
         <source>Display Rectangle</source>
         <translation>Visa rektangel</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="586"/>
         <source>Defines the area in the overlay image that the game image will be drawn into.</source>
         <translation>Definierar det område i överläggsbilden som spelbilden ska ritas in i.</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="592"/>
-        <location filename="../postprocessingsettingswidget.cpp" line="595"/>
         <source>Unchecked</source>
         <translation>Omarkerad</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="593"/>
         <source>If checked, the overlay image will be alpha blended with the framebuffer, i.e. transparency will be applied.</source>
         <translation>Om den är markerad kommer överlagringsbilden att alfablandas med framebufferten, dvs. transparens kommer att tillämpas.</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="596"/>
         <source>If checked, the game image will be blended with the inverse amount of alpha in the overlay image. For example, an image with alpha of 0.75 will draw the game image at 25% brightness.</source>
         <translation>Om den är markerad kommer spelbilden att blandas med den omvända mängden alfa i överläggsbilden. Till exempel kommer en bild med alfa på 0,75 att rita spelbilden med 25% ljusstyrka.</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="640"/>
         <source>Select Image</source>
         <translation>Välj bild</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="641"/>
         <source>All Cover Image Types (*.jpg *.jpeg *.png *.webp)</source>
         <translation>Alla omslagsbildtyper (*.jpg *.jpeg *.png *.webp)</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="651"/>
         <source>Export to YAML</source>
         <translation>Exportera till YAML</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="651"/>
         <source>YAML Files (*.yml)</source>
         <translation>YAML-filer (*.yml)</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="674"/>
         <source>Export Error</source>
         <translation>Exportfel</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="675"/>
         <source>Failed to save file: %1</source>
         <translation>Misslyckades med att spara filen: %1</translation>
     </message>
@@ -10909,32 +8408,26 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>PostProcessingSelectShaderDialog</name>
     <message>
-        <location filename="../postprocessingselectshaderdialog.ui" line="14"/>
         <source>Select Shader</source>
         <translation>Välj shader</translation>
     </message>
     <message>
-        <location filename="../postprocessingselectshaderdialog.ui" line="51"/>
         <source>All</source>
         <translation>Alla</translation>
     </message>
     <message>
-        <location filename="../postprocessingselectshaderdialog.ui" line="64"/>
         <source>GLSL</source>
         <translation>GLSL</translation>
     </message>
     <message>
-        <location filename="../postprocessingselectshaderdialog.ui" line="74"/>
         <source>Reshade</source>
         <translation>Reshade</translation>
     </message>
     <message>
-        <location filename="../postprocessingselectshaderdialog.ui" line="84"/>
         <source>Slang</source>
         <translation>Slang</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="691"/>
         <source>Add</source>
         <translation>Lägg till</translation>
     </message>
@@ -10942,17 +8435,14 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>PostProcessingSettingsWidget</name>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="36"/>
         <source>Display</source>
         <translation>Skärm</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="38"/>
         <source>Internal</source>
         <translation>Intern</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="39"/>
         <source>Border Overlay</source>
         <translation>Kantöverlägg</translation>
     </message>
@@ -10960,27 +8450,22 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>PostProcessingShaderConfigWidget</name>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="462"/>
         <source>Red</source>
         <translation>Röd</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="462"/>
         <source>Green</source>
         <translation>Grön</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="462"/>
         <source>Blue</source>
         <translation>Blå</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="462"/>
         <source>Alpha</source>
         <translation>Alfa</translation>
     </message>
     <message>
-        <location filename="../postprocessingsettingswidget.cpp" line="463"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
@@ -10988,39 +8473,30 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>QtHost</name>
     <message>
-        <location filename="../qthost.cpp" line="3540"/>
-        <location filename="../qthost.cpp" line="3567"/>
-        <location filename="../qthost.cpp" line="3586"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="3541"/>
         <source>File &apos;%1&apos; does not exist.</source>
         <translation>Filen &apos;%1&apos; finns inte.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="3568"/>
         <source>The specified save state does not exist.</source>
         <translation>Det angivna sparade tillståndet finns inte.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="3588"/>
         <source>Cannot use no-gui mode, because no boot filename was specified.</source>
         <translation>Kan inte använda no-gui-läget därför att inget uppstartsfilnamn angavs.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="3589"/>
         <source>Cannot use batch mode, because no boot filename was specified.</source>
         <translation>Kan inte använda batch-läget därför att inget uppstartsfilnamn angavs.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="2627"/>
         <source>System Language</source>
         <translation>Systemspråk</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="434"/>
         <source>We have detected that LD_LIBRARY_PATH has been set to the following value:
 
 %1
@@ -11029,12 +8505,10 @@ This will likely prevent DuckStation from working correctly. You should modify y
         <translation>Miljövariabeln LD_LIBRARY_PATH är satt till:\n%1\n\nDetta kommer sannolikt att hindra DuckStation från att fungera korrekt. Ändra din miljö så att LD_LIBRARY_PATH inte är satt.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="440"/>
         <source>Don&apos;t show again</source>
         <translation>Visa inte igen</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="590"/>
         <source>Would you like to create a launcher shortcut for DuckStation?
 
 This will add DuckStation to your application menu, allowing you to launch it more easily.
@@ -11049,19 +8523,16 @@ Genvägen skapas på:
 %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="597"/>
         <source>Don&apos;t ask again</source>
         <translation>Fråga inte igen</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="620"/>
         <source>Failed to create launcher shortcut shortcut:
 %1</source>
         <translation>Det gick inte att skapa startgenvägen:
 %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="626"/>
         <source>Launcher shortcut created successfully.
 
 You can find DuckStation in your application menu.</source>
@@ -11070,7 +8541,6 @@ You can find DuckStation in your application menu.</source>
 Du hittar DuckStation i programmenyn.</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="650"/>
         <source>The existing launcher shortcut points to a different location:
 
 Current: %1
@@ -11085,21 +8555,18 @@ Genväg: %2
 Vill du uppdatera genvägen så att den pekar på den aktuella platsen?</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="666"/>
         <source>Failed to remove old launcher shortcut:
 %1</source>
         <translation>Det gick inte att ta bort den gamla startgenvägen:
 %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="675"/>
         <source>Failed to create updated launcher shortcut:
 %1</source>
         <translation>Det gick inte att skapa den uppdaterade startgenvägen:
 %1</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="681"/>
         <source>Launcher shortcut updated successfully.</source>
         <translation>Startgenvägen har uppdaterats.</translation>
     </message>
@@ -11107,7 +8574,6 @@ Vill du uppdatera genvägen så att den pekar på den aktuella platsen?</transla
 <context>
     <name>SearchBox</name>
     <message>
-        <location filename="../searchbox.cpp" line="13"/>
         <source>Search...</source>
         <translation>Sök...</translation>
     </message>
@@ -11115,37 +8581,30 @@ Vill du uppdatera genvägen så att den pekar på den aktuella platsen?</transla
 <context>
     <name>SelectDiscDialog</name>
     <message>
-        <location filename="../selectdiscdialog.ui" line="20"/>
         <source>Select the disc that you want to boot.</source>
         <translation>Välj skivan som du vill starta upp.</translation>
     </message>
     <message>
-        <location filename="../selectdiscdialog.ui" line="31"/>
         <source>Disc</source>
         <translation>Skiva</translation>
     </message>
     <message>
-        <location filename="../selectdiscdialog.ui" line="36"/>
         <source>File Name</source>
         <translation>Filnamn</translation>
     </message>
     <message>
-        <location filename="../selectdiscdialog.ui" line="41"/>
         <source>Last Played</source>
         <translation>Senast spelat</translation>
     </message>
     <message>
-        <location filename="../selectdiscdialog.ui" line="64"/>
         <source>Select</source>
         <translation>Välj</translation>
     </message>
     <message>
-        <location filename="../selectdiscdialog.ui" line="74"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
-        <location filename="../selectdiscdialog.cpp" line="90"/>
         <source>Select Disc for %1</source>
         <translation>Välj skiva för %1</translation>
     </message>
@@ -11153,28 +8612,22 @@ Vill du uppdatera genvägen så att den pekar på den aktuella platsen?</transla
 <context>
     <name>SettingWidgetBinder</name>
     <message>
-        <location filename="../settingwidgetbinder.h" line="145"/>
         <source>Use Global Setting [Enabled]</source>
         <translation>Använd global inställning [aktiverad]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="146"/>
         <source>Use Global Setting [Disabled]</source>
         <translation>Använd global inställning [inaktiverad]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="421"/>
-        <location filename="../settingwidgetbinder.h" line="557"/>
         <source>Global: </source>
         <translation>Globalt: </translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1290"/>
         <source>Confirm Folder</source>
         <translation>Bekräfta mapp</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1291"/>
         <source>The chosen directory does not currently exist:
 
 %1
@@ -11187,36 +8640,26 @@ Do you want to create this directory?</source>
 Vill du skapa denna katalog?</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1314"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1315"/>
         <source>Folder path cannot be empty.</source>
         <translation>Mappsökvägen får inte vara tom.</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1382"/>
         <source>%1 [incompatible]</source>
         <translation>%1 [inkompatibel]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1404"/>
         <source>%1 [forced]</source>
         <translation>%1 [tvingad]</translation>
     </message>
     <message>
-        <location filename="../settingwidgetbinder.h" line="1374"/>
-        <location filename="../settingwidgetbinder.h" line="1378"/>
         <source>Incompatible with this game</source>
         <translation>Inkompatibelt med detta spel</translation>
     </message>
     <message>
-        <location filename="../achievementsettingswidget.cpp" line="168"/>
-        <location filename="../graphicssettingswidget.cpp" line="887"/>
-        <location filename="../settingwidgetbinder.h" line="154"/>
-        <location filename="../settingwidgetbinder.h" line="170"/>
         <source>Use Global Setting [%1]</source>
         <translation>Använd global inställning [%1]</translation>
     </message>
@@ -11224,208 +8667,167 @@ Vill du skapa denna katalog?</translation>
 <context>
     <name>SettingsWindow</name>
     <message>
-        <location filename="../settingswindow.ui" line="96"/>
         <source>Restore Defaults</source>
         <translation>Återställ standardvärden</translation>
     </message>
     <message>
-        <location filename="../settingswindow.ui" line="103"/>
         <source>Copy Global Settings</source>
         <translation>Kopiera globala inställningar</translation>
     </message>
     <message>
-        <location filename="../settingswindow.ui" line="110"/>
         <source>Clear Settings</source>
         <translation>Töm inställningar</translation>
     </message>
     <message>
-        <location filename="../settingswindow.ui" line="117"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="68"/>
         <source>Summary</source>
         <translation>Sammandrag</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="70"/>
         <source>&lt;strong&gt;Summary&lt;/strong&gt;&lt;hr&gt;This page shows information about the selected game, and allows you to validate your disc was dumped correctly.</source>
         <translation>&lt;strong&gt;Sammandrag&lt;/strong&gt;&lt;hr&gt;Denna sida visar information om det valda spelet och låter dig validera att din skiva dumpades korrekt.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="100"/>
         <source>&lt;strong&gt;Interface Settings&lt;/strong&gt;&lt;hr&gt;These options control how the emulator looks and behaves.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Gränssnittsinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr hur emulatorn ser ut och uppför sig.&lt;br&gt;&lt;br&gt;Hovra över ett alternativ för ytterligare information, och Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="108"/>
         <source>&lt;strong&gt;Game List Settings&lt;/strong&gt;&lt;hr&gt;The list above shows the directories which will be searched by DuckStation to populate the game list. Search directories can be added, removed, and switched to recursive/non-recursive.</source>
         <translation>&lt;strong&gt;Inställningar för spellista&lt;/strong&gt;&lt;hr&gt;Listan ovanför visar katalogerna som kommer att sökas igenom av DuckStation för att fylla upp spellistan. Sökkataloger kan läggas till, tas bort och växlas mellan rekursiv/icke-rekursiv sökninig.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="117"/>
         <source>Console</source>
         <translation>Konsol</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="119"/>
         <source>&lt;strong&gt;Console Settings&lt;/strong&gt;&lt;hr&gt;These options determine the configuration of the simulated console.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Konsolinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ bestämmer konfigurationen för den simulerade konsolen.&lt;br&gt;&lt;br&gt;Hovra över ett alternativ för ytterligare information samt Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="124"/>
         <source>&lt;strong&gt;Emulation Settings&lt;/strong&gt;&lt;hr&gt;These options determine the speed and runahead behavior of the system.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Emuleringsinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ bestämmer hastighet och runahead-beteende för systemet.&lt;br&gt;&lt;br&gt;Hovra över ett alternativ för ytterligare information samt Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="131"/>
         <source>&lt;strong&gt;Patches&lt;/strong&gt;&lt;hr&gt;This section allows you to select optional patches to apply to the game, which may provide performance, visual, or gameplay improvements. Activating game patches can cause unpredictable behavior, crashing, soft-locks, or broken saved games. Use patches at your own risk, no support will be provided to users who have enabled game patches.</source>
         <translation>&lt;strong&gt;Patchar&lt;/strong&gt;&lt;hr&gt;Denna sektion låter dig att välja valfria patchar att använda för spelet som kan tillhandahålla ökad prestanda, visuellt bätte eller ökat spelvärde. Aktivering av spelpatchar kan orsaka oförutsedda problem, krascher, låsningar eller trasiga sparade tillstånd. Använd patchar på egen risk, ingen support kan tillhandahållas till användare som har aktiverat spelpatchar.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="137"/>
         <source>&lt;strong&gt;Cheats&lt;/strong&gt;&lt;hr&gt;This section allows you to select which cheats you wish to enable. &lt;strong&gt;Using cheats can have unpredictable effects on games, causing crashes, graphical glitches, and corrupted saves.&lt;/strong&gt; Cheats also persist through save states even after being disabled, please remember to reset/reboot the game after turning off any codes.</source>
         <translation>&lt;strong&gt;Fusk&lt;/strong&gt;&lt;hr&gt;Denna sektion låter dig välja vilka fusk som du vill aktivera. &lt;strong&gt;Användning av fusk har oförutsedda effekter på spel, kan orsaka krascher, grafiska problem och skadade sparade spel.&lt;/strong&gt; Fusk är också bestående genom sparade tillstånd även efter de inaktiverats. Kom ihåg att starta om spelet efter att koderna har stängts av.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="146"/>
         <source>&lt;strong&gt;Memory Card Settings&lt;/strong&gt;&lt;hr&gt;This page lets you control what mode the memory card emulation will function in, and where the images for these cards will be stored on disk.</source>
         <translation>&lt;strong&gt;Inställningar för minneskort&lt;/strong&gt;&lt;hr&gt;Denna sida låter dig stura vilket läge som minneskortsemulering ska använda och var avbilderna för dessa kort kommer att lagras på disk.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="150"/>
         <source>&lt;strong&gt;Graphics Settings&lt;/strong&gt;&lt;hr&gt;These options control how the graphics of the emulated console are rendered. Not all options are available for the software renderer. Mouse over each option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Grafikinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr hur grafiken för den emulerade konsolen renderas. Inte alla alternativ finns tillgängliga för programvarurenderaren. Hovra över ett alternativ för ytterligare information samt Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="154"/>
         <source>On-Screen Display</source>
         <extracomment>Translators may want to shorten On-Screen Display to &quot;OSD&quot;.</extracomment>
         <translation>On-Screen Display</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="156"/>
         <source>&lt;strong&gt;On-Screen Display Settings&lt;/strong&gt;&lt;hr&gt;These options determine the behavior of the messages that are displayed while content is running.</source>
         <translation>&lt;strong&gt;Inställningar för skärmvisning&lt;/strong&gt;&lt;hr&gt;Dessa alternativ bestämmer hur meddelanden som visas medan innehåll körs ska fungera.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="159"/>
         <source>Post-Processing</source>
         <translation>Efterbehandling</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="161"/>
         <source>&lt;strong&gt;Post-Processing Settings&lt;/strong&gt;&lt;hr&gt;Post processing allows you to alter the appearance of the image displayed on the screen with various filters. Shaders will be executed in sequence. Additional shaders can be downloaded from &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;.</source>
         <translation>&lt;strong&gt;Inställningar för efterbehandling&lt;/strong&gt;&lt;hr&gt;Efterbehandling låter dig ändra utseendet för bilden som visas på skärmen med olika filter. Shaders kommer att köras i sekvens. Ytterligare shaders kan hämtas från &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="167"/>
         <source>&lt;strong&gt;Audio Settings&lt;/strong&gt;&lt;hr&gt;These options control the audio output of the console. Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Ljudinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr ljudutmatningen för konsolen. Hovra över ett alternativ för ytterligare information.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="187"/>
         <source>&lt;strong&gt;Advanced Settings&lt;/strong&gt;&lt;hr&gt;These options control logging and internal behavior of the emulator. Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Avancerade inställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr loggning och interna beteendet för emulatorn. Hovra över ett alternativ för ytterligare information samt Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="202"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="203"/>
         <source>Disables all enhancement options, simulating the system as accurately as possible. Use to quickly determine whether an enhancement is responsible for game bugs.</source>
         <translation>Inaktiverar alla alternativ för förbättringar, simulerar systemet så precist som möjligt. Använd för att snabbt bestämma huruvida en förbättringar orsakar vissa spelbuggar.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="713"/>
         <source>%1 [%2]</source>
         <translation>%1 [%2]</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="98"/>
         <source>Interface</source>
         <translation>Gränssnitt</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="106"/>
         <source>Game List</source>
         <translation>Spellista</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="113"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="122"/>
         <source>Emulation</source>
         <translation>Emulering</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="129"/>
         <source>Patches</source>
         <translation>Patchar</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="135"/>
         <source>Cheats</source>
         <translation>Fusk</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="148"/>
         <source>Graphics</source>
         <translation>Grafik</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="166"/>
         <source>Audio</source>
         <translation>Ljud</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="144"/>
         <source>Memory Cards</source>
         <translation>Minneskort</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="170"/>
         <source>Achievements</source>
         <translation>Prestationer</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="178"/>
         <source>Capture</source>
         <translation>Fånga</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="180"/>
         <source>&lt;strong&gt;Capture Settings&lt;/strong&gt;&lt;hr&gt;These options determine how screenshots and videos are captured by the application.</source>
         <translation>&lt;strong&gt;Fångstinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ bestämmer hur programmet tar skärmbilder och spelar in video.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="185"/>
         <source>Advanced</source>
         <translation>Avancerat</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="194"/>
         <source>Debugging</source>
         <translation>Felsökning</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="196"/>
         <source>&lt;strong&gt;Debugging Settings&lt;/strong&gt;&lt;hr&gt;These options control internal behavior of the emulator. You should not modify anything on this page without a good reason to do so.</source>
         <translation>&lt;strong&gt;Felsökningsinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr emulatorns interna funktion. Ändra inget på den här sidan utan ett gott skäl.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="333"/>
         <source>Confirm Restore Defaults</source>
         <translation>Bekräfta återställ standardvärden</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="350"/>
         <source>The configuration for this game will be replaced by the current global settings.
 
 Any current setting values will be overwritten.
@@ -11438,12 +8840,10 @@ Alla aktuella inställningsvärden kommer att skrivas över.
 Vill du fortsätta?</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="368"/>
         <source>Per-game configuration copied from global settings.</source>
         <translation>Konfiguration per-spel har kopierats från globala inställningar.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="378"/>
         <source>The configuration for this game will be cleared.
 
 Any current setting values will be lost.
@@ -11456,37 +8856,26 @@ Alla aktuella inställningsvärden kommer att förloras.
 Vill du fortsätta?</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="390"/>
         <source>Per-game configuration cleared.</source>
         <translation>Konfiguration per-spel har tömts.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="417"/>
         <source>Recommended Value</source>
         <translation>Rekommenderat värde</translation>
     </message>
     <message>
-        <location filename="../settingswindow.ui" line="20"/>
-        <location filename="../settingswindow.cpp" line="349"/>
-        <location filename="../settingswindow.cpp" line="367"/>
-        <location filename="../settingswindow.cpp" line="377"/>
-        <location filename="../settingswindow.cpp" line="389"/>
         <source>DuckStation Settings</source>
         <translation>Inställningar för DuckStation</translation>
     </message>
     <message>
-        <location filename="../settingswindow.ui" line="76"/>
-        <location filename="../settingswindow.cpp" line="202"/>
         <source>Safe Mode</source>
         <translation>Säkert läge</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="114"/>
         <source>&lt;strong&gt;BIOS Settings&lt;/strong&gt;&lt;hr&gt;These options control which BIOS and expansion port is used.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;BIOS-inställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr vilken BIOS och expansionsport som används.&lt;br&gt;&lt;br&gt;Hovra över ett alternativ för ytterligare information och Shift+mushjul för att bläddra i panelen.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="334"/>
         <source>Are you sure you want to restore the default settings? Any preferences will be lost.
 
 You cannot undo this action.</source>
@@ -11495,7 +8884,6 @@ You cannot undo this action.</source>
 Du kan inte ångra den här åtgärden.</translation>
     </message>
     <message>
-        <location filename="../settingswindow.cpp" line="172"/>
         <source>&lt;strong&gt;Achievement Settings&lt;/strong&gt;&lt;hr&gt;DuckStation uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;. To view the achievement list in-game, press the hotkey for &lt;strong&gt;Open Pause Menu&lt;/strong&gt; and select &lt;strong&gt;Achievements&lt;/strong&gt; from the menu. Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Inställningar för prestationer&lt;/strong&gt;&lt;hr&gt;DuckStation använder RetroAchievements som prestationsdatabas och för att spåra framsteg. För att använda prestationer, registrera ett konto på &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;. För att visa prestationslistan i spelet, tryck på snabbtangenten för &lt;strong&gt;Öppna pausmenyn&lt;/strong&gt; och välj &lt;strong&gt;Prestationer&lt;/strong&gt; från menyn. Håll muspekaren över ett alternativ för ytterligare information och tryck på Skift+hjul för att bläddra i panelen.</translation>
     </message>
@@ -11503,87 +8891,70 @@ Du kan inte ångra den här åtgärden.</translation>
 <context>
     <name>SetupWizardDialog</name>
     <message>
-        <location filename="../setupwizarddialog.ui" line="85"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="92"/>
         <source>BIOS Image</source>
         <translation>BIOS-avbild</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="99"/>
         <source>Game Directories</source>
         <translation>Spelkataloger</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="106"/>
         <source>Controller Setup</source>
         <translation>Handkontroller</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="127"/>
         <source>Interface Selection</source>
         <translation>Val av gränssnitt</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="134"/>
         <source>View Selection</source>
         <translation>Val av vy</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="141"/>
         <source>Complete</source>
         <translation>Färdig</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="252"/>
         <source>Language:</source>
         <translation>Språk:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="269"/>
         <source>Theme:</source>
         <translation>Tema:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="279"/>
         <source>Enable Automatic Updates</source>
         <translation>Aktivera automatiska uppdateringar</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="397"/>
         <source>NTSC-J (Japan):</source>
         <translation>NTSC-J (Japan):</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="414"/>
         <source>NTSC-U/C (US/Canada):</source>
         <translation>NTSC-U/C (US, Kanada):</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="431"/>
         <source>PAL (Europe, Australia):</source>
         <translation>PAL (Europa, Australien):</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="465"/>
         <source>Open in Explorer...</source>
         <translation>Öppna i Utforskaren...</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1165"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation supports earning achievements and leaderboard tracking with RetroAchievements.&lt;/p&gt;&lt;p&gt;If you have a RetroAchievements account, you can use the form below to log in. If not, you can register by clicking the Register button below.&lt;/p&gt;&lt;p&gt;A RetroAchievements account is &lt;span style=&quot; font-weight:700;&quot;&gt;not&lt;/span&gt; required to use DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation har stöd för att låsa upp prestationer och följa ledartavlor med RetroAchievements.&lt;/p&gt;&lt;p&gt;Om du har ett RetroAchievements-konto kan du logga in med formuläret nedan. Annars kan du registrera dig genom att klicka på knappen Registrera nedan.&lt;/p&gt;&lt;p&gt;Ett RetroAchievements-konto är &lt;span style=&quot; font-weight:700;&quot;&gt;inte&lt;/span&gt; nödvändigt för att använda DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1213"/>
         <source>Register</source>
         <translation>Registrera</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1315"/>
         <source>Choose the interface DuckStation should show when it starts. Desktop Mode is designed for mouse and keyboard use, while Big Picture Mode is optimized for navigation with a controller on a TV.
 
 You can change this at a later time by toggling the &quot;Start In Big Picture Mode&quot; setting in Interface Settings.</source>
@@ -11592,17 +8963,14 @@ You can change this at a later time by toggling the &quot;Start In Big Picture M
 Du kan ändra detta senare genom att växla inställningen &quot;Starta i storbildsläge&quot; i gränssnittsinställningarna.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1335"/>
         <source>Desktop Mode</source>
         <translation>Skrivbordsläge</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1355"/>
         <source>Big Picture Mode</source>
         <translation>Storbildsläge</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1409"/>
         <source>Choose how games should initially be displayed in both Desktop and Big Picture Mode. List View shows detailed information in columns, while Grid View shows game cover art.
 
 You can change this option at a later time by using the toolbar in Desktop Mode or shortcuts in Big Picture Mode.</source>
@@ -11611,133 +8979,102 @@ You can change this option at a later time by using the toolbar in Desktop Mode 
 Du kan ändra detta senare med verktygsfältet i skrivbordsläget eller snabbkommandon i storbildsläget.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1429"/>
         <source>List View</source>
         <translation>Listvy</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1449"/>
         <source>Grid View</source>
         <translation>Rutnätsvy</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1500"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Setup Complete!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;You are now ready to run games.&lt;/p&gt;&lt;p&gt;Further options are available under the settings menu. You can also use the Big Picture UI for navigation entirely with a gamepad.&lt;/p&gt;&lt;p&gt;We hope you enjoy using DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Konfigurationen är färdig!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;Du är nu klar för att starta spel.&lt;/p&gt;&lt;p&gt;Ytterligare alternativ finns tillgängliga i inställningsmenyn. Du kan även använda Storbildsläget för att navigera helt med en handkontroller.&lt;/p&gt;&lt;p&gt;Vi hoppas att du har kul med DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="361"/>
         <source>BIOS Directory:</source>
         <translation>BIOS-katalog:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation requires a PS1 or PS2 BIOS in order to run.&lt;/p&gt;&lt;p&gt;For legal reasons, you must obtain a BIOS &lt;span style=&quot; font-weight:700;&quot;&gt;from an actual PS1/PS2 unit that you own&lt;/span&gt; (borrowing doesn&apos;t count). You should use Caetla or another utility to create an image from your console&apos;s BIOS ROM on your PC.&lt;/p&gt;&lt;p&gt;Once you have dumped the BIOS from your console, you can click the &amp;quot;Install BIOS&amp;quot; button below to add this image to DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation kräver ett PS1- eller PS2-BIOS för att köras.&lt;/p&gt;&lt;p&gt;Av juridiska skäl måste du skaffa ett BIOS &lt;span style=&quot; font-weight:700;&quot;&gt;från en faktisk PS1-/PS2-enhet som du äger&lt;/span&gt; (det räknas inte att låna en). Du bör använda Caetla eller ett annat verktyg för att skapa en avbild från konsolens BIOS-ROM på datorn.&lt;/p&gt;&lt;p&gt;När du har dumpat BIOS från konsolen kan du klicka på knappen &amp;quot;Installera BIOS&amp;quot; nedan för att lägga till avbilden i DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="339"/>
         <source>Install BIOS...</source>
         <translation>Installera BIOS...</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="353"/>
         <source>Advanced Settings</source>
         <translation>Avancerade inställningar</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="371"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="382"/>
         <source>Reset</source>
         <translation>Nollställ</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="476"/>
         <source>Refresh List</source>
         <translation>Uppdatera lista</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="521"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation will automatically scan and identify games from the selected directories below, and populate the game list. These games should be dumped from discs you own. Utilities such as ImgBurn can be used to create images of game discs in .bin/.cue format.&lt;/p&gt;&lt;p&gt;Supported formats for dumps include: %1&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation söker automatiskt igenom och identifierar spel i de valda katalogerna nedan och fyller spellistan. Spelen ska ha dumpats från skivor som du äger. Verktyg som ImgBurn kan användas för att skapa avbilder av spelskivor i .bin/.cue-format.&lt;/p&gt;&lt;p&gt;Dumpformat som stöds: %1&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="536"/>
         <source>Search Directories (will be scanned for games)</source>
         <translation>Sökkataloger (kommer att genomsökas efter spel)</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="562"/>
         <source>Add...</source>
         <translation>Lägg till...</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="579"/>
-        <location filename="../setupwizarddialog.cpp" line="307"/>
         <source>Remove</source>
         <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="646"/>
         <source>Controller Port 1</source>
         <translation>Kontrollerport 1</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="662"/>
-        <location filename="../setupwizarddialog.ui" line="723"/>
         <source>Controller Mapped To:</source>
         <translation>Handkontroll ansluten till:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="652"/>
-        <location filename="../setupwizarddialog.ui" line="713"/>
         <source>Controller Type:</source>
         <translation>Kontrollertyp:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="636"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, DuckStation will map your keyboard to the virtual controller. &lt;span style=&quot; font-weight:700;&quot;&gt;To use an external controller, you must map it first. &lt;/span&gt;On this screen, you can automatically map any controller which is currently connected. If your controller is not currently connected, you can plug it in now.&lt;/p&gt;&lt;p&gt;To change controller bindings in more detail, or use multi-tap, open the Settings menu and choose Controllers once you have completed the Setup Wizard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Som standard mappar DuckStation tangentbordet till den virtuella handkontrollen. &lt;span style=&quot; font-weight:700;&quot;&gt;För att använda en extern handkontroll måste du först mappa den. &lt;/span&gt;På den här skärmen kan du automatiskt mappa en ansluten handkontroll. Om handkontrollen inte är ansluten kan du ansluta den nu.&lt;/p&gt;&lt;p&gt;Om du vill ändra handkontrollsbindningarna mer ingående eller använda multitap öppnar du menyn Inställningar och väljer Handkontroller när du har slutfört installationsguiden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="671"/>
-        <location filename="../setupwizarddialog.ui" line="732"/>
         <source>Default (Keyboard)</source>
         <translation>Standard (tangentbord)</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="691"/>
-        <location filename="../setupwizarddialog.ui" line="752"/>
         <source>Automatic Mapping</source>
         <translation>Automatisk mappning</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="707"/>
         <source>Controller Port 2</source>
         <translation>Kontrollerport 2</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="183"/>
         <source>&amp;Back</source>
         <translation>&amp;Bakåt</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="190"/>
-        <location filename="../setupwizarddialog.cpp" line="139"/>
         <source>&amp;Next</source>
         <translation>&amp;Nästa</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="200"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Avbryt</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="60"/>
         <source>No BIOS images were found. DuckStation WILL NOT be able to run games without a BIOS image.
 
 Are you sure you wish to continue without selecting a BIOS image?</source>
@@ -11746,7 +9083,6 @@ Are you sure you wish to continue without selecting a BIOS image?</source>
 Är du säker på att du vill fortsätta utan att välja en BIOS-avbild?</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="75"/>
         <source>No game directories have been selected. You will have to manually open any game dumps you want to play, DuckStation&apos;s list will be empty.
 
 Are you sure you want to continue?</source>
@@ -11755,7 +9091,6 @@ Are you sure you want to continue?</source>
 Är du säker på att du vill fortsätta?</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="147"/>
         <source>Are you sure you want to cancel DuckStation setup?
 
 Any changes have been saved, and the wizard will run again next time you start DuckStation.</source>
@@ -11764,27 +9099,22 @@ Any changes have been saved, and the wizard will run again next time you start D
 Ändringar har sparats och konfígurationsguiden kommer att köras nästa gång du startar DuckStation.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="224"/>
         <source>Select BIOS Directory</source>
         <translation>Välj BIOS-katalog</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="139"/>
         <source>&amp;Finish</source>
         <translation>&amp;Färdig</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="146"/>
         <source>Cancel Setup</source>
         <translation>Avbryt konfiguration</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="262"/>
         <source>No BIOS images found. Please install one to continue.</source>
         <translation>Inga BIOS-avbilder hittades. Installera en för att fortsätta.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../setupwizarddialog.cpp" line="271"/>
         <source>%n BIOS images found. You can install additional BIOS images if desired.</source>
         <comment>BIOS Count</comment>
         <translation>
@@ -11793,22 +9123,18 @@ Any changes have been saved, and the wizard will run again next time you start D
         </translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="310"/>
         <source>Open Directory...</source>
         <translation>Öppna katalog...</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="318"/>
         <source>Select Search Directory</source>
         <translation>Välj sökkatalog</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="324"/>
         <source>Scan Recursively?</source>
         <translation>Sök igenom rekursivt?</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="325"/>
         <source>Would you like to scan the directory &quot;%1&quot; recursively?
 
 Scanning recursively takes more time, but will identify files in subdirectories.</source>
@@ -11817,225 +9143,181 @@ Scanning recursively takes more time, but will identify files in subdirectories.
 Söka igenom den rekursivt tar längre tid men identifierar filer i underkataloger.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="407"/>
         <source>Open Pause Menu</source>
         <translation>Öppna pausmenyn</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="436"/>
         <source>Multiple Devices...</source>
         <translation>Flera enheter...</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="441"/>
         <source>No devices available</source>
         <translation>Inga enheter tillgängliga</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="491"/>
         <source>PGXP is not enabled. Increasing the resolution without enabling PGXP will result in visible polygon glitches.</source>
         <translation>PGXP är inte aktiverat. Om upplösningen höjs utan att PGXP aktiveras uppstår synliga polygonfel.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="628"/>
         <source>Logged in as %1
 Token generated %2</source>
         <translation>Inloggad som: %1
 Token genererades %2</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="455"/>
         <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
         <translation>Inga generiska bindningar genererades för enheten &apos;%1&apos;. Handkontrollen/källan kanske inte har stöd för automatisk mappning.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="14"/>
         <source>DuckStation Setup Wizard</source>
         <translation>Konfigurationsguide för DuckStation</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="231"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Welcome to DuckStation!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;This wizard will help guide you through the configuration steps required to use the application. It is recommended if this is your first time installing DuckStation that you view the setup guide at &lt;a href=&quot;https://github.com/stenzek/duckstation#downloading-and-running&quot;&gt;https://github.com/stenzek/duckstation#downloading-and-running&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;By default, DuckStation will connect to the server at &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt; to check for updates, and if available and confirmed, download update packages from &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt;. If you do not wish for DuckStation to make any network connections on startup, you should uncheck the Automatic Updates option now. The Automatic Update setting can be changed later at any time in Interface Settings.&lt;/p&gt;&lt;p&gt;Please choose a language and theme to begin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Välkommen till DuckStation!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;Denna guide hjälper dig genom konfigurationen som krävs för att kunna använda programmet. Om det är första gången du installerar DuckStation så rekommenderas det att du tittar på guiden &lt;a href=&quot;https://github.com/stenzek/duckstation#downloading-and-running&quot;&gt;https://github.com/stenzek/duckstation#downloading-and-running&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;DuckStation kommer som standard att ansluta till servern på &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt; för att leta efter uppdateringar och, om tillgängligt och bekräftat, hämta uppdateringspaket från &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt;. Om du inte vill att DuckStation ska göra några nätverksanslutningar vid uppstart så kan du inaktivera automatiska uppdateringar nu. Inställningen för automatiska uppdateringar kan ändras senare i användargränssnittet.&lt;/p&gt;&lt;p&gt;Välj ett språk och tema för att börja.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="113"/>
         <source>Graphics Setup</source>
         <translation>Grafikkonfiguration</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="120"/>
         <source>RetroAchievements</source>
         <translation>RetroAchievements</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="896"/>
         <source>Internal Resolution:</source>
         <translation>Intern upplösning:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="931"/>
         <source>Texture Filtering:</source>
         <translation>Texturfiltrering:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="945"/>
         <source>Sprite Texture Filtering:</source>
         <translation>Filtrering av sprite-textur:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="973"/>
         <source>Aspect Ratio:</source>
         <translation>Bildförhållande:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="999"/>
         <source>:</source>
         <translation>:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1018"/>
         <source>Crop:</source>
         <translation>Beskär:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1032"/>
         <source>Scaling:</source>
         <translation>Skalning:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1071"/>
         <source>Widescreen Rendering</source>
         <translation>Bredbildsrendering</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1061"/>
         <source>PGXP Geometry Correction</source>
         <translation>PGXP geometrikorrigering</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1260"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1266"/>
         <source>Enable Achievements</source>
         <translation>Aktivera prestationer</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1273"/>
         <source>Enable Hardcore Mode</source>
         <translation>Aktivera hardcore-läge</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1224"/>
         <source>View Profile...</source>
         <translation>Visa profil...</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1235"/>
         <source>Login...</source>
         <translation>Logga in...</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1246"/>
         <source>Logout</source>
         <translation>Logga ut</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="634"/>
         <source>Not Logged In.</source>
         <translation>Inte inloggad.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="924"/>
         <source>Setting this beyond 1x will enhance the resolution of rendered 3D polygons and lines. Only applies to the hardware backends. &lt;br&gt;This option is usually safe, with most games looking fine at higher resolutions. Higher resolutions require a more powerful GPU.</source>
         <translation>Om du ställer in detta värde till mer än 1x förbättras upplösningen för renderade 3D-polygoner och linjer. Gäller endast för hårdvarubackends. &lt;br&gt;Det här alternativet är vanligtvis säkert, och de flesta spel ser bra ut i högre upplösningar. Högre upplösningar kräver en kraftfullare GPU.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="938"/>
         <source>Smooths out the blockiness of magnified textures on 3D objects by using filtering. &lt;br&gt;Will have a greater effect on higher resolution scales.</source>
         <translation>Utjämnar blockigheten i förstorade texturer på 3D-objekt med hjälp av filtrering. &lt;br&gt;Har större effekt på skalor med högre upplösning.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="952"/>
         <source>Smooths out the blockiness of magnified textures on 2D objects by using filtering. This filter only applies to sprites and other 2D elements, such as the HUD.</source>
         <translation>Utjämnar blockigheten i förstorade texturer på 2D-objekt med hjälp av filtrering. Detta filter gäller endast sprites och andra 2D-element, t.ex. HUD.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="982"/>
         <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is Auto (Game Native) which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era.</source>
         <translation>Ändrar det bildförhållande som används för att visa konsolens utdata på skärmen. Standardinställningen är Automatiskt (spelets inbyggda) som automatiskt justerar bildförhållandet så att det motsvarar hur ett spel skulle visas på en typisk TV för den tiden.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1025"/>
         <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide. Some games display content in the overscan area, or use it for screen effects. May not display correctly with the &quot;All Borders&quot; setting. &quot;Only Overscan&quot; offers a good compromise between stability and hiding black borders.</source>
         <translation>Bestämmer hur stor del av det område som normalt inte syns på en konsument-TV-apparat som ska beskäras/döljas. Vissa spel visar innehåll i overscan-området eller använder det för skärmeffekter. Visas kanske inte korrekt med inställningen ”Alla kanter. ”Endast överskanning” är en bra kompromiss mellan stabilitet och att dölja svarta kanter.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1039"/>
         <source>Determines how the emulated console&apos;s output is upscaled or downscaled to your monitor&apos;s resolution.</source>
         <translation>Bestämmer hur den emulerade konsolens utdata ska upp- eller nedskalas till din bildskärms upplösning.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1068"/>
         <source>Scales vertex positions in screen-space to a widescreen aspect ratio, essentially increasing the field of view from 4:3 to the chosen display aspect ratio in 3D games. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Skalar vertexpositioner i skärmrymden till ett bredbildsförhållande, vilket i princip ökar synfältet från 4:3 till det valda bildförhållandet i 3D-spel. &lt;b&gt;&lt;u&gt;Kanske inte är kompatibel med alla spel.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1058"/>
         <source>Reduces &quot;wobbly&quot; polygons and &quot;warping&quot; textures that are common in PS1 games. &lt;strong&gt;May not be compatible with all games.&lt;/strong&gt;</source>
         <translation>Reducerar &quot;vingliga&quot; polygoner och &quot;skeva&quot; texturer som är vanliga i PS1-spel. &lt;strong&gt;Kanske inte är kompatibel med alla spel.&lt;/strong&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="768"/>
         <source>Pause Menu Hotkey</source>
         <translation>Snabbtangent för pausmeny</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="774"/>
         <source>Pressing this key will open the pause menu when ingame, allowing you to load/save state, change settings, and perform other functions without needing to use a mouse. Click the button to change the trigger.</source>
         <translation>När du trycker på tangenten öppnas pausmenyn under spelet. Där kan du läsa in eller spara tillstånd, ändra inställningar och utföra andra åtgärder utan mus. Klicka på knappen för att ändra utlösaren.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="855"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This page includes some of the commonly set graphics options in DuckStation.&lt;/p&gt;&lt;p&gt;These options are generally safe to enable, and compatible with most games. Changing the internal resolution and enabling PGXP geometry correction will significantly improve the graphical fidelity of most games.&lt;/p&gt;&lt;p&gt;You can change these options and others in &lt;span style=&quot; font-weight:700;&quot;&gt;Graphics Settings &lt;/span&gt;after completing setup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Den här sidan innehåller några av de vanligaste grafikinställningarna i DuckStation.&lt;/p&gt;&lt;p&gt;Alternativen är i allmänhet säkra att aktivera och kompatibla med de flesta spel. En högre intern upplösning och PGXP-geometrikorrigering förbättrar grafikkvaliteten avsevärt i de flesta spel.&lt;/p&gt;&lt;p&gt;Du kan ändra dessa och andra alternativ under &lt;span style=&quot; font-weight:700;&quot;&gt;Grafikinställningar &lt;/span&gt;när installationen är klar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="959"/>
         <source>Dithering:</source>
         <translation>Dithering:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="966"/>
         <source>Controls how dithering is applied in the emulated GPU. True Color disables dithering and produces the nicest looking gradients. Scaled options make the dither pattern less noticeable at higher resolutions. Shader Blending options perform blending in software, and are more accurate but have a &lt;strong&gt;significant&lt;/strong&gt; performance penalty.</source>
         <translation>Kontrollerar hur dithering tillämpas i den emulerade GPU:n. True Color inaktiverar dithering och ger de snyggaste gradienterna. Med skalade alternativ blir dithermönstret mindre märkbart i högre upplösningar. Alternativet Shader-blandning utför blandning i programvara och är mer exakt, men har en &lt;strong&gt;betydande&lt;/strong&gt; prestandaförlust.</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1153"/>
         <source>RetroAchievements</source>
         <comment>Header text</comment>
         <translation>RetroAchievements</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.ui" line="1046"/>
         <source>FMV Scaling:</source>
         <translation>FMV-skalning:</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="59"/>
         <source>No BIOS Image Found</source>
         <translation>Ingen BIOS-avbild hittades</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="74"/>
         <source>No Game Directories Selected</source>
         <translation>Inga spelkataloger valda</translation>
     </message>
     <message>
-        <location filename="../setupwizarddialog.cpp" line="454"/>
         <source>Automatic Binding Failed</source>
         <translation>Automatisk bindning misslyckades</translation>
     </message>
@@ -12043,12 +9325,10 @@ Token genererades %2</translation>
 <context>
     <name>System</name>
     <message>
-        <location filename="../qthost.cpp" line="1100"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location filename="../qthost.cpp" line="1107"/>
         <source>Do you want to install a BIOS file now?</source>
         <translation>Vill du installera en BIOS-fil nu?</translation>
     </message>
@@ -12056,156 +9336,118 @@ Token genererades %2</translation>
 <context>
     <name>TextureReplacementSettingsDialog</name>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="14"/>
         <source>Texture Replacement Settings</source>
         <translation>Inställningar för texturersättning</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="44"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Texture Replacement Settings&lt;/span&gt;&lt;br/&gt;These settings fine-tune the behavior of the texture replacement system. You can also export a game-specific configuration file. Each of the options is explained in the configuration file, and at &lt;a href=&quot;https://github.com/stenzek/duckstation/wiki/Texture-Replacement&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0078d4;&quot;&gt;https://github.com/stenzek/duckstation/wiki/Texture-Replacement&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Inställningar för texturersättningar&lt;/span&gt;&lt;br/&gt;Dessa inställningar finjusterar beteendet för texturersättningssystemet. Du kan även exportera en spelspecifik konfigurationsfil. Varje alternativ förklaras i konfigurationsfilen och på &lt;a href=&quot;https://github.com/stenzek/duckstation/wiki/Texture-Replacement&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0078d4;&quot;&gt;https://github.com/stenzek/duckstation/wiki/Texture-Replacement&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="65"/>
         <source>Texture Dumping Mode</source>
         <translation>Texturdumpningsläge</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="71"/>
         <source>Reduce Palette Range</source>
         <translation>Reducera palettomfång</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="78"/>
         <source>Dump Texture Pages</source>
         <translation>Dumpa textursidor</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="85"/>
         <source>Dump C16 Textures</source>
         <translation>Dumpa C16-texturer</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="92"/>
         <source>Dump Full Texture Pages</source>
         <translation>Dumpa fullständiga textursidor</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="99"/>
         <source>The texture dumping system can either operate in page mode, or write-tracking mode. Replacements can be loaded from either dump method.</source>
         <translation>Texturdumpningssystemet kan antingen jobba i sidläge eller skrivspårningsläge. Ersättningar kan läsas in från valfri dumpmetod.</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="112"/>
         <source>Write Tracking Options</source>
         <translation>Alternativ för skrivspårning</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="118"/>
         <source>Maximum Write Coalesce Size:</source>
         <translation>Maximal storlek på Write Coalesce:</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="127"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="150"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="221"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="241"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="291"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="311"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="143"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="234"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="304"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="168"/>
         <source>Maximum Write Splits:</source>
         <translation>Maximalt antal uppdelade skrivningar:</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="187"/>
         <source>Convert Copies To Writes</source>
         <translation>Konvertera kopior till skrivningar</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="194"/>
         <source>Bilinear Replacement Scaling</source>
         <translation>Skalning för bilinjär ersättning</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="206"/>
         <source>Texture Dumping Options</source>
         <translation>Alternativ för texturdumpning</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="212"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="282"/>
         <source>Dump Size Threshold:</source>
         <translation>Tröskelvärde för dumpstorlek:</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="254"/>
-        <location filename="../texturereplacementsettingsdialog.ui" line="324"/>
         <source>Set Alpha Channel</source>
         <translation>Ställ in alfakanal</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="263"/>
         <source>Determines the minimum size of a texture that will be dumped. Textures with a size smaller than this value will be ignored.</source>
         <translation>Bestämmer minimal storlek för en textur som ska dumpas. Texturer med en storlek mindre än detta värde kommer att ignoreras.</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="276"/>
         <source>Background Dumping Options</source>
         <translation>Alternativ för bakgrundsdumpning</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="333"/>
         <source>Determines the minimum size of a VRAM write that will be dumped, in background dumping mode. Uploads smaller than this size will be ignored.</source>
         <translation>Bestämmer minimal storlek för a VRAM-skrivning som ska dumpas, i bakgrundsdumpningsläge. Inläsningar mindre än denna storlek kommer att ignoreras.</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="374"/>
         <source>Export...</source>
         <translation>Exportera...</translation>
     </message>
     <message>
-        <location filename="../texturereplacementsettingsdialog.ui" line="381"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="1271"/>
         <source>Texture Replacement Configuration</source>
         <translation>Konfiguration för texturersättning</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="1274"/>
         <source>Texture Replacement Configuration (config.yaml)</source>
         <translation>Konfiguration för texturersättning (config.yaml)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="1276"/>
         <source>Save As...</source>
         <translation>Spara som...</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="1279"/>
         <source>Save Configuration</source>
         <translation>Spara konfiguration</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="1279"/>
         <source>Configuration Files (config.yaml)</source>
         <translation>Konfigurationsfiler (config.yaml)</translation>
     </message>
     <message>
-        <location filename="../graphicssettingswidget.cpp" line="1287"/>
         <source>Write Failed</source>
         <translation>Skrivning misslyckades</translation>
     </message>

--- a/src/duckstation-qt/translations/duckstation-qt_sv.ts
+++ b/src/duckstation-qt/translations/duckstation-qt_sv.ts
@@ -4,42 +4,52 @@
 <context>
     <name>AboutDialog</name>
     <message>
+        <location filename="../aboutdialog.cpp" line="56"/>
         <source>License</source>
         <translation>Licens</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.ui" line="14"/>
         <source>About DuckStation</source>
         <translation>Om DuckStation</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.ui" line="53"/>
         <source>DuckStation</source>
         <translation>DuckStation</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.cpp" line="36"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.cpp" line="50"/>
         <source>DuckStation is a free simulator/emulator of the Sony PlayStation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt; console, focusing on playability, speed, and long-term maintainability.</source>
         <translation>DuckStation är en fri simulator/emulator för konsolen Sony Playstation&lt;span style=&quot;vertical-align:super;&quot;&gt;TM&lt;/span&gt;, med fokus på spelbarhet, hastighet och långtidsunderhåll.</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.cpp" line="53"/>
         <source>Authors</source>
         <translation>Upphovspersoner</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.cpp" line="55"/>
         <source>Icon by</source>
         <translation>Ikon av</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.cpp" line="68"/>
         <source>DuckStation Third-Party Notices</source>
         <translation>Tredjepartsinformation för DuckStation</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.cpp" line="83"/>
         <source>Missing thirdparty.html file. You should request it from where-ever you obtained DuckStation.</source>
         <translation>Saknar filen thirdparty.html. Du bör begära den från var du fick tag på DuckStation.</translation>
     </message>
     <message>
+        <location filename="../aboutdialog.cpp" line="54"/>
         <source>and other contributors</source>
         <translation>och andra bidragsgivare</translation>
     </message>
@@ -47,44 +57,54 @@
 <context>
     <name>AchievementLoginDialog</name>
     <message>
+        <location filename="../achievementlogindialog.ui" line="26"/>
         <source>RetroAchievements Login</source>
         <comment>Window title</comment>
         <translation>Inloggning för RetroAchievements</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.ui" line="92"/>
         <source>RetroAchievements Login</source>
         <comment>Header text</comment>
         <translation>Inloggning för RetroAchievements</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.ui" line="107"/>
         <source>Please enter your user name and password for retroachievements.org below. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
         <translation>Ange ditt användarnamn och lösenord för RetroAchievements.org nedan. Ditt lösenord kommer inte att sparas i DuckStation, däremot kommer ett access token att genereras och användas.</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.ui" line="32"/>
         <source>User Name:</source>
         <translation>Användarnamn:</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.ui" line="39"/>
         <source>Password:</source>
         <translation>Lösenord:</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.ui" line="46"/>
         <source>Ready...</source>
         <translation>Redo...</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="38"/>
         <source>&amp;Login</source>
         <translation>&amp;Logga in</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="51"/>
         <source>Logging in...</source>
         <translation>Loggar in...</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="86"/>
         <source>Login Error</source>
         <translation>Inloggningsfel</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="87"/>
         <source>Login failed.
 Error: %1
 
@@ -95,14 +115,17 @@ Fel: %1
 Kontrollera ditt användarnamn och lösenord. Försök igen.</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="88"/>
         <source>Login failed.</source>
         <translation>Inloggningen misslyckades.</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="112"/>
         <source>Enable Achievements</source>
         <translation>Aktivera prestationer</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="113"/>
         <source>Achievement tracking is not currently enabled. Your login will have no effect until after tracking is enabled.
 
 Do you want to enable tracking now?</source>
@@ -111,10 +134,12 @@ Do you want to enable tracking now?</source>
 Vill du aktivera kontrollen nu?</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="135"/>
         <source>Enable Hardcore Mode</source>
         <translation>Aktivera hardcore-läge</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="136"/>
         <source>Hardcore mode is not currently enabled. Enabling hardcore mode allows you to set times, scores, and participate in game-specific leaderboards.
 
 However, hardcore mode also prevents the usage of save states, cheats and slowdown functionality.
@@ -127,14 +152,17 @@ Dock förhindrar även Hardcore-läget att man kan spara tillstånd, använda fu
 Vill du aktivera hardcore-läget?</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="159"/>
         <source>Restart Game</source>
         <translation>Starta om spelet</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="160"/>
         <source>Hardcore mode will not be enabled until the game is restarted. Do you want to restart the game now?</source>
         <translation>Hardcore-läget aktiveras inte förrän spelet har startats om. Vill du starta om spelet nu?</translation>
     </message>
     <message>
+        <location filename="../achievementlogindialog.cpp" line="33"/>
         <source>&lt;strong&gt;Your RetroAchievements login token is no longer valid.&lt;/strong&gt; You must re-enter your credentials for achievements to be tracked. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
         <translation>&lt;strong&gt;Din inloggningstoken för RetroAchievements är inte giltig längre.&lt;/strong&gt; Du måste ange dina inloggningsuppgifter igen för att kontrollera prestationer. Ditt lösenord kommer inte att sparas i DuckStation, istället kommer en accesstoken att genereras och användas.</translation>
     </message>
@@ -142,110 +170,156 @@ Vill du aktivera hardcore-läget?</translation>
 <context>
     <name>AchievementSettingsWidget</name>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="120"/>
+        <location filename="../achievementsettingswidget.cpp" line="76"/>
         <source>Enable Achievements</source>
         <translation>Aktivera prestationer</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="127"/>
+        <location filename="../achievementsettingswidget.cpp" line="78"/>
         <source>Enable Hardcore Mode</source>
         <translation>Aktivera hardcore-läge</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="86"/>
         <source>Test Unofficial Achievements</source>
         <translation>Testa inofficiella prestationer</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="275"/>
+        <location filename="../achievementsettingswidget.cpp" line="97"/>
         <source>Enable Sound Effects</source>
         <translation>Aktivera ljudeffekter</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="165"/>
         <source>Notifications</source>
         <translation>Aviseringar</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="205"/>
+        <location filename="../achievementsettingswidget.ui" line="251"/>
         <source>5 seconds</source>
         <translation>5 sekunder</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="89"/>
         <source>Login...</source>
         <translation>Logga in...</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="78"/>
         <source>View Profile...</source>
         <translation>Visa profil...</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="67"/>
         <source>Register</source>
         <translation>Registrera</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="114"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="134"/>
+        <location filename="../achievementsettingswidget.cpp" line="83"/>
         <source>Enable Spectator Mode</source>
         <translation>Aktivera åskådarläget</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="141"/>
+        <location filename="../achievementsettingswidget.cpp" line="81"/>
         <source>Enable Encore Mode</source>
         <translation>Aktivera Encore-läget</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="148"/>
         <source>Track Unofficial Achievements</source>
         <translation>Spåra inofficiella prestationer</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="155"/>
+        <location filename="../achievementsettingswidget.cpp" line="99"/>
         <source>Prefetch Badges</source>
         <translation>Förhämta märken</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="171"/>
+        <location filename="../achievementsettingswidget.cpp" line="89"/>
         <source>Show Achievement Notifications</source>
         <translation>Visa aviseringar om prestationer</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="217"/>
+        <location filename="../achievementsettingswidget.cpp" line="92"/>
         <source>Show Leaderboard Notifications</source>
         <translation>Visa aviseringar om ledartavlor</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="370"/>
         <source>Indicator Size:</source>
         <translation>Indikatorstorlek:</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="76"/>
+        <location filename="../achievementsettingswidget.cpp" line="78"/>
+        <location filename="../achievementsettingswidget.cpp" line="81"/>
+        <location filename="../achievementsettingswidget.cpp" line="83"/>
+        <location filename="../achievementsettingswidget.cpp" line="86"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="77"/>
         <source>When enabled and logged in, DuckStation will scan for achievements on startup.</source>
         <translation>När aktiverat och inloggad kommer DuckStation att söka efter prestationer vid uppstart.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="79"/>
         <source>&quot;Challenge&quot; mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions.</source>
         <translation>&quot;Challenge&quot;-läget för prestationer, inklusive koll på ledartavlor. Inaktiverar sparat tillstånd, fusk och funktioner för sakta körning.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="89"/>
+        <location filename="../achievementsettingswidget.cpp" line="92"/>
+        <location filename="../achievementsettingswidget.cpp" line="94"/>
+        <location filename="../achievementsettingswidget.cpp" line="97"/>
+        <location filename="../achievementsettingswidget.cpp" line="99"/>
+        <location filename="../achievementsettingswidget.cpp" line="121"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="98"/>
         <source>Plays sound effects for events such as achievement unlocks and leaderboard submissions.</source>
         <translation>Spelar upp ljudeffekter för händelser såsom en prestation låses upp och insändningar till ledartavlor.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="84"/>
         <source>When enabled, DuckStation will assume all achievements are locked and not send any unlock notifications to the server.</source>
         <translation>När aktiverad kommer DuckStation att anta att alla prestationer är låsta och inte skicka några upplåsniingsaviseringar till servern.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="90"/>
         <source>Displays popup messages on events such as achievement unlocks and game completion.</source>
         <translation>Visar popupmeddelanden vid händelser såsom en prestation låses upp och spel färdigställs.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="93"/>
         <source>Displays popup messages when starting, submitting, or failing a leaderboard challenge.</source>
         <translation>Visar popupmeddelanden vid start, insändning eller misslyckanden av en ledartavleutmaning.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="82"/>
         <source>When enabled, each session will behave as if no achievements have been unlocked.</source>
         <translation>När aktiverat kommer varje session att bete sig som att ingen prestation har låsts upp.</translation>
     </message>
     <message numerus="yes">
+        <location filename="../achievementsettingswidget.cpp" line="283"/>
+        <location filename="../achievementsettingswidget.cpp" line="290"/>
         <source>%n seconds</source>
         <translation>
             <numerusform>%n second</numerusform>
@@ -253,162 +327,210 @@ Vill du aktivera hardcore-läget?</translation>
         </translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="100"/>
         <source>Logout</source>
         <translation>Logga ut</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="326"/>
         <source>Not Logged In.</source>
         <translation>Inte inloggad.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="263"/>
+        <location filename="../achievementsettingswidget.cpp" line="94"/>
         <source>Show Leaderboard Trackers</source>
         <translation>Visa ledartavlor</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="304"/>
         <source>Notification Size:</source>
         <translation>Aviseringsstorlek:</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="316"/>
+        <location filename="../achievementsettingswidget.ui" line="382"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="334"/>
         <source>Progress Tracking</source>
         <translation>Framstegsspårning</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="340"/>
         <source>Challenge Indicators:</source>
         <translation>Utmaningsindikatorer:</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="110"/>
         <source>Challenge Indicators</source>
         <translation>Utmaningsindikatorer</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="110"/>
         <source>Show Notifications</source>
         <translation>Visa aviseringar</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="294"/>
         <source>Notification Location:</source>
         <translation>Aviseringsplats:</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="350"/>
         <source>Progress Indicators:</source>
         <translation>Förloppsindikatorer:</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.ui" line="360"/>
         <source>Indicator Location:</source>
         <translation>Indikatorplats:</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="74"/>
         <source>(Customize)</source>
         <translation>(Anpassa)</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="87"/>
         <source>When enabled, DuckStation will track unofficial achievements. Unlocks will be saved locally and not sent to RetroAchievements.</source>
         <translation>När detta är aktiverat spårar DuckStation inofficiella prestationer. Upplåsningar sparas lokalt och skickas inte till RetroAchievements.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="95"/>
         <source>Shows a timer in the selected location when leaderboard challenges are active.</source>
         <translation>Visar en timer på vald plats när ledartavlans-utmaningar är aktiva.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="100"/>
         <source>Downloads all locked achievement badges while starting the game. This will reduce delays in the images being shown when unlocking achievements.</source>
         <translation>Hämtar alla låsta prestationsmärken när spelet startas. Det minskar fördröjningen när bilder visas vid upplåsning av prestationer.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="102"/>
         <source>Notification Location</source>
         <translation>Aviseringsplats</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="102"/>
         <source>Top Left</source>
         <translation>Överst till vänster</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="103"/>
         <source>Selects the screen location for achievement and leaderboard notifications.</source>
         <translation>Väljer skärmplatsen för aviseringar om prestationer och ledartavlor.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="104"/>
         <source>Notification Size</source>
         <translation>Aviseringsstorlek</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="104"/>
+        <location filename="../achievementsettingswidget.cpp" line="115"/>
+        <location filename="../achievementsettingswidget.cpp" line="169"/>
+        <location filename="../achievementsettingswidget.cpp" line="172"/>
         <source>Automatic</source>
         <translation>Automatisk</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="105"/>
         <source>Determines the size of achievement notification popups. Automatic will use the same scaling as the Big Picture UI.</source>
         <translation>Bestämmer storleken på prestationsaviseringar. Automatiskt använder samma skalning som storbildsgränssnittet.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="107"/>
         <source>Custom Notification Scale</source>
         <translation>Anpassad aviseringsskala</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="107"/>
+        <location filename="../achievementsettingswidget.cpp" line="118"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="108"/>
         <source>Sets the custom scale percentage for achievement notifications.</source>
         <translation>Anger den anpassade skalningsprocenten för prestationsaviseringar.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="111"/>
         <source>Shows a notification or icons in the selected location when a challenge/primed achievement is active.</source>
         <translation>Visar en avisering eller ikoner på vald plats när en utmatning/förberedd prestation är aktiv.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="113"/>
         <source>Indicator Location</source>
         <translation>Indikatorplats</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="113"/>
         <source>Bottom Right</source>
         <translation>Nederst till höger</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="114"/>
         <source>Selects the screen location for challenge/progress indicators, and leaderboard trackers.</source>
         <translation>Väljer skärmplatsen för utmaning/framstegsindikatorer samt följa ledartavlan.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="115"/>
         <source>Indicator Size</source>
         <translation>Indikatorstorlek</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="116"/>
         <source>Determines the size of challenge/progress indicators. Automatic will use the same scaling as the Big Picture UI.</source>
         <translation>Bestämmer storleken på utmanings- och förloppsindikatorer. Automatiskt använder samma skalning som storbildsgränssnittet.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="118"/>
         <source>Custom Indicator Scale</source>
         <translation>Anpassad indikatorskala</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="119"/>
         <source>Sets the custom scale percentage for challenge/progress indicators.</source>
         <translation>Anger den anpassade skalningsprocenten för utmanings- och förloppsindikatorer.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="121"/>
         <source>Progress Indicators</source>
         <translation>Förloppsindikatorer</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="122"/>
         <source>Shows a popup in the selected location when progress towards a measured achievement changes.</source>
         <translation>Visar ett popup-fönster på vald plats när framstegen mot en uppmätt prestation förändras.</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="169"/>
+        <location filename="../achievementsettingswidget.cpp" line="173"/>
         <source>Use OSD Scale</source>
         <translation>Använd OSD-skala</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="169"/>
+        <location filename="../achievementsettingswidget.cpp" line="174"/>
         <source>Custom</source>
         <translation>Anpassad</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="272"/>
         <source>Restart Game</source>
         <translation>Starta om spelet</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="273"/>
         <source>Hardcore mode will not be enabled until the game is restarted. Do you want to restart the game now?</source>
         <translation>Hardcore-läget aktiveras inte förrän spelet har startats om. Vill du starta om spelet nu?</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="320"/>
         <source>Logged in as %1
 Token generated %2</source>
         <translation>Inloggad som: %1
@@ -416,1484 +538,697 @@ Token genererades %2</translation>
     </message>
 </context>
 <context>
-    <name>Achievements</name>
-    <message>
-        <source>{0}, {1}.</source>
-        <translation>{0}, {1}.</translation>
-    </message>
-    <message numerus="yes">
-        <source>You have unlocked {} of %n achievements</source>
-        <comment>Achievement popup</comment>
-        <translation>
-            <numerusform>Du har låst upp {} av %n prestation</numerusform>
-            <numerusform>Du har låst upp {} av %n prestationer</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>and earned {} of %n points</source>
-        <comment>Achievement popup</comment>
-        <translation>
-            <numerusform>och tjänat {} av %n poäng</numerusform>
-            <numerusform>och tjänat {} av %n poäng</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Hardcore mode is enabled. Cheats and save states are unavailable.</source>
-        <translation>Hardcore-läget är aktiverat. Fusk och sparade tillstånd är inte tillgängliga.</translation>
-    </message>
-    <message>
-        <source>{} (Unofficial)</source>
-        <translation>{} (Inte officiell)</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n achievements</source>
-        <comment>Mastery popup</comment>
-        <translation>
-            <numerusform>%n prestation</numerusform>
-            <numerusform>%n prestationer</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n points</source>
-        <comment>Achievement points</comment>
-        <translation>
-            <numerusform>%n poäng</numerusform>
-            <numerusform>%n poäng</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Leaderboard attempt started.</source>
-        <translation>Ledartavleförsök startat.</translation>
-    </message>
-    <message>
-        <source>Leaderboard attempt failed.</source>
-        <translation>Ledartavleförsök misslyckades.</translation>
-    </message>
-    <message>
-        <source>Your Score: {}</source>
-        <translation>Dina poäng: {}</translation>
-    </message>
-    <message>
-        <source>Your Time: {0} (Best: {1})</source>
-        <translation>Din tid: {0} (Bästa: {1})</translation>
-    </message>
-    <message>
-        <source>Your Score: {0} (Best: {1})</source>
-        <translation>Dina poäng: {0} (Bästa: {1})</translation>
-    </message>
-    <message>
-        <source>Your Value: {0} (Best: {1})</source>
-        <translation>Ditt värde: {0} (Bästa: {1})</translation>
-    </message>
-    <message>
-        <source>Leaderboard Position: {0} of {1}</source>
-        <translation>Position på ledartavlan: {0} av {1}</translation>
-    </message>
-    <message>
-        <source>Achievements Disconnected</source>
-        <translation>Prestationer frånkopplade</translation>
-    </message>
-    <message>
-        <source>Achievements Reconnected</source>
-        <translation>Prestationer återansluten</translation>
-    </message>
-    <message>
-        <source>All pending unlock requests have completed.</source>
-        <translation>Alla väntande upplösningsbegäran har färdigställts.</translation>
-    </message>
-    <message>
-        <source>Downloading achievements data...</source>
-        <translation>Hämtar data om prestationer...</translation>
-    </message>
-    <message>
-        <source>Achievement unlocks will not be submitted for this session.
-Error: {}</source>
-        <translation>Upplåsningar för prestationer kommer inte att skickas in för denna session.
-Fel: {}</translation>
-    </message>
-    <message>
-        <source>RetroAchievements Login Failed</source>
-        <translation>Inloggning till RetroAchievements misslyckades</translation>
-    </message>
-    <message numerus="yes">
-        <source>Prefetching achievement badges (%n remaining)...</source>
-        <comment>Achievement badge prefetch count</comment>
-        <translation>
-            <numerusform>Förhämtar prestationsmärken (%n återstår)...</numerusform>
-            <numerusform>Förhämtar prestationsmärken (%n återstår)...</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Confirm Hardcore Mode Disable</source>
-        <translation>Bekräfta inaktivering av Hardcore-läget</translation>
-    </message>
-    <message>
-        <source>{0} cannot be performed while hardcore mode is active. Do you want to disable hardcore mode? {0} will be cancelled if you select No.</source>
-        <translation>{0} kan inte genomföras under tiden hardcore-läget är aktivt. Vill du inaktivera hardcore-läget? {0} kommer att avbrytas om du väljer Nej.</translation>
-    </message>
-    <message>
-        <source> (Hardcore Mode)</source>
-        <translation> (Hardcore-läge)</translation>
-    </message>
-    <message numerus="yes">
-        <source>You have unlocked all achievements and earned %n points!</source>
-        <comment>Point count</comment>
-        <translation>
-            <numerusform>Du har låst upp alla prestationer och tjänat %n poäng!</numerusform>
-            <numerusform>Du har låst upp alla prestationer och tjänat %n poäng!</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>You have unlocked {0} of {1} achievements, earning {2} of {3} possible points.</source>
-        <translation>Du har låst upp {0} av {1}  prestationer och tjänat {2} of {3} möjliga poäng.</translation>
-    </message>
-    <message>
-        <source>You have unlocked {0} of {1} unofficial achievements, earning {2} of {3} possible points.</source>
-        <translation>Du har låst upp {0} av {1} inofficiella prestationer och tjänat {2} av {3} möjliga poäng.</translation>
-    </message>
-    <message>
-        <source>Game was beaten {0}, and completed {1}.</source>
-        <translation>Spelet klarades av {0} och färdigställdes {1}.</translation>
-    </message>
-    <message>
-        <source>Subset was beaten {0}, and completed {1}.</source>
-        <translation>Deluppsättningen klarades av {0} och färdigställdes {1}.</translation>
-    </message>
-    <message>
-        <source>Game was beaten {0}.</source>
-        <translation>Spelet klarades av {0}.</translation>
-    </message>
-    <message>
-        <source>Subset was beaten {0}.</source>
-        <translation>Deluppsättningen klarades av {0}.</translation>
-    </message>
-    <message>
-        <source>Game was completed {0}.</source>
-        <translation>Spelet färdigställdes {0}.</translation>
-    </message>
-    <message>
-        <source>Subset was completed {0}.</source>
-        <translation>Deluppsättningen färdigställdes {0}.</translation>
-    </message>
-    <message>
-        <source>Recently Unlocked</source>
-        <translation>Senast upplåsta</translation>
-    </message>
-    <message>
-        <source>Unlocked in Casual</source>
-        <translation>Upplåst i avslappnat läge</translation>
-    </message>
-    <message>
-        <source>Change Selection</source>
-        <translation>Byt val</translation>
-    </message>
-    <message>
-        <source>Reset Unofficial Unlocks</source>
-        <translation>Återställ inofficiella upplåsningar</translation>
-    </message>
-    <message>
-        <source>View Details</source>
-        <translation>Visa detaljer</translation>
-    </message>
-    <message>
-        <source>Back</source>
-        <translation>Bakåt</translation>
-    </message>
-    <message>
-        <source>Unlocked {}</source>
-        <translation>Upplåst {}</translation>
-    </message>
-    <message numerus="yes">
-        <source>This game has %n leaderboards.</source>
-        <comment>Leaderboard count</comment>
-        <translation>
-            <numerusform>Detta spel har %n ledartavla.</numerusform>
-            <numerusform>Detta spel har %n ledartavlor.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Submitting scores is disabled because hardcore mode is off. Leaderboards are read-only.</source>
-        <translation>Skicka in poäng är inaktiverat därför att hardcore-läget är av. Ledartavlor är endast läsbara.</translation>
-    </message>
-    <message>
-        <source>Rank</source>
-        <translation>Rank</translation>
-    </message>
-    <message>
-        <source>Score</source>
-        <translation>Poäng</translation>
-    </message>
-    <message>
-        <source>Date Submitted</source>
-        <translation>Datum inskickad</translation>
-    </message>
-    <message>
-        <source>Open Leaderboard</source>
-        <translation>Öppna ledartavla</translation>
-    </message>
-    <message>
-        <source>Downloading leaderboard data, please wait...</source>
-        <translation>Hämtar data från ledartavlan. Vänta...</translation>
-    </message>
-    <message>
-        <source>Change Page</source>
-        <translation>Byt sida</translation>
-    </message>
-    <message>
-        <source>View Profile</source>
-        <translation>Visa profil</translation>
-    </message>
-    <message>
-        <source>Leaderboard download failed</source>
-        <translation>Hämtning av ledartavlan misslyckades</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation>Okänt</translation>
-    </message>
-    <message>
-        <source>Locked</source>
-        <translation>Låst</translation>
-    </message>
-    <message>
-        <source>Unlocked</source>
-        <translation>Upplåst</translation>
-    </message>
-    <message>
-        <source>Unsupported</source>
-        <translation>Stöds inte</translation>
-    </message>
-    <message>
-        <source>Unofficial</source>
-        <translation>Inofficiell</translation>
-    </message>
-    <message>
-        <source>Active Challenges</source>
-        <translation>Aktiva utmaningar</translation>
-    </message>
-    <message>
-        <source>Almost There</source>
-        <translation>Nästan där</translation>
-    </message>
-    <message>
-        <source>XXX points</source>
-        <translation>XXX poäng</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Namn</translation>
-    </message>
-    <message>
-        <source>Time</source>
-        <translation>Tid</translation>
-    </message>
-    <message>
-        <source>Value</source>
-        <translation>Värde</translation>
-    </message>
-    <message>
-        <source>Loading...</source>
-        <translation>Läser in...</translation>
-    </message>
-    <message>
-        <source>This game has no achievements.</source>
-        <translation>Detta spel har inga prestationer.</translation>
-    </message>
-    <message>
-        <source>Overriding executable</source>
-        <translation>Åsidosätter körbar fil</translation>
-    </message>
-    <message>
-        <source>Resuming state</source>
-        <translation>Återupptar tillstånd</translation>
-    </message>
-    <message>
-        <source>Loading state</source>
-        <translation>Läser in tillstånd</translation>
-    </message>
-    <message>
-        <source>Achievements Unlocked</source>
-        <comment>Pause Menu</comment>
-        <translation>Prestationer upplåsta</translation>
-    </message>
-    <message>
-        <source>Most Recent</source>
-        <comment>Pause Menu</comment>
-        <translation>Senaste</translation>
-    </message>
-    <message>
-        <source>Nearest Completion</source>
-        <comment>Pause Menu</comment>
-        <translation>Nära färdigställande</translation>
-    </message>
-    <message>
-        <source>Active Challenge Achievements</source>
-        <comment>Pause Menu</comment>
-        <translation>Aktiva utmaningsprestationer</translation>
-    </message>
-    <message>
-        <source>Missable</source>
-        <translation>Saknade</translation>
-    </message>
-    <message>
-        <source>Progression</source>
-        <translation>Utveckling</translation>
-    </message>
-    <message>
-        <source>Win Condition</source>
-        <translation>Villkor för att vinna</translation>
-    </message>
-    <message>
-        <source>{:.1f}% of players have this achievement</source>
-        <translation>{:.1f}% av spelarna har den här prestationen</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n unlocks have not been confirmed by the server.</source>
-        <comment>Pause Menu</comment>
-        <translation>
-            <numerusform>%n upplåsning har inte bekräftats av servern.</numerusform>
-            <numerusform>%n upplåsningar har inte bekräftats av servern.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Hardcore mode is disabled. Leaderboards will not be tracked.</source>
-        <translation>Hardcore-läget är inaktiverat. Ledartavlor kommer inte att följas.</translation>
-    </message>
-    <message>
-        <source>User is not logged in.</source>
-        <translation>Användaren är inte inloggad.</translation>
-    </message>
-    <message>
-        <source>Game database is already being updated.</source>
-        <translation>Speldatabasen uppdateras redan.</translation>
-    </message>
-    <message>
-        <source>Refresh game list failed</source>
-        <translation>Det gick inte att uppdatera spellistan</translation>
-    </message>
-    <message>
-        <source>Progress is already being updated.</source>
-        <translation>Framstegen är redan uppdaterade.</translation>
-    </message>
-    <message>
-        <source>Refresh all progress failed</source>
-        <translation>Uppdatering av alla framsteg misslyckades</translation>
-    </message>
-    <message>
-        <source>Unsupported Achievements</source>
-        <translation>Prestationer som inte stöds</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n achievements are not supported by DuckStation.</source>
-        <comment>Achievement popup</comment>
-        <translation>
-            <numerusform>%n prestation stöds inte av DuckStation.</numerusform>
-            <numerusform>%n prestationer stöds inte av DuckStation.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Challenge Started: {}</source>
-        <translation>Utmaning startad: {}</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n achievements are not supported by DuckStation and cannot be unlocked.</source>
-        <comment>Unsupported achievement count</comment>
-        <translation>
-            <numerusform>%n prestation stöds inte av DuckStation och kan inte låsas upp.</numerusform>
-            <numerusform>%n prestationer stöds inte av DuckStation och kan inte låsas upp.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Challenge Failed: {}</source>
-        <translation>Utmaning misslyckades: {}</translation>
-    </message>
-    <message>
-        <source>Last Progress Update</source>
-        <comment>Pause Menu</comment>
-        <translation>Senaste framstegsuppdatering</translation>
-    </message>
-    <message>
-        <source>Spectator mode enabled.</source>
-        <translation>Åskådarläge aktiverat.</translation>
-    </message>
-    <message>
-        <source>All achievements are locked, and unlocks will not be recorded in your account.</source>
-        <translation>Alla prestationer är låsta och upplåsningar registreras inte på ditt konto.</translation>
-    </message>
-    <message>
-        <source>Encore mode enabled.</source>
-        <translation>Encore-läge aktiverat.</translation>
-    </message>
-    <message>
-        <source>All achievements are locked, but unlocks will still be recorded in your account.</source>
-        <translation>Alla prestationer är låsta, men upplåsningar registreras fortfarande på ditt konto.</translation>
-    </message>
-    <message>
-        <source>Hardcore mode will be enabled on game restart.</source>
-        <translation>Hardcore-läget aktiveras när spelet startas om.</translation>
-    </message>
-    <message>
-        <source>Server error in {}</source>
-        <translation>Serverfel i {}</translation>
-    </message>
-    <message>
-        <source>An unlock request could not be completed.
-We will keep trying to submit this request.</source>
-        <translation>En upplåsningsbegäran kunde inte färdigställas.
-Vi kommer att fortsätta försöka skicka in begäran.</translation>
-    </message>
-    <message>
-        <source>Hardcore mode enabled.</source>
-        <translation>Hardcore-läget aktiverat.</translation>
-    </message>
-    <message>
-        <source>Hardcore mode disabled.</source>
-        <translation>Hardcore-läget inaktiverat.</translation>
-    </message>
-    <message>
-        <source>Restrictions are now active.</source>
-        <translation>Begränsningar är nu aktiva.</translation>
-    </message>
-    <message>
-        <source>Restrictions are no longer active.</source>
-        <translation>Begränsningar är inte längre aktiva.</translation>
-    </message>
-    <message>
-        <source>Score: {} ({} casual)
-Unread messages: {}</source>
-        <extracomment>Summary for login notification.</extracomment>
-        <translation>Poäng: {} ({} avslappnat)
-Olästa meddelanden: {}</translation>
-    </message>
-    <message>
-        <source>Score: {} ({} casual)</source>
-        <extracomment>Score summary, shown in Big Picture mode.</extracomment>
-        <translation>Poäng: {} ({} avslappnat)</translation>
-    </message>
-    <message>
-        <source>Refreshing game database...</source>
-        <translation>Uppdaterar speldatabasen...</translation>
-    </message>
-    <message>
-        <source>Achievements are not available.</source>
-        <translation>Prestationer är inte tillgängliga.</translation>
-    </message>
-    <message>
-        <source>Achievements are disabled in settings.</source>
-        <translation>Prestationer är inaktiverade i inställningarna.</translation>
-    </message>
-    <message>
-        <source>Leaderboards are not available.</source>
-        <translation>Ledartavlor är inte tillgängliga.</translation>
-    </message>
-    <message>
-        <source>This game has no leaderboards.</source>
-        <translation>Detta spel har inga ledartavlor.</translation>
-    </message>
-    <message>
-        <source>Refreshing achievement progress...</source>
-        <translation>Uppdaterar prestationsförlopp...</translation>
-    </message>
-    <message>
-        <source>Core</source>
-        <translation>Kärna</translation>
-    </message>
-    <message>
-        <source>{0} - {1}</source>
-        <translation>{0} - {1}</translation>
-    </message>
-    <message>
-        <source>This subset has no achievements.</source>
-        <translation>Denna deluppsättning har inga prestationer.</translation>
-    </message>
-    <message>
-        <source>Change Subset</source>
-        <translation>Ändra deluppsättning</translation>
-    </message>
-    <message numerus="yes">
-        <source>This subset has %n leaderboards.</source>
-        <comment>Leaderboard count</comment>
-        <translation>
-            <numerusform>Denna deluppsättning har %n ledartavla.</numerusform>
-            <numerusform>Denna deluppsättning har %n ledartavlor.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>Game complete.
-{0} and {1}.</source>
-        <translation>Spelet är färdigställt.
-{0} och {1}.</translation>
-    </message>
-    <message>
-        <source>Subset complete.
-{0} and {1}.</source>
-        <translation>Deluppsättning färdigställt.
-{0} och {1}.</translation>
-    </message>
-    <message>
-        <source>Your Time: {}</source>
-        <translation>Din tid: {}</translation>
-    </message>
-    <message>
-        <source>Your Value: {}</source>
-        <translation>Ditt värde: {}</translation>
-    </message>
-    <message>
-        <source>Active Leaderboard Attempts</source>
-        <comment>Pause Menu</comment>
-        <translation>Aktiva försök för ledartavlor</translation>
-    </message>
-    <message numerus="yes">
-        <source>You have unlocked all achievements in this subset and earned %n points!</source>
-        <comment>Point count</comment>
-        <translation>
-            <numerusform>Du har låst upp alla prestationer i denna deluppsättning och tjänat %n poäng!</numerusform>
-            <numerusform>Du har låst upp alla prestationer i denna deluppsättning och tjänat %n poäng!</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>You have unlocked {0} of {1} achievements in this subset, earning {2} of {3} possible points.</source>
-        <translation>Du har låst upp {0} av {1} prestationer i denna deluppsättning och tjänat {2} av {3} möjliga poäng.</translation>
-    </message>
-    <message>
-        <source>Not Confirmed</source>
-        <translation>Inte bekräftad</translation>
-    </message>
-    <message>
-        <source>Pin Achievement</source>
-        <translation>Fäst prestation</translation>
-    </message>
-</context>
-<context>
     <name>AdvancedSettingsWidget</name>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="79"/>
+        <location filename="../advancedsettingswidget.cpp" line="82"/>
+        <location filename="../advancedsettingswidget.cpp" line="99"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="29"/>
         <source>Logging</source>
         <translation>Loggning</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="35"/>
         <source>Log Level:</source>
         <translation>Loggnivå:</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="52"/>
         <source>Log Channels</source>
         <translation>Loggkanaler</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="65"/>
+        <location filename="../advancedsettingswidget.cpp" line="67"/>
         <source>Log To System Console</source>
         <translation>Logga till systemkonsol</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="79"/>
+        <location filename="../advancedsettingswidget.cpp" line="71"/>
         <source>Log To Window</source>
         <translation>Logga till fönster</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="112"/>
         <source>Interface Settings</source>
         <translation>Gränssnittsinställningar</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="125"/>
+        <location filename="../advancedsettingswidget.cpp" line="82"/>
         <source>Rich Presence Monitor</source>
         <translation>Rich Presence-övervakare</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="132"/>
         <source>Enable RAIntegration</source>
         <translation>Aktivera RAIntegration</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="142"/>
+        <location filename="../advancedsettingswidget.cpp" line="85"/>
         <source>Cache Directory</source>
         <translation>Cachekatalog</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="148"/>
         <source>Used for storing compiled shaders and game list data.</source>
         <translation>Används för att lagra kompilerade shaders och data för spellistan.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="158"/>
+        <location filename="../advancedsettingswidget.ui" line="210"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="169"/>
+        <location filename="../advancedsettingswidget.ui" line="221"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="180"/>
+        <location filename="../advancedsettingswidget.ui" line="232"/>
         <source>Reset</source>
         <translation>Återställ</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="194"/>
+        <location filename="../advancedsettingswidget.cpp" line="87"/>
         <source>Covers Directory</source>
         <translation>Omslagskatalog</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="200"/>
         <source>Used for storing covers in the game grid/Big Picture UIs.</source>
         <translation>Används för att lagra omslag i spelrutnätet/Storbildsläge.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="246"/>
         <source>Web Cache</source>
         <translation>Webbcache</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="259"/>
         <source>Refresh</source>
         <translation>Uppdatera</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="270"/>
         <source>Clear</source>
         <translation>Töm</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="72"/>
+        <location filename="../advancedsettingswidget.cpp" line="69"/>
         <source>Log To Debug Console</source>
         <translation>Logga till felsökningskonsol</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="86"/>
+        <location filename="../advancedsettingswidget.cpp" line="73"/>
         <source>Log To File</source>
         <translation>Logga till fil</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="118"/>
+        <location filename="../advancedsettingswidget.cpp" line="79"/>
         <source>Show Debug Menu</source>
         <translation>Visa felsökningsmeny</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="54"/>
         <source>Select Cache Directory</source>
         <translation>Välj cachekatalog</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="57"/>
         <source>Select Covers Directory</source>
         <translation>Välj omslagskatalog</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="65"/>
         <source>Log Level</source>
         <translation>Loggnivå</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="65"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="66"/>
         <source>Sets the verbosity of messages logged. Higher levels will log more messages.</source>
         <translation>Ställer in nivån av meddelanden som loggas. Högre nivåer kommer logga fler meddelanden.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="67"/>
+        <location filename="../advancedsettingswidget.cpp" line="69"/>
+        <location filename="../advancedsettingswidget.cpp" line="71"/>
+        <location filename="../advancedsettingswidget.cpp" line="73"/>
+        <location filename="../advancedsettingswidget.cpp" line="75"/>
+        <location filename="../advancedsettingswidget.cpp" line="77"/>
         <source>User Preference</source>
         <translation>Användarinställningar</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="68"/>
         <source>Logs messages to the console window.</source>
         <translation>Loggar meddelanden till konsollfönstret.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="70"/>
         <source>Logs messages to the debug console where supported.</source>
         <translation>Loggar meddelanden till felsökningskonsollen där det stöds.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="72"/>
         <source>Logs messages to the window.</source>
         <translation>Loggar meddelanden till fönstret.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="74"/>
         <source>Logs messages to duckstation.log in the user directory.</source>
         <translation>Loggar meddelanden till duckstation.log i användarkatalogen.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="80"/>
         <source>Shows a debug menu bar with additional statistics and quick settings.</source>
         <translation>Visar en felsökningsmenyrad med ytterligare statistik och snabbinställningar.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="83"/>
         <source>Always displays the current RetroAchievements rich presence string in the indicator area.</source>
         <translation>Visar alltid den aktuella RetroAchievements Rich Presence-strängen i indikatorområdet.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="85"/>
+        <location filename="../advancedsettingswidget.cpp" line="87"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="86"/>
         <source>Specifies the directory where compiled shaders and game list data will be stored.</source>
         <translation>Anger katalogen där kompilerade shaders och data för spellistan ska lagras.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="88"/>
         <source>Specifies the directory where game cover images that are used in the game grid and Big Picture UI will be stored.</source>
         <translation>Anger katalogen där spelomslag som används i spelrutnätet och storbildsgränssnittet ska lagras.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="99"/>
         <source>Enable RAIntegration (Development Only)</source>
         <translation>Aktivera RAIntegration (endast för utveckling)</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="100"/>
         <source>When enabled, DuckStation will load the RAIntegration DLL which allows for achievement development.&lt;br&gt;The RA_Integration.dll file must be placed in the same directory as the DuckStation executable.</source>
         <translation>När den är aktiverad läser DuckStation in RAIntegration DLL vilket möjliggör utveckling av prestationer.&lt;br&gt;Filen RA_Integration.dll måste placeras i samma katalog som DuckStations-körbara fil.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="143"/>
         <source>Current Cache Size: %1 MB (%2 MB in %3 objects)</source>
         <translation>Aktuell cachestorlek: %1 MB (%2 MB i %3 objekt)</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="93"/>
+        <location filename="../advancedsettingswidget.cpp" line="75"/>
         <source>Log Timestamps</source>
         <translation>Logga tidsstämplar</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.ui" line="100"/>
+        <location filename="../advancedsettingswidget.cpp" line="77"/>
         <source>Log File Timestamps</source>
         <translation>Tidsstämplar för loggfil</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="76"/>
         <source>Includes the elapsed time since the application start in window and console logs.</source>
         <translation>Inkluderar den tid som har förflutit sedan applikationen startade i fönster- och konsolloggar.</translation>
     </message>
     <message>
+        <location filename="../advancedsettingswidget.cpp" line="78"/>
         <source>Includes the elapsed time since the application start in file logs.</source>
         <translation>Inkluderar den tid som förflutit sedan programmet startades i filloggarna.</translation>
     </message>
 </context>
 <context>
-    <name>AnalogController</name>
-    <message>
-        <source>Controller {} switched to analog mode.</source>
-        <translation>Handkontroller {} växlades till analogt läge.</translation>
-    </message>
-    <message>
-        <source>Controller {} switched to digital mode.</source>
-        <translation>Handkontroller {} växlades till digitalt läge.</translation>
-    </message>
-    <message>
-        <source>Controller {} is locked to analog mode by the game.</source>
-        <translation>Handkontroller {} växlades till analogt läge av spelet.</translation>
-    </message>
-    <message>
-        <source>Controller {} is locked to digital mode by the game.</source>
-        <translation>Handkontroller {} växlades till digitalt läge av spelet.</translation>
-    </message>
-    <message>
-        <source>D-Pad Up</source>
-        <translation>Riktningsknapp upp</translation>
-    </message>
-    <message>
-        <source>D-Pad Right</source>
-        <translation>Riktningsknapp höger</translation>
-    </message>
-    <message>
-        <source>D-Pad Down</source>
-        <translation>Riktningsknapp ner</translation>
-    </message>
-    <message>
-        <source>D-Pad Left</source>
-        <translation>Riktningsknapp vänster</translation>
-    </message>
-    <message>
-        <source>Triangle</source>
-        <translation>Triangel</translation>
-    </message>
-    <message>
-        <source>Circle</source>
-        <translation>Cirkel</translation>
-    </message>
-    <message>
-        <source>Cross</source>
-        <translation>Kryss</translation>
-    </message>
-    <message>
-        <source>Square</source>
-        <translation>Fyrkant</translation>
-    </message>
-    <message>
-        <source>Select</source>
-        <translation>Select</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>Analog Toggle</source>
-        <translation>Analog växling</translation>
-    </message>
-    <message>
-        <source>L1</source>
-        <translation>L1</translation>
-    </message>
-    <message>
-        <source>R1</source>
-        <translation>R1</translation>
-    </message>
-    <message>
-        <source>L2</source>
-        <translation>L2</translation>
-    </message>
-    <message>
-        <source>R2</source>
-        <translation>R2</translation>
-    </message>
-    <message>
-        <source>L3</source>
-        <translation>L3</translation>
-    </message>
-    <message>
-        <source>R3</source>
-        <translation>R3</translation>
-    </message>
-    <message>
-        <source>Left Stick Left</source>
-        <translation>Vänster spak vänster</translation>
-    </message>
-    <message>
-        <source>Left Stick Right</source>
-        <translation>Vänster spak höger</translation>
-    </message>
-    <message>
-        <source>Left Stick Down</source>
-        <translation>Vänster spak ner</translation>
-    </message>
-    <message>
-        <source>Left Stick Up</source>
-        <translation>Vänster spak upp</translation>
-    </message>
-    <message>
-        <source>Right Stick Left</source>
-        <translation>Höger spak vänster</translation>
-    </message>
-    <message>
-        <source>Right Stick Right</source>
-        <translation>Höger spak höger</translation>
-    </message>
-    <message>
-        <source>Right Stick Down</source>
-        <translation>Höger spak ner</translation>
-    </message>
-    <message>
-        <source>Right Stick Up</source>
-        <translation>Höger spak upp</translation>
-    </message>
-    <message>
-        <source>Large Motor</source>
-        <translation>Stor motor</translation>
-    </message>
-    <message>
-        <source>Small Motor</source>
-        <translation>Liten motor</translation>
-    </message>
-    <message>
-        <source>Not Inverted</source>
-        <translation>Inte inverterad</translation>
-    </message>
-    <message>
-        <source>Invert Left/Right</source>
-        <translation>Invertera vänster/höger</translation>
-    </message>
-    <message>
-        <source>Invert Up/Down</source>
-        <translation>Invertera upp/ner</translation>
-    </message>
-    <message>
-        <source>Invert Left/Right + Up/Down</source>
-        <translation>Invertera vänster/höger + upp/ner</translation>
-    </message>
-    <message>
-        <source>Disable Simultaneous Opposing Cardinal Directions</source>
-        <translation>Inaktivera samtidiga motsatta riktningar</translation>
-    </message>
-    <message>
-        <source>Prevents concurrent left/right or up/down inputs from being presented to the game.</source>
-        <translation>Förhindrar att samtidiga inmatningar åt vänster/höger eller upp/ner presenteras för spelet.</translation>
-    </message>
-    <message>
-        <source>Allows you to use the right analog stick to control the shoulder buttons (L1/R1), as well as the buttons.</source>
-        <translation>Låter dig använda höger analogspak för att styra axelknapparna (L1/R1) samt knapparna.</translation>
-    </message>
-    <message>
-        <source>Use Right Analog for Trigger Buttons</source>
-        <translation>Använd höger analogspak för avtryckarknappar</translation>
-    </message>
-    <message>
-        <source>Allows you to use the right analog stick to control the trigger buttons (L2/R2), as well as the buttons.</source>
-        <translation>Låter dig använda höger analogspak för att styra avtryckarknapparna (L2/R2) samt knapparna.</translation>
-    </message>
-    <message>
-        <source>Analog Deadzone</source>
-        <translation>Analogt dödläge</translation>
-    </message>
-    <message>
-        <source>Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.</source>
-        <translation>Ställer in dödläget för analoga spaken, alltså den del av spakrörelser som kommer att ignoreras.</translation>
-    </message>
-    <message>
-        <source>Analog Sensitivity</source>
-        <translation>Analog känslighet</translation>
-    </message>
-    <message>
-        <source>Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent controllers, e.g. DualShock 4, Xbox One Controller.</source>
-        <translation>Ställer in skalningsfaktorn för den analoga spakens axlar. Ett värde mellan 130% och 140% rekommenderas när senare handkontroller används, t.ex. DualShock 4, Xbox One-handkontroller.</translation>
-    </message>
-    <message>
-        <source>Button/Trigger Deadzone</source>
-        <translation>Dödläge för knapp/skjutknapp</translation>
-    </message>
-    <message>
-        <source>Sets the deadzone for activating buttons/triggers, i.e. the fraction of the trigger which will be ignored.</source>
-        <translation>Ställer in dödläget för aktivering av knappar/skjutknappar, alltså den del av knappen  som kommer att ignoreras.</translation>
-    </message>
-    <message>
-        <source>Large Motor Vibration Bias</source>
-        <translation>Vibrationsjustering för stor motor</translation>
-    </message>
-    <message>
-        <source>Sets the bias value for the large vibration motor. If vibration in some games is too weak or not functioning, try increasing this value. Negative values will decrease the intensity of vibration.</source>
-        <translation>Anger justeringsvärdet för stor vibrationsmotor. Om vibrationen i vissa spel är för svag eller inte fungerar så prova att öka detta värde. Negativa värden kommer att sänka intensiteten för vibrationen.</translation>
-    </message>
-    <message>
-        <source>Small Motor Vibration Bias</source>
-        <translation>Vibrationsjustering för liten  motor</translation>
-    </message>
-    <message>
-        <source>Sets the bias value for the small vibration motor. If vibration in some games is too weak or not functioning, try increasing this value. Negative values will decrease the intensity of vibration.</source>
-        <translation>Anger justeringsvärdet för liten vibrationsmotor. Om vibrationen i vissa spel är för svag eller inte fungerar så prova att öka detta värde. Negativa värden kommer att sänka intensiteten för vibrationen.</translation>
-    </message>
-    <message>
-        <source>Invert Left Stick</source>
-        <translation>Invertera vänster spak</translation>
-    </message>
-    <message>
-        <source>Inverts the direction of the left analog stick.</source>
-        <translation>Inverterar riktningen för den vänstra analoga spaken.</translation>
-    </message>
-    <message>
-        <source>Invert Right Stick</source>
-        <translation>Invertera höger spak</translation>
-    </message>
-    <message>
-        <source>Inverts the direction of the right analog stick.</source>
-        <translation>Inverterar riktningen för den högra analoga spaken.</translation>
-    </message>
-    <message>
-        <source>Never</source>
-        <translation>Aldrig</translation>
-    </message>
-    <message>
-        <source>Digital Mode Only</source>
-        <translation>Endast digitalt läge</translation>
-    </message>
-    <message>
-        <source>Analog and Digital Modes</source>
-        <translation>Analoga och digitala lägen</translation>
-    </message>
-    <message>
-        <source>Automatically Enable Analog Mode</source>
-        <translation>Aktivera analogt läge automatiskt</translation>
-    </message>
-    <message>
-        <source>Forces the controller to analog mode when the game is started/restarted.</source>
-        <translation>Tvingar handkontrollen till analogt läge när spelet startas eller startas om.</translation>
-    </message>
-    <message>
-        <source>Use Left Analog for D-Pad in Digital Mode</source>
-        <translation>Använd vänster analog som riktningsknappar i digitalt läge</translation>
-    </message>
-    <message>
-        <source>Allows you to use the left analog stick to control the d-pad in digital mode, as well as the buttons.</source>
-        <translation>Gör att du kan använda den vänstra analoga spaken för att styra riktningsknapparna i digitalt läge, samt knapparna.</translation>
-    </message>
-    <message>
-        <source>Use Right Analog for Shoulder Buttons</source>
-        <translation>Använd höger analog för axelknapparna</translation>
-    </message>
-    <message>
-        <source>Analog LED</source>
-        <translation>Analog LED</translation>
-    </message>
-    <message>
-        <source>Mode LED</source>
-        <translation>Mode LED</translation>
-    </message>
-</context>
-<context>
-    <name>AnalogJoystick</name>
-    <message>
-        <source>D-Pad Up</source>
-        <translation>Riktningsknapp upp</translation>
-    </message>
-    <message>
-        <source>D-Pad Right</source>
-        <translation>Riktningsknapp höger</translation>
-    </message>
-    <message>
-        <source>D-Pad Down</source>
-        <translation>Riktningsknapp ner</translation>
-    </message>
-    <message>
-        <source>D-Pad Left</source>
-        <translation>Riktningsknapp vänster</translation>
-    </message>
-    <message>
-        <source>Triangle</source>
-        <translation>Triangel</translation>
-    </message>
-    <message>
-        <source>Circle</source>
-        <translation>Cirkel</translation>
-    </message>
-    <message>
-        <source>Cross</source>
-        <translation>Kryss</translation>
-    </message>
-    <message>
-        <source>Square</source>
-        <translation>Fyrkant</translation>
-    </message>
-    <message>
-        <source>Select</source>
-        <translation>Select</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>Mode Toggle</source>
-        <translation>Lägesväxling</translation>
-    </message>
-    <message>
-        <source>L1</source>
-        <translation>L1</translation>
-    </message>
-    <message>
-        <source>R1</source>
-        <translation>R1</translation>
-    </message>
-    <message>
-        <source>L2</source>
-        <translation>L2</translation>
-    </message>
-    <message>
-        <source>R2</source>
-        <translation>R2</translation>
-    </message>
-    <message>
-        <source>L3</source>
-        <translation>L3</translation>
-    </message>
-    <message>
-        <source>R3</source>
-        <translation>R3</translation>
-    </message>
-    <message>
-        <source>Left Stick Left</source>
-        <translation>Vänster spak vänster</translation>
-    </message>
-    <message>
-        <source>Left Stick Right</source>
-        <translation>Vänster spak höger</translation>
-    </message>
-    <message>
-        <source>Left Stick Down</source>
-        <translation>Vänster spak ner</translation>
-    </message>
-    <message>
-        <source>Left Stick Up</source>
-        <translation>Vänster spak upp</translation>
-    </message>
-    <message>
-        <source>Right Stick Left</source>
-        <translation>Höger spak vänster</translation>
-    </message>
-    <message>
-        <source>Right Stick Right</source>
-        <translation>Höger spak höger</translation>
-    </message>
-    <message>
-        <source>Right Stick Down</source>
-        <translation>Höger spak ner</translation>
-    </message>
-    <message>
-        <source>Right Stick Up</source>
-        <translation>Höger spak upp</translation>
-    </message>
-    <message>
-        <source>Not Inverted</source>
-        <translation>Inte inverterad</translation>
-    </message>
-    <message>
-        <source>Invert Left/Right</source>
-        <translation>Invertera vänster/höger</translation>
-    </message>
-    <message>
-        <source>Invert Up/Down</source>
-        <translation>Invertera upp/ner</translation>
-    </message>
-    <message>
-        <source>Invert Left/Right + Up/Down</source>
-        <translation>Invertera vänster/höger + Upp/Ner</translation>
-    </message>
-    <message>
-        <source>Disable Simultaneous Opposing Cardinal Directions</source>
-        <translation>Inaktivera samtidiga motsatta riktningar</translation>
-    </message>
-    <message>
-        <source>Prevents concurrent left/right or up/down inputs from being presented to the game.</source>
-        <translation>Förhindrar att samtidiga inmatningar åt vänster/höger eller upp/ner presenteras för spelet.</translation>
-    </message>
-    <message>
-        <source>Analog Deadzone</source>
-        <translation>Analogt dödläge</translation>
-    </message>
-    <message>
-        <source>Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.</source>
-        <translation>Ställer in dödläget för analoga spaken, alltså den del av spakrörelser som kommer att ignoreras.</translation>
-    </message>
-    <message>
-        <source>Analog Sensitivity</source>
-        <translation>Analog känslighet</translation>
-    </message>
-    <message>
-        <source>Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent controllers, e.g. DualShock 4, Xbox One Controller.</source>
-        <translation>Ställer in skalningsfaktorn för den analoga spakens axlar. Ett värde mellan 130% och 140% rekommenderas när senare handkontroller används, t.ex. DualShock 4, Xbox One-handkontroller.</translation>
-    </message>
-    <message>
-        <source>Invert Left Stick</source>
-        <translation>Invertera vänster spak</translation>
-    </message>
-    <message>
-        <source>Inverts the direction of the left analog stick.</source>
-        <translation>Inverterar riktningen för den vänstra analoga spaken.</translation>
-    </message>
-    <message>
-        <source>Invert Right Stick</source>
-        <translation>Invertera höger spak</translation>
-    </message>
-    <message>
-        <source>Inverts the direction of the right analog stick.</source>
-        <translation>Inverterar riktningen för den högra analoga spaken.</translation>
-    </message>
-    <message>
-        <source>Mode LED</source>
-        <translation>Mode LED</translation>
-    </message>
-</context>
-<context>
     <name>AudioSettingsWidget</name>
     <message>
+        <location filename="../audiosettingswidget.ui" line="162"/>
         <source>Configuration</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="229"/>
         <source>Buffer Size:</source>
         <translation>Buffertstorlek:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="168"/>
         <source>Backend:</source>
         <translation>Bakände:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="266"/>
+        <location filename="../audiosettingswidget.ui" line="320"/>
+        <location filename="../audiosettingswidget.ui" line="390"/>
+        <location filename="../audiosettingswidget.ui" line="446"/>
+        <location filename="../audiosettingswidget.ui" line="502"/>
         <source>0 ms</source>
         <translation>0 ms</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="29"/>
         <source>Controls</source>
         <translation>Kontroller</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="35"/>
         <source>Output Volume:</source>
         <translation>Utmatningsvolym:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="67"/>
+        <location filename="../audiosettingswidget.ui" line="120"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="88"/>
         <source>Fast Forward Volume:</source>
         <translation>Volym för snabbspolning:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="143"/>
+        <location filename="../audiosettingswidget.cpp" line="114"/>
         <source>Mute All Sound</source>
         <translation>Tysta allt ljud</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="150"/>
+        <location filename="../audiosettingswidget.cpp" line="116"/>
         <source>Mute CD Audio</source>
         <translation>Tysta cd-ljud</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="286"/>
         <source>Output Latency:</source>
         <translation>Utmatningslatens:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="327"/>
         <source>Minimal</source>
         <translation>Minimal</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="212"/>
         <source>Stretch Mode:</source>
         <translation>Sträckläge:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="195"/>
         <source>Output Device:</source>
         <translation>Utmatningsenhet:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="193"/>
+        <location filename="../audiosettingswidget.cpp" line="240"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="105"/>
         <source>Output Latency</source>
         <translation>Utmatningslatens</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="349"/>
+        <location filename="../audiosettingswidget.cpp" line="350"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="123"/>
+        <location filename="../audiosettingswidget.cpp" line="126"/>
+        <location filename="../audiosettingswidget.cpp" line="149"/>
+        <location filename="../audiosettingswidget.cpp" line="152"/>
+        <location filename="../audiosettingswidget.cpp" line="155"/>
+        <location filename="../audiosettingswidget.cpp" line="283"/>
         <source>N/A</source>
         <translation>Inte tillgängligt</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="79"/>
+        <location filename="../audiosettingswidget.cpp" line="82"/>
+        <location filename="../audiosettingswidget.cpp" line="406"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="94"/>
         <source>Audio Backend</source>
         <translation>Ljudbakände</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="95"/>
         <source>The audio backend determines how frames produced by the emulator are submitted to the host. Cubeb provides the lowest latency, if you encounter issues, try the SDL backend. The null backend disables all host audio output.</source>
         <translation>Ljudbakänden bestämmer hur ljud produceras av emulatorn skickas till värden. Cubeb tillhandahåller lägsta latensen, om du påträffar problem, prova SDL-bakänden. Null-bakänden inaktiverar all ljudutmatning på värden.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="34"/>
+        <location filename="../audiosettingswidget.cpp" line="41"/>
+        <location filename="../audiosettingswidget.cpp" line="44"/>
+        <location filename="../audiosettingswidget.cpp" line="47"/>
+        <location filename="../audiosettingswidget.cpp" line="99"/>
+        <location filename="../audiosettingswidget.cpp" line="105"/>
+        <location filename="../audiosettingswidget.cpp" line="130"/>
+        <location filename="../audiosettingswidget.cpp" line="134"/>
+        <location filename="../audiosettingswidget.cpp" line="138"/>
+        <location filename="../audiosettingswidget.cpp" line="283"/>
+        <location filename="../audiosettingswidget.cpp" line="427"/>
+        <location filename="../audiosettingswidget.cpp" line="443"/>
+        <location filename="../audiosettingswidget.cpp" line="459"/>
+        <location filename="../audiosettingswidget.cpp" line="471"/>
         <source>%1 ms</source>
         <translation>%1 ms</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="100"/>
         <source>The buffer size determines the size of the chunks of audio which will be pulled by the host. Smaller values reduce the output latency, but may cause hitches if the emulation speed is inconsistent. Note that the Cubeb backend uses smaller chunks regardless of this value, so using a low value here may not significantly change latency.</source>
         <translation>Buffertstorleken bestämmer storleken på de ljudbitar som ska hämtas av värden. Mindre värden minskar utmatningslatensen, men kan orsaka problem om emuleringshastigheten är inkonsekvent. Observera att Cubeb-backend använder mindre bitar oavsett detta värde, så att använda ett lågt värde här kanske inte ändrar latensen nämnvärt.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="110"/>
         <source>Output Volume</source>
         <translation>Utmatningsvolym</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="111"/>
         <source>Controls the volume of the audio played on the host.</source>
         <translation>Styr volymen för ljudet som spelas på värden.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="112"/>
         <source>Fast Forward Volume</source>
         <translation>Snabbspolningsvolym</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="113"/>
         <source>Controls the volume of the audio played on the host when fast forwarding.</source>
         <translation>Styr volymen för ljudet som spelas på värden vid snabbspolning.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="108"/>
+        <location filename="../audiosettingswidget.cpp" line="114"/>
+        <location filename="../audiosettingswidget.cpp" line="116"/>
+        <location filename="../audiosettingswidget.cpp" line="142"/>
+        <location filename="../audiosettingswidget.cpp" line="146"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="115"/>
         <source>Prevents the emulator from producing any audible sound.</source>
         <translation>Förhindrar att emulatorn skapar någon form av ljud.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="117"/>
         <source>Forcibly mutes both CD-DA and XA audio from the CD-ROM. Can be used to disable background music in some games.</source>
         <translation>Tvingar både CD-DA och XA-ljud från cd-rom att vara tyst. Kan användas för att inaktivera bakgrundsmusik i vissa spel.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="120"/>
         <source>Stretch Mode</source>
         <translation>Sträckläge</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="349"/>
+        <location filename="../audiosettingswidget.cpp" line="120"/>
         <source>Time Stretching</source>
         <translation>Tidssträckning</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="121"/>
         <source>When running outside of 100% speed, adjusts the tempo on audio instead of dropping frames. Produces much nicer fast forward/slowdown audio at a small cost to performance.</source>
         <translation>Vid körning utanför 100% hastighet justeras tempot på ljudet istället för att släppa bildrutor. Ger mycket finare ljud vid snabbspolning framåt/hastighetssänkning till en liten bekostnad av prestandan.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="124"/>
+        <location filename="../audiosettingswidget.cpp" line="127"/>
         <source>Resets volume back to the global/inherited setting.</source>
         <translation>Nollställer volymen tillbaka till global/ärvd inställning.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="125"/>
+        <location filename="../audiosettingswidget.cpp" line="128"/>
         <source>Resets volume back to the default, i.e. full.</source>
         <translation>Nollställer volymen tillbaka till standard, t.ex full.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="123"/>
         <source>Reset Volume</source>
         <translation>Nollställ volym</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="130"/>
+        <location filename="../audiosettingswidget.cpp" line="126"/>
         <source>Reset Fast Forward Volume</source>
         <translation>Nollställ snabbspolningsvolym</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="324"/>
         <source>Maximum Latency: %1 ms (%2 ms buffer + %3 ms output)</source>
         <translation>Maximal latens: %1 ms (%2 ms buffert + %3 ms utdata)</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="342"/>
         <source>Maximum Latency: %1 ms (minimum output latency unknown)</source>
         <translation>Maximal latens: %1 ms (minimum utdatalatens okänd)</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="77"/>
         <source>Reset Output Volume</source>
         <translation>Återställ utmatningsvolym</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="99"/>
         <source>Buffer Size</source>
         <translation>Buffertstorlek</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="106"/>
         <source>Determines how much latency there is between the audio being picked up by the host API, and played through speakers.</source>
         <translation>Bestämmer hur stor fördröjning det är mellan det att ljudet plockas upp av värd-API:et och spelas upp i högtalarna.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="108"/>
         <source>Minimal Output Latency</source>
         <translation>Minimal utdatalatens</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="109"/>
         <source>When enabled, the minimum supported output latency will be used for the host API.</source>
         <translation>När den är aktiverad används den minsta stödda utmatningslatensen för värd-API:et.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="261"/>
         <source>%1 [Unavailable]</source>
         <translation>%1 [inte tillgänglig]</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="316"/>
         <source>Maximum Latency: %1 ms (%2 ms stretch + %3 ms buffer + %4 ms output)</source>
         <translation>Maximal latens: %1 ms (%2 ms utsträckning + %3 ms buffert + %4 ms utgång)</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="335"/>
         <source>Maximum Latency: %1 ms (%2 ms stretch + %3 ms buffer, minimum output latency unknown)</source>
         <translation>Maximal latens: %1 ms (%2 ms utsträckning + %3 ms buffert, minsta utgångslatens okänd)</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="273"/>
         <source>Reset Buffer Size</source>
         <translation>Återställ buffertstorlek</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="336"/>
         <source>Maximum Latency: 0 ms (0 ms stretch + 0 ms buffer + 0 ms output)</source>
         <translation>Maximal latens: 0 ms (0 ms utsträckning + 0 ms buffert + 0 ms utmatning)</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="355"/>
         <source>Sequence Length:</source>
         <translation>Sekvenslängd:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="400"/>
+        <location filename="../audiosettingswidget.cpp" line="149"/>
         <source>Reset Sequence Length</source>
         <translation>Återställ sekvenslängd</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="411"/>
         <source>Seek Window:</source>
         <translation>Spolningsfönster:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="456"/>
+        <location filename="../audiosettingswidget.cpp" line="152"/>
         <source>Reset Seek Window</source>
         <translation>Återställ spolningsfönster</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="467"/>
         <source>Overlap:</source>
         <translation>Överlappning:</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="512"/>
+        <location filename="../audiosettingswidget.cpp" line="155"/>
         <source>Reset Overlap</source>
         <translation>Återställ överlappning</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="525"/>
         <source>Use Quick Seek</source>
         <translation>Använd snabbspolning</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.ui" line="532"/>
         <source>Use Anti-Aliasing Filter</source>
         <translation>Använd kantutjämningsfilter</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="129"/>
         <source>Stretch Sequence Length</source>
         <translation>Sträck ut sekvenslängd</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="131"/>
         <source>Determines how long individual sequences are when the time-stretch algorithm chops the audio. Longer sequences can improve quality but increase latency.</source>
         <translation>Bestämmer hur långa enskilda sekvenser är när tidssträckningsalgoritmen delar upp ljudet. Längre sekvenser kan förbättra kvaliteten men öka latensen.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="134"/>
         <source>Stretch Seek Window</source>
         <translation>Sträck ut spolningsfönster</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="135"/>
         <source>Controls how wide a window the algorithm searches for the best overlap position when joining consecutive sequences. Larger windows may yield better joins at the cost of increased CPU work.</source>
         <translation>Styr hur stort ett fönster är som algoritmen söker efter den bästa överlappningspositionen när den sammanfogar på varandra följande sekvenser. Större fönster kan ge bättre sammanfogningar, men kräver mer CPU-kraft.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="137"/>
         <source>Stretch Overlap Length</source>
         <translation>Sträck ut överlappningslängd</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="139"/>
         <source>Specifies how long two consecutive sequences are overlapped when mixed back together. Greater overlap can make transitions smoother but increases latency.</source>
         <translation>Anger hur länge två på varandra följande sekvenser överlappar varandra när de blandas ihop igen. Större överlappning kan göra övergångarna mjukare men ökar latensen.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="141"/>
         <source>Enable Quick Seek</source>
         <translation>Aktivera snabbspolning</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="142"/>
+        <location filename="../audiosettingswidget.cpp" line="146"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="143"/>
         <source>Enables the quick seeking algorithm in the time-stretch routine. Reduces CPU usage at a minor cost to audio quality.</source>
         <translation>Aktiverar algoritmen för snabb sökning i tidssträckningsrutinen. Minskar CPU-användningen till en mindre kostnad för ljudkvaliteten.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="145"/>
         <source>Enable Anti-Alias Filter</source>
         <translation>Använd kantutjämningsfilter</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="147"/>
         <source>Enables an anti-aliasing filter used by the pitch transposer. Disabling it may reduce quality when pitch shifting but can slightly reduce CPU usage.</source>
         <translation>Aktiverar ett kantutjämningsfilter som används av tonhöjdstransponeraren. Om du inaktiverar det kan kvaliteten försämras vid tonhöjdsförskjutning, men CPU-användningen kan minska något.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="150"/>
+        <location filename="../audiosettingswidget.cpp" line="153"/>
+        <location filename="../audiosettingswidget.cpp" line="156"/>
         <source>Resets value back to the global/inherited setting.</source>
         <translation>Återställer värdet till den globala/ärvda inställningen.</translation>
     </message>
     <message>
+        <location filename="../audiosettingswidget.cpp" line="151"/>
+        <location filename="../audiosettingswidget.cpp" line="154"/>
+        <location filename="../audiosettingswidget.cpp" line="157"/>
         <source>Resets value back to the default.</source>
         <translation>Återställer värdet tillbaka till standard.</translation>
     </message>
 </context>
 <context>
-    <name>AudioStream</name>
-    <message>
-        <source>Default</source>
-        <translation>Standard</translation>
-    </message>
-</context>
-<context>
     <name>AutoUpdaterDialog</name>
     <message>
+        <location filename="../autoupdaterdialog.ui" line="14"/>
+        <location filename="../autoupdaterdialog.cpp" line="393"/>
         <source>Automatic Updater</source>
         <translation>Automatisk uppdatering</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.ui" line="58"/>
         <source>Update Available</source>
         <translation>Uppdatering tillgänglig</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.ui" line="77"/>
         <source>Current Version: </source>
         <translation>Aktuell version: </translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.ui" line="92"/>
         <source>New Version: </source>
         <translation>Ny version: </translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.ui" line="107"/>
         <source>Download Size:</source>
         <translation>Hämtningsstorlek:</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.ui" line="144"/>
         <source>Download and Install...</source>
         <translation>Hämta och installera...</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.ui" line="151"/>
         <source>Skip This Update</source>
         <translation>Hoppa över denna uppdatering</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.ui" line="158"/>
         <source>Remind Me Later</source>
         <translation>Påminn mig senare</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="192"/>
         <source>Do not show again</source>
         <translation>Visa inte igen</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="297"/>
         <source>Failed to retrieve or download update:
 
 %1
@@ -1906,579 +1241,634 @@ You can manually update DuckStation by re-downloading the latest release. Do you
 Du kan uppdatera DuckStation manuellt genom att hämta ner den senaste utgåvan igen. Vill du öppna hämtningssidan nu?</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="300"/>
+        <location filename="../autoupdaterdialog.cpp" line="844"/>
         <source>Updater Error</source>
         <translation>Fel vid uppdatering</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="394"/>
         <source>No updates are currently available. Please try again later.</source>
         <translation>Inga uppdateringar finns för närvarande tillgängliga. Försök igen senare.</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="464"/>
+        <location filename="../autoupdaterdialog.cpp" line="468"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="471"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="474"/>
         <source>Loading...</source>
         <translation>Läser in...</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="521"/>
         <source>&lt;h2&gt;Changes:&lt;/h2&gt;</source>
         <translation>&lt;h2&gt;Ändringar:&lt;/h2&gt;</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="550"/>
         <source>&lt;h2&gt;Save State Warning&lt;/h2&gt;&lt;p&gt;Installing this update will make your save states &lt;b&gt;incompatible&lt;/b&gt;. Please ensure you have saved your games to memory card before installing this update or you will lose progress.&lt;/p&gt;</source>
         <translation>&lt;h2&gt;Varning för sparade tillstånd&lt;/h2&gt;&lt;p&gt;Installation av denna uppdatering kommer att göra dina sparade tillstånd &lt;b&gt;inkompatibla&lt;/b&gt;. Försäkra dig om att du har sparat dina spel till minneskort innan du installerar denna uppdatering annars kommer du förlora dem.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="741"/>
         <source>&lt;h1&gt;Inconsistent Application State&lt;/h1&gt;&lt;h3&gt;The update zip is missing the current executable:&lt;/h3&gt;&lt;div align=&quot;center&quot;&gt;&lt;pre&gt;%1&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;&lt;strong&gt;This is usually a result of manually renaming the file.&lt;/strong&gt; Continuing to install this update may result in a broken installation if the renamed executable is used. The DuckStation executable should be named:&lt;/p&gt;&lt;div align=&quot;center&quot;&gt;&lt;pre&gt;%2&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Do you want to continue anyway?&lt;/p&gt;</source>
         <translation>&lt;h1&gt;Inkonsekvent programtillstånd&lt;/h1&gt;&lt;h3&gt;Den aktuella körbara filen saknas i uppdateringens zip-fil:&lt;/h3&gt;&lt;div align=&quot;center&quot;&gt;&lt;pre&gt;%1&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;&lt;strong&gt;Detta beror vanligtvis på att filen har bytt namn manuellt.&lt;/strong&gt; Om du fortsätter att installera uppdateringen kan installationen sluta fungera om filen med det ändrade namnet används. DuckStations körbara fil ska heta:&lt;/p&gt;&lt;div align=&quot;center&quot;&gt;&lt;pre&gt;%2&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Vill du fortsätta ändå?&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="740"/>
         <source>Updater Warning</source>
         <translation>Uppdateringsvarning</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="845"/>
         <source>Failed to remove updater exe after update:
 %1</source>
         <translation>Misslyckades med att ta bort uppdateringsfil efter uppdatering:
 %1</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="107"/>
         <source>Stable Releases</source>
         <translation>Stabila utgåvor</translation>
     </message>
     <message>
+        <location filename="../autoupdaterdialog.cpp" line="108"/>
         <source>Preview Releases</source>
         <translation>Förhandsvisningar</translation>
     </message>
 </context>
 <context>
-    <name>AutoUpdaterWindow</name>
-    <message>
-        <source>Downloading Update...</source>
-        <translation>Hämtar uppdatering...</translation>
-    </message>
-    <message>
-        <source>Processing Update...</source>
-        <translation>Bearbetar uppdatering...</translation>
-    </message>
-</context>
-<context>
     <name>BIOSSettingsWidget</name>
     <message>
+        <location filename="../biossettingswidget.ui" line="89"/>
         <source>BIOS Directory</source>
         <translation>BIOS-katalog</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="136"/>
+        <location filename="../biossettingswidget.ui" line="207"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="29"/>
         <source>BIOS Selection</source>
         <translation>Val av BIOS</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="69"/>
         <source>PAL (Europe, Australia):</source>
         <translation>PAL (Europa, Australien):</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="35"/>
         <source>NTSC-J (Japan):</source>
         <translation>NTSC-J (Japan):</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="52"/>
         <source>NTSC-U/C (US/Canada):</source>
         <translation>NTSC-U/C (US, Kanada):</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="95"/>
         <source>DuckStation will search for BIOS images in this directory.</source>
         <translation>DuckStation kommer att söka efter BIOS-avbilder i denna katalog.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="107"/>
+        <location filename="../biossettingswidget.cpp" line="111"/>
         <source>Install BIOS</source>
         <translation>Installera BIOS</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="118"/>
+        <location filename="../biossettingswidget.cpp" line="109"/>
         <source>Refresh List</source>
         <translation>Uppdatera lista</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="147"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="158"/>
         <source>Reset</source>
         <translation>Nollställ</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="245"/>
+        <location filename="../biossettingswidget.cpp" line="126"/>
         <source>Enable TTY Logging</source>
         <translation>Aktivera TTY-loggning</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="174"/>
         <source>Parallel Port</source>
         <translation>Parallellport</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="180"/>
         <source>Device Type:</source>
         <translation>Enhetstyp:</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="197"/>
         <source>Image Path:</source>
         <translation>Avbildssökväg:</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="220"/>
+        <location filename="../biossettingswidget.cpp" line="119"/>
         <source>Cartridge Switch On</source>
         <translation>Cartridge-brytaren på</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="227"/>
+        <location filename="../biossettingswidget.cpp" line="123"/>
         <source>Allow Image Writes</source>
         <translation>Tillåt avbildsskrivningar</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="123"/>
+        <location filename="../biossettingswidget.cpp" line="126"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="127"/>
         <source>Logs BIOS calls to printf(). Not all games contain debugging messages.</source>
         <translation>Loggar BIOS-anrop till printf(). Inte alla spel innehåller felsökningsmeddelanden.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="114"/>
         <source>Device Type</source>
         <translation>Enhetstyp</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="110"/>
         <source>Refreshes the list of BIOS images that can be selected.</source>
         <translation>Uppdaterar listan över BIOS-avbilder som kan väljas.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="112"/>
         <source>Installs a new BIOS image into the emulator&apos;s BIOS directory.</source>
         <translation>Installerar en ny BIOS-avbild i emulatorns BIOS-katalog.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="114"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="115"/>
         <source>Simulates a device plugged into the console&apos;s parallel port. Usually these are flash cartridges, and require some sort of image dump to function.</source>
         <translation>Simulerar en enhet ansluten till konsollens parallellport. Oftast är dessa flash-cartridge och kräver någon form av avbildsdump för att fungera.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="117"/>
         <source>Image Path</source>
         <translation>Avbildssökväg</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="117"/>
         <source>Empty</source>
         <translation>Tom</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="118"/>
         <source>Sets the path to the image used for flash cartridges.</source>
         <translation>Anger sökvägen till avbilden som används för flash-cartridge.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="119"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="120"/>
         <source>Simulates the position of the switch on the cartridge. Most cartridges require the switch to be on for it to activate on startup.</source>
         <translation>Simulerar positionen för brytaren på cartridgen. De flesta cartridge kräver att brytaren är på för att aktivera den vid uppstart.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="124"/>
         <source>Stores any images made to the cartridge&apos;s flash storage back to the host&apos;s file system. &lt;strong&gt;This will overwrite your cartridge dump,&lt;/strong&gt; you should ensure you have a backup first.</source>
         <translation>Lagrar alla avbilder gjorda på cartridgens flash-lagring tillbaka till värdens filsystem. &lt;strong&gt;Detta kommer att skriva över din cartridge-dump,&lt;/strong&gt; du bör försäkra dig om att ha en säkerhetskopia först.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="89"/>
         <source>Select BIOS Directory</source>
         <translation>Välj BIOS-katalog</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="134"/>
         <source>Select BIOS Image</source>
         <translation>Välj BIOS-avbild</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="143"/>
+        <location filename="../biossettingswidget.cpp" line="170"/>
         <source>BIOS Install Error</source>
         <translation>Fel vid BIOS-installation</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="157"/>
         <source>BIOS Already Installed</source>
         <translation>BIOS redan installerad</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="158"/>
         <source>The BIOS file &apos;%1&apos; is already installed. Do you want to overwrite it?</source>
         <translation>BIOS-filen &apos;%1&apos; är redan installerad. Vill du skriva över den?</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="176"/>
         <source>BIOS Installed</source>
         <translation>BIOS installerad</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="177"/>
         <source>BIOS &apos;%1&apos; installed as &apos;%2&apos;.</source>
         <translation>BIOS &apos;%1&apos; installerad som &apos;%2&apos;.</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="206"/>
         <source>Use Global Setting</source>
         <translation>Använd global inställning</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="208"/>
         <source>Auto-Detect</source>
         <translation>Identifiera automatiskt</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="178"/>
+        <location filename="../biossettingswidget.cpp" line="225"/>
         <source>Unknown</source>
         <translation>Okänd</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="250"/>
         <source>%1 (Missing)</source>
         <translation>%1 (saknas)</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.cpp" line="275"/>
         <source>Select PIO Image</source>
         <translation>VÄLJ PIO-avbild</translation>
     </message>
     <message>
+        <location filename="../biossettingswidget.ui" line="239"/>
         <source>Options</source>
         <translation>Alternativ</translation>
     </message>
 </context>
 <context>
-    <name>CDImage</name>
-    <message>
-        <source>Audio</source>
-        <comment>TrackMode</comment>
-        <translation>Ljud</translation>
-    </message>
-    <message>
-        <source>Mode 1</source>
-        <comment>TrackMode</comment>
-        <translation>Läge 1</translation>
-    </message>
-    <message>
-        <source>Mode 1/Raw</source>
-        <comment>TrackMode</comment>
-        <translation>Läge 1/Rå</translation>
-    </message>
-    <message>
-        <source>Mode 2</source>
-        <comment>TrackMode</comment>
-        <translation>Läge 2</translation>
-    </message>
-    <message>
-        <source>Mode 2/Form 1</source>
-        <comment>TrackMode</comment>
-        <translation>Läge 2/Form 1</translation>
-    </message>
-    <message>
-        <source>Mode 2/Form 2</source>
-        <comment>TrackMode</comment>
-        <translation>Läge 2/Form 2</translation>
-    </message>
-    <message>
-        <source>Mode 2/Mix</source>
-        <comment>TrackMode</comment>
-        <translation>Läge 2/Mix</translation>
-    </message>
-    <message>
-        <source>Mode 2/Raw</source>
-        <comment>TrackMode</comment>
-        <translation>Läge 2/Rå</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n tracks covering {0} MB ({1} MB on disk)</source>
-        <comment>Number of tracks</comment>
-        <translation>
-            <numerusform>%n spår som omfattar {0} MB ({1} MB på disken)</numerusform>
-            <numerusform>%n spår som omfattar {0} MB ({1} MB på disken)</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>{0} is {1}-bit with {2} channels at {3}hz.
-WAV files must be 16-bit stereo and use a sample rate of 44100hz.</source>
-        <translation>{0} är {1}-bitars med {2} kanaler vid {3} Hz.
-WAV-filer måste vara 16-bitars stereo och använda en samplingsfrekvens på 44100 Hz.</translation>
-    </message>
-    <message>
-        <source>Preload Image To RAM</source>
-        <translation>Läs in avbild först till RAM</translation>
-    </message>
-    <message>
-        <source>Allocating {} MB memory for precaching...</source>
-        <translation>Allokerar {} MB minne för förinläsning...</translation>
-    </message>
-    <message>
-        <source>Loading Track {0} ({1})...</source>
-        <translation>Läser in spår {0} ({1})...</translation>
-    </message>
-</context>
-<context>
-    <name>CDImageHasher</name>
-    <message>
-        <source>Computing hash for Track {}...</source>
-        <translation>Beräknar kontrollsumma för spår {}...</translation>
-    </message>
-</context>
-<context>
-    <name>CDROM</name>
-    <message>
-        <source>Disc Read Error</source>
-        <translation>Fel vid skivläsning</translation>
-    </message>
-    <message>
-        <source>The game will probably crash now.
-Your dump may be corrupted, or the physical disc is scratched.</source>
-        <translation>Spelet kommer antagligen att krascha nu.
-Din dump kan vara skadad eller så är den fysiska skivan repad.</translation>
-    </message>
-</context>
-<context>
     <name>CaptureSettingsWidget</name>
     <message>
+        <location filename="../capturesettingswidget.ui" line="29"/>
         <source>Screenshots</source>
         <translation>Skärmbilder</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="35"/>
         <source>Screenshot Size:</source>
         <translation>Storlek för skärmbild:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="50"/>
         <source>Quality:</source>
         <translation>Kvalitet:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="57"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="72"/>
+        <location filename="../capturesettingswidget.ui" line="148"/>
         <source>File Name Format:</source>
         <translation>Filnamnsformat:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="82"/>
+        <location filename="../capturesettingswidget.ui" line="158"/>
         <source>Save Location:</source>
         <translation>Lagringsplats:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="94"/>
+        <location filename="../capturesettingswidget.ui" line="170"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="105"/>
+        <location filename="../capturesettingswidget.ui" line="181"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="116"/>
+        <location filename="../capturesettingswidget.ui" line="192"/>
         <source>Reset</source>
         <translation>Återställ</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="132"/>
         <source>Media Capture</source>
         <translation>Mediafångst</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="138"/>
         <source>Backend:</source>
         <translation>Bakände:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="228"/>
+        <location filename="../capturesettingswidget.ui" line="359"/>
         <source>Container:</source>
         <translation>Container:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="238"/>
+        <location filename="../capturesettingswidget.ui" line="369"/>
         <source>Codec:</source>
         <translation>Kodek:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="248"/>
+        <location filename="../capturesettingswidget.ui" line="379"/>
         <source>Bitrate:</source>
         <translation>Bitfrekvens:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="255"/>
+        <location filename="../capturesettingswidget.ui" line="386"/>
         <source> kbps</source>
         <extracomment>Unit that will appear next to a number. Alter the space or whatever is needed before the text depending on your language.</extracomment>
         <translation> kbps</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="274"/>
         <source>Resolution:</source>
         <translation>Upplösning:</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="299"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="322"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.ui" line="331"/>
+        <location filename="../capturesettingswidget.ui" line="405"/>
         <source>Extra Arguments</source>
         <translation>Extra argument</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="65"/>
         <source>Select Screenshots Directory</source>
         <translation>Välj katalog för skärmbilder</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="69"/>
         <source>Select Media Capture Directory</source>
         <translation>Välj katalog för mediafångst</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="119"/>
         <source>Screenshot Size</source>
         <translation>Skärmbildsstorlek</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="119"/>
         <source>Screen Resolution</source>
         <translation>Skärmupplösning</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="120"/>
         <source>Determines the resolution at which screenshots will be saved. Internal resolutions preserve more detail at the cost of file size.</source>
         <translation>Bestämmer vilken upplösning som skärmbilderna ska sparas med. Interna upplösningar bevarar fler detaljer på bekostnad av filstorleken.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="122"/>
+        <location filename="../capturesettingswidget.cpp" line="141"/>
         <source>Save Location</source>
         <translation>Lagringsplats</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="122"/>
+        <location filename="../capturesettingswidget.cpp" line="141"/>
+        <location filename="../capturesettingswidget.cpp" line="152"/>
+        <location filename="../capturesettingswidget.cpp" line="173"/>
+        <location filename="../capturesettingswidget.cpp" line="247"/>
+        <location filename="../capturesettingswidget.cpp" line="296"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="123"/>
         <source>Specifies the directory where screenshots will be saved.</source>
         <translation>Anger katalogen där skärmbilder ska sparas.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="125"/>
+        <location filename="../capturesettingswidget.cpp" line="144"/>
         <source>Save Name</source>
         <translation>Sparningsnamn</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="127"/>
+        <location filename="../capturesettingswidget.cpp" line="146"/>
         <source>Determines the format of the filename used when saving screenshots, and whether a subdirectory is created per-game.</source>
         <translation>Bestämmer filnamnsformatet för sparade skärmbilder och om en underkatalog skapas för varje spel.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="130"/>
         <source>Screenshot Format</source>
         <translation>Skärmbildsformat</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="132"/>
         <source>Selects the format which will be used to save screenshots. JPEG produces smaller files, but loses detail.</source>
         <translation>Väljer det format som ska användas för att spara skärmbilder. JPEG ger mindre filer, men förlorar detaljer.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="133"/>
         <source>Screenshot Quality</source>
         <translation>Skärmbildskvalitet</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="135"/>
         <source>Selects the quality at which screenshots will be compressed. Higher values preserve more detail for JPEG, and reduce file size for PNG.</source>
         <translation>Väljer den kvalitet med vilken skärmbilder komprimeras. Högre värden bevarar fler detaljer för JPEG och minskar filstorleken för PNG.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="138"/>
         <source>Backend</source>
         <translation>Bakände</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="140"/>
         <source>Selects the framework that is used to encode video/audio.</source>
         <translation>Väljer det ramverk som används för att koda video/ljud.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="148"/>
+        <location filename="../capturesettingswidget.cpp" line="169"/>
         <source>Container</source>
         <translation>Container</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="150"/>
         <source>Determines the file format used to contain the captured video.</source>
         <translation>Bestämmer filformatet för den inspelade videon.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="171"/>
         <source>Determines the file format used to contain the captured audio.</source>
         <translation>Bestämmer filformatet för det inspelade ljudet.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="259"/>
+        <location filename="../capturesettingswidget.cpp" line="308"/>
         <source>%1 (Unknown)</source>
         <translation>%1 (Okänd)</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="142"/>
         <source>Specifies the directory where media capture (video/audio) will be saved.</source>
         <translation>Anger katalogen där mediafångster (video/ljud) ska sparas.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="152"/>
         <source>Video Codec</source>
         <translation>Videokodek</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="153"/>
         <source>Selects which Video Codec to be used for media capture. &lt;b&gt;If unsure, leave it on default.&lt;/b&gt;</source>
         <translation>Väljer videokodeken som ska användas för mediafångst. &lt;b&gt;Lämna standardvärdet om du är osäker.&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="154"/>
         <source>Video Bitrate</source>
         <translation>Bitfrekvens för video</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="155"/>
+        <location filename="../capturesettingswidget.cpp" line="176"/>
         <source>%1 kbps</source>
         <translation>%1 kbps</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="156"/>
         <source>Sets the video bitrate to be used. Larger bitrate generally yields better video quality at the cost of larger resulting file size.</source>
         <translation>Ställer in den videobitfrekvens som ska användas. Högre bitfrekvens ger i allmänhet bättre videokvalitet till priset av större filstorlek.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="159"/>
         <source>Automatic Resolution</source>
         <translation>Automatisk upplösning</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="159"/>
+        <location filename="../capturesettingswidget.cpp" line="163"/>
+        <location filename="../capturesettingswidget.cpp" line="178"/>
         <source>Unchecked</source>
         <translation>Avmarkerad</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="160"/>
         <source>When checked, the video capture resolution will follows the internal resolution of the running game. &lt;b&gt;Be careful when using this setting especially when you are upscaling, as higher internal resolutions (above 4x) can cause system slowdown.&lt;/b&gt;</source>
         <translation>När detta är markerat kommer videoinspelningens upplösning att följa den interna upplösningen i det spel som körs. &lt;b&gt;Var försiktig när du använder den här inställningen, särskilt när du uppskalar, eftersom högre interna upplösningar (över 4x) kan göra att systemet saktar ner.&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="163"/>
         <source>Enable Extra Video Arguments</source>
         <translation>Aktivera extra videoargument</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="164"/>
         <source>Allows you to pass arguments to the selected video codec.</source>
         <translation>Gör det möjligt att skicka argument till den valda videokodeken.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="166"/>
         <source>Extra Video Arguments</source>
         <translation>Extra videoargument</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="166"/>
+        <location filename="../capturesettingswidget.cpp" line="181"/>
         <source>Empty</source>
         <translation>Tom</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="167"/>
         <source>Parameters passed to the selected video codec.&lt;br&gt;&lt;b&gt;You must use &apos;=&apos; to separate key from value and &apos;:&apos; to separate two pairs from each other.&lt;/b&gt;&lt;br&gt;For example: &quot;crf = 21 : preset = veryfast&quot;</source>
         <translation>Parametrar som skickas till den valda videokodeken.&lt;br&gt;&lt;b&gt;Du måste använda &apos;=&apos; för att skilja nyckel från värde och &apos;:&apos; för att skilja två par från varandra.&lt;/b&gt;&lt;br&gt;Till exempel: &quot;crf = 21 : preset = veryfast&quot;</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="173"/>
         <source>Audio Codec</source>
         <translation>Ljudkodek</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="174"/>
         <source>Selects which Audio Codec to be used for media capture. &lt;b&gt;If unsure, leave it on default.&lt;/b&gt;</source>
         <translation>Väljer ljudkodeken som ska användas för mediafångst. &lt;b&gt;Lämna standardvärdet om du är osäker.&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="175"/>
         <source>Audio Bitrate</source>
         <translation>Bitfrekvens för ljud</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="177"/>
         <source>Sets the audio bitrate to be used.</source>
         <translation>Ställer in ljudbitfrekvensen att använda.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="178"/>
         <source>Enable Extra Audio Arguments</source>
         <translation>Aktivera extra ljudargument</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="179"/>
         <source>Allows you to pass arguments to the selected audio codec.</source>
         <translation>Gör det möjligt att skicka argument till den valda ljudkodeken.</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="181"/>
         <source>Extra Audio Arguments</source>
         <translation>Extra ljudargument</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="182"/>
         <source>Parameters passed to the selected audio codec.&lt;br&gt;&lt;b&gt;You must use &apos;=&apos; to separate key from value and &apos;:&apos; to separate two pairs from each other.&lt;/b&gt;&lt;br&gt;For example: &quot;compression_level = 4 : joint_stereo = 1&quot;</source>
         <translation>Parametrar som skickas till den valda ljudkodeken.&lt;br&gt;&lt;b&gt;Du måste använda &apos;=&apos; för att skilja nyckel från värde och &apos;:&apos; för att skilja två par från varandra.&lt;/b&gt;&lt;br&gt;Till exempel: &quot;compression_level = 4 : joint_stereo = 1&quot;</translation>
     </message>
     <message>
+        <location filename="../capturesettingswidget.cpp" line="208"/>
+        <location filename="../capturesettingswidget.cpp" line="214"/>
+        <location filename="../capturesettingswidget.cpp" line="252"/>
+        <location filename="../capturesettingswidget.cpp" line="301"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
@@ -2486,44 +1876,58 @@ Din dump kan vara skadad eller så är den fysiska skivan repad.</translation>
 <context>
     <name>CheatCodeEditorDialog</name>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="831"/>
         <source>Enter Group Name</source>
         <translation>Ange gruppnamn</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="831"/>
         <source>Enter name for the code group. Using backslashes (\) will create sub-trees.</source>
         <translation>Ange namn för kodgruppen. Använd bakstreck (\) för att skapa underträd.</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="859"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="866"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="878"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="898"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="939"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="859"/>
         <source>Name cannot be empty.</source>
         <translation>Namnet får inte vara tomt.</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="866"/>
         <source>Instructions cannot be empty.</source>
         <translation>Instruktioner får inte vara tomma.</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="899"/>
         <source>A code with the name &apos;%1&apos; already exists.</source>
         <translation>En kod med namnet &apos;%1&apos; finns redan.</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="940"/>
         <source>Failed to save cheat code:
 %1</source>
         <translation>Misslyckades med att spara fuskkod:
 %1</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="988"/>
         <source>Ungrouped</source>
         <translation>Inte grupperad</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="993"/>
         <source>New...</source>
         <translation>Ny...</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="879"/>
         <source>The entered cheat code is not valid:
 
 %1
@@ -2537,83 +1941,9 @@ Om du försöker använda denna fuskkod kommer den inte att fungera som förvän
     </message>
 </context>
 <context>
-    <name>Cheats</name>
-    <message>
-        <source>Gameshark</source>
-        <translation>Gameshark</translation>
-    </message>
-    <message>
-        <source>Assembly</source>
-        <translation>Assembler</translation>
-    </message>
-    <message>
-        <source>Manual</source>
-        <translation>Manuell</translation>
-    </message>
-    <message>
-        <source>Automatic (Frame End)</source>
-        <translation>Automatisk (Frame End)</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n game patches are active.</source>
-        <comment>OSD Message</comment>
-        <translation>
-            <numerusform>%n spelpatch är aktiva.</numerusform>
-            <numerusform>%n spelpatchar är aktiva.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>No cheats/patches are found or enabled.</source>
-        <translation>Inga fusk/patchar hittades eller aktiverade.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n cheats</source>
-        <comment>Cheats blocked by hardcore mode</comment>
-        <translation>
-            <numerusform>%n fusk</numerusform>
-            <numerusform>%n fusk</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n patches</source>
-        <comment>Patches blocked by hardcore mode</comment>
-        <translation>
-            <numerusform>%n patch</numerusform>
-            <numerusform>%n patchar</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>{0} and {1} disabled by achievements hardcore mode/safe mode.</source>
-        <translation>{0} och {1} inaktiverade av prestationer på grund av hardcore-läget/säkert läge.</translation>
-    </message>
-    <message>
-        <source>{} disabled by achievements hardcore mode/safe mode.</source>
-        <translation>{} inaktiverade av prestationer på grund av hardcore-läget/säkert läge.</translation>
-    </message>
-    <message>
-        <source>Cheat &apos;{}&apos; applied.</source>
-        <translation>Fusket  &apos;{}&apos; tillämpades.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n cheats are enabled.</source>
-        <comment>OSD Message</comment>
-        <translation>
-            <numerusform>%n fusk är aktiverade.</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>This may crash games.</source>
-        <translation>Detta kan krascha spel.</translation>
-    </message>
-    <message>
-        <source>Failed to parse cheat code</source>
-        <translation>Misslyckades med att tolka fuskkoden</translation>
-    </message>
-</context>
-<context>
     <name>ColorPickerButton</name>
     <message>
+        <location filename="../colorpickerbutton.cpp" line="74"/>
         <source>Select LED Color</source>
         <translation>Välj LED-färg</translation>
     </message>
@@ -2621,186 +1951,251 @@ Om du försöker använda denna fuskkod kommer den inte att fungera som förvän
 <context>
     <name>ConsoleSettingsWidget</name>
     <message>
+        <location filename="../consolesettingswidget.ui" line="29"/>
         <source>Console</source>
         <translation>Konsol</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="35"/>
         <source>Region:</source>
         <translation>Region:</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="78"/>
+        <location filename="../consolesettingswidget.cpp" line="96"/>
         <source>Enable 8MB RAM (Dev Console)</source>
         <translation>Aktivera 8MB RAM (Utvecklarkonsol)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="90"/>
         <source>CPU Emulation</source>
         <translation>CPU-emulering</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="96"/>
         <source>Execution Mode:</source>
         <translation>Körningsläge:</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="108"/>
+        <location filename="../consolesettingswidget.cpp" line="105"/>
         <source>Enable Clock Speed Control (Overclocking/Underclocking)</source>
         <translation>Aktivera klockfrekvenskontroll (överklockning/underklockning)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="168"/>
+        <location filename="../consolesettingswidget.cpp" line="109"/>
         <source>Enable Recompiler ICache</source>
         <translation>Aktivera ICache för omkompilerare</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="178"/>
         <source>CD-ROM Emulation</source>
         <translation>Cd-rom-emulering</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="184"/>
         <source>Read Speedup:</source>
         <translation>Högre läshastighet:</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="192"/>
+        <location filename="../consolesettingswidget.cpp" line="115"/>
         <source>None (Double Speed)</source>
         <translation>Ingen (dubbel hastighet)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="197"/>
         <source>2x (Quad Speed)</source>
         <translation>2x (fyrdubbel hastighet)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="202"/>
         <source>3x (6x Speed)</source>
         <translation>3x (6x hastighet)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="207"/>
         <source>4x (8x Speed)</source>
         <translation>4x (8x hastighet)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="212"/>
         <source>5x (10x Speed)</source>
         <translation>5x (10x hastighet)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="217"/>
         <source>6x (12x Speed)</source>
         <translation>6x (12x hastighet)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="230"/>
         <source>Seek Speedup:</source>
         <translation>Sök snabbare:</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="237"/>
+        <location filename="../consolesettingswidget.ui" line="241"/>
+        <location filename="../consolesettingswidget.cpp" line="119"/>
         <source>None (Normal Speed)</source>
         <translation>Ingen (normal hastighet)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="246"/>
         <source>2x</source>
         <translation>2x</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="251"/>
         <source>3x</source>
         <translation>3x</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="256"/>
         <source>4x</source>
         <translation>4x</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="261"/>
         <source>5x</source>
         <translation>5x</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="266"/>
         <source>6x</source>
         <translation>6x</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="295"/>
+        <location filename="../consolesettingswidget.cpp" line="126"/>
         <source>Apply Image Patches</source>
         <translation>Verkställ bildpatchar</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="288"/>
+        <location filename="../consolesettingswidget.cpp" line="134"/>
         <source>Ignore Drive Subcode</source>
         <translation>Ignorera enhetens underkod</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="79"/>
         <source>Region</source>
         <translation>Region</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="79"/>
+        <location filename="../consolesettingswidget.cpp" line="82"/>
         <source>Auto-Detect</source>
         <translation>Identifiera automatiskt</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="80"/>
         <source>Determines the emulated hardware type.</source>
         <translation>Bestämmer emulerad hårdvarutyp.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="102"/>
         <source>Execution Mode</source>
         <translation>Körningsläge</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="102"/>
         <source>Recompiler (Fastest)</source>
         <translation>Omkompilerare (snabbaste)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="103"/>
         <source>Determines how the emulated CPU executes instructions.</source>
         <translation>Fastställer hur den emulerade CPUn kör instruktioner.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="87"/>
+        <location filename="../consolesettingswidget.cpp" line="89"/>
+        <location filename="../consolesettingswidget.cpp" line="92"/>
+        <location filename="../consolesettingswidget.cpp" line="96"/>
+        <location filename="../consolesettingswidget.cpp" line="105"/>
+        <location filename="../consolesettingswidget.cpp" line="109"/>
+        <location filename="../consolesettingswidget.cpp" line="123"/>
+        <location filename="../consolesettingswidget.cpp" line="126"/>
+        <location filename="../consolesettingswidget.cpp" line="130"/>
+        <location filename="../consolesettingswidget.cpp" line="134"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="106"/>
         <source>When this option is chosen, the clock speed set below will be used.</source>
         <translation>När detta alternativ väljs så kommer klockfrekvensen som anges nedan att användas.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="107"/>
         <source>Overclocking Percentage</source>
         <translation>Överklockningsprocent</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="107"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="108"/>
         <source>Selects the percentage of the normal clock speed the emulated hardware will run at.</source>
         <translation>Väljer den procentandel av den normala klockfrekvensen som den emulerade maskinvaran ska köras med.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="110"/>
         <source>Simulates stalls in the recompilers when the emulated CPU would have to fetch instructions into its cache. Makes games run closer to their console framerate, at a small cost to performance. Interpreter mode always simulates the instruction cache.</source>
         <translation>Simulerar uppehåll i omkompilerarna när den emulerade processorn måste hämta instruktioner i cacheminnet. Gör att spelen körs närmare konsolens bildfrekvens, till en liten bekostnad av prestanda. I tolkningsläget simuleras alltid instruktionscachen.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="97"/>
         <source>Enables an additional 6MB of RAM to obtain a total of 2+6 = 8MB, usually present on dev consoles. Games have to use a larger heap size for this additional RAM to be usable. Titles which rely on memory mirrors may break, so it should only be used with compatible mods.</source>
         <translation>Möjliggör ytterligare 6 MB RAM för att få totalt 2+6 = 8 MB, vilket vanligtvis finns på utvecklingskonsoler. Spel måste använda en större heap-storlek för att detta extra RAM-minne ska kunna användas. Titlar som förlitar sig på minnesspeglar kan gå sönder, så det bör endast användas med kompatibla moddar.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="281"/>
+        <location filename="../consolesettingswidget.cpp" line="123"/>
         <source>Preload Image to RAM</source>
         <translation>Förinläs avbild till RAM</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="124"/>
         <source>Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay. In some cases also eliminates stutter when games initiate audio track playback.</source>
         <translation>Läser in spelavbildningen till RAM-minnet. Användbart för nätverkssökvägar som kan bli otillförlitliga under spelets gång. I vissa fall elimineras även hack när spel initierar uppspelning av ljudspår.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="115"/>
         <source>CD-ROM Read Speedup</source>
         <translation>Ökad läshastighet för CD-ROM</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="116"/>
         <source>Speeds up CD-ROM reads by the specified factor. Only applies to double-speed reads, and is ignored when audio is playing. May improve loading speeds in some games, at the cost of breaking others.</source>
         <translation>Ökar hastigheten på CD-ROM-läsningen med den angivna faktorn. Gäller endast för dubbelsnabb läsning och ignoreras när ljud spelas upp. Kan förbättra inläsningshastigheten i vissa spel, på bekostnad av att andra går sönder.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="119"/>
         <source>CD-ROM Seek Speedup</source>
         <translation>Snabbare CD-ROM-sökning</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="120"/>
         <source>Reduces the simulated time for the CD-ROM sled to move to different areas of the disc. Can improve loading times, but crash games which do not expect the CD-ROM to operate faster.</source>
         <translation>Förkortar den simulerade tiden för CD-ROM-släden att förflytta sig till olika områden på skivan. Kan förbättra inläsningstiderna, men kraschar spel som inte förväntar sig att CD-ROM-skivan ska arbeta snabbare.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="127"/>
         <source>Automatically applies patches to disc images when they are present in the same directory. Currently only PPF patches are supported with this option.</source>
         <translation>Tillämpar automatiskt patchar på skivavbildningar när de finns i samma katalog. För närvarande stöds endast PPF-patchar med detta alternativ.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="135"/>
         <source>Ignores the subchannel provided by the drive when using physical discs, instead always generating subchannel data. Won&apos;t work with libcrypt games, but can improve read reliability on some drives.</source>
         <translation>Ignorerar den underkanal som tillhandahålls av enheten vid användning av fysiska skivor, och genererar istället alltid underkanaldata. Fungerar inte med libcrypt-spel, men kan förbättra lästillförlitligheten på vissa enheter.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="192"/>
         <source>Enabling CPU overclocking will break games, cause bugs, reduce performance and can significantly increase system requirements.
 
 By enabling this option you are agreeing to not create any bug reports unless you have confirmed the bug also occurs with overclocking disabled.
@@ -2813,148 +2208,166 @@ Genom att aktivera det här alternativet samtycker du till att inte skapa några
 Den här varningen visas bara en gång.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="196"/>
         <source>CPU Overclocking Warning</source>
         <translation>Varning för CPU-överklockning</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="199"/>
         <source>Yes, I will confirm bugs without overclocking before reporting.</source>
         <translation>Ja, jag kommer bekräfta buggar utan överklockning innan rapportering.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="200"/>
         <source>No, take me back to safety.</source>
         <translation>Nej, ta mig tillbaka till säkerhet.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="242"/>
         <source>%1% (%2MHz)</source>
         <translation>%1% (%2MHz)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="57"/>
+        <location filename="../consolesettingswidget.cpp" line="87"/>
         <source>Fast Boot</source>
         <translation>Snabb uppstart</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="71"/>
+        <location filename="../consolesettingswidget.cpp" line="89"/>
         <source>Fast Forward Boot</source>
         <translation>Snabbspolad uppstart</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="64"/>
+        <location filename="../consolesettingswidget.cpp" line="92"/>
         <source>Fast Forward Memory Card Access</source>
         <translation>Snabbspolning av minneskort</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="88"/>
         <source>Skips the boot animation. Safe to enable.</source>
         <translation>Hoppar över uppstartsanimationen. Säkert att aktivera.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="90"/>
         <source>Fast forwards through the early loading process when fast booting, saving time. Results may vary between games.</source>
         <translation>Snabbspolar igenom den tidiga inläsningsprocessen vid snabb uppstart, vilket sparar tid. Resultaten kan variera mellan spel.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="93"/>
         <source>Fast forwards through memory card access, both loading and saving. Can reduce waiting times in games that frequently access memory cards.</source>
         <translation>Snabbspolar genom minneskortsåtkomst, både inläsning och lagring. Kan minska väntetiderna i spel som ofta använder minneskort.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="45"/>
         <source>Frame Rate:</source>
         <translation>Bildfrekvens:</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="83"/>
         <source>Utilizes the chosen frame timing regardless of the active region. This feature can be used to force PAL games to run at 60Hz and NTSC games to run at 50Hz. For most games which have a speed tied to the framerate, this will result in the game running approximately 17% faster or slower. For variable frame rate games, it may not affect the speed.</source>
         <translation>Använder den valda bildtimingen oavsett vilken region som är aktiv. Denna funktion kan användas för att tvinga PAL-spel att köras med 60 Hz och NTSC-spel att köras med 50 Hz. För de flesta spel som har en hastighet som är knuten till bildfrekvensen kommer detta att resultera i att spelet körs ungefär 17% snabbare eller långsammare. För spel med variabel bildfrekvens kanske det inte påverkar hastigheten.</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="302"/>
+        <location filename="../consolesettingswidget.cpp" line="130"/>
         <source>Switch to Next Disc on Stop</source>
         <translation>Växla till nästa skiva vid stopp</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="131"/>
         <source>Automatically switches to the next disc in the game when the game stops the CD-ROM motor. No switch will occur if the last disc in the game is already selected. &lt;strong&gt;Does not work for all games.&lt;/strong&gt;</source>
         <translation>Växlar automatiskt till nästa skiva i spelet när spelet stoppar CD-ROM-motorn. Ingen växling sker om den sista skivan i spelet redan är vald. &lt;strong&gt;Fungerar inte för alla spel.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.cpp" line="82"/>
         <source>Frame Rate</source>
         <translation>Bildfrekvens</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="222"/>
+        <location filename="../consolesettingswidget.ui" line="271"/>
         <source>Maximum (Safer)</source>
         <translation>Maximalt (Säkrare)</translation>
     </message>
     <message>
+        <location filename="../consolesettingswidget.ui" line="128"/>
         <source>100% (33.87MHz)</source>
         <translation>100% (33.87MHz)</translation>
     </message>
 </context>
 <context>
-    <name>Controller</name>
-    <message>
-        <source>Controller {} switched to analog mode.</source>
-        <translation>Handkontroll {} växlades till analogt läge.</translation>
-    </message>
-    <message>
-        <source>Controller {} switched to digital mode.</source>
-        <translation>Handkontroll {} växlades till digitalt läge.</translation>
-    </message>
-    <message>
-        <source>Controller {} switched to JogCon mode.</source>
-        <translation>Handkontroll {} växlades till JogCon-läge.</translation>
-    </message>
-    <message>
-        <source>Controller {} switched to Digital mode.</source>
-        <translation>Handkontroll {} växlades till digitalt läge.</translation>
-    </message>
-</context>
-<context>
     <name>ControllerBindingWidget</name>
     <message>
+        <location filename="../controllerbindingwidget.ui" line="40"/>
         <source>Bindings</source>
         <translation>Bindningar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget.ui" line="60"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget.ui" line="80"/>
         <source>Macros</source>
         <translation>Makron</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget.ui" line="117"/>
         <source>Automatic Mapping</source>
         <translation>Automatisk mappning</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget.ui" line="128"/>
+        <location filename="../controllerbindingwidgets.cpp" line="307"/>
         <source>Clear Mapping</source>
         <translation>Töm mappning</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="292"/>
         <source>Multiple devices...</source>
         <translation>Flera enheter...</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="297"/>
         <source>No devices available</source>
         <translation>Inga enheter tillgängliga</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="308"/>
         <source>Are you sure you want to clear all mappings for this controller? This action cannot be undone.</source>
         <translation>Är du säker på att du vill tömma alla mappningar för denna handkontroller? Denna åtgärd går inte att ångra.</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="517"/>
         <source>Controller %1 %2</source>
         <translation>Handkontroll %1 %2</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="427"/>
         <source>Axes</source>
         <translation>Axlar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="458"/>
         <source>Buttons</source>
         <translation>Knappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="362"/>
         <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
         <translation>Inga generiska bindningar genererades för enheten &apos;%1&apos;. Handkontrollern/källan kanske inte har stöd för automatisk mappning.</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget.ui" line="29"/>
         <source>Controller Type</source>
         <translation>Handkontrollertyp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="361"/>
         <source>Automatic Mapping Failed</source>
         <translation>Automatisk mappning misslyckades</translation>
     </message>
@@ -2962,98 +2375,130 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_AnalogController</name>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="43"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="49"/>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="206"/>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="795"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="86"/>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="243"/>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="758"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="123"/>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="280"/>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="869"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="160"/>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="317"/>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="832"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="200"/>
         <source>Left Analog</source>
         <translation>Vänster analog</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="357"/>
         <source>Large Motor</source>
         <translation>Stor motor</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="405"/>
         <source>R2</source>
         <translation>R2</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="436"/>
         <source>Select</source>
         <translation>Välj</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="467"/>
         <source>L2</source>
         <translation>L2</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="498"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="529"/>
         <source>R1</source>
         <translation>R1</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="560"/>
         <source>L1</source>
         <translation>L1</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="595"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="601"/>
         <source>Cross</source>
         <translation>Kryss</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="638"/>
         <source>Square</source>
         <translation>Fyrkant</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="675"/>
         <source>Triangle</source>
         <translation>Triangel</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="712"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="752"/>
         <source>Right Analog</source>
         <translation>Höger analog</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="909"/>
         <source>Small Motor</source>
         <translation>Liten motor</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="1071"/>
         <source>R3</source>
         <translation>R3</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="1040"/>
         <source>Analog</source>
         <translation>Analog</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="1009"/>
         <source>L3</source>
         <translation>L3</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_controller.ui" line="1102"/>
         <source>Analog LED</source>
         <translation>Analog LED</translation>
     </message>
@@ -3061,86 +2506,115 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_AnalogJoystick</name>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="43"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="49"/>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="206"/>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="764"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="86"/>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="243"/>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="727"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="123"/>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="280"/>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="838"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="160"/>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="317"/>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="801"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="200"/>
         <source>Left Analog</source>
         <translation>Vänster analog</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="374"/>
         <source>R1</source>
         <translation>R1</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="405"/>
         <source>L1</source>
         <translation>L1</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="436"/>
         <source>L2</source>
         <translation>L2</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="467"/>
         <source>R2</source>
         <translation>R2</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="498"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="529"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="564"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="570"/>
         <source>Cross</source>
         <translation>Kryss</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="607"/>
         <source>Square</source>
         <translation>Fyrkant</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="644"/>
         <source>Triangle</source>
         <translation>Triangel</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="681"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="721"/>
         <source>Right Analog</source>
         <translation>Höger analog</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="947"/>
         <source>R3</source>
         <translation>R3</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="984"/>
         <source>L3</source>
         <translation>L3</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_analog_joystick.ui" line="1034"/>
         <source>Mode</source>
         <translation>Läge</translation>
     </message>
@@ -3148,66 +2622,82 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_DigitalController</name>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="43"/>
         <source>L1</source>
         <translation>L1</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="74"/>
         <source>L2</source>
         <translation>L2</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="105"/>
         <source>R2</source>
         <translation>R2</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="136"/>
         <source>R1</source>
         <translation>R1</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="184"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="190"/>
         <source>Cross</source>
         <translation>Kryss</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="227"/>
         <source>Square</source>
         <translation>Fyrkant</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="264"/>
         <source>Triangle</source>
         <translation>Triangel</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="301"/>
         <source>Circle</source>
         <translation>Cirkel</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="440"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="446"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="483"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="520"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="557"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="614"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_digital_controller.ui" line="645"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
@@ -3215,59 +2705,73 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_GunCon</name>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="43"/>
         <source>Pointer Setup</source>
         <translation>Konfigurera pekare</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="49"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, lightguns will use the mouse pointer. To use the mouse, you &lt;span style=&quot; font-weight:700;&quot;&gt;do not&lt;/span&gt; need to configure any bindings apart from the trigger and buttons. Aiming only needs to be set when you want to use multiple mice.&lt;/p&gt;&lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;span style=&quot; font-weight:700;&quot;&gt;left unbound&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE: &lt;/span&gt;Mouse mapping must be enabled in Global Settings to bind your PC&apos;s mouse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Som standard använder ljuspistoler muspekaren. För att använda musen behöver du &lt;span style=&quot; font-weight:700;&quot;&gt;inte&lt;/span&gt; konfigurera några bindningar utöver avtryckaren och knapparna. Siktet behöver endast ställas in om du vill använda flera möss.&lt;/p&gt;&lt;p&gt;Om du vill använda en handkontroll eller en ljuspistol som simulerar en handkontroll i stället för en mus ska den bindas till relativ siktning. Annars ska relativ siktning &lt;span style=&quot; font-weight:700;&quot;&gt;lämnas obunden&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;OBS! &lt;/span&gt;Musmappning måste aktiveras i globala inställningar för att datorns mus ska kunna bindas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="65"/>
         <source>Relative Aiming</source>
         <extracomment>Try to use Sony&apos;s official terminology for this. A good place to start would be in the console or the DualShock 2&apos;s manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.</extracomment>
         <translation>Relative Aiming</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="71"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="108"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="145"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="182"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="330"/>
         <source>Aiming</source>
         <translation>Sikte</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="367"/>
         <source>Trigger</source>
         <translation>Skjutknapp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="373"/>
         <source>Fire Offscreen</source>
         <translation>Skjut utanför skärm</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="410"/>
         <source>Fire</source>
         <translation>Skjut</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="450"/>
         <source>Side Buttons</source>
         <translation>Sidoknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="456"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_guncon.ui" line="493"/>
         <source>A</source>
         <translation>A</translation>
     </message>
@@ -3275,59 +2779,73 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_Justifier</name>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="43"/>
         <source>Pointer Setup</source>
         <translation>Konfigurera pekare</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="49"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, lightguns will use the mouse pointer. To use the mouse, you &lt;span style=&quot; font-weight:700;&quot;&gt;do not&lt;/span&gt; need to configure any bindings apart from the trigger and buttons. Aiming only needs to be set when you want to use multiple mice.&lt;/p&gt;&lt;p&gt;If you want to use a controller, or lightgun which simulates a controller instead of a mouse, then you should bind it to Relative Aiming. Otherwise, Relative Aiming should be &lt;span style=&quot; font-weight:700;&quot;&gt;left unbound&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE: &lt;/span&gt;Mouse mapping must be enabled in Global Settings to bind your PC&apos;s mouse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Som standard använder ljuspistoler muspekaren. För att använda musen behöver du &lt;span style=&quot; font-weight:700;&quot;&gt;inte&lt;/span&gt; konfigurera några bindningar utöver avtryckaren och knapparna. Siktet behöver endast ställas in om du vill använda flera möss.&lt;/p&gt;&lt;p&gt;Om du vill använda en handkontroll eller en ljuspistol som simulerar en handkontroll i stället för en mus ska den bindas till relativ siktning. Annars ska relativ siktning &lt;span style=&quot; font-weight:700;&quot;&gt;lämnas obunden&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;OBS! &lt;/span&gt;Musmappning måste aktiveras i globala inställningar för att datorns mus ska kunna bindas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="65"/>
         <source>Relative Aiming</source>
         <extracomment>Try to use Sony&apos;s official terminology for this. A good place to start would be in the console or the DualShock 2&apos;s manual. If this element was officially translated to your language by Sony in later DualShocks, you may use that term.</extracomment>
         <translation>Relative Aiming</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="71"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="108"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="145"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="182"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="330"/>
         <source>Aiming</source>
         <translation>Sikte</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="367"/>
         <source>Trigger</source>
         <translation>Skjutknapp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="373"/>
         <source>Fire Offscreen</source>
         <translation>Skjut utanför skärm</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="410"/>
         <source>Fire</source>
         <translation>Skjut</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="450"/>
         <source>Side Buttons</source>
         <translation>Sidoknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="456"/>
         <source>Back</source>
         <translation>Bakåt</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_justifier.ui" line="493"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
@@ -3335,22 +2853,27 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_Mouse</name>
     <message>
+        <location filename="../controllerbindingwidget_mouse.ui" line="62"/>
         <source>Pointer</source>
         <translation>Pekare</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_mouse.ui" line="53"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;NOTE: &lt;/span&gt;Mouse mapping must be enabled in Global Settings to bind your PC&apos;s mouse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;OBS! &lt;/span&gt;Musmappning måste aktiveras i globala inställningar för att datorns mus ska kunna bindas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_mouse.ui" line="113"/>
         <source>Buttons</source>
         <translation>Knappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_mouse.ui" line="119"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_mouse.ui" line="156"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
@@ -3358,58 +2881,74 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_NeGcon</name>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="56"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="62"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="99"/>
+        <location filename="../controllerbindingwidget_negcon.ui" line="609"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="136"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="173"/>
+        <location filename="../controllerbindingwidget_negcon.ui" line="572"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="213"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="261"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="292"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="340"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="346"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="383"/>
         <source>II</source>
         <translation>II</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="420"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="457"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negcon.ui" line="566"/>
         <source>Steering/Twist</source>
         <translation>Styrning/Twist</translation>
     </message>
@@ -3417,70 +2956,89 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerBindingWidget_NeGconRumble</name>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="56"/>
         <source>D-Pad</source>
         <translation>Riktningsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="62"/>
         <source>Down</source>
         <translation>Ner</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="99"/>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="609"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="136"/>
         <source>Up</source>
         <translation>Upp</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="173"/>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="572"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="213"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="261"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="292"/>
         <source>R</source>
         <translation>R</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="340"/>
         <source>Face Buttons</source>
         <translation>Handlingsknappar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="346"/>
         <source>I</source>
         <translation>I</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="383"/>
         <source>II</source>
         <translation>II</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="420"/>
         <source>B</source>
         <translation>B</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="457"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="566"/>
         <source>Steering/Twist</source>
         <translation>Styrning/Twist</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="662"/>
         <source>Analog</source>
         <translation>Analog</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="681"/>
         <source>Large Motor</source>
         <translation>Stor motor</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidget_negconrumble.ui" line="718"/>
         <source>Small Motor</source>
         <translation>Liten motor</translation>
     </message>
@@ -3488,14 +3046,17 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerCustomSettingsWidget</name>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="978"/>
         <source>Restore Default Settings</source>
         <translation>Återställ standardinställningar</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="862"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="867"/>
         <source>Select File</source>
         <translation>Välj fil</translation>
     </message>
@@ -3503,184 +3064,230 @@ Den här varningen visas bara en gång.</translation>
 <context>
     <name>ControllerGlobalSettingsWidget</name>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="31"/>
         <source>SDL Input Source</source>
         <translation>Källa för SDL-inmatning</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="77"/>
         <source>Enable SDL Input Source</source>
         <translation>Aktivera källa för SDL-inmatning</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="107"/>
         <source>Enable Touchpad</source>
         <translation>Aktivera pekplatta</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="48"/>
         <source>Enable DualSense Player LED</source>
         <translation>Aktivera Player LED för DualSense</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="117"/>
         <source>XInput Source</source>
         <translation>XInput-källa</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="298"/>
         <source>Using raw input improves precision when you bind controller sticks to the mouse pointer. Also enables multiple mice to be used.</source>
         <translation>Användning av rå inmatning förbättrar precisionen när du binder kontrollerspakar till muspekaren. Gör också att flera möss kan användas.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="175"/>
         <source>Horizontal Sensitivity:</source>
         <translation>Horisontell känslighet:</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="104"/>
         <source>Allows use of the touchpad for DualShock 4 / DualSense controllers as a pointer, for use with lightguns.</source>
         <translation>Gör det möjligt att använda styrplattan på DualShock 4-/DualSense-handkontroller som pekare för ljuspistoler.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="221"/>
+        <location filename="../controllerglobalsettingswidget.ui" line="276"/>
         <source>10</source>
         <translation>10</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="230"/>
         <source>Vertical Sensitivity:</source>
         <translation>Vertikal känslighet:</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="288"/>
         <source>Use Raw Input</source>
         <translation>Använd rå inmatning</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="366"/>
         <source>Multitap Mode:</source>
         <translation>Multitap-läge:</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="379"/>
         <source>Profile Settings</source>
         <translation>Profilinställningar</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.cpp" line="221"/>
         <source>Controller LED Settings</source>
         <translation>LED-inställningar för handkontroller</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="350"/>
         <source>Controller Multitap</source>
         <translation>Multitap för handkontroller</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="356"/>
         <source>The multitap enables up to 8 controllers to be connected to the console. Each multitap provides 4 ports. Multitap is not supported by all games.</source>
         <translation>Multitap (eller flerspelaradapter) gör att upp till 8 handkontrollrar kan anslutas till konsollen. Varje multitap ger 4 portar. Multitap stöds inte av alla spel.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="169"/>
         <source>Mouse/Pointer Source</source>
         <translation>Källa för mus/pekare</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="330"/>
         <source>Enable Mouse Mapping</source>
         <translation>Aktivera musmappning</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="427"/>
         <source>Detected Devices</source>
         <translation>Identifierade enheter</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="123"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The XInput source provides support for controllers that use the XInput protocol. This source should &lt;span style=&quot; font-weight:700;&quot;&gt;only&lt;/span&gt; be used if you are using a XInput wrapper library.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;XInput-källan ger stöd för styrenheter som använder XInput-protokollet. Denna källa bör &lt;span style=&quot; font-weight:700;&quot;&gt;endast&lt;/span&gt; användas om du använder ett XInput-wrapperbibliotek.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.cpp" line="186"/>
         <source>Advanced SDL Options</source>
         <translation>Avancerade SDL-alternativ</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.cpp" line="215"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.cpp" line="215"/>
         <source>No SDL devices are currently connected.</source>
         <translation>Inga SDL-enheter är för närvarande anslutna.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.cpp" line="231"/>
         <source>&lt;strong&gt;Controller LED Settings&lt;/strong&gt;&lt;br&gt;
 The &quot;alternate&quot; color is used when analog mode is active.</source>
         <translation>&lt;strong&gt;Inställningar för kontrollerns LED-lampor&lt;/strong&gt;&lt;br&gt;
 Den ”alternativa” färgen används när analogt läge är aktivt.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.cpp" line="259"/>
         <source>Alternate Mode:</source>
         <translation>Alternativt läge:</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.cpp" line="259"/>
         <source>Normal Mode:</source>
         <translation>Normalt läge:</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="45"/>
         <source>Enables the player LED on DualSense controllers.</source>
         <translation>Aktiverar spelarens LED på DualSense-kontroller.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="61"/>
         <source>Adjusts LED settings for controllers with configurable LEDs.</source>
         <translation>Justerar LED-inställningar för kontroller med konfigurerbar LED.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="74"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the SDL input source and detection of controllers.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aktiverar SDL-ingångskällan och detektering av styrenheter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="84"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Allows rumble and LED effects for DualShock 4 / DualSense controllers in Bluetooth mode. This option is not required for wired connections.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Enabling enhanced reports may result in your controller being unusable in other applications until it is turned off and on again.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tillåter vibrationer och LED-effekter för DualShock 4-/DualSense-kontroller i Bluetooth-läge. Det här alternativet krävs inte för kabelanslutningar. &lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Om du aktiverar förbättrade rapporter kan det hända att din kontroller inte går att använda i andra program förrän du stänger av och slår på den igen.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="87"/>
         <source>DualShock 4 / DualSense Enhanced Mode (Bluetooth Only)</source>
         <translation>DualShock 4 / DualSense förbättrat läge (endast Bluetooth)</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="94"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The SDL input source supports most controllers, and is the preferred option. Enhanced mode may be required for the Vibration/LED functionality of DualShock 4 / DualSense pads in Bluetooth mode. You can also edit &lt;a href=&quot;ADVANCED_SDL_OPTIONS&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#99ebff;&quot;&gt;advanced options&lt;/span&gt;&lt;/a&gt; which control device-specific behavior.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;SDL-ingångskällan stöder de flesta kontroller och är det rekommenderade alternativet. Förbättrat läge kan krävas för vibrations-/LED-funktionen hos DualShock 4-/DualSense-kontroller i Bluetooth-läge. Du kan också redigera &lt;a href=&quot;ADVANCED_SDL_OPTIONS&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#99ebff;&quot;&gt;avancerade alternativ&lt;/span&gt;&lt;/a&gt; som styr enhetsspecifikt beteende.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="133"/>
         <source>Enable XInput Source</source>
         <translation>Aktivera XInput-källa</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="143"/>
         <source>DirectInput Source</source>
         <translation>DirectInput-källa</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="149"/>
         <source>The DirectInput source provides support for legacy controllers which do not support XInput. Accessing these controllers via SDL is recommended instead.</source>
         <translation>DirectInput-källan ger stöd för äldre kontroller som inte stöder XInput. Istället rekommenderas att du använder SDL för att komma åt dessa kontroller.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="159"/>
         <source>Enable DirectInput Source</source>
         <translation>Aktivera DirectInput-källa</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="311"/>
         <source>Mapping Settings</source>
         <translation>Mappningsinställningar</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="317"/>
         <source>By default, mapping mouse movement and device sensors is disabled to avoid accidential bindings when manually mapping.</source>
         <translation>Som standard är mappning av musrörelser och enhetssensorer inaktiverad för att undvika oavsiktliga bindningar vid manuell mappning.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="327"/>
         <source>Allows the mouse to be mapped to emulated controls. By default movement of the mouse will be ignored.</source>
         <translation>Gör det möjligt att mappa musen till emulerade kontroller. Som standard ignoreras musens rörelser.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="285"/>
         <source>Uses raw input for mice input. Enable if you wish to use multiple mice/lightguns.</source>
         <translation>Använder rå inmatning för musinmatning. Aktivera om du vill använda flera möss/ljuspistoler.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="337"/>
         <source>Allows sensors such as accelerometers to be mapped to emulated controls. By default sensors will be ignored.</source>
         <translation>Gör det möjligt att mappa sensorer, exempelvis accelerometrar, till emulerade kontroller. Sensorer ignoreras som standard.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="340"/>
         <source>Enable Sensor Mapping</source>
         <translation>Aktivera sensormappning</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="385"/>
         <source>When these options are enabled, input sources and hotkeys can be set in this input profile, and will be used instead of the global source/hotkey configuration. By default, sources and hotkeys are always shared between all profiles.</source>
         <translation>När dessa alternativ är aktiverade kan inmatningskällor och snabbtangenter ställas in i denna inmatningsprofil och kommer att användas istället för den globala käll-/snabbtangentkonfigurationen. Som standard delas källor och snabbtangenter alltid mellan alla profiler.</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="395"/>
         <source>Use Profile Input Sources</source>
         <translation>Använd profilens inmatningskällor</translation>
     </message>
     <message>
+        <location filename="../controllerglobalsettingswidget.ui" line="402"/>
         <source>Use Profile Hotkeys</source>
         <translation>Använd profilens snabbtangenter</translation>
     </message>
@@ -3688,74 +3295,94 @@ Den ”alternativa” färgen används när analogt läge är aktivt.</translati
 <context>
     <name>ControllerMacroEditWidget</name>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="29"/>
         <source>Binds/Buttons</source>
         <translation>Bindningar/Knappar</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="35"/>
         <source>Select the buttons which you want to trigger with this macro. All buttons are activated concurrently.</source>
         <translation>Välj knapparna som du vill utlösa med detta makro. Alla knappar är aktiverade samtidigt.</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="51"/>
         <source>Pressure</source>
         <translation>Tryckkänslighet</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="57"/>
         <source>For buttons which are pressure sensitive, this slider controls how much force will be simulated when the macro is active.</source>
         <translation>För knappar som är tryckkänsliga så kontrollerar denna draglist hur mycket kraft som ska simuleras när makrot är aktivt.</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="91"/>
+        <location filename="../controllermacroeditwidget.ui" line="171"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="103"/>
         <source>Trigger</source>
         <translation>Utlösare</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="111"/>
         <source>Select the trigger to activate this macro. This can be a single button, or combination of buttons (chord). Shift-click for multiple triggers.</source>
         <translation>Välj utlösaren för att aktivera detta makro. Detta kan vara en enda knapp eller en kombination av knappar (ackord). Skift-klicka för flera utlösare.</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="124"/>
         <source>Press To Toggle</source>
         <translation>Tryck för att växla</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="142"/>
         <source>Deadzone:</source>
         <translation>Dödläge:</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="183"/>
         <source>Frequency</source>
         <translation>Frekvens</translation>
     </message>
     <message>
+        <location filename="../controllermacroeditwidget.ui" line="191"/>
         <source>Macro will toggle every N frames.</source>
         <translation>Makrot kommer växla var N bildruta.</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="636"/>
         <source>Controller %1 Macro %2</source>
         <translation>Handkontroll %1 makro %2</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="655"/>
         <source>Not Configured</source>
         <translation>Inte konfigurerad</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="660"/>
+        <location filename="../controllerbindingwidgets.cpp" line="665"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="671"/>
         <source>Set Frequency</source>
         <translation>Ställ in frekvens</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="671"/>
         <source>Frequency: </source>
         <translation>Frekvens: </translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="700"/>
         <source>Macro will not repeat.</source>
         <translation>Makrot kommer inte upprepas.</translation>
     </message>
     <message numerus="yes">
+        <location filename="../controllerbindingwidgets.cpp" line="702"/>
         <source>Macro will toggle buttons every %n frame(s).</source>
         <translation>
             <numerusform>Makrot kommer att växla knappar var %n bildruta.</numerusform>
@@ -3766,10 +3393,12 @@ Den ”alternativa” färgen används när analogt läge är aktivt.</translati
 <context>
     <name>ControllerMacroWidget</name>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="529"/>
         <source>Controller Port %1 Macros</source>
         <translation>Kontrollerport %1-makron</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="539"/>
         <source>Macro %1
 %2</source>
         <translation>Makro %1
@@ -3779,66 +3408,85 @@ Den ”alternativa” färgen används när analogt läge är aktivt.</translati
 <context>
     <name>ControllerSettingsWindow</name>
     <message>
+        <location filename="../controllersettingswindow.ui" line="78"/>
         <source>Editing Preset:</source>
         <translation>Redigerar förval:</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.ui" line="95"/>
         <source>New Preset</source>
         <translation>Nytt förval</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.ui" line="106"/>
         <source>Apply Preset</source>
         <translation>Tillämpa förval</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.ui" line="117"/>
         <source>Delete Preset</source>
         <translation>Ta bort förval</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.ui" line="128"/>
         <source>Copy Global Settings</source>
         <translation>Kopiera globala inställningar</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="298"/>
         <source>Restore Defaults</source>
         <translation>Återställ standardvärden</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="184"/>
+        <location filename="../controllersettingswindow.cpp" line="582"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="327"/>
         <source>Per-game controller configuration reset to global settings.</source>
         <translation>Handkontrollerkonfiguration för per-spel nollställdes till globala inställningar.</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="76"/>
         <source>DuckStation Controller Presets</source>
         <translation>Handkontrollerförval för DuckStation</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="175"/>
+        <location filename="../controllersettingswindow.cpp" line="190"/>
+        <location filename="../controllersettingswindow.cpp" line="204"/>
         <source>Create Controller Preset</source>
         <translation>Skapa handkontrollerförval</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="175"/>
         <source>Enter the name for the new controller preset:</source>
         <translation>Ange namnet för det nya handkontrollerförvalet:</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="185"/>
         <source>A preset with the name &apos;%1&apos; already exists.</source>
         <translation>Ett förval med namnet &quot;%1&quot; finns redan.</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="191"/>
         <source>Do you want to copy all bindings from the currently-selected preset to the new preset? Selecting No will create a completely empty preset.</source>
         <translation>Vill du kopiera alla bindningar från aktuellt valt förval till det nya förvalet? Väljer du Nej så kommer en helt tomt förval att skapas.</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="205"/>
         <source>Do you want to copy the current hotkey bindings from global settings to the new controller preset?</source>
         <translation>Vill du kopiera de aktuella snabbtangentsbindningarna från globala inställningar till det nya handkontrollerförvalet?</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="248"/>
         <source>Load Controller Preset</source>
         <translation>Läs in handkontrollerförval</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="249"/>
         <source>Are you sure you want to apply the controller preset named &apos;%1&apos;?
 
 All current global bindings will be removed, and the preset bindings loaded.
@@ -3851,10 +3499,12 @@ Alla aktuella globala bindningar kommer att tas bort och förvalsbindningarna at
 Du kan inte ångra denna åtgärd.</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="275"/>
         <source>Delete Controller Preset</source>
         <translation>Ta bort handkontrollerförval</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="276"/>
         <source>Are you sure you want to delete the controller preset named &apos;%1&apos;?
 
 You cannot undo this action.</source>
@@ -3863,6 +3513,7 @@ You cannot undo this action.</source>
 Du kan inte ångra denna åtgärd.</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="299"/>
         <source>Are you sure you want to restore the default controller configuration?
 
 All bindings and configuration will be lost. You cannot undo this action.</source>
@@ -3871,106 +3522,74 @@ All bindings and configuration will be lost. You cannot undo this action.</sourc
 Alla bindningar och konfigurationen kommer att förloras . Du kan inte ångra denna åtgärd.</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="328"/>
         <source>Controller preset reset to global settings.</source>
         <translation>Handkontrollerförval nollställdes till globala inställningar.</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="438"/>
         <source>Global Settings</source>
         <translation>Globala inställningar</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="464"/>
+        <location filename="../controllersettingswindow.cpp" line="515"/>
         <source>Controller Port %1
 %2</source>
         <translation>Kontrollerport %1
 %2</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="477"/>
         <source>Hotkeys</source>
         <translation>Snabbtangenter</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.cpp" line="583"/>
         <source>The controller preset named &apos;%1&apos; cannot be found.</source>
         <translation>Handkontrollerförvalet med namnet &apos;%1&apos; kan inte hittas.</translation>
     </message>
     <message>
+        <location filename="../controllersettingswindow.ui" line="20"/>
+        <location filename="../controllersettingswindow.cpp" line="326"/>
         <source>DuckStation Controller Settings</source>
         <translation>Handkontrollerinställningar för DuckStation</translation>
     </message>
 </context>
 <context>
-    <name>ControllerType</name>
-    <message>
-        <source>Analog Controller</source>
-        <translation>Analog handkontroller</translation>
-    </message>
-    <message>
-        <source>Analog Joystick</source>
-        <translation>Analog joystick</translation>
-    </message>
-    <message>
-        <source>Not Connected</source>
-        <translation>Inte ansluten</translation>
-    </message>
-    <message>
-        <source>Digital Controller</source>
-        <translation>Digital handkontroller</translation>
-    </message>
-    <message>
-        <source>Pop&apos;n Controller</source>
-        <translation>Pop&apos;n Controller</translation>
-    </message>
-    <message>
-        <source>Densha de Go! Controller</source>
-        <translation>Densha de Go!-kontroller</translation>
-    </message>
-    <message>
-        <source>GunCon</source>
-        <translation>GunCon</translation>
-    </message>
-    <message>
-        <source>NeGcon</source>
-        <translation>NeGcon</translation>
-    </message>
-    <message>
-        <source>NeGcon (Rumble)</source>
-        <translation>NeGcon (Rumble)</translation>
-    </message>
-    <message>
-        <source>Mouse</source>
-        <translation>Mus</translation>
-    </message>
-    <message>
-        <source>Justifier</source>
-        <translation>Justifier</translation>
-    </message>
-    <message>
-        <source>JogCon</source>
-        <translation>JogCon</translation>
-    </message>
-</context>
-<context>
     <name>CoreThread</name>
     <message>
+        <location filename="../qthost.cpp" line="3136"/>
         <source>%1x%2</source>
         <translation>%1x%2</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1140"/>
+        <location filename="../qthost.cpp" line="1165"/>
+        <location filename="../qthost.cpp" line="1536"/>
+        <location filename="../qthost.cpp" line="1650"/>
+        <location filename="../qthost.cpp" line="1681"/>
+        <location filename="../qthost.cpp" line="1793"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1140"/>
         <source>Cannot change GPU dump state without restarting the system.</source>
         <translation>GPU-dumpens tillstånd kan inte ändras utan att systemet startas om.</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1166"/>
         <source>Failed to load state: %1</source>
         <translation>Misslyckades med att läsa in tillstånd: %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1414"/>
         <source>Memory Card Busy</source>
         <translation>Minneskortet är upptaget</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1415"/>
         <source>WARNING: Your game is still saving to the memory card. Continuing to %1 may IRREVERSIBLY DESTROY YOUR MEMORY CARD. We recommend resuming your game and waiting 5 seconds for it to finish saving.
 
 Do you want to %1 anyway?</source>
@@ -3979,10 +3598,12 @@ Do you want to %1 anyway?</source>
 Vill du %1 ändå?</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1424"/>
         <source>Achievement Unlocks Unconfirmed</source>
         <translation>Prestationsupplåsningar är obekräftade</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1425"/>
         <source>%1 achievement unlocks have not been confirmed by the server. Continuing to %2 will result in loss of these unlocks. Once network connectivity has been re-established, these unlocks will be confirmed automatically.
 
 Do you want to %2 anyway?</source>
@@ -3991,26 +3612,32 @@ Do you want to %2 anyway?</source>
 Vill du %2 ändå?</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1451"/>
         <source>shut down</source>
         <translation>stäng av</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1473"/>
         <source>reset</source>
         <translation>starta om</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1505"/>
         <source>change disc</source>
         <translation>byt skiva</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1536"/>
         <source>Failed to switch to subimage %1</source>
         <translation>Misslyckades med att växla till underbild %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1640"/>
         <source>Confirm Download</source>
         <translation>Bekräfta hämtning</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1641"/>
         <source>Your DuckStation installation does not have the padtest application available.
 
 This file is approximately 206KB, do you want to download it now?</source>
@@ -4019,26 +3646,32 @@ This file is approximately 206KB, do you want to download it now?</source>
 Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1793"/>
         <source>Failed to save state: %1</source>
         <translation>Misslyckades med att spara tillstånd: %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="3136"/>
         <source>No Image</source>
         <translation>Ingen bild</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="3146"/>
         <source>Game: %1 FPS</source>
         <translation>Spel: %1 bilder/s</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="3155"/>
         <source>Video: %1 FPS (%2%)</source>
         <translation>Video: %1 bilder/s (%2%)</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1791"/>
         <source>State saved to %1.</source>
         <translation>Tillstånd sparades till %1.</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1651"/>
         <source>Failed to download padtest application: %1</source>
         <translation>Misslyckades med att hämta applikationen padtest: %1</translation>
     </message>
@@ -4046,207 +3679,112 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>CoverDownloadWindow</name>
     <message>
+        <location filename="../coverdownloadwindow.ui" line="14"/>
         <source>Download Covers</source>
         <translation>Hämta omslagsbilder</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.ui" line="36"/>
         <source>DuckStation can automatically download covers for games which do not currently have a cover set. We do not host any cover images, the user must provide their own source for images.</source>
         <translation>DuckStation kan automatiskt hämta omslagsbilder för spel som du för närvarande inte har ett omslag för. Vi tillhandahåller inte några omslagsbilder och användaren måste tillhandahålla sin egna källa för bilder.</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.ui" line="54"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Depending on your jurisdiction, &lt;span style=&quot; font-weight:700;&quot;&gt;game covers may be copyrighted&lt;/span&gt;. You are only authorized to use this tool with &lt;span style=&quot; font-weight:700;&quot;&gt;your own servers and images&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;In the box below, specify the URLs to download covers from, with one template URL per line. The following variables are available:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${title}:&lt;/span&gt; Title of the game.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${savetitle}:&lt;/span&gt; Title of the game including the region.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${localizedtitle}:&lt;/span&gt; Localized (native language) title of the game.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${filetitle}:&lt;/span&gt; Name component of the game&apos;s filename.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${serial}:&lt;/span&gt; Serial of the game.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Example:&lt;/span&gt; https://www.example-not-a-real-domain.com/covers/${serial}.jpg&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Beroende på din jurisdiktion kan &lt;span style=&quot; font-weight:700;&quot;&gt;spelomslag vara upphovsrättsskyddade&lt;/span&gt;. Du får endast använda verktyget med &lt;span style=&quot; font-weight:700;&quot;&gt;dina egna servrar och bilder&lt;/span&gt;.&lt;/p&gt;&lt;p&gt;Ange webbadresserna som omslag ska hämtas från i rutan nedan, med en malladress per rad. Följande variabler är tillgängliga:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${title}:&lt;/span&gt; Spelets titel.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${savetitle}:&lt;/span&gt; Spelets titel inklusive region.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${localizedtitle}:&lt;/span&gt; Lokaliserad titel (originalspråk).&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${filetitle}:&lt;/span&gt; Titeldelen av spelets filnamn.&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;${serial}:&lt;/span&gt; Spelets serienummer.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Exempel:&lt;/span&gt; https://www.example-not-a-real-domain.com/covers/${serial}.jpg&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.ui" line="73"/>
         <source>By default, the downloaded covers will be saved with the game&apos;s title. If this is not desired, you can check the &quot;Use Serial File Names&quot; box below. Using serials instead of game titles will prevent conflicts when multiple regions of the same game are used.</source>
         <translation>Som standard kommer hämtade omslagsbilder att sparas med spelets titel. Om detta inte är önskvärt så kan du välja &quot;Använd filnamn för serienummer&quot; nedan. Använda serienummer istället för speltitlar förhindrar konflikter när flera regioner av samma spel används.</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.ui" line="83"/>
         <source>Use Serial File Names</source>
         <translation>Använd filnamn för serienummer</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.ui" line="90"/>
         <source>Waiting to start...</source>
         <translation>Väntar på att starta...</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.ui" line="105"/>
+        <location filename="../coverdownloadwindow.cpp" line="107"/>
         <source>Start</source>
         <translation>Starta</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.ui" line="119"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.cpp" line="93"/>
         <source>Download complete.</source>
         <translation>Hämtningen är färdig.</translation>
     </message>
     <message>
+        <location filename="../coverdownloadwindow.cpp" line="107"/>
         <source>Stop</source>
         <translation>Stoppa</translation>
     </message>
 </context>
 <context>
-    <name>DDGoController</name>
-    <message>
-        <source>Select</source>
-        <translation>Select</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <source>C</source>
-        <translation>C</translation>
-    </message>
-    <message>
-        <source>Power 1</source>
-        <translation>Gas 1</translation>
-    </message>
-    <message>
-        <source>Power 2</source>
-        <translation>Gas 2</translation>
-    </message>
-    <message>
-        <source>Power 3</source>
-        <translation>Gas 3</translation>
-    </message>
-    <message>
-        <source>Brake 1</source>
-        <translation>Broms 1</translation>
-    </message>
-    <message>
-        <source>Brake 3</source>
-        <translation>Broms 3</translation>
-    </message>
-    <message>
-        <source>Brake 2</source>
-        <translation>Broms 2</translation>
-    </message>
-    <message>
-        <source>Brake 4</source>
-        <translation>Broms 4</translation>
-    </message>
-    <message>
-        <source>Power Off</source>
-        <translation>Gasreglage av</translation>
-    </message>
-    <message>
-        <source>Power 4</source>
-        <translation>Gas 4</translation>
-    </message>
-    <message>
-        <source>Power 5</source>
-        <translation>Gas 5</translation>
-    </message>
-    <message>
-        <source>Brake Released</source>
-        <translation>Broms släppt</translation>
-    </message>
-    <message>
-        <source>Brake 5</source>
-        <translation>Broms 5</translation>
-    </message>
-    <message>
-        <source>Brake 6</source>
-        <translation>Broms 6</translation>
-    </message>
-    <message>
-        <source>Brake 7</source>
-        <translation>Broms 7</translation>
-    </message>
-    <message>
-        <source>Brake 8</source>
-        <translation>Broms 8</translation>
-    </message>
-    <message>
-        <source>Brake Emergency</source>
-        <translation>Nödbroms</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation>Gas</translation>
-    </message>
-    <message>
-        <source>Brake</source>
-        <translation>Broms</translation>
-    </message>
-    <message>
-        <source>Analog Deadzone</source>
-        <translation>Analogt dödläge</translation>
-    </message>
-    <message>
-        <source>Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.</source>
-        <translation>Ställer in dödläget för analoga spaken, alltså den del av spakrörelser som kommer att ignoreras.</translation>
-    </message>
-    <message>
-        <source>Analog Sensitivity</source>
-        <translation>Analog känslighet</translation>
-    </message>
-    <message>
-        <source>Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent controllers, e.g. DualShock 4, Xbox One Controller.</source>
-        <translation>Ställer in skalningsfaktorn för den analoga spakens axlar. Ett värde mellan 130% och 140% rekommenderas när senare handkontroller används, t.ex. DualShock 4, Xbox One-handkontroller.</translation>
-    </message>
-    <message>
-        <source>Power Transition Frames</source>
-        <translation>Bildrutor för gasövergång</translation>
-    </message>
-    <message>
-        <source>Sets the number of frames that the controller will report the transitioning/inbetween state when changing power level.</source>
-        <translation>Ställer in antalet bildrutor som styrenheten ska rapportera övergångs-/mellanläget vid ändring av gasnivå.</translation>
-    </message>
-    <message>
-        <source>Brake Transition Frames</source>
-        <translation>Bildrutor för bromsövergång</translation>
-    </message>
-    <message>
-        <source>Sets the number of frames that the controller will report the transitioning/inbetween state when changing brake level.</source>
-        <translation>Ställer in antalet bildrutor som styrenheten ska rapportera övergångs-/mellanläget vid ändring av bromsnivå.</translation>
-    </message>
-</context>
-<context>
     <name>DebuggerAddBreakpointDialog</name>
     <message>
+        <location filename="../debuggeraddbreakpointdialog.ui" line="14"/>
         <source>Add Breakpoint</source>
         <translation>Lägg till brytpunkt</translation>
     </message>
     <message>
+        <location filename="../debuggeraddbreakpointdialog.ui" line="20"/>
         <source>Address:</source>
         <translation>Adress:</translation>
     </message>
     <message>
+        <location filename="../debuggeraddbreakpointdialog.ui" line="30"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
+        <location filename="../debuggeraddbreakpointdialog.ui" line="42"/>
         <source>Execute</source>
         <translation>Kör</translation>
     </message>
     <message>
+        <location filename="../debuggeraddbreakpointdialog.ui" line="52"/>
         <source>Read</source>
         <translation>Läs</translation>
     </message>
     <message>
+        <location filename="../debuggeraddbreakpointdialog.ui" line="59"/>
         <source>Write</source>
         <translation>Skriv</translation>
     </message>
 </context>
 <context>
+    <name>DebuggerCallStackModel</name>
+    <message>
+        <location filename="../debuggermodels.cpp" line="253"/>
+        <source>Address</source>
+        <translation>Adress</translation>
+    </message>
+    <message>
+        <location filename="../debuggermodels.cpp" line="255"/>
+        <source>Frame</source>
+        <translation>Bildruta</translation>
+    </message>
+</context>
+<context>
     <name>DebuggerRegistersModel</name>
     <message>
+        <location filename="../debuggermodels.cpp" line="100"/>
         <source>Register</source>
         <translation>Register</translation>
     </message>
     <message>
+        <location filename="../debuggermodels.cpp" line="102"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
@@ -4254,14 +3792,30 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>DebuggerStackModel</name>
     <message>
+        <location filename="../debuggermodels.cpp" line="158"/>
         <source>&lt;invalid&gt;</source>
         <translation>&lt;ogiltig&gt;</translation>
     </message>
     <message>
+        <location filename="../debuggermodels.cpp" line="174"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
+        <location filename="../debuggermodels.cpp" line="176"/>
+        <source>Value</source>
+        <translation>Värde</translation>
+    </message>
+</context>
+<context>
+    <name>DebuggerThreadsModel</name>
+    <message>
+        <location filename="../debuggermodels.cpp" line="397"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="../debuggermodels.cpp" line="399"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
@@ -4269,565 +3823,645 @@ Denna fil är ungefär 206 KB. Vill du hämta den nu?</translation>
 <context>
     <name>DebuggerWindow</name>
     <message>
+        <location filename="../debuggerwindow.ui" line="382"/>
         <source>Step Into</source>
         <translation>Stega in i</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="385"/>
         <source>F11</source>
         <translation>F11</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="397"/>
         <source>Step Over</source>
         <translation>Stega över</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="400"/>
         <source>F10</source>
         <translation>F10</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="436"/>
         <source>Step Out</source>
         <translation>Stega ut</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="14"/>
         <source>CPU Debugger</source>
         <translation>CPU-felsökare</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="34"/>
         <source>&amp;Debug</source>
         <translation>&amp;Felsök</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="53"/>
+        <location filename="../debuggerwindow.ui" line="258"/>
         <source>Breakpoints</source>
         <translation>Brytpunkter</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="65"/>
         <source>toolBar</source>
         <translation>verktygsrad</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="95"/>
         <source>Disassembly</source>
         <translation>Disassembler</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="114"/>
         <source>Registers</source>
         <translation>Register</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="145"/>
         <source>Memory</source>
         <translation>Minne</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="167"/>
         <source>RAM</source>
         <translation>RAM</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="177"/>
         <source>Scratchpad</source>
         <translation>Skissblock</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="184"/>
         <source>EXP1</source>
         <translation>EXP1</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="191"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="198"/>
         <source>VRAM</source>
         <translation>VRAM</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="205"/>
         <source>SPU RAM</source>
         <translation>SPU-RAM</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="230"/>
         <source>Search</source>
         <translation>Sök</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="278"/>
         <source>#</source>
         <translation>#</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="283"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="288"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="293"/>
         <source>Hit Count</source>
         <translation>Antal träffar</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="303"/>
         <source>Stack</source>
         <translation>Stapel</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="322"/>
+        <source>Threads</source>
+        <translation>Trådar</translation>
+    </message>
+    <message>
+        <location filename="../debuggerwindow.ui" line="341"/>
+        <source>Call Stack</source>
+        <translation>Anropsstack</translation>
+    </message>
+    <message>
+        <location filename="../debuggerwindow.ui" line="364"/>
         <source>&amp;Pause/Continue</source>
         <translation>&amp;Paus/Fortsätt</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="367"/>
         <source>Pause/Continue</source>
         <translation>Paus/Fortsätt</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="370"/>
         <source>F5</source>
         <translation>F5</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="379"/>
         <source>&amp;Step Into</source>
         <translation>&amp;Stega in i</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="394"/>
         <source>Step &amp;Over</source>
         <translation>Stega ö&amp;ver</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="409"/>
+        <location filename="../debuggerwindow.cpp" line="349"/>
         <source>Toggle &amp;Breakpoint</source>
         <translation>Växla &amp;brytpunkt</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="412"/>
         <source>Toggle Breakpoint</source>
         <translation>Växla brytpunkt</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="415"/>
         <source>F9</source>
         <translation>F9</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="424"/>
         <source>&amp;Close</source>
         <translation>S&amp;täng</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="433"/>
         <source>Step O&amp;ut</source>
         <translation>Stega &amp;ut</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="439"/>
         <source>Ctrl+F11</source>
         <translation>Ctrl+F11</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="448"/>
+        <location filename="../debuggerwindow.cpp" line="352"/>
         <source>&amp;Run To Cursor</source>
         <translation>&amp;Kör till markör</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="451"/>
         <source>Run To Cursor</source>
         <translation>Kör till markör</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="454"/>
         <source>Ctrl+F10</source>
         <translation>Ctrl+F10</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="463"/>
         <source>&amp;Clear Breakpoints</source>
         <translation>&amp;Töm brytpunkter</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="466"/>
         <source>Clear Breakpoints</source>
         <translation>Töm brytpunkter</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="469"/>
         <source>Ctrl+Del</source>
         <translation>Ctrl+Del</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="478"/>
         <source>&amp;Add Breakpoint</source>
         <translation>&amp;Lägg till brytpunkt</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="481"/>
         <source>Add Breakpoint</source>
         <translation>Lägg till brytpunkt</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="484"/>
         <source>Ctrl+F9</source>
         <translation>Ctrl+F9</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="493"/>
         <source>&amp;Go To PC</source>
         <translation>&amp;Gå till PC</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="496"/>
         <source>Go To PC</source>
         <translation>Gå till PC</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="499"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="508"/>
         <source>Go To &amp;Address</source>
         <translation>Gå till &amp;adress</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="511"/>
         <source>Go To Address</source>
         <translation>Gå till adress</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="514"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="523"/>
         <source>&amp;Dump Address</source>
         <translation>&amp;Dumpa adress</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="526"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="535"/>
         <source>&amp;Trace</source>
         <translation>S&amp;påra</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="538"/>
         <source>Trace</source>
         <translation>Spåra</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.ui" line="541"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
+        <location filename="../debuggermodels.cpp" line="530"/>
+        <location filename="../qtutils.cpp" line="220"/>
         <source>Invalid address. It should be in hex (0x12345678 or 12345678)</source>
         <translation>Ogiltig adress. Den bör anges i hex (0x12345678 eller 12345678)</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="168"/>
         <source>No address selected.</source>
         <translation>Ingen adress vald.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="184"/>
         <source>Enter code address:</source>
         <translation>Ange kodadress:</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="194"/>
+        <location filename="../qtutils.cpp" line="203"/>
         <source>Enter memory address:</source>
         <translation>Ange minnesadress:</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="218"/>
         <source>Trace logging started to cpu_log.txt.
 This file can be several gigabytes, so be aware of SSD wear.</source>
         <translation>Spårloggning startad till cpu_log.txt.
 Denna fil kan bli flera gigabytes så tänk på diskutrymmet.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="223"/>
         <source>Trace logging to cpu_log.txt stopped.</source>
         <translation>Spårloggning till cpu_log.txt stoppad.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="262"/>
         <source>&amp;Remove</source>
         <translation>&amp;Ta bort</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="314"/>
         <source>Debugger</source>
         <translation>Felsökare</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="315"/>
         <source>Failed to add step-out breakpoint, are you in a valid function?</source>
         <translation>Misslyckades med att stega ut ur brytpunkt. Är du i en giltig funktion?</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="363"/>
         <source>&amp;Patch Instruction</source>
         <translation>&amp;Patcha instruktion</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="367"/>
         <source>&amp;Nop Instruction</source>
         <translation>&amp;Noppa instruktion</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="372"/>
         <source>View in &amp;Dump</source>
         <translation>Visa i &amp;dump</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="375"/>
         <source>&amp;Follow Load/Store</source>
         <translation>&amp;Följ läs in/Lagra</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="417"/>
         <source>Failed to read the instruction at 0x%1.</source>
         <translation>Det gick inte att läsa instruktionen vid 0x%1.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="428"/>
         <source>Patch Instruction</source>
         <translation>Patcha instruktion</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="429"/>
         <source>Enter replacement instruction for 0x%1:</source>
         <translation>Ange ersättningsinstruktion för 0x%1:</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="444"/>
         <source>Invalid Instruction</source>
         <translation>Ogiltig instruktion</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="463"/>
         <source>Failed to write patched instruction to 0x%1.</source>
         <translation>Det gick inte att skriva den patchade instruktionen till 0x%1.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="469"/>
         <source>Patched instruction at 0x%1.</source>
         <translation>Patchade instruktionen vid 0x%1.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="520"/>
+        <location filename="../debuggerwindow.cpp" line="547"/>
         <source>Invalid search pattern. It should contain hex digits or question marks.</source>
         <translation>Ogiltigt sökmönster. Det bör innehålla hexadecimala siffror eller frågetecken.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="559"/>
         <source>Pattern not found.</source>
         <translation>Mönstret hittades inte.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="575"/>
         <source>Pattern found at 0x%1 (passed the end of memory).</source>
         <translation>Mönster hittades vid 0x%1 (passerat minnets slut).</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="581"/>
         <source>Pattern found at 0x%1.</source>
         <translation>Mönster hittades på 0x%1.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="911"/>
         <source>Failed to add breakpoint. A breakpoint may already exist at this address.</source>
         <translation>Misslyckades med att lägga till brytpunkt. En brytpunkt kanske redan finns på denna adress.</translation>
     </message>
     <message>
+        <location filename="../debuggerwindow.cpp" line="931"/>
         <source>Failed to remove breakpoint. This breakpoint may not exist.</source>
         <translation>Misslyckades med att ta bort brytpunkt. Denna brytpunkt kanske inte finns.</translation>
+    </message>
+    <message>
+        <location filename="../debuggerwindow.cpp" line="1043"/>
+        <source>Loaded %1 saved breakpoints.</source>
+        <translation>Läste in %1 sparade brytpunkter.</translation>
     </message>
 </context>
 <context>
     <name>DebuggingSettingsWidget</name>
     <message>
+        <location filename="../debuggingsettingswidget.ui" line="51"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Changing these settings may cause games to become unstable or crash.&lt;/span&gt; Do not change any settings on this page if you do not know what you are doing, or understand what the impact of the change will be.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Om du ändrar dessa inställningar kan spel bli instabila eller krascha.&lt;/span&gt; Ändra inte inställningarna på den här sidan om du inte vet vad du gör eller förstår vilka konsekvenser ändringen får.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.ui" line="64"/>
         <source>Reset To Default</source>
         <translation>Återställ till standard</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.ui" line="85"/>
         <source>Option</source>
         <translation>Alternativ</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.ui" line="90"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="145"/>
         <source>Select folder for %1</source>
         <translation>Välj mapp för %1</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="184"/>
         <source>Apply Game Settings</source>
         <translation>Tillämpa spelinställningar</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="188"/>
         <source>Apply Compatibility Settings</source>
         <translation>Tillämpa kompatibilitetsinställningar</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="190"/>
         <source>Load Devices From Save States</source>
         <translation>Läs in enheter från sparade tillstånd</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="192"/>
         <source>Pause On Start</source>
         <translation>Pausa vid start</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="193"/>
         <source>Save State Compression</source>
         <translation>Komprimering för sparat tillstånd</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="201"/>
         <source>Display Active Start Offset</source>
         <translation>Visa aktiv startoffset</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="203"/>
         <source>Display Active End Offset</source>
         <translation>Visa aktiv slutoffset</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="205"/>
         <source>Display Line Start Offset</source>
         <translation>Offset för visningsradens början</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="207"/>
         <source>Display Line End Offset</source>
         <translation>Offset för visning av linjens slut</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="211"/>
         <source>DMA Max Slice Ticks</source>
         <translation>DMA Max Slice Ticks</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="212"/>
+        <location filename="../debuggingsettingswidget.cpp" line="214"/>
+        <location filename="../debuggingsettingswidget.cpp" line="218"/>
+        <location filename="../debuggingsettingswidget.cpp" line="237"/>
+        <location filename="../debuggingsettingswidget.cpp" line="240"/>
         <source> cycles</source>
         <translation> cykler</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="213"/>
         <source>DMA Halt Ticks</source>
         <translation>DMA Halt Ticks</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="215"/>
         <source>GPU FIFO Size</source>
         <translation>GPU FIFO-storlek</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="216"/>
         <source> words</source>
         <translation> ord</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="217"/>
         <source>GPU Max Runahead</source>
         <translation>GPU Max Runahead</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="220"/>
         <source>Enable Recompiler Memory Exceptions</source>
         <translation>Aktivera minnesundantag för omkompilerare</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="222"/>
         <source>Enable Recompiler Block Linking</source>
         <translation>Aktivera blocklänkning för omkompilerare</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="224"/>
         <source>Enable Recompiler Fast Memory Access</source>
         <translation>Aktivera snabb minnesåtkomst för omkompilerare</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="229"/>
         <source>CD-ROM Mechacon Version</source>
         <translation>CD-ROM Mechacon-version</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="233"/>
         <source>CD-ROM Readahead Sectors</source>
         <translation>CD-ROM Readahead-sektorer</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="234"/>
         <source> sectors</source>
         <translation> sektorer</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="235"/>
         <source>CD-ROM Max Read Speedup Cycles</source>
         <translation>Maximalt antal accelerationscykler för CD-ROM-läsning</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="238"/>
         <source>CD-ROM Max Seek Speedup Cycles</source>
         <translation>Maximalt antal accelerationscykler för CD-ROM-sökning</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="241"/>
         <source>CD-ROM Disable Speedup on MDEC</source>
         <translation>Inaktivera CD-ROM-hastighetsökning på MDEC</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="243"/>
         <source>CD-ROM Region Check</source>
         <translation>Regionskontroll för CD-ROM</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="244"/>
         <source>CD-ROM SubQ Skew</source>
         <translation>CD-ROM SubQ Skew</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="245"/>
         <source>Allow Booting Without SBI File</source>
         <translation>Tillåt uppstarter utan SBI-fil</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="248"/>
         <source>Enable GDB Server</source>
         <translation>Aktivera GDB-server</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="249"/>
         <source>GDB Server Port</source>
         <translation>GDB-serverport</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="252"/>
         <source>Enable PCSX Expansion Region</source>
         <translation>Aktivera PCSX-expansionsområde</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="254"/>
         <source>Export Shared Memory</source>
         <translation>Exportera delat minne</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="256"/>
         <source>Redirect SIO to TTY</source>
         <translation>Omdirigera SIO till TTY</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="257"/>
         <source>Enable PCDrv</source>
         <translation>Aktivera PCDrv</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="258"/>
         <source>Enable PCDrv Writes</source>
         <translation>Aktivera PCDrv-skrivningar</translation>
     </message>
     <message>
+        <location filename="../debuggingsettingswidget.cpp" line="259"/>
         <source>PCDrv Root Directory</source>
         <translation>Rotkatalog för PCDrv</translation>
     </message>
 </context>
 <context>
-    <name>DigitalController</name>
-    <message>
-        <source>Disable Simultaneous Opposing Cardinal Directions</source>
-        <translation>Inaktivera samtidiga motsatta riktningar</translation>
-    </message>
-    <message>
-        <source>Prevents concurrent left/right or up/down inputs from being presented to the game.</source>
-        <translation>Förhindrar att samtidiga inmatningar åt vänster/höger eller upp/ner presenteras för spelet.</translation>
-    </message>
-    <message>
-        <source>D-Pad Up</source>
-        <translation>Riktningsknapp upp</translation>
-    </message>
-    <message>
-        <source>D-Pad Right</source>
-        <translation>Riktningsknapp höger</translation>
-    </message>
-    <message>
-        <source>D-Pad Down</source>
-        <translation>Riktningsknapp ner</translation>
-    </message>
-    <message>
-        <source>D-Pad Left</source>
-        <translation>Riktningsknapp vänster</translation>
-    </message>
-    <message>
-        <source>Triangle</source>
-        <translation>Triangel</translation>
-    </message>
-    <message>
-        <source>Circle</source>
-        <translation>Cirkel</translation>
-    </message>
-    <message>
-        <source>Cross</source>
-        <translation>Kryss</translation>
-    </message>
-    <message>
-        <source>Square</source>
-        <translation>Fyrkant</translation>
-    </message>
-    <message>
-        <source>Select</source>
-        <translation>Select</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>L1</source>
-        <translation>L1</translation>
-    </message>
-    <message>
-        <source>R1</source>
-        <translation>R1</translation>
-    </message>
-    <message>
-        <source>L2</source>
-        <translation>L2</translation>
-    </message>
-    <message>
-        <source>R2</source>
-        <translation>R2</translation>
-    </message>
-</context>
-<context>
     <name>EditGameSerialDialog</name>
     <message>
+        <location filename="../editgameserialdialog.ui" line="14"/>
         <source>Edit Game Serial</source>
         <translation>Redigera spelets serienummer</translation>
     </message>
     <message>
+        <location filename="../editgameserialdialog.ui" line="53"/>
         <source>Changing the serial for a game will make it appear as a different game, and will not share save data or settings with the original game.
 
 Clicking Reset will restore the serial back to the value scanned from in the disc image.</source>
@@ -4836,14 +4470,17 @@ Clicking Reset will restore the serial back to the value scanned from in the dis
 Om du klickar på Återställ återställs serienumret till värdet som lästes från skivavbilden.</translation>
     </message>
     <message>
+        <location filename="../editgameserialdialog.ui" line="73"/>
         <source>Path:</source>
         <translation>Sökväg:</translation>
     </message>
     <message>
+        <location filename="../editgameserialdialog.ui" line="87"/>
         <source>New Serial:</source>
         <translation>Nytt serienummer:</translation>
     </message>
     <message>
+        <location filename="../editgameserialdialog.ui" line="97"/>
         <source>This game currently has a custom serial set.</source>
         <translation>Spelet har för närvarande ett anpassat serienummer.</translation>
     </message>
@@ -4851,14 +4488,17 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
 <context>
     <name>EmptyGameListWidget</name>
     <message>
+        <location filename="../emptygamelistwidget.ui" line="82"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;No games in supported formats were found.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Please add a directory with games to begin.&lt;/p&gt;&lt;p&gt;Game dumps in the following formats will be scanned and listed:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Inga spel i format som stöds hittades.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Lägg till en katalog med spel för att börja.&lt;/p&gt;&lt;p&gt;Speldumpar i följande format kommer att sökas igenom och listas:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../emptygamelistwidget.ui" line="114"/>
         <source>Add Game Directory...</source>
         <translation>Lägg till spelkatalog...</translation>
     </message>
     <message>
+        <location filename="../emptygamelistwidget.ui" line="155"/>
         <source>Scan For New Games</source>
         <translation>Sök efter nya spel</translation>
     </message>
@@ -4866,270 +4506,359 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
 <context>
     <name>EmulationSettingsWidget</name>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="29"/>
         <source>Speed Control</source>
         <translation>Hastighetskontroll</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="42"/>
         <source>Fast Forward Speed:</source>
         <translation>Hastighet för snabbspolning:</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="49"/>
         <source>Turbo Speed:</source>
         <translation>Turbohastighet:</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="164"/>
         <source>Latency Control</source>
         <translation>Latenskontroll</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="191"/>
+        <location filename="../emulationsettingswidget.cpp" line="197"/>
         <source>Reduce Input Latency</source>
         <translation>Reducera inmatningslatens</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="177"/>
+        <location filename="../emulationsettingswidget.cpp" line="184"/>
         <source>Sync To Host Refresh Rate</source>
         <translation>Synka till värdens uppdateringsfrekvens</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="198"/>
+        <location filename="../emulationsettingswidget.cpp" line="206"/>
         <source>Skip Duplicate Frame Display</source>
         <translation>Hoppa över dubblett bildvisning</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="213"/>
         <source>Frame Time Buffer:</source>
         <translation>Bildtidsbuffert:</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="220"/>
         <source> Milliseconds</source>
         <translation> millisekunder</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="291"/>
         <source>Enable Rewinding</source>
         <translation>Aktivera tillbakaspolning</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="244"/>
         <source>Rewind Save Frequency:</source>
         <translation>Frekvens för sparande av tillbakaspolning:</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="278"/>
         <source> Seconds</source>
         <translation> sekunder</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="271"/>
         <source>Rewind Buffer Size:</source>
         <translation>Buffertstorlek för tillbakaspolning:</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="35"/>
         <source>Normal Speed:</source>
         <translation>Normal hastighet:</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="58"/>
+        <location filename="../emulationsettingswidget.ui" line="93"/>
+        <location filename="../emulationsettingswidget.ui" line="128"/>
+        <location filename="../emulationsettingswidget.cpp" line="73"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="78"/>
         <source>Reset Normal Speed</source>
         <translation>Återställ normal hastighet</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="113"/>
         <source>Reset Fast Forward Speed</source>
         <translation>Återställ snabbspolningshastighet</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="148"/>
         <source>Reset Turbo Speed</source>
         <translation>Återställ turbohastighet</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="251"/>
         <source> Frames</source>
         <translation> bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="314"/>
         <source>Runahead:</source>
         <translation>Runahead:</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="327"/>
         <source>1 Frame</source>
         <translation>1 bildruta</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="337"/>
         <source>3 Frames</source>
         <translation>3 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="342"/>
         <source>4 Frames</source>
         <translation>4 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="347"/>
         <source>5 Frames</source>
         <translation>5 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="352"/>
         <source>6 Frames</source>
         <translation>6 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="357"/>
         <source>7 Frames</source>
         <translation>7 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="362"/>
         <source>8 Frames</source>
         <translation>8 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="367"/>
         <source>9 Frames</source>
         <translation>9 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="372"/>
         <source>10 Frames</source>
         <translation>10 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="322"/>
+        <location filename="../emulationsettingswidget.cpp" line="224"/>
         <source>Disabled</source>
         <translation>Inaktiverad</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="184"/>
+        <location filename="../emulationsettingswidget.cpp" line="191"/>
         <source>Optimal Frame Pacing</source>
         <translation>Optimal bildrytm</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="170"/>
+        <location filename="../emulationsettingswidget.cpp" line="179"/>
         <source>Vertical Sync (VSync)</source>
         <translation>Vertikal sync (VSync)</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="63"/>
         <source>N/A</source>
         <translation>Inte tillgängligt</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="72"/>
         <source>% (Normal Speed)</source>
         <translation>% (normal hastighet)</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="169"/>
         <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached, and if not, the emulator will run as fast as it can manage.</source>
         <translation>Ställer in målhastigheten för emuleringen. Det är inte säkert att denna hastighet uppnås, och om så inte är fallet körs emulatorn så snabbt som den klarar av.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="172"/>
         <source>Fast Forward Speed</source>
         <translation>Hastighet för snabbspolning</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="172"/>
+        <location filename="../emulationsettingswidget.cpp" line="175"/>
         <source>User Preference</source>
         <translation>Användarinställningar</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="173"/>
         <source>Sets the fast forward speed. This speed will be used when the fast forward hotkey is pressed/toggled.</source>
         <translation>Ställer in hastigheten för snabbspolning framåt. Denna hastighet används när snabbtangenten för snabbspolning trycks in/växlas.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="175"/>
         <source>Turbo Speed</source>
         <translation>Turbohastighet</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="176"/>
         <source>Sets the turbo speed. This speed will be used when the turbo hotkey is pressed/toggled. Turboing will take priority over fast forwarding if both hotkeys are pressed/toggled.</source>
         <translation>Ställer in turbo-hastigheten. Denna hastighet används när snabbtangenten för turbo trycks in/växlas. Turbo prioriteras framför snabbspolning framåt om båda snabbknapparna är nedtryckta/växlade.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="180"/>
         <source>Synchronizes presentation of the console&apos;s frames to the host. Enabling may result in smoother animations, at the cost of increased input lag. &lt;strong&gt;GSync/FreeSync users should enable Optimal Frame Pacing instead.&lt;/strong&gt;</source>
         <translation>Synkroniserar presentationen av konsolens bildrutor till värden. Aktivering kan resultera i mjukare animeringar, men till priset av ökad input lag. &lt;strong&gt;GSync/FreeSync-användare bör aktivera Optimal bildrytm istället.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="185"/>
         <source>Adjusts the emulation speed so the console&apos;s refresh rate matches the host&apos;s refresh rate when VSync is enabled. This results in the smoothest animations possible, at the cost of potentially increasing the emulation speed by less than 1%. Sync To Host Refresh Rate will not take effect if the console&apos;s refresh rate is too far from the host&apos;s refresh rate. Users with variable refresh rate displays should disable this option.</source>
         <translation>Justerar emuleringshastigheten så att konsolens uppdateringsfrekvens matchar värdens uppdateringsfrekvens när VSync är aktiverat. Detta ger så mjuka animeringar som möjligt, till priset av en potentiell ökning av emuleringshastigheten med mindre än 1%. Synkronisering med värddatorns uppdateringsfrekvens fungerar inte om konsolens uppdateringsfrekvens ligger för långt från värddatorns uppdateringsfrekvens. Användare med skärmar med variabel uppdateringsfrekvens bör inaktivera det här alternativet.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="192"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="193"/>
         <source>Enabling this option will ensure every frame the console renders is displayed to the screen, at a consistent rate, for optimal frame pacing. If you have a GSync/FreeSync display, enable this option. If you are having difficulties maintaining full speed, or are getting audio glitches, try disabling this option.</source>
         <translation>Om du aktiverar det här alternativet kommer varje bildruta som konsolen renderar att visas på skärmen med en jämn hastighet, vilket ger optimal bildrytm. Om du har en GSync/FreeSync-skärm ska du aktivera det här alternativet. Om du har svårt att hålla full hastighet eller om du får ljudstörningar kan du försöka inaktivera det här alternativet.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="198"/>
         <source>Reduces input latency by delaying the start of frame until closer to the presentation time. This may cause dropped frames on slower systems with higher frame time variance, if the buffer size is not sufficient.</source>
         <translation>Minskar inmatningslatensen genom att fördröja starten av bildrutan till närmare presentationstiden. Detta kan orsaka tappade bildrutor på långsammare system med högre bildtidsvarians, om buffertstorleken inte är tillräcklig.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="200"/>
         <source>Frame Time Buffer</source>
         <translation>Bildtidsbuffert</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="201"/>
         <source>%1 ms</source>
         <translation>%1 ms</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="202"/>
         <source>Specifies the amount of buffer time added, which reduces the additional sleep time introduced. Higher values increase input latency, but decrease the risk of overrun, or missed frames. Lower values require faster hardware.</source>
         <translation>Anger hur mycket bufferttid som läggs till, vilket minskar den extra sömntid som införs. Högre värden ökar inmatningslatensen, men minskar risken för överkörning eller missade bilder. Lägre värden kräver snabbare hårdvara.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="207"/>
         <source>Skips the presentation/display of frames that are not unique. Can be combined with driver-level frame generation to increase perceptible frame rate. Can result in worse frame pacing, and is not compatible with syncing to host refresh.</source>
         <translation>Hoppar över presentation/visning av bildrutor som inte är unika. Kan kombineras med bildgenerering på drivrutinsnivå för att öka den märkbara bildfrekvensen. Kan resultera i sämre bildrytm och är inte kompatibel med synkronisering med host refresh.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="211"/>
         <source>Rewinding</source>
         <translation>Tillbakaspolning</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="212"/>
         <source>&lt;b&gt;Enable Rewinding:&lt;/b&gt; Saves state periodically so you can rewind any mistakes while playing.&lt;br&gt; &lt;b&gt;Rewind Save Frequency:&lt;/b&gt; How often a rewind state will be created. Higher frequencies have greater system requirements.&lt;br&gt; &lt;b&gt;Rewind Buffer Size:&lt;/b&gt; How many saves will be kept for rewinding. Higher values have greater memory requirements.</source>
         <translation>&lt;b&gt;Aktivera tillbakaspolning:&lt;/b&gt; Sparar tillståndet regelbundet så att du kan spola tillbaka om du gör fel under spelningen.&lt;br&gt; &lt;b&gt;Frekvens för sparande av tillbakaspolning:&lt;/b&gt; Hur ofta ett tillbakaspolningstillstånd skapas. Högre frekvenser har högre systemkrav.&lt;br&gt; &lt;b&gt;Buffertstorlek för återspolning:&lt;/b&gt; Hur många sparningar som behålls för tillbakaspolning. Högre värden kräver mer minne.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="308"/>
+        <location filename="../emulationsettingswidget.cpp" line="224"/>
         <source>Runahead</source>
         <translation>Runahead</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="225"/>
         <source>Simulates the system ahead of time and rolls back/replays to reduce input lag. Very high system requirements.</source>
         <translation>Simulerar systemet i förväg och rullar tillbaka/spelar upp för att minska fördröjningen. Mycket höga systemkrav.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="43"/>
         <source>Use Global Setting [Unlimited]</source>
         <translation>Använd global inställning  [obegränsat]</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="302"/>
         <source>Rewind is disabled because runahead is enabled. Runahead will significantly increase system requirements.</source>
         <translation>Tillbakaspolning är inaktiverad eftersom runahead är aktiverat. Runahead kommer att öka systemkraven avsevärt.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="308"/>
         <source>Rewind is not enabled. Please note that enabling rewind may significantly increase system requirements.</source>
         <translation>Tillbakaspolning är inte aktiverad. Observera att aktivera tillbakaspolning kan öka systemkraven mycket.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="179"/>
+        <location filename="../emulationsettingswidget.cpp" line="184"/>
+        <location filename="../emulationsettingswidget.cpp" line="192"/>
+        <location filename="../emulationsettingswidget.cpp" line="197"/>
+        <location filename="../emulationsettingswidget.cpp" line="206"/>
+        <location filename="../emulationsettingswidget.cpp" line="211"/>
+        <location filename="../emulationsettingswidget.cpp" line="218"/>
+        <location filename="../emulationsettingswidget.cpp" line="228"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="332"/>
         <source>2 Frames</source>
         <translation>2 bildrutor</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="44"/>
         <source>Use Global Setting [%1%]</source>
         <translation>Använd global inställning [%1%]</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="71"/>
+        <location filename="../emulationsettingswidget.ui" line="106"/>
+        <location filename="../emulationsettingswidget.ui" line="141"/>
         <source>Unlimited</source>
         <translation>Obegränsat</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="168"/>
         <source>Emulation Speed</source>
         <translation>Emuleringshastighet</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="238"/>
         <source>Rewind</source>
         <translation>Spola tillbaka</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="380"/>
+        <location filename="../emulationsettingswidget.cpp" line="228"/>
         <source>Enable for Analog Input</source>
         <translation>Aktivera för analog inmatning</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="229"/>
         <source>Activates runahead when analog input changes, which significantly increases system requirements.</source>
         <translation>Aktiverar runahead när analog inmatning ändras, vilket avsevärt ökar systemkraven.</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.ui" line="298"/>
+        <location filename="../emulationsettingswidget.cpp" line="217"/>
         <source>Use Software Renderer (Low VRAM Mode)</source>
         <translation>Använd programvarurenderare (lågt VRAM-läge)</translation>
     </message>
     <message>
+        <location filename="../emulationsettingswidget.cpp" line="219"/>
         <source>Uses the software renderer when creating rewind states to prevent additional VRAM usage. Especially useful when upscaling, as this will significantly reduce the system requirements for rewinding.</source>
         <translation>Använder programvarurenderaren när tillbakaspolningstillstånd skapas för att förhindra ytterligare VRAM-användning. Särskilt användbart vid uppskalning, eftersom detta avsevärt minskar systemkraven för tillbakaspolning.</translation>
     </message>
     <message numerus="yes">
+        <location filename="../emulationsettingswidget.cpp" line="288"/>
         <source>Rewind for %n frame(s), lasting %1 second(s) will require %2MB of RAM and %3MB of VRAM.</source>
         <translation>
             <numerusform>Spola tillbaka %n bildruta, varaktighet %1 sekund(er) kommer kräva %2MB RAM och %3MB VRAM.</numerusform>
@@ -5137,6 +4866,7 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../emulationsettingswidget.cpp" line="292"/>
         <source>Rewind for %n frame(s), lasting %1 second(s) will require %2MB of RAM.</source>
         <translation>
             <numerusform>Spola tillbaka %n bildruta, varaktighet %1 sekund(er) kräver %2MB RAM.</numerusform>
@@ -5145,3996 +4875,51 @@ Om du klickar på Återställ återställs serienumret till värdet som lästes 
     </message>
 </context>
 <context>
-    <name>FullscreenUI</name>
-    <message>
-        <source>Use Global Setting</source>
-        <translation>Använd global inställning</translation>
-    </message>
-    <message>
-        <source>Create New...</source>
-        <translation>Skapa ny...</translation>
-    </message>
-    <message>
-        <source>Launch a game from images scanned from your game directories.</source>
-        <translation>Starta ett spel från avbilder inlästa från dina spelkataloger.</translation>
-    </message>
-    <message>
-        <source>Launch a game by selecting a file/disc image.</source>
-        <translation>Starta ett spel genom att välja en fil/skivavbild.</translation>
-    </message>
-    <message>
-        <source>Start the console without any disc inserted.</source>
-        <translation>Starta konsolen utan någon skiva inmatad.</translation>
-    </message>
-    <message>
-        <source>Start a game from a disc in your PC&apos;s DVD drive.</source>
-        <translation>Starta ett spel från en skiva i din dators dvd-enhet.</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation>Okänt</translation>
-    </message>
-    <message>
-        <source>OK</source>
-        <translation>Ok</translation>
-    </message>
-    <message>
-        <source>Select Device</source>
-        <translation>Välj enhet</translation>
-    </message>
-    <message>
-        <source>Details</source>
-        <translation>Detaljer</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation>Standard</translation>
-    </message>
-    <message>
-        <source>Speed Control</source>
-        <translation>Hastighetskontroll</translation>
-    </message>
-    <message>
-        <source>Enable Cheats</source>
-        <translation>Aktivera fusk</translation>
-    </message>
-    <message>
-        <source>Aspect Ratio</source>
-        <translation>Bildförhållande</translation>
-    </message>
-    <message>
-        <source>Screenshot Size</source>
-        <translation>Skärmbildsstorlek</translation>
-    </message>
-    <message>
-        <source>Screenshot Format</source>
-        <translation>Skärmbildsformat</translation>
-    </message>
-    <message>
-        <source>Screenshot Quality</source>
-        <translation>Skärmbildskvalitet</translation>
-    </message>
-    <message>
-        <source>Internal Resolution</source>
-        <translation>Intern upplösning</translation>
-    </message>
-    <message>
-        <source>%d ms</source>
-        <translation>%d ms</translation>
-    </message>
-    <message>
-        <source>Uses a second thread for drawing graphics. Provides a significant speed improvement particularly with the software renderer, and is safe to use.</source>
-        <translation>Använder en andra tråd för att rita grafik. Ger en betydande hastighetsförbättring, särskilt med programvarurenderaren och är säker att använda.</translation>
-    </message>
-    <message>
-        <source>Change Selection</source>
-        <translation>Byt markering</translation>
-    </message>
-    <message>
-        <source>Select</source>
-        <translation>Välj</translation>
-    </message>
-    <message>
-        <source>Enter Value</source>
-        <translation>Ange värde</translation>
-    </message>
-    <message>
-        <source>About</source>
-        <translation>Om</translation>
-    </message>
-    <message>
-        <source>Toggle Fullscreen</source>
-        <translation>Växla helskärm</translation>
-    </message>
-    <message>
-        <source>Navigate</source>
-        <translation>Navigera</translation>
-    </message>
-    <message>
-        <source>Change Page</source>
-        <translation>Byt sida</translation>
-    </message>
-    <message>
-        <source>Return To Game</source>
-        <translation>Återgå till spelet</translation>
-    </message>
-    <message>
-        <source>Select State</source>
-        <translation>Välj tillstånd</translation>
-    </message>
-    <message>
-        <source>Select Game</source>
-        <translation>Välj spel</translation>
-    </message>
-    <message>
-        <source>Change View</source>
-        <translation>Byt vy</translation>
-    </message>
-    <message>
-        <source>Launch Options</source>
-        <translation>Startalternativ</translation>
-    </message>
-    <message>
-        <source>Configuration</source>
-        <translation>Konfiguration</translation>
-    </message>
-    <message>
-        <source>Start Game</source>
-        <translation>Starta spel</translation>
-    </message>
-    <message>
-        <source>Launch a game from a file, disc, or starts the console without any disc inserted.</source>
-        <translation>Starta ett spel från en fil, skiva eller startar konsolen utan någon skiva inmatad.</translation>
-    </message>
-    <message>
-        <source>Changes settings for the application.</source>
-        <translation>Ändrar inställningar för programmet.</translation>
-    </message>
-    <message>
-        <source>Return to desktop mode, or exit the application.</source>
-        <translation>Återgå till skrivbordsläge eller avsluta programmet.</translation>
-    </message>
-    <message>
-        <source>Back</source>
-        <translation>Bakåt</translation>
-    </message>
-    <message>
-        <source>Desktop Mode</source>
-        <translation>Skrivbordsläge</translation>
-    </message>
-    <message>
-        <source>Input Sources</source>
-        <translation>Inmatningskällor</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <translation>Inställningar</translation>
-    </message>
-    <message>
-        <source>Load State</source>
-        <translation>Läs in tillstånd</translation>
-    </message>
-    <message>
-        <source>Save State</source>
-        <translation>Spara tillstånd</translation>
-    </message>
-    <message>
-        <source>Compatibility: </source>
-        <translation>Kompatibilitet: </translation>
-    </message>
-    <message>
-        <source>Download Covers</source>
-        <translation>Hämta omslagsbilder</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation>Fel</translation>
-    </message>
-    <message>
-        <source>Buffer Size</source>
-        <translation>Buffertstorlek</translation>
-    </message>
-    <message>
-        <source>{} is not a valid disc image.</source>
-        <translation>{} är inte en giltig skivavbild.</translation>
-    </message>
-    <message>
-        <source>{} does not exist.</source>
-        <translation>{} finns inte.</translation>
-    </message>
-    <message>
-        <source>{} deleted.</source>
-        <translation>{} togs bort.</translation>
-    </message>
-    <message>
-        <source>Summary</source>
-        <translation>Sammandrag</translation>
-    </message>
-    <message>
-        <source>Interface Settings</source>
-        <translation>Gränssnittsinställningar</translation>
-    </message>
-    <message>
-        <source>Audio Settings</source>
-        <translation>Ljudinställningar</translation>
-    </message>
-    <message>
-        <source>Achievements Settings</source>
-        <translation>Inställningar för prestationer</translation>
-    </message>
-    <message>
-        <source>Advanced Settings</source>
-        <translation>Avancerade inställningar</translation>
-    </message>
-    <message>
-        <source>Cheats</source>
-        <translation>Fusk</translation>
-    </message>
-    <message>
-        <source>Disabled</source>
-        <translation>Inaktiverad</translation>
-    </message>
-    <message>
-        <source>1 Frame</source>
-        <translation>1 bildruta</translation>
-    </message>
-    <message>
-        <source>2 Frames</source>
-        <translation>2 bildrutor</translation>
-    </message>
-    <message>
-        <source>3 Frames</source>
-        <translation>3 bildrutor</translation>
-    </message>
-    <message>
-        <source>2x</source>
-        <translation>2x</translation>
-    </message>
-    <message>
-        <source>4x</source>
-        <translation>4x</translation>
-    </message>
-    <message>
-        <source>8x</source>
-        <translation>8x</translation>
-    </message>
-    <message>
-        <source>16x</source>
-        <translation>16x</translation>
-    </message>
-    <message>
-        <source>-</source>
-        <translation>-</translation>
-    </message>
-    <message>
-        <source>restart</source>
-        <translation>starta om</translation>
-    </message>
-    <message>
-        <source>{0} achievement unlocks have not been confirmed by the server. Continuing to {1} will result in loss of these unlocks. Once network connectivity has been re-established, these unlocks will be confirmed automatically.
-
-Do you want to {1} anyway?</source>
-        <translation>{0} prestationsupplåsningar har inte bekräftats av servern. Om du fortsätter att {1} går dessa upplåsningar förlorade. När nätverksanslutningen har återställts bekräftas upplåsningarna automatiskt.
-
-Vill du {1} ändå?</translation>
-    </message>
-    <message>
-        <source>{} Frames</source>
-        <translation>{} bildrutor</translation>
-    </message>
-    <message>
-        <source>Game List</source>
-        <translation>Spellista</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation>Typ</translation>
-    </message>
-    <message>
-        <source>Serial</source>
-        <translation>Serienummer</translation>
-    </message>
-    <message>
-        <source>Title</source>
-        <translation>Titel</translation>
-    </message>
-    <message>
-        <source>Last Played</source>
-        <translation>Senast spelat</translation>
-    </message>
-    <message>
-        <source>Select Disc Image</source>
-        <translation>Välj skivavbild</translation>
-    </message>
-    <message>
-        <source>Select Disc Drive</source>
-        <translation>Välj skivenhet</translation>
-    </message>
-    <message>
-        <source>Start File</source>
-        <translation>Starta fil</translation>
-    </message>
-    <message>
-        <source>Start BIOS</source>
-        <translation>Starta BIOS</translation>
-    </message>
-    <message>
-        <source>Start Disc</source>
-        <translation>Starta skiva</translation>
-    </message>
-    <message>
-        <source>Exit</source>
-        <translation>Avsluta</translation>
-    </message>
-    <message>
-        <source>Path</source>
-        <translation>Sökväg</translation>
-    </message>
-    <message>
-        <source>Start Fullscreen</source>
-        <translation>Starta helskärm</translation>
-    </message>
-    <message>
-        <source>Show Speed</source>
-        <translation>Visa hastighet</translation>
-    </message>
-    <message>
-        <source>Show FPS</source>
-        <translation>Visa bilder/s</translation>
-    </message>
-    <message>
-        <source>Show CPU Usage</source>
-        <translation>Visa CPU-användning</translation>
-    </message>
-    <message>
-        <source>Show GPU Usage</source>
-        <translation>Visa GPU-användning</translation>
-    </message>
-    <message>
-        <source>Show Resolution</source>
-        <translation>Visa upplösning</translation>
-    </message>
-    <message>
-        <source>Show Status Indicators</source>
-        <translation>Visa statusindikatorer</translation>
-    </message>
-    <message>
-        <source>Reset Settings</source>
-        <translation>Nollställ inställningar</translation>
-    </message>
-    <message>
-        <source>Create</source>
-        <translation>Skapa</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Avbryt</translation>
-    </message>
-    <message>
-        <source>Buttons</source>
-        <translation>Knappar</translation>
-    </message>
-    <message>
-        <source>Frequency</source>
-        <translation>Frekvens</translation>
-    </message>
-    <message>
-        <source>Resume Game</source>
-        <translation>Återuppta spel</translation>
-    </message>
-    <message>
-        <source>Game Properties</source>
-        <translation>Spelegenskaper</translation>
-    </message>
-    <message>
-        <source>Achievements</source>
-        <translation>Prestationer</translation>
-    </message>
-    <message>
-        <source>Save Screenshot</source>
-        <translation>Spara skärmbild</translation>
-    </message>
-    <message>
-        <source>Change Disc</source>
-        <translation>Byt skiva</translation>
-    </message>
-    <message>
-        <source>Close Game</source>
-        <translation>Stäng spelet</translation>
-    </message>
-    <message>
-        <source>Close Menu</source>
-        <translation>Stäng menyn</translation>
-    </message>
-    <message>
-        <source>Reset Play Time</source>
-        <translation>Nollställ spelad tid</translation>
-    </message>
-    <message>
-        <source>Add Search Directory</source>
-        <translation>Lägg till sökkatalog</translation>
-    </message>
-    <message>
-        <source>Remove From List</source>
-        <translation>Ta bort från lista</translation>
-    </message>
-    <message>
-        <source>Sort By</source>
-        <translation>Sortera efter</translation>
-    </message>
-    <message>
-        <source>Scan For New Games</source>
-        <translation>Sök efter nya spel</translation>
-    </message>
-    <message>
-        <source>Rescan All Games</source>
-        <translation>Sök igenom alla spel igen</translation>
-    </message>
-    <message>
-        <source>GitHub Repository</source>
-        <translation>GitHub-förråd</translation>
-    </message>
-    <message>
-        <source>Close</source>
-        <translation>Stäng</translation>
-    </message>
-    <message>
-        <source>Enable Achievements</source>
-        <translation>Aktivera prestationer</translation>
-    </message>
-    <message>
-        <source>Enable VRAM Write Replacement</source>
-        <translation>Aktivera VRAM-skrivningsersättning</translation>
-    </message>
-    <message>
-        <source>Enter the name of the controller preset you wish to create.</source>
-        <translation>Ange namnet på det kontrollerförval som du vill skapa.</translation>
-    </message>
-    <message>
-        <source>Failed to save controller preset &apos;{}&apos;.</source>
-        <translation>Misslyckades med att spara kontrollerförvalet &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Replaces these settings with a previously saved controller preset.</source>
-        <translation>Ersätter dessa inställningar med ett tidigare sparat förval för kontrollern.</translation>
-    </message>
-    <message>
-        <source>Reset Controller Settings</source>
-        <translation>Nollställ kontrollerinställningar</translation>
-    </message>
-    <message>
-        <source>Runs the software renderer in parallel for VRAM readbacks. On some systems, this may result in greater performance when using graphical enhancements with the hardware renderer.</source>
-        <translation>Kör programvarurenderingen parallellt för VRAM-återläsningar. På vissa system kan detta resultera i bättre prestanda när du använder grafiska förbättringar med hårdvarurenderaren.</translation>
-    </message>
-    <message>
-        <source>Sound Effects</source>
-        <translation>Ljudeffekter</translation>
-    </message>
-    <message>
-        <source>Stores the current settings to a controller preset.</source>
-        <translation>Lagrar de aktuella inställningarna till ett kontrollförval.</translation>
-    </message>
-    <message>
-        <source>User Name</source>
-        <translation>Användarnamn</translation>
-    </message>
-    <message>
-        <source>Logout</source>
-        <translation>Logga ut</translation>
-    </message>
-    <message>
-        <source>%.1f ms</source>
-        <translation>%.1f ms</translation>
-    </message>
-    <message>
-        <source>%.2f Seconds</source>
-        <translation>%.2f sekunder</translation>
-    </message>
-    <message>
-        <source>%d Frames</source>
-        <translation>%d bildrutor</translation>
-    </message>
-    <message>
-        <source>%d sectors</source>
-        <translation>%d sektorer</translation>
-    </message>
-    <message>
-        <source>10 Frames</source>
-        <translation>10 bildrutor</translation>
-    </message>
-    <message>
-        <source>10x</source>
-        <translation>10x</translation>
-    </message>
-    <message>
-        <source>11x</source>
-        <translation>11x</translation>
-    </message>
-    <message>
-        <source>12x</source>
-        <translation>12x</translation>
-    </message>
-    <message>
-        <source>13x</source>
-        <translation>13x</translation>
-    </message>
-    <message>
-        <source>14x</source>
-        <translation>14x</translation>
-    </message>
-    <message>
-        <source>15x</source>
-        <translation>15x</translation>
-    </message>
-    <message>
-        <source>1x</source>
-        <translation>1x</translation>
-    </message>
-    <message>
-        <source>2x (Quad Speed)</source>
-        <translation>2x (fyrdubbel hastighet)</translation>
-    </message>
-    <message>
-        <source>3x</source>
-        <translation>3x</translation>
-    </message>
-    <message>
-        <source>3x (6x Speed)</source>
-        <translation>3x (6x hastighet)</translation>
-    </message>
-    <message>
-        <source>3x (for 720p)</source>
-        <translation>3x (för 720p)</translation>
-    </message>
-    <message>
-        <source>4 Frames</source>
-        <translation>4 bildrutor</translation>
-    </message>
-    <message>
-        <source>4x (8x Speed)</source>
-        <translation>4x (8x hastighet)</translation>
-    </message>
-    <message>
-        <source>5 Frames</source>
-        <translation>5 bildrutor</translation>
-    </message>
-    <message>
-        <source>5x</source>
-        <translation>5x</translation>
-    </message>
-    <message>
-        <source>5x (10x Speed)</source>
-        <translation>5x (10x hastighet)</translation>
-    </message>
-    <message>
-        <source>5x (for 1080p)</source>
-        <translation>5x (för 1080p)</translation>
-    </message>
-    <message>
-        <source>6 Frames</source>
-        <translation>6 bildrutor</translation>
-    </message>
-    <message>
-        <source>6x</source>
-        <translation>6x</translation>
-    </message>
-    <message>
-        <source>6x (12x Speed)</source>
-        <translation>6x (12x hastighet)</translation>
-    </message>
-    <message>
-        <source>6x (for 1440p)</source>
-        <translation>6x (för 1440p)</translation>
-    </message>
-    <message>
-        <source>7 Frames</source>
-        <translation>7 bildrutor</translation>
-    </message>
-    <message>
-        <source>7x</source>
-        <translation>7x</translation>
-    </message>
-    <message>
-        <source>8 Frames</source>
-        <translation>8 bildrutor</translation>
-    </message>
-    <message>
-        <source>9 Frames</source>
-        <translation>9 bildrutor</translation>
-    </message>
-    <message>
-        <source>9x (for 4K)</source>
-        <translation>9x (för 4K)</translation>
-    </message>
-    <message>
-        <source>Achievement Notifications</source>
-        <translation>Aviseringar om prestationer</translation>
-    </message>
-    <message>
-        <source>Achievement Unlock/Count</source>
-        <translation>Prestation upplåsning/antal</translation>
-    </message>
-    <message>
-        <source>Add Shader</source>
-        <translation>Lägg till shader</translation>
-    </message>
-    <message>
-        <source>Adds a new directory to the game search list.</source>
-        <translation>Lägger till en ny katalog till spelsökningslistan.</translation>
-    </message>
-    <message>
-        <source>Adds a new shader to the chain.</source>
-        <translation>Lägger till en ny shader till kedjan.</translation>
-    </message>
-    <message>
-        <source>Adds additional precision to PGXP data post-projection. May improve visuals in some games.</source>
-        <translation>Lägger till ytterligare precision till PGXP-data efterprojicering. Kan förbättra grafiken i vissa spel.</translation>
-    </message>
-    <message>
-        <source>Adjusts the emulation speed so the console&apos;s refresh rate matches the host when VSync is enabled.</source>
-        <translation>Justerar emuleringshastigheten så att konsolens uppdateringsfrekvens matchar värdens när VSync är aktiverat.</translation>
-    </message>
-    <message>
-        <source>All Time: {}</source>
-        <translation>All tid: {}</translation>
-    </message>
-    <message>
-        <source>All unofficial achievement progress for the current game will be removed. This cannot be undone.</source>
-        <translation>Alla inofficiella prestationsframsteg för det aktuella spelet tas bort. Detta kan inte ångras.</translation>
-    </message>
-    <message>
-        <source>Allow Booting Without SBI File</source>
-        <translation>Tillåt uppstarter utan SBI-fil</translation>
-    </message>
-    <message>
-        <source>Alpha Blending</source>
-        <translation>Alfa-blandning</translation>
-    </message>
-    <message>
-        <source>Always Track Uploads</source>
-        <translation>Spåra alltid insändningar</translation>
-    </message>
-    <message>
-        <source>An error occurred while deleting empty game settings:
-{}</source>
-        <translation>Ett fel inträffade vid borttagning av tomma spelinställningar:
-{}</translation>
-    </message>
-    <message>
-        <source>An error occurred while saving game settings:
-{}</source>
-        <translation>Ett fel inträffade vid sparandet  av spelinställningar:
-{}</translation>
-    </message>
-    <message>
-        <source>Apply Image Patches</source>
-        <translation>Verkställ bildpatchar</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to clear all mappings for this controller?
-
-You cannot undo this action.</source>
-        <translation>Är du säker på att du vill tömma alla mappningar för den här kontrollern?
-
-Du kan inte ångra den här åtgärden.</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to clear the current post-processing chain? All configuration will be lost.</source>
-        <translation>Är du säker på att du vill tömma aktuell efterbehandlingskedja? All konfiguration kommer att förloras.</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to restore the default controller configuration?
-
-All bindings and configuration will be lost. You cannot undo this action.</source>
-        <translation>Är du säker på att du vill återställa standardkonfigurationen för handkontrollen?
-
-Alla bindningar och konfigurationen kommer att förloras . Du kan inte ångra denna åtgärd.</translation>
-    </message>
-    <message>
-        <source>Attempts to detect one pixel high/wide lines that rely on non-upscaled rasterization behavior, filling in gaps introduced by upscaling.</source>
-        <translation>Försök att upptäcka en pixel höga/breda linjer som förlitar sig på icke uppskalad rastrering och fyller i luckor som uppstått genom uppskalning.</translation>
-    </message>
-    <message>
-        <source>Attempts to map the selected port to a chosen controller.</source>
-        <translation>Försöker att mappa vald port till en vald handkontroller.</translation>
-    </message>
-    <message>
-        <source>Audio Backend</source>
-        <translation>Ljudbakände</translation>
-    </message>
-    <message>
-        <source>Audio Control</source>
-        <translation>Ljudkontroll</translation>
-    </message>
-    <message>
-        <source>Auto-Detect</source>
-        <translation>Identifiera automatiskt</translation>
-    </message>
-    <message>
-        <source>Automatic Mapping</source>
-        <translation>Automatisk mappning</translation>
-    </message>
-    <message>
-        <source>Automatic based on window size</source>
-        <translation>Automatiskt baserat på fönsterstorlek</translation>
-    </message>
-    <message>
-        <source>Automatic mapping completed for {}.</source>
-        <translation>Automatisk mappning färdigställd för {}.</translation>
-    </message>
-    <message>
-        <source>Automatic mapping failed for {}.</source>
-        <translation>Automatisk mappning misslyckades för {}.</translation>
-    </message>
-    <message>
-        <source>Automatic mapping failed, no devices are available.</source>
-        <translation>Automatisk mappning misslyckades, inga enheter tillgängliga.</translation>
-    </message>
-    <message>
-        <source>Automatically Resize Window</source>
-        <translation>Storleksändra fönstret automatiskt</translation>
-    </message>
-    <message>
-        <source>Automatically applies patches to disc images when they are present, currently only PPF is supported.</source>
-        <translation>Tillämpar automatiskt patchar till skivavbilder när de finns tillgängliga. Endast PPF stöds för närvarande.</translation>
-    </message>
-    <message>
-        <source>Automatically resizes the window to match the internal resolution.</source>
-        <translation>Storleksändrar automatiskt fönstret för att matcha interna upplösningen.</translation>
-    </message>
-    <message>
-        <source>Automatically switches to fullscreen mode when the program is started.</source>
-        <translation>Växlar automatiskt till helskärmsläge när programmet startas.</translation>
-    </message>
-    <message>
-        <source>Avoids calls to C++ code, significantly speeding up the recompiler.</source>
-        <translation>Undviker anrop till C++-kod, snabbar upp omkompileraren avsevärt.</translation>
-    </message>
-    <message>
-        <source>BIOS &apos;{}&apos; installed as &apos;{}&apos;.</source>
-        <translation>BIOS &apos;{}&apos; installerad som &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>BIOS Already Installed</source>
-        <translation>BIOS redan installerad</translation>
-    </message>
-    <message>
-        <source>BIOS Directory</source>
-        <translation>BIOS-katalog</translation>
-    </message>
-    <message>
-        <source>BIOS Install Error</source>
-        <translation>Fel vid BIOS-installation</translation>
-    </message>
-    <message>
-        <source>BIOS Installed</source>
-        <translation>BIOS installerad</translation>
-    </message>
-    <message>
-        <source>BIOS Selection</source>
-        <translation>Val av BIOS</translation>
-    </message>
-    <message>
-        <source>BIOS Settings</source>
-        <translation>BIOS-inställningar</translation>
-    </message>
-    <message>
-        <source>BIOS for {}</source>
-        <translation>BIOS för {}</translation>
-    </message>
-    <message>
-        <source>BIOS to use when emulating {} consoles.</source>
-        <translation>BIOS att använda vid emulering av {}-konsoler.</translation>
-    </message>
-    <message>
-        <source>Back To Pause Menu</source>
-        <translation>Tillbaka till pausmenyn</translation>
-    </message>
-    <message>
-        <source>Backend Settings</source>
-        <translation>Inställningar för bakände</translation>
-    </message>
-    <message>
-        <source>Behavior</source>
-        <translation>Beteende</translation>
-    </message>
-    <message>
-        <source>Borderless Fullscreen</source>
-        <translation>Ramlös helskärm</translation>
-    </message>
-    <message>
-        <source>CD-ROM Emulation</source>
-        <translation>Cd-rom-emulering</translation>
-    </message>
-    <message>
-        <source>CPU Emulation</source>
-        <translation>CPU-emulering</translation>
-    </message>
-    <message>
-        <source>CPU Mode</source>
-        <translation>CPU-läge</translation>
-    </message>
-    <message>
-        <source>Capture</source>
-        <translation>Fånga</translation>
-    </message>
-    <message>
-        <source>Changes the aspect ratio used to display the console&apos;s output to the screen.</source>
-        <translation>Ändrar bildförhållandet som används för att visa konsolens utmatning på skärmen.</translation>
-    </message>
-    <message>
-        <source>Chooses the language used for UI elements.</source>
-        <translation>Väljer språket som används för gränssnittselementen.</translation>
-    </message>
-    <message>
-        <source>Clean Boot</source>
-        <translation>Ren uppstart</translation>
-    </message>
-    <message>
-        <source>Clear Mappings</source>
-        <translation>Töm mappningar</translation>
-    </message>
-    <message>
-        <source>Clear Settings</source>
-        <translation>Töm inställningar</translation>
-    </message>
-    <message>
-        <source>Clear Shaders</source>
-        <translation>Töm shaders</translation>
-    </message>
-    <message>
-        <source>Clears a shader from the chain.</source>
-        <translation>Tömmer en shader från kedjan.</translation>
-    </message>
-    <message>
-        <source>Clears all settings set for this game.</source>
-        <translation>Tömmer alla inställningar inställda för detta spel.</translation>
-    </message>
-    <message>
-        <source>Completely exits the application, returning you to your desktop.</source>
-        <translation>Avslutar programmet helt och återvänder till ditt skrivbord.</translation>
-    </message>
-    <message>
-        <source>Console Settings</source>
-        <translation>Konsolinställningar</translation>
-    </message>
-    <message>
-        <source>Contributor List</source>
-        <translation>Lista över bidragspersoner</translation>
-    </message>
-    <message>
-        <source>Controller Port {}</source>
-        <translation>Kontrollerport {}</translation>
-    </message>
-    <message>
-        <source>Controller Settings</source>
-        <translation>Inställningar för handkontroller</translation>
-    </message>
-    <message>
-        <source>Controller Type</source>
-        <translation>Handkontrollertyp</translation>
-    </message>
-    <message>
-        <source>Controller mapping cleared.</source>
-        <translation>Kontrollerns mappning tömdes.</translation>
-    </message>
-    <message>
-        <source>Controller preset &apos;{}&apos; loaded.</source>
-        <translation>Kontrollerförvalet &apos;{}&apos; lästes in.</translation>
-    </message>
-    <message>
-        <source>Controller preset &apos;{}&apos; saved.</source>
-        <translation>Kontrollerförvalet &apos;{}&apos; sparades.</translation>
-    </message>
-    <message>
-        <source>Controller settings reset to default.</source>
-        <translation>Kontrollerinställningar nollställda till standardvärden.</translation>
-    </message>
-    <message>
-        <source>Controls</source>
-        <translation>Handkontroller</translation>
-    </message>
-    <message>
-        <source>Controls the volume of the audio played on the host when fast forwarding.</source>
-        <translation>Styr volymen för ljudet som spelas på värden vid snabbspolning.</translation>
-    </message>
-    <message>
-        <source>Controls the volume of the audio played on the host.</source>
-        <translation>Styr volymen för ljudet som spelas på värden.</translation>
-    </message>
-    <message>
-        <source>Copies a BIOS image to the configured global BIOS directory.</source>
-        <translation>Kopierar en BIOS-avbild till den konfigurerade globala BIOS-katalogen.</translation>
-    </message>
-    <message>
-        <source>Copies the current global settings to this game.</source>
-        <translation>Kopierar de aktuella globala inställningar till detta spel.</translation>
-    </message>
-    <message>
-        <source>Copies the global controller configuration to this game.</source>
-        <translation>Kopierar global kontrollerkonfiguration till detta spel.</translation>
-    </message>
-    <message>
-        <source>Copy Global Settings</source>
-        <translation>Kopiera globala inställningar</translation>
-    </message>
-    <message>
-        <source>Copy Settings</source>
-        <translation>Kopiera inställningar</translation>
-    </message>
-    <message>
-        <source>Could not find any CD/DVD-ROM devices. Please ensure you have a drive connected and sufficient permissions to access it.</source>
-        <translation>Kunde inte hitta några cd/dvd-rom-enheter. Försäkra dig om att du har en enhet ansluten och tillräcklig behörighet att komma åt den.</translation>
-    </message>
-    <message>
-        <source>Cover Settings</source>
-        <translation>Inställningar för omslagsbilder</translation>
-    </message>
-    <message>
-        <source>Covers Directory</source>
-        <translation>Omslagskatalog</translation>
-    </message>
-    <message>
-        <source>Create Save State Backups</source>
-        <translation>Skapa säkerhetskopior av sparade tillstånd</translation>
-    </message>
-    <message>
-        <source>Crop Mode</source>
-        <translation>Beskäringsläge</translation>
-    </message>
-    <message>
-        <source>Culling Correction</source>
-        <translation>Rensningskorrigering</translation>
-    </message>
-    <message>
-        <source>Deadzone</source>
-        <translation>Dödläge</translation>
-    </message>
-    <message>
-        <source>Debugging Settings</source>
-        <translation>Inställningar för felsökning</translation>
-    </message>
-    <message>
-        <source>Default Boot</source>
-        <translation>Standarduppstart</translation>
-    </message>
-    <message>
-        <source>Default View</source>
-        <translation>Standardvy</translation>
-    </message>
-    <message>
-        <source>Default: Disabled</source>
-        <translation>Standard: inaktiverat</translation>
-    </message>
-    <message>
-        <source>Default: Enabled</source>
-        <translation>Standard: aktiverat</translation>
-    </message>
-    <message>
-        <source>Deinterlacing Mode</source>
-        <translation>Deinterlacing-läge</translation>
-    </message>
-    <message>
-        <source>Delete</source>
-        <translation>Ta bort</translation>
-    </message>
-    <message>
-        <source>Delete Save</source>
-        <translation>Ta bort sparning</translation>
-    </message>
-    <message>
-        <source>Delete State</source>
-        <translation>Ta bort tillstånd</translation>
-    </message>
-    <message>
-        <source>Depth Clear Threshold</source>
-        <translation>Tröskelvärde för djuptömning</translation>
-    </message>
-    <message>
-        <source>Depth Test Transparent Polygons</source>
-        <translation>Transparenta polygoner för djuptest</translation>
-    </message>
-    <message>
-        <source>Determines how large the on-screen messages and monitor are.</source>
-        <translation>Bestämmer hur stora OSD-meddelanden och skärmen är.</translation>
-    </message>
-    <message>
-        <source>Determines how much button pressure is ignored before activating the macro.</source>
-        <translation>Bestämmer hur hårt knapptryck som ignoreras innan makrot aktiveras.</translation>
-    </message>
-    <message>
-        <source>Determines how much latency there is between the audio being picked up by the host API, and played through speakers.</source>
-        <translation>Bestämmer hur stor fördröjning det är mellan det att ljudet plockas upp av värd-API:et och spelas upp i högtalarna.</translation>
-    </message>
-    <message>
-        <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide.</source>
-        <translation>Bestämmer hur stor del av området som normalt inte syns på en konsument-TV som ska beskäras/döljas.</translation>
-    </message>
-    <message>
-        <source>Determines how much pressure is simulated when macro is active.</source>
-        <translation>Bestämmer hur hårt tryck som simuleras när makrot är aktivt.</translation>
-    </message>
-    <message>
-        <source>Determines how the emulated CPU executes instructions.</source>
-        <translation>Fastställer hur den emulerade CPUn kör instruktioner.</translation>
-    </message>
-    <message>
-        <source>Determines how the emulated console&apos;s output is upscaled or downscaled to your monitor&apos;s resolution.</source>
-        <translation>Bestämmer hur den emulerade konsolens utdata ska upp- eller nedskalas till din bildskärms upplösning.</translation>
-    </message>
-    <message>
-        <source>Determines quality of audio when not running at 100% speed.</source>
-        <translation>Bestämmer kvaliteten på ljudet när det inte körs på 100% hastighet.</translation>
-    </message>
-    <message>
-        <source>Determines that field that the game list will be sorted by.</source>
-        <translation>Bestämmer fältet som spellistan ska sorteras efter.</translation>
-    </message>
-    <message>
-        <source>Determines the amount of audio buffered before being pulled by the host API.</source>
-        <translation>Bestämmer hur mycket ljud som buffras innan det hämtas av värd-API:et.</translation>
-    </message>
-    <message>
-        <source>Determines the emulated hardware type.</source>
-        <translation>Bestämmer emulerad hårdvarutyp.</translation>
-    </message>
-    <message>
-        <source>Determines the format that screenshots will be saved/compressed with.</source>
-        <translation>Bestämmer det format som skärmbilder ska sparas/komprimeras med.</translation>
-    </message>
-    <message>
-        <source>Determines the frequency at which the macro will toggle the buttons on and off (aka auto fire).</source>
-        <translation>Bestämmer frekvensen vid vilken makrot ska växla mellan att slå på och av knapparna (s.k. auto fire).</translation>
-    </message>
-    <message>
-        <source>Determines the margin between the edge of the screen and on-screen messages.</source>
-        <translation>Bestämmer marginalen mellan kanten av skärmen och OSD-meddelanden.</translation>
-    </message>
-    <message>
-        <source>Determines the position on the screen when black borders must be added.</source>
-        <translation>Bestämmer positionen på skärmen när svarta sorgkanter måste läggas till.</translation>
-    </message>
-    <message>
-        <source>Determines the rotation of the simulated TV screen.</source>
-        <translation>Bestämmer rotationen för den simulerade tv-skärmen.</translation>
-    </message>
-    <message>
-        <source>Determines the size of screenshots created by DuckStation.</source>
-        <translation>Bestämmer storleken för skärmbilder som skapas av DuckStation.</translation>
-    </message>
-    <message>
-        <source>Determines which algorithm is used to convert interlaced frames to progressive for display on your system.</source>
-        <translation>Bestämmer vilken algoritm som används för att konvertera sammanflätade bildrutor till progressiva för visning på ditt system.</translation>
-    </message>
-    <message>
-        <source>Device Settings</source>
-        <translation>Enhetsinställningar</translation>
-    </message>
-    <message>
-        <source>Disable Mailbox Presentation</source>
-        <translation>Inaktivera presentation av brevlåda</translation>
-    </message>
-    <message>
-        <source>Disable Subdirectory Scanning</source>
-        <translation>Inaktivera inläsning av underkataloger</translation>
-    </message>
-    <message>
-        <source>Disable on 2D Polygons</source>
-        <translation>Inaktivera för 2D-polygoner</translation>
-    </message>
-    <message>
-        <source>Discord Server</source>
-        <translation>Discord-server</translation>
-    </message>
-    <message>
-        <source>Displays popup messages on events such as achievement unlocks and leaderboard submissions.</source>
-        <translation>Visar popup-meddelanden vid händelser som t.ex. upplåsning av prestationer och insändning av ledartavlor.</translation>
-    </message>
-    <message>
-        <source>Displays popup messages when starting, submitting, or failing a leaderboard challenge.</source>
-        <translation>Visar popupmeddelanden vid start, insändning eller misslyckanden av en ledartavleutmaning.</translation>
-    </message>
-    <message>
-        <source>Do you want to continue from the automatic save created {}?</source>
-        <translation>Vill du fortsätta från den automatiska sparning som skapades {}?</translation>
-    </message>
-    <message>
-        <source>Double-Click Toggles Fullscreen</source>
-        <translation>Dubbelklick växlar helskärm</translation>
-    </message>
-    <message>
-        <source>Downloads covers from a user-specified URL template.</source>
-        <translation>Hämtar omslagsbilder från en användarangiven URL-mall.</translation>
-    </message>
-    <message>
-        <source>Downsamples the rendered image prior to displaying it. Can improve overall image quality in mixed 2D/3D games.</source>
-        <translation>Samplar ner den renderade bilden innan den visas. Kan förbättra den övergripande bildkvaliteten i blandade 2D/3D-spel.</translation>
-    </message>
-    <message>
-        <source>Downsampling</source>
-        <translation>Nersampling</translation>
-    </message>
-    <message>
-        <source>Downsampling Display Scale</source>
-        <translation>Skala för skärmnedsampling</translation>
-    </message>
-    <message>
-        <source>Duck icon by icons8 (https://icons8.com/icon/74847/platforms.undefined.short-title)</source>
-        <translation>Ankikon av icons8 (https://icons8.com/icon/74847/platforms.undefined.short-title)</translation>
-    </message>
-    <message>
-        <source>DuckStation is a free simulator/emulator of the Sony PlayStation(TM) console, focusing on playability, speed, and long-term maintainability.</source>
-        <translation>DuckStation är en fri simulator/emulator för konsolen Sony PlayStation(TM) med fokus på spelbarhet, hastighet och långtidsunderhåll.</translation>
-    </message>
-    <message>
-        <source>Dump Replaced Textures</source>
-        <translation>Dumpa ersatta texturer</translation>
-    </message>
-    <message>
-        <source>Dumps textures that have replacements already loaded.</source>
-        <translation>Dumpar texturer som har ersättningar redan inlästa.</translation>
-    </message>
-    <message>
-        <source>Emulation Settings</source>
-        <translation>Emuleringsinställningar</translation>
-    </message>
-    <message>
-        <source>Emulation Speed</source>
-        <translation>Emuleringshastighet</translation>
-    </message>
-    <message>
-        <source>Enable 8MB RAM</source>
-        <translation>Aktivera 8MB RAM</translation>
-    </message>
-    <message>
-        <source>Enable Discord Presence</source>
-        <translation>Aktivera Discord-närvaro</translation>
-    </message>
-    <message>
-        <source>Enable Fast Boot</source>
-        <translation>Aktivera snabb uppstart</translation>
-    </message>
-    <message>
-        <source>Enable Overclocking</source>
-        <translation>Aktivera överklockning</translation>
-    </message>
-    <message>
-        <source>Enable Post Processing</source>
-        <translation>Aktivera efterbehandling</translation>
-    </message>
-    <message>
-        <source>Enable Recompiler Block Linking</source>
-        <translation>Aktivera blocklänkning för omkompilerare</translation>
-    </message>
-    <message>
-        <source>Enable Recompiler ICache</source>
-        <translation>Aktivera ICache för omkompilerare</translation>
-    </message>
-    <message>
-        <source>Enable Recompiler Memory Exceptions</source>
-        <translation>Aktivera minnesundantag för omkompilerare</translation>
-    </message>
-    <message>
-        <source>Enable Region Check</source>
-        <translation>Aktivera regionskontroll</translation>
-    </message>
-    <message>
-        <source>Enable Rewinding</source>
-        <translation>Aktivera tillbakaspolning</translation>
-    </message>
-    <message>
-        <source>Enable SDL Input Source</source>
-        <translation>Aktivera källa för SDL-inmatning</translation>
-    </message>
-    <message>
-        <source>Enable Subdirectory Scanning</source>
-        <translation>Aktivera sökning i underkataloger</translation>
-    </message>
-    <message>
-        <source>Enable TTY Logging</source>
-        <translation>Aktivera TTY-loggning</translation>
-    </message>
-    <message>
-        <source>Enable Texture Cache</source>
-        <translation>Aktivera texturcache</translation>
-    </message>
-    <message>
-        <source>Enable Texture Dumping</source>
-        <translation>Aktivera texturdumpning</translation>
-    </message>
-    <message>
-        <source>Enable Texture Replacements</source>
-        <translation>Aktivera texturersättningar</translation>
-    </message>
-    <message>
-        <source>Enable VRAM Write Dumping</source>
-        <translation>Aktivera VRAM-skrivdumpning</translation>
-    </message>
-    <message>
-        <source>Enable XInput Input Source</source>
-        <translation>Aktivera inmatningskälla för XInput</translation>
-    </message>
-    <message>
-        <source>Enable debugging when supported by the host&apos;s renderer API. Only for developer use.</source>
-        <translation>Aktivera felsökning när detta stöds av värdens API för rendering. Endast för användning av utvecklare.</translation>
-    </message>
-    <message>
-        <source>Enable/Disable the Player LED on DualSense controllers.</source>
-        <translation>Aktivera/inaktivera Player LED på DualSense-kontroller.</translation>
-    </message>
-    <message>
-        <source>Enables alignment and bus exceptions. Not needed for any known games.</source>
-        <translation>Aktiverar justering och bussundantag. Behövs inte för några kända spel.</translation>
-    </message>
-    <message>
-        <source>Enables an additional 6MB of RAM to obtain a total of 2+6 = 8MB, usually present on dev consoles.</source>
-        <translation>Aktiverar ytterligare 6 MB RAM för att få totalt 2+6 = 8 MB, vanligtvis på utvecklingskonsoler.</translation>
-    </message>
-    <message>
-        <source>Enables an additional three controller slots on each port. Not supported in all games.</source>
-        <translation>Aktiverar ytterligare tre kontrollerplatser på varje port. Stöds inte i alla spel.</translation>
-    </message>
-    <message>
-        <source>Enables caching of guest textures, required for texture replacement.</source>
-        <translation>Aktiverar cachning av gästtexturer, krävs för texturersättning.</translation>
-    </message>
-    <message>
-        <source>Enables depth testing for semi-transparent polygons. Usually these include shadows, and tend to clip through the ground when depth testing is enabled.</source>
-        <translation>Aktiverar djuptestning för halvgenomskinliga polygoner. Vanligtvis innehåller dessa skuggor och tenderar att klippa genom marken när djuptestning är aktiverat.</translation>
-    </message>
-    <message>
-        <source>Enables dumping of textures to image files, which can be replaced. Not compatible with all games.</source>
-        <translation>Aktiverar dumpning av texturer till bildfiler, som kan ersättas. Inte kompatibel med alla spel.</translation>
-    </message>
-    <message>
-        <source>Enables loading of cheats for this game from DuckStation&apos;s database.</source>
-        <translation>Aktiverar inläsning av fusk för detta spel från Duckstations databas.</translation>
-    </message>
-    <message>
-        <source>Enables loading of replacement textures. Not compatible with all games.</source>
-        <translation>Aktiverar inläsning av ersättningstexturer. Inte kompatibelt med alla spel.</translation>
-    </message>
-    <message>
-        <source>Enables the cheats that are selected below.</source>
-        <translation>Aktiverar fusken som väljs nedan.</translation>
-    </message>
-    <message>
-        <source>Enables the older, less accurate MDEC decoding routines. May be required for old replacement backgrounds to match/load.</source>
-        <translation>Möjliggör de äldre, mindre exakta MDEC-avkodningsrutinerna. Kan krävas för att gamla ersättningsbakgrunder ska matcha/läsas in.</translation>
-    </message>
-    <message>
-        <source>Enables the replacement of background textures in supported games.</source>
-        <translation>Aktiverar ersättning av bakgrundstexturer i spel som stöds.</translation>
-    </message>
-    <message>
-        <source>Encore Mode</source>
-        <translation>Encore-läge</translation>
-    </message>
-    <message>
-        <source>Ensures every frame generated is displayed for optimal pacing. Enable for variable refresh displays, such as GSync/FreeSync. Disable if you are having speed or sound issues.</source>
-        <translation>Säkerställer att varje bildruta som genereras visas för optimal bildrytm. Aktivera för skärmar med variabel uppdatering, t.ex. GSync/FreeSync. Inaktivera om du har problem med hastighet eller ljud.</translation>
-    </message>
-    <message>
-        <source>Execution Mode</source>
-        <translation>Körningsläge</translation>
-    </message>
-    <message>
-        <source>Exit DuckStation</source>
-        <translation>Avsluta DuckStation</translation>
-    </message>
-    <message>
-        <source>Exits Big Picture mode, returning to the desktop interface.</source>
-        <translation>Avslutar storbildsläget och återvänder till skrivbordsgränssnittet.</translation>
-    </message>
-    <message>
-        <source>FMV Chroma Smoothing</source>
-        <translation>FMV Chroma-utjämning</translation>
-    </message>
-    <message>
-        <source>Failed to copy text to clipboard.</source>
-        <translation>Misslyckades med att kopiera text till urklipp.</translation>
-    </message>
-    <message>
-        <source>Failed to delete save state.</source>
-        <translation>Misslyckades med att ta bort sparat tillstånd.</translation>
-    </message>
-    <message>
-        <source>Failed to delete {}.</source>
-        <translation>Misslyckades med att ta bort {}.</translation>
-    </message>
-    <message>
-        <source>Failed to load &apos;{}&apos;.</source>
-        <translation>Misslyckades med att läsa in: {}.</translation>
-    </message>
-    <message>
-        <source>Failed to load shader {}. It may be invalid.
-Error was:</source>
-        <translation>Misslyckades med att läsa in shadern {}. Den kan vara ogiltig.
-Felet var:</translation>
-    </message>
-    <message>
-        <source>Fast Boot</source>
-        <translation>Snabb uppstart</translation>
-    </message>
-    <message>
-        <source>Fast Forward Boot</source>
-        <translation>Snabbspolad uppstart</translation>
-    </message>
-    <message>
-        <source>Fast Forward Speed</source>
-        <translation>Hastighet för snabbspolning</translation>
-    </message>
-    <message>
-        <source>Fast Forward Volume</source>
-        <translation>Snabbspolningsvolym</translation>
-    </message>
-    <message>
-        <source>Fast forwards through the early loading process when fast booting, saving time. Results may vary between games.</source>
-        <translation>Snabbspolar igenom den tidiga inläsningsprocessen vid snabb uppstart, vilket sparar tid. Resultaten kan variera mellan spel.</translation>
-    </message>
-    <message>
-        <source>File Size</source>
-        <translation>Filstorlek</translation>
-    </message>
-    <message>
-        <source>File Title</source>
-        <translation>Filtitel</translation>
-    </message>
-    <message>
-        <source>Force 4:3 For FMVs</source>
-        <translation>Tvinga 4:3 för FMVs</translation>
-    </message>
-    <message>
-        <source>Forces a full rescan of all games previously identified.</source>
-        <translation>Tvingar en fullständig genomsökning av alla spel som tidigare identifierats.</translation>
-    </message>
-    <message>
-        <source>Forces texture upload tracking to be enabled regardless of whether it is needed.</source>
-        <translation>Tvingar att spårning av texturuppladdning aktiveras oavsett om det behövs eller inte.</translation>
-    </message>
-    <message>
-        <source>Forces the use of FIFO over Mailbox presentation, i.e. double buffering instead of triple buffering. Usually results in worse frame pacing.</source>
-        <translation>Tvingar fram användning av FIFO i stället för brevlådepresentation, dvs. dubbelbuffring i stället för trippelbuffring. Detta resulterar vanligen i sämre bildrytm.</translation>
-    </message>
-    <message>
-        <source>Forcibly mutes both CD-DA and XA audio from the CD-ROM. Can be used to disable background music in some games.</source>
-        <translation>Tvingar både CD-DA och XA-ljud från cd-rom att vara tyst. Kan användas för att inaktivera bakgrundsmusik i vissa spel.</translation>
-    </message>
-    <message>
-        <source>Frame Time Buffer</source>
-        <translation>Bildtidsbuffert</translation>
-    </message>
-    <message>
-        <source>From File...</source>
-        <translation>Från fil...</translation>
-    </message>
-    <message>
-        <source>Fullscreen Resolution</source>
-        <translation>Helskärmsupplösning</translation>
-    </message>
-    <message>
-        <source>GPU Adapter</source>
-        <translation>GPU-adapter</translation>
-    </message>
-    <message>
-        <source>GPU Renderer</source>
-        <translation>GPU-renderare</translation>
-    </message>
-    <message>
-        <source>Game Grid</source>
-        <translation>Spelrutnät</translation>
-    </message>
-    <message>
-        <source>Game List Settings</source>
-        <translation>Inställningar för spellista</translation>
-    </message>
-    <message>
-        <source>Game Patches</source>
-        <translation>Spelpatchar</translation>
-    </message>
-    <message>
-        <source>Game Quick Save</source>
-        <translation>Snabbsparning</translation>
-    </message>
-    <message>
-        <source>Game Slot {0}##game_slot_{0}</source>
-        <translation>Spelplats {0}##game_slot_{0}</translation>
-    </message>
-    <message>
-        <source>Game compatibility rating copied to clipboard.</source>
-        <translation>Spelets kompatibilitetsbetyg kopierat till urklipp.</translation>
-    </message>
-    <message>
-        <source>Game path copied to clipboard.</source>
-        <translation>Spelets sökväg kopierat till urklipp.</translation>
-    </message>
-    <message>
-        <source>Game region copied to clipboard.</source>
-        <translation>Spelets region kopierat till urklipp.</translation>
-    </message>
-    <message>
-        <source>Game serial copied to clipboard.</source>
-        <translation>Spelets serienummer kopierat till urklipp.</translation>
-    </message>
-    <message>
-        <source>Game settings have been cleared for &apos;{}&apos;.</source>
-        <translation>Spelinställningar har tömts för &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Game settings initialized with global settings for &apos;{}&apos;.</source>
-        <translation>Spelinställningar initierades med globala inställningar för &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Game title copied to clipboard.</source>
-        <translation>Spelets titel kopierad till urklipp.</translation>
-    </message>
-    <message>
-        <source>Game type copied to clipboard.</source>
-        <translation>Speltypen kopierad till urklipp.</translation>
-    </message>
-    <message>
-        <source>Geometry Tolerance</source>
-        <translation>Geometritolerans</translation>
-    </message>
-    <message>
-        <source>Global Slot {0} - {1}##global_slot_{0}</source>
-        <translation>Global plats {0} - {1}##global_slot_{0}</translation>
-    </message>
-    <message>
-        <source>Global Slot {0}##global_slot_{0}</source>
-        <translation>Global plats {0}##global_slot_{0}</translation>
-    </message>
-    <message>
-        <source>Graphics Settings</source>
-        <translation>Grafikinställningar</translation>
-    </message>
-    <message>
-        <source>Hardcore Mode</source>
-        <translation>Hardcore-läge</translation>
-    </message>
-    <message>
-        <source>Hide Cursor In Fullscreen</source>
-        <translation>Dölj markör i helskärm</translation>
-    </message>
-    <message>
-        <source>Hides the mouse pointer/cursor when the emulator is in fullscreen mode.</source>
-        <translation>Döljer muspekaren/markören när emulatorn är i helskärmsläge.</translation>
-    </message>
-    <message>
-        <source>How many saves will be kept for rewinding. Higher values have greater memory requirements.</source>
-        <translation>Hur många sparade filer som ska sparas för tillbakaspolning. Högre värden kräver större minneskapacitet.</translation>
-    </message>
-    <message>
-        <source>How often a rewind state will be created. Higher frequencies have greater system requirements.</source>
-        <translation>Hur ofta ett tillbakaspolningstillstånd ska skapas. Högre frekvenser ställer högre krav på systemet.</translation>
-    </message>
-    <message>
-        <source>Identifies any new files added to the game directories.</source>
-        <translation>Identifierar alla nya filer som lagts till i spelkatalogerna.</translation>
-    </message>
-    <message>
-        <source>If enabled, the transparency of the overlay image will be applied.</source>
-        <translation>Om den är aktiverad kommer transparensen i överlagringsbilden att tillämpas.</translation>
-    </message>
-    <message>
-        <source>If not enabled, the current post processing chain will be ignored.</source>
-        <translation>Om den inte är aktiverad ignoreras den aktuella efterbehandlingskedjan.</translation>
-    </message>
-    <message>
-        <source>Increases the field of view from 4:3 to the chosen display aspect ratio in 3D games.</source>
-        <translation>Ökar synfältet från 4:3 till det valda bildförhållandet i 3D-spel.</translation>
-    </message>
-    <message>
-        <source>Increases the precision of polygon culling, reducing the number of holes in geometry.</source>
-        <translation>Ökar precisionen i polygonutrensningen, vilket minskar antalet hål i geometrin.</translation>
-    </message>
-    <message>
-        <source>Inhibit Screensaver</source>
-        <translation>Förhindra skärmsläckare</translation>
-    </message>
-    <message>
-        <source>Install BIOS</source>
-        <translation>Installera BIOS</translation>
-    </message>
-    <message>
-        <source>Language: </source>
-        <translation>Språk: </translation>
-    </message>
-    <message>
-        <source>Latency Control</source>
-        <translation>Latenskontroll</translation>
-    </message>
-    <message>
-        <source>Leaderboard Notifications</source>
-        <translation>Aviseringar för ledartavlor</translation>
-    </message>
-    <message>
-        <source>Leaderboards</source>
-        <translation>Ledartavlor</translation>
-    </message>
-    <message>
-        <source>Line Detection</source>
-        <translation>Linjedetektion</translation>
-    </message>
-    <message>
-        <source>List Settings</source>
-        <translation>Listinställningar</translation>
-    </message>
-    <message>
-        <source>Load Database Cheats</source>
-        <translation>Läs in databasfusk</translation>
-    </message>
-    <message>
-        <source>Load Devices From Save States</source>
-        <translation>Läs in enheter från sparade tillstånd</translation>
-    </message>
-    <message>
-        <source>Load Global State</source>
-        <translation>Läs in globalt tillstånd</translation>
-    </message>
-    <message>
-        <source>Load Preset</source>
-        <translation>Läs in förval</translation>
-    </message>
-    <message>
-        <source>Load Resume State</source>
-        <translation>Läs in återställt tillstånd</translation>
-    </message>
-    <message>
-        <source>Loads all replacement texture to RAM, reducing stuttering at runtime.</source>
-        <translation>Läser in alla ersättningstexturer till RAM-minnet, vilket gör att det går snabbare att köra.</translation>
-    </message>
-    <message>
-        <source>Loads the game image into RAM. Useful for network paths that may become unreliable during gameplay.</source>
-        <translation>Läser in spelavbildningen till RAM-minnet. Användbart för nätverksvägar som kan bli opålitliga under spelets gång.</translation>
-    </message>
-    <message>
-        <source>Log Level</source>
-        <translation>Loggnivå</translation>
-    </message>
-    <message>
-        <source>Log To Debug Console</source>
-        <translation>Logga till felsökningskonsol</translation>
-    </message>
-    <message>
-        <source>Log To File</source>
-        <translation>Logga till fil</translation>
-    </message>
-    <message>
-        <source>Log To System Console</source>
-        <translation>Logga till systemkonsol</translation>
-    </message>
-    <message>
-        <source>Logging Settings</source>
-        <translation>Loggningsinställningar</translation>
-    </message>
-    <message>
-        <source>Logging in to RetroAchievements...</source>
-        <translation>Loggar in på RetroAchievements...</translation>
-    </message>
-    <message>
-        <source>Login</source>
-        <translation>Logga in</translation>
-    </message>
-    <message>
-        <source>Login Failed.
-Error: {}
-Please check your username and password, and try again.</source>
-        <translation>Inloggningen misslyckades.
-Fel: {}
-Kontrollera ditt användarnamn och lösenord. Försök igen.</translation>
-    </message>
-    <message>
-        <source>Logs BIOS calls to printf(). Not all games contain debugging messages.</source>
-        <translation>Loggar BIOS-anrop till printf(). Inte alla spel innehåller felsökningsmeddelanden.</translation>
-    </message>
-    <message>
-        <source>Logs messages to duckstation.log in the user directory.</source>
-        <translation>Loggar meddelanden till duckstation.log i användarkatalogen.</translation>
-    </message>
-    <message>
-        <source>Logs messages to the console window.</source>
-        <translation>Loggar meddelanden till konsollfönstret.</translation>
-    </message>
-    <message>
-        <source>Logs messages to the debug console where supported.</source>
-        <translation>Loggar meddelanden till felsökningskonsollen där det stöds.</translation>
-    </message>
-    <message>
-        <source>Makes games run closer to their console framerate, at a small cost to performance.</source>
-        <translation>Gör att spelen körs närmare konsolens bildfrekvens, till en liten bekostnad av prestandan.</translation>
-    </message>
-    <message>
-        <source>Memory Card Busy</source>
-        <translation>Minneskortet är upptaget</translation>
-    </message>
-    <message>
-        <source>Memory Card Directory</source>
-        <translation>Katalog för minneskort</translation>
-    </message>
-    <message>
-        <source>Memory Card Port {}</source>
-        <translation>Port för minneskort {}</translation>
-    </message>
-    <message>
-        <source>Memory Card Settings</source>
-        <translation>Inställningar för minneskort</translation>
-    </message>
-    <message>
-        <source>Memory Card {} Type</source>
-        <translation>Minneskort {} typ</translation>
-    </message>
-    <message>
-        <source>Menu Background</source>
-        <translation>Menybakgrund</translation>
-    </message>
-    <message>
-        <source>Merge Multi-Disc Games</source>
-        <translation>Slå samman flerskivsspel</translation>
-    </message>
-    <message>
-        <source>Merges multi-disc games into one item in the game list.</source>
-        <translation>Slår samman flerskivsspel till ett objekt i spellistan.</translation>
-    </message>
-    <message>
-        <source>Minimal Output Latency</source>
-        <translation>Minimal utdatalatens</translation>
-    </message>
-    <message>
-        <source>Move Cursor</source>
-        <translation>Flytta markören</translation>
-    </message>
-    <message>
-        <source>Move Down</source>
-        <translation>Flytta ner</translation>
-    </message>
-    <message>
-        <source>Move Up</source>
-        <translation>Flytta upp</translation>
-    </message>
-    <message>
-        <source>Moves this shader higher in the chain, applying it earlier.</source>
-        <translation>Flyttar den här shadern högre upp i kedjan och applicerar den tidigare.</translation>
-    </message>
-    <message>
-        <source>Moves this shader lower in the chain, applying it later.</source>
-        <translation>Flyttar den här shadern längre ner i kedjan och applicerar den senare.</translation>
-    </message>
-    <message>
-        <source>Multitap</source>
-        <translation>Multitap</translation>
-    </message>
-    <message>
-        <source>Multitap Mode</source>
-        <translation>Multitap-läge</translation>
-    </message>
-    <message>
-        <source>Mute All Sound</source>
-        <translation>Tysta allt ljud</translation>
-    </message>
-    <message>
-        <source>Mute CD Audio</source>
-        <translation>Tysta cd-ljud</translation>
-    </message>
-    <message>
-        <source>No Game Selected</source>
-        <translation>Inget spel valt</translation>
-    </message>
-    <message>
-        <source>No Vibration</source>
-        <translation>Ingen vibration</translation>
-    </message>
-    <message>
-        <source>No cheats are available for this game.</source>
-        <translation>Det finns inga fusk tillgängliga för detta spel.</translation>
-    </message>
-    <message>
-        <source>No devices with vibration motors were detected.</source>
-        <translation>Inga enheter med vibrationsmotorer hittades.</translation>
-    </message>
-    <message>
-        <source>No patches are available for this game.</source>
-        <translation>Det finns inga patchar tillgängliga för detta spel.</translation>
-    </message>
-    <message>
-        <source>No resume save state found.</source>
-        <translation>Inget återupptagningsbart sparat tillstånd hittades.</translation>
-    </message>
-    <message>
-        <source>No save present in this slot.</source>
-        <translation>Ingen sparning finns på denna plats.</translation>
-    </message>
-    <message>
-        <source>No save states found.</source>
-        <translation>Inga sparade tillstånd hittades.</translation>
-    </message>
-    <message>
-        <source>No, resume the game.</source>
-        <translation>Nej, återuppta spelet.</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Ingen</translation>
-    </message>
-    <message>
-        <source>None (Double Speed)</source>
-        <translation>Ingen (dubbel hastighet)</translation>
-    </message>
-    <message>
-        <source>None (Normal Speed)</source>
-        <translation>Ingen (normal hastighet)</translation>
-    </message>
-    <message>
-        <source>Not Logged In</source>
-        <translation>Inte inloggad</translation>
-    </message>
-    <message>
-        <source>Not Scanning Subdirectories</source>
-        <translation>Söker inte igenom underkataloger</translation>
-    </message>
-    <message>
-        <source>OSD Scale</source>
-        <translation>OSD-skala</translation>
-    </message>
-    <message>
-        <source>On-Screen Display</source>
-        <translation>On-Screen Display</translation>
-    </message>
-    <message>
-        <source>Open Containing Directory</source>
-        <translation>Öppna överliggande katalog</translation>
-    </message>
-    <message>
-        <source>Open in File Browser</source>
-        <translation>Öppna i filbläddrare</translation>
-    </message>
-    <message>
-        <source>Operations</source>
-        <translation>Operationer</translation>
-    </message>
-    <message>
-        <source>Optimal Frame Pacing</source>
-        <translation>Optimal bildrytm</translation>
-    </message>
-    <message>
-        <source>Options</source>
-        <translation>Inställningar</translation>
-    </message>
-    <message>
-        <source>Output Latency</source>
-        <translation>Utmatningslatens</translation>
-    </message>
-    <message>
-        <source>Output Volume</source>
-        <translation>Utmatningsvolym</translation>
-    </message>
-    <message>
-        <source>Overclocking Percentage</source>
-        <translation>Överklockningsprocent</translation>
-    </message>
-    <message>
-        <source>Overlays or replaces normal triangle drawing with a wireframe/line view.</source>
-        <translation>Överlagrar eller ersätter normal triangelritning med en wireframe/linjevy.</translation>
-    </message>
-    <message>
-        <source>PGXP (Precision Geometry Transform Pipeline)</source>
-        <translation>PGXP (Precision Geometry Transform Pipeline)</translation>
-    </message>
-    <message>
-        <source>PGXP Depth Buffer</source>
-        <translation>PGXP-djupbuffert</translation>
-    </message>
-    <message>
-        <source>PGXP Geometry Correction</source>
-        <translation>PGXP-geometrikorrigering</translation>
-    </message>
-    <message>
-        <source>Parent Directory</source>
-        <translation>Överliggande katalog</translation>
-    </message>
-    <message>
-        <source>Patches</source>
-        <translation>Patchar</translation>
-    </message>
-    <message>
-        <source>Patches the BIOS to skip the boot animation. Safe to enable.</source>
-        <translation>Patchar BIOS till att hoppa över uppstartsanimeringen. Säkert att aktivera.</translation>
-    </message>
-    <message>
-        <source>Pause On Controller Disconnection</source>
-        <translation>Pausa när handkontroller kopplas från</translation>
-    </message>
-    <message>
-        <source>Pause On Focus Loss</source>
-        <translation>Pausa när fokus tappas</translation>
-    </message>
-    <message>
-        <source>Pause On Start</source>
-        <translation>Pausa vid start</translation>
-    </message>
-    <message>
-        <source>Pauses the emulator when a controller with bindings is disconnected.</source>
-        <translation>Pausar emulatorn när en handkontroller med bindningar kopplas från.</translation>
-    </message>
-    <message>
-        <source>Pauses the emulator when a game is started.</source>
-        <translation>Pausar emulatorn när ett spel startas.</translation>
-    </message>
-    <message>
-        <source>Pauses the emulator when you minimize the window or switch to another application, and unpauses when you switch back.</source>
-        <translation>Pausar emulatorn när du minimerar fönstret eller byter till ett annat program samt avpausar när du byter tillbaka.</translation>
-    </message>
-    <message>
-        <source>Per-Game Configuration</source>
-        <translation>Konfiguration per-spel</translation>
-    </message>
-    <message>
-        <source>Per-game controller configuration initialized with global settings.</source>
-        <translation>Kontrollerkonfiguration per-spel initierades med globala inställningar.</translation>
-    </message>
-    <message>
-        <source>Performance enhancement - jumps directly between blocks instead of returning to the dispatcher.</source>
-        <translation>Prestandaförbättring - hoppar direkt mellan blocken i stället för att återvända till avsändaren.</translation>
-    </message>
-    <message>
-        <source>Perspective Correct Colors</source>
-        <translation>Korrekta färger för perspektiv</translation>
-    </message>
-    <message>
-        <source>Perspective Correct Textures</source>
-        <translation>Korrekta texturer för perspektiv</translation>
-    </message>
-    <message>
-        <source>Plays sound effects for events such as achievement unlocks and leaderboard submissions.</source>
-        <translation>Spelar upp ljudeffekter för händelser såsom en prestation låses upp och insändningar till ledartavlor.</translation>
-    </message>
-    <message>
-        <source>Please enter your user name and password for retroachievements.org below. Your password will not be saved in DuckStation, an access token will be generated and used instead.</source>
-        <translation>Ange ditt användarnamn och lösenord för retroachievements.org nedan. Ditt lösenord kommer inte att sparas i DuckStation, däremot kommer ett access token att genereras och användas.</translation>
-    </message>
-    <message>
-        <source>Port {} Controller Type</source>
-        <translation>Port {} kontrollertyp</translation>
-    </message>
-    <message>
-        <source>Post-Processing Settings</source>
-        <translation>Inställningar för efterbehandling</translation>
-    </message>
-    <message>
-        <source>Post-processing chain cleared.</source>
-        <translation>Efterbehandlingskedja tömd.</translation>
-    </message>
-    <message>
-        <source>Post-processing shaders reloaded.</source>
-        <translation>Shaders för efterbehandling lästes om.</translation>
-    </message>
-    <message>
-        <source>Preload Images to RAM</source>
-        <translation>Förinläs avbilder till RAM</translation>
-    </message>
-    <message>
-        <source>Preload Replacement Textures</source>
-        <translation>Förinläs ersättningstexturer</translation>
-    </message>
-    <message>
-        <source>Preserve Projection Precision</source>
-        <translation>Bevara projektionens precision</translation>
-    </message>
-    <message>
-        <source>Press To Toggle</source>
-        <translation>Tryck för att växla</translation>
-    </message>
-    <message>
-        <source>Pressure</source>
-        <translation>Tryckkänslighet</translation>
-    </message>
-    <message>
-        <source>Prevents the emulator from producing any audible sound.</source>
-        <translation>Förhindrar att emulatorn skapar någon form av ljud.</translation>
-    </message>
-    <message>
-        <source>Prevents the screen saver from activating and the host from sleeping while emulation is running.</source>
-        <translation>Förhindrar att skärmsläckaren aktiveras och värden från att gå i viloläge när emuleringen körs.</translation>
-    </message>
-    <message>
-        <source>Provides vibration and LED control support over Bluetooth.</source>
-        <translation>Ger stöd för vibrations- och LED-styrning via Bluetooth.</translation>
-    </message>
-    <message>
-        <source>Push a controller button or axis now.</source>
-        <translation>Tryck på en knapp eller spak på handkontrollern nu.</translation>
-    </message>
-    <message>
-        <source>Quick Save</source>
-        <translation>Snabbsparning</translation>
-    </message>
-    <message>
-        <source>Read Speedup</source>
-        <translation>Högre läshastighet</translation>
-    </message>
-    <message>
-        <source>Readahead Sectors</source>
-        <translation>Readahead-sektorer</translation>
-    </message>
-    <message>
-        <source>Recompiler Fast Memory Access</source>
-        <translation>Snabb minnesåtkomst för omkompilator</translation>
-    </message>
-    <message>
-        <source>Reduce Input Latency</source>
-        <translation>Reducera inmatningslatens</translation>
-    </message>
-    <message>
-        <source>Reduces &quot;wobbly&quot; polygons by attempting to preserve the fractional component through memory transfers.</source>
-        <translation>Minskar &quot;vingliga&quot; polygoner genom att försöka bevara den fraktionerade komponenten genom minnesöverföringar.</translation>
-    </message>
-    <message>
-        <source>Reduces hitches in emulation by reading/decompressing CD data asynchronously on a worker thread.</source>
-        <translation>Minskar problem i emuleringen genom att läsa/dekomprimera CD-data asynkront i en arbetstråd.</translation>
-    </message>
-    <message>
-        <source>Reduces input latency by delaying the start of frame until closer to the presentation time.</source>
-        <translation>Minskar inmatningslatensen genom att fördröja starten av bildrutan till närmare presentationstiden.</translation>
-    </message>
-    <message>
-        <source>Reduces polygon Z-fighting through depth testing. Low compatibility with games.</source>
-        <translation>Minskar polygon Z-fighting genom djuptestning. Låg kompatibilitet med spel.</translation>
-    </message>
-    <message>
-        <source>Reduces the size of save states by compressing the data before saving.</source>
-        <translation>Minskar storleken på sparade tillstånd genom att komprimera data innan de sparas.</translation>
-    </message>
-    <message>
-        <source>Region</source>
-        <translation>Region</translation>
-    </message>
-    <message>
-        <source>Region: </source>
-        <translation>Region: </translation>
-    </message>
-    <message>
-        <source>Reload Shaders</source>
-        <translation>Läs om shaders</translation>
-    </message>
-    <message>
-        <source>Reloads the shaders from disk, applying any changes.</source>
-        <translation>Läser om shaders från disk och tillämpar eventuella ändringar.</translation>
-    </message>
-    <message>
-        <source>Remove From Chain</source>
-        <translation>Ta bort från kedja</translation>
-    </message>
-    <message>
-        <source>Removed stage {} ({}).</source>
-        <translation>Tog bort steg {} ({}).</translation>
-    </message>
-    <message>
-        <source>Removes all bindings for this controller port.</source>
-        <translation>Tar bort alla bindningar för den här kontrollerporten.</translation>
-    </message>
-    <message>
-        <source>Removes this shader from the chain.</source>
-        <translation>Tar bort denna shader från kedjan.</translation>
-    </message>
-    <message>
-        <source>Renames existing save states when saving to a backup file.</source>
-        <translation>Byter namn på befintliga sparade tillstånd vid sparning till en säkerhetskopiefil.</translation>
-    </message>
-    <message>
-        <source>Rendering</source>
-        <translation>Rendering</translation>
-    </message>
-    <message>
-        <source>Reset Unlock</source>
-        <translation>Återställ upplåsning</translation>
-    </message>
-    <message>
-        <source>Reset Unofficial Achievement</source>
-        <translation>Återställ inofficiell prestation</translation>
-    </message>
-    <message>
-        <source>Reset Unofficial Achievement Unlocks</source>
-        <translation>Återställ upplåsningar för inofficiella prestationer</translation>
-    </message>
-    <message>
-        <source>Resets all configuration to defaults (including bindings).</source>
-        <translation>Nollställer all konfiguration till standardvärden (inklusive bindningar).</translation>
-    </message>
-    <message>
-        <source>Resume Last Session</source>
-        <translation>Återuppta senaste session</translation>
-    </message>
-    <message>
-        <source>Return to the previous menu.</source>
-        <translation>Återgå till föregående meny.</translation>
-    </message>
-    <message>
-        <source>Reverses the game list sort order from the default (usually ascending to descending).</source>
-        <translation>Väntar på spellistans sorteringsordning från standard (vanligtvis stigande till fallande).</translation>
-    </message>
-    <message>
-        <source>Rewind Save Frequency</source>
-        <translation>Sparningsfrekvens för tillbakaspolning</translation>
-    </message>
-    <message>
-        <source>Rewind Save Slots</source>
-        <translation>Sparplatser för tillbakaspolning</translation>
-    </message>
-    <message>
-        <source>Rewind is disabled because runahead is enabled. Runahead will significantly increase system requirements.</source>
-        <translation>Tillbakaspolning är inaktiverad eftersom runahead är aktiverat. Runahead kommer att öka systemkraven avsevärt.</translation>
-    </message>
-    <message>
-        <source>Rewind is not enabled. Please note that enabling rewind may significantly increase system requirements.</source>
-        <translation>Tillbakaspolning är inte aktiverad. Observera att aktivera tillbakaspolning kan öka systemkraven mycket.</translation>
-    </message>
-    <message>
-        <source>Round Upscaled Texture Coordinates</source>
-        <translation>Avrunda uppskalade texturkoordinater</translation>
-    </message>
-    <message>
-        <source>Rounds texture coordinates instead of flooring when upscaling. Can fix misaligned textures in some games, but break others, and is incompatible with texture filtering.</source>
-        <translation>Avrundar texturkoordinater istället för flooring vid uppskalning. Kan fixa feljusterade texturer i vissa spel, men förstöra andra, och är inkompatibel med texturfiltrering.</translation>
-    </message>
-    <message>
-        <source>Runahead</source>
-        <translation>Runahead</translation>
-    </message>
-    <message>
-        <source>Runahead/Rewind</source>
-        <translation>Runahead/Tillbakaspolning</translation>
-    </message>
-    <message>
-        <source>SDL DualSense Player LED</source>
-        <translation>SDL DualSense Player LED</translation>
-    </message>
-    <message>
-        <source>SDL DualShock 4 / DualSense Enhanced Mode</source>
-        <translation>SDL DualShock 4 / DualSense utökat läge</translation>
-    </message>
-    <message>
-        <source>Safe Mode</source>
-        <translation>Säkert läge</translation>
-    </message>
-    <message>
-        <source>Save Controller Preset</source>
-        <translation>Spara kontrollerförval</translation>
-    </message>
-    <message>
-        <source>Save Preset</source>
-        <translation>Spara förval</translation>
-    </message>
-    <message>
-        <source>Save State Compression</source>
-        <translation>Komprimering för sparat tillstånd</translation>
-    </message>
-    <message>
-        <source>Saved {}</source>
-        <translation>Sparat {}</translation>
-    </message>
-    <message>
-        <source>Saves state periodically so you can rewind any mistakes while playing.</source>
-        <translation>Sparar tillståndet regelbundet så att du kan spola tillbaka eventuella misstag medan du spelar.</translation>
-    </message>
-    <message>
-        <source>Scaling</source>
-        <translation>Skalning</translation>
-    </message>
-    <message>
-        <source>Scanning Subdirectories</source>
-        <translation>Söker igenom underkataloger</translation>
-    </message>
-    <message>
-        <source>Screen Margins</source>
-        <translation>Skärmmarginaler</translation>
-    </message>
-    <message>
-        <source>Screen Position</source>
-        <translation>Skärmposition</translation>
-    </message>
-    <message>
-        <source>Screen Rotation</source>
-        <translation>Skärmrotering</translation>
-    </message>
-    <message>
-        <source>Search Directories</source>
-        <translation>Sökkataloger</translation>
-    </message>
-    <message>
-        <source>Seek Speedup</source>
-        <translation>Snabba upp sökning</translation>
-    </message>
-    <message>
-        <source>Select BIOS Image</source>
-        <translation>Välj BIOS-avbild</translation>
-    </message>
-    <message>
-        <source>Select Disc</source>
-        <translation>Välj skiva</translation>
-    </message>
-    <message>
-        <source>Select Key</source>
-        <translation>Välj tangent</translation>
-    </message>
-    <message>
-        <source>Select Macro {} Binds</source>
-        <translation>Välj bindning för makro {}</translation>
-    </message>
-    <message>
-        <source>Selects the GPU to use for rendering.</source>
-        <translation>Väljer den GPU att använda för rendering.</translation>
-    </message>
-    <message>
-        <source>Selects the percentage of the normal clock speed the emulated hardware will run at.</source>
-        <translation>Väljer den procentandel av den normala klockfrekvensen som den emulerade hårdvaran ska köras med.</translation>
-    </message>
-    <message>
-        <source>Selects the quality at which screenshots will be compressed.</source>
-        <translation>Väljer kvaliteten för vilken skärmbilder ska komprimeras med.</translation>
-    </message>
-    <message>
-        <source>Selects the resolution scale that will be applied to the final image. 1x will downsample to the original console resolution.</source>
-        <translation>Väljer den upplösningsskala som ska tillämpas på den slutliga bilden. 1x innebär nedskalning till den ursprungliga konsolupplösningen.</translation>
-    </message>
-    <message>
-        <source>Selects the resolution to use in fullscreen modes.</source>
-        <translation>Väljer upplösningen att använda i helskärmslägen.</translation>
-    </message>
-    <message>
-        <source>Selects the type of emulated controller for this port.</source>
-        <translation>Väljer typ av emulerad kontroller för den här porten.</translation>
-    </message>
-    <message>
-        <source>Selects the view that the game list will open to.</source>
-        <translation>Väljer vyn som spellistan ska öppnas med.</translation>
-    </message>
-    <message>
-        <source>Session: {}</source>
-        <translation>Session: {}</translation>
-    </message>
-    <message>
-        <source>Set Input Binding</source>
-        <translation>Ställ in inmatningsbindning</translation>
-    </message>
-    <message>
-        <source>Sets a threshold for discarding precise values when exceeded. May help with glitches in some games.</source>
-        <translation>Ställer in ett tröskelvärde för att kassera exakta värden när de överskrids. Kan hjälpa till med småfel i vissa spel.</translation>
-    </message>
-    <message>
-        <source>Sets a threshold for discarding the emulated depth buffer. May help in some games.</source>
-        <translation>Ställer in ett tröskelvärde för att kassera den emulerade djupbufferten. Kan vara till hjälp i vissa spel.</translation>
-    </message>
-    <message>
-        <source>Sets the fast forward speed. It is not guaranteed that this speed will be reached on all systems.</source>
-        <translation>Ställer in hastigheten för snabbspolning framåt. Det är inte säkert att denna hastighet kan uppnås på alla system.</translation>
-    </message>
-    <message>
-        <source>Sets the target emulation speed. It is not guaranteed that this speed will be reached on all systems.</source>
-        <translation>Ställer in målhastigheten för emuleringen. Det är inte säkert att denna hastighet uppnås på alla system.</translation>
-    </message>
-    <message>
-        <source>Sets the turbo speed. It is not guaranteed that this speed will be reached on all systems.</source>
-        <translation>Ställer in turbohastigheten. Det är inte säkert att denna hastighet uppnås på alla system.</translation>
-    </message>
-    <message>
-        <source>Sets the verbosity of messages logged. Higher levels will log more messages.</source>
-        <translation>Ställer in verbositeten för loggade meddelanden. Högre nivåer kommer att logga fler meddelanden.</translation>
-    </message>
-    <message>
-        <source>Sets which sort of memory card image will be used for slot {}.</source>
-        <translation>Anger vilken typ av minneskortsavbild som ska användas för plats {}.</translation>
-    </message>
-    <message>
-        <source>Setting {} binding {}.</source>
-        <translation>Ställer in {} bindning {}.</translation>
-    </message>
-    <message>
-        <source>Shader {} added as stage {}.</source>
-        <translation>Shader {} lades till som steg {}.</translation>
-    </message>
-    <message>
-        <source>Shared Card Name</source>
-        <translation>Delat kortnamn</translation>
-    </message>
-    <message>
-        <source>Show Achievement Trophy Icons</source>
-        <translation>Visa ikoner för prestationstroféer</translation>
-    </message>
-    <message>
-        <source>Show Controller Input</source>
-        <translation>Visa kontrollerinmatning</translation>
-    </message>
-    <message>
-        <source>Show Enhancement Settings</source>
-        <translation>Visa förbättringsinställningar</translation>
-    </message>
-    <message>
-        <source>Show Frame Times</source>
-        <translation>Visa bildrutetider</translation>
-    </message>
-    <message>
-        <source>Show GPU Statistics</source>
-        <translation>Visa GPU-statistik</translation>
-    </message>
-    <message>
-        <source>Show Latency Statistics</source>
-        <translation>Visa latensstatistik</translation>
-    </message>
-    <message>
-        <source>Shows a background image or shader when a game isn&apos;t running. Backgrounds are located in resources/fullscreenui/backgrounds in the data directory.</source>
-        <translation>Visar en bakgrundsbild eller shader när ett spel inte är igång. Bakgrunderna finns i resources/fullscreenui/backgrounds i datakatalogen.</translation>
-    </message>
-    <message>
-        <source>Shows a visual history of frame times in the upper-left corner of the display.</source>
-        <translation>Visar en visuell historik över bildrutetider i övre vänstra hörnet på skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows enhancement settings in the bottom-right corner of the screen.</source>
-        <translation>Visar förbättringsinställningar i nedre högra hörnet av skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows information about input and audio latency in the top-right corner of the display.</source>
-        <translation>Visar information om inmatnings- och ljudlatens i övre högra hörnet av skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows information about the emulated GPU in the top-right corner of the display.</source>
-        <translation>Visar information om emulerad GPU i övre högra hörnet av skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows persistent icons when turbo is active or when paused.</source>
-        <translation>Visar bestående ikoner när turbo är aktivt eller när pausat.</translation>
-    </message>
-    <message>
-        <source>Shows the current controller state of the system in the bottom-left corner of the display.</source>
-        <translation>Visar aktuellt tillstånd för handkontroller för systemet i nedre vänstra hörnet av skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows the current emulation speed of the system in the top-right corner of the display as a percentage.</source>
-        <translation>Visar aktuell emuleringshastighet för systemet i övre högra hörnet av skärmen som ett procenttal.</translation>
-    </message>
-    <message>
-        <source>Shows the current rendering resolution of the system in the top-right corner of the display.</source>
-        <translation>Visar aktuell renderingsupplösning för systemet i övre högra hörnet av skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows the game you are currently playing as part of your profile in Discord.</source>
-        <translation>Visar spelet som du för närvarande spelar som en del av din profil i Discord.</translation>
-    </message>
-    <message>
-        <source>Shows the host&apos;s CPU usage of each system thread in the top-right corner of the display.</source>
-        <translation>Visar värdens CPU-användning för varje systemtråd i övre högra hörnet av skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows the host&apos;s GPU usage in the top-right corner of the display.</source>
-        <translation>Visar värdens GPU-användning i övre högra hörnet av skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows the number of frames (or v-syncs) displayed per second by the system in the top-right corner of the display.</source>
-        <translation>Visar antalet bildrutor (eller v-syncs) som visas per sekund av systemet i övre högra hörnet av skärmen.</translation>
-    </message>
-    <message>
-        <source>Shows trophy icons in game grid when games have achievements or have been mastered.</source>
-        <translation>Visar troféikoner i spelrutnätet när spelen har prestationer eller har klarats av.</translation>
-    </message>
-    <message>
-        <source>Simulates the region check present in original, unmodified consoles.</source>
-        <translation>Simulerar den regionskontroll som finns i ursprungliga, omodifierade konsoler.</translation>
-    </message>
-    <message>
-        <source>Simulates the system ahead of time and rolls back/replays to reduce input lag. Very high system requirements.</source>
-        <translation>Simulerar systemet i förväg och rullar tillbaka/spelar upp för att minska inmatningsfördröjning. Mycket höga systemkrav.</translation>
-    </message>
-    <message>
-        <source>Skip Duplicate Frame Display</source>
-        <translation>Hoppa över duplicerad bildvisning</translation>
-    </message>
-    <message>
-        <source>Skips the presentation/display of frames that are not unique. Can result in worse frame pacing.</source>
-        <translation>Hoppar över presentation/visning av bildrutor som inte är unika. Kan resultera i sämre bildrytm.</translation>
-    </message>
-    <message>
-        <source>Slow Boot</source>
-        <translation>Långsam uppstart</translation>
-    </message>
-    <message>
-        <source>Smooth Scrolling</source>
-        <translation>Mjuk rullning</translation>
-    </message>
-    <message>
-        <source>Smooths out blockyness between colour transitions in 24-bit content, usually FMVs.</source>
-        <translation>Utjämnar blockighet mellan färgövergångar i 24-bitars innehåll, vanligtvis FMV.</translation>
-    </message>
-    <message>
-        <source>Smooths out the blockiness of magnified textures on 2D objects.</source>
-        <translation>Utjämnar blockigheten i förstorade texturer på 2D-objekt.</translation>
-    </message>
-    <message>
-        <source>Smooths out the blockiness of magnified textures on 3D objects.</source>
-        <translation>Utjämnar blockigheten i förstorade texturer på 3D-objekt.</translation>
-    </message>
-    <message>
-        <source>Sort Reversed</source>
-        <translation>Omvänd sortering</translation>
-    </message>
-    <message>
-        <source>Specifies the amount of buffer time added, which reduces the additional sleep time introduced.</source>
-        <translation>Anger hur mycket bufferttid som läggs till, vilket minskar den extra sömntid som införs.</translation>
-    </message>
-    <message>
-        <source>Spectator Mode</source>
-        <translation>Åskådarläge</translation>
-    </message>
-    <message>
-        <source>Speeds up CD-ROM reads by the specified factor. May improve loading speeds in some games, and break others.</source>
-        <translation>Snabbar upp CD-ROM-läsningen med den angivna faktorn. Kan förbättra inläsningshastigheter i vissa spel och förstöra andra.</translation>
-    </message>
-    <message>
-        <source>Speeds up CD-ROM seeks by the specified factor. May improve loading speeds in some games, and break others.</source>
-        <translation>Snabbar upp hastigheten på CD-ROM-sökningar med den angivna faktorn. Kan förbättra inläsningshastigheter i vissa spel och förstöra andra.</translation>
-    </message>
-    <message>
-        <source>Sprite Texture Filtering</source>
-        <translation>Filtrering av sprite-textur</translation>
-    </message>
-    <message>
-        <source>Stage {}: {}</source>
-        <translation>Steg {}: {}</translation>
-    </message>
-    <message>
-        <source>Stretch Mode</source>
-        <translation>Utsträckningsläge</translation>
-    </message>
-    <message>
-        <source>Switches back to 4:3 display aspect ratio when displaying 24-bit content, usually FMVs.</source>
-        <translation>Växlar tillbaka till bildförhållandet 4:3 vid visning av 24-bitars innehåll, vanligtvis FMV.</translation>
-    </message>
-    <message>
-        <source>Switches between full screen and windowed when the window is double-clicked.</source>
-        <translation>Växlar mellan helskärm och fönsterläge när fönstret dubbelklickas.</translation>
-    </message>
-    <message>
-        <source>Sync To Host Refresh Rate</source>
-        <translation>Synka till värdens uppdateringsfrekvens</translation>
-    </message>
-    <message>
-        <source>Synchronizes presentation of the console&apos;s frames to the host. GSync/FreeSync users should enable Optimal Frame Pacing instead.</source>
-        <translation>Synkroniserar presentationen av konsolens bildrutor till värden. GSync/FreeSync-användare bör aktivera Optimal bildrytm istället.</translation>
-    </message>
-    <message>
-        <source>Temporarily disables all enhancements, useful when testing.</source>
-        <translation>Inaktiverar tillfälligt alla förbättringar, användbart vid testning.</translation>
-    </message>
-    <message>
-        <source>Texture Filtering</source>
-        <translation>Texturfiltrering</translation>
-    </message>
-    <message>
-        <source>Texture Replacements</source>
-        <translation>Texturersättningar</translation>
-    </message>
-    <message>
-        <source>Textures Directory</source>
-        <translation>Texturkatalog</translation>
-    </message>
-    <message>
-        <source>The BIOS file &apos;{}&apos; is already installed. Do you want to overwrite it?</source>
-        <translation>BIOS-filen &apos;{}&apos; är redan installerad. Vill du skriva över den?</translation>
-    </message>
-    <message>
-        <source>The SDL input source supports most controllers.</source>
-        <translation>SDL-inmatningskällan har stöd för de flesta kontroller.</translation>
-    </message>
-    <message>
-        <source>The audio backend determines how frames produced by the emulator are submitted to the host.</source>
-        <translation>Ljudbakänden avgör hur ramar som produceras av emulatorn skickas till värden.</translation>
-    </message>
-    <message>
-        <source>The selected memory card image will be used in shared mode for this slot.</source>
-        <translation>Den valda minneskortsavbilden kommer att användas i delat läge för denna plats.</translation>
-    </message>
-    <message>
-        <source>Threaded Rendering</source>
-        <translation>Trådad rendering</translation>
-    </message>
-    <message>
-        <source>Time Played</source>
-        <translation>Tid spelat</translation>
-    </message>
-    <message>
-        <source>Timing out in {:.0f} seconds...</source>
-        <translation>Tidsgräns går ut om {:.0f} sekunder...</translation>
-    </message>
-    <message>
-        <source>Toggle Analog</source>
-        <translation>Växla analog</translation>
-    </message>
-    <message>
-        <source>Toggle Case</source>
-        <translation>Växla skiftläge</translation>
-    </message>
-    <message>
-        <source>Toggle Fast Forward</source>
-        <translation>Växla snabbspolning</translation>
-    </message>
-    <message>
-        <source>Toggle every %d frames</source>
-        <translation>Växla var %d bildruta</translation>
-    </message>
-    <message>
-        <source>Toggles the macro when the button is pressed, instead of held.</source>
-        <translation>Växlar makrot när knappen trycks in, istället för att hållas intryckt.</translation>
-    </message>
-    <message>
-        <source>Trigger</source>
-        <translation>Utlösare</translation>
-    </message>
-    <message>
-        <source>Turbo Speed</source>
-        <translation>Turbohastighet</translation>
-    </message>
-    <message>
-        <source>Uncompressed Size</source>
-        <translation>Okomprimerad storlek</translation>
-    </message>
-    <message>
-        <source>Undo Load State</source>
-        <translation>Ångra inläst tillstånd</translation>
-    </message>
-    <message>
-        <source>Ungrouped</source>
-        <translation>Inte grupperad</translation>
-    </message>
-    <message>
-        <source>Unknown File Size</source>
-        <translation>Okänd filstorlek</translation>
-    </message>
-    <message>
-        <source>Unlimited</source>
-        <translation>Obegränsad</translation>
-    </message>
-    <message>
-        <source>Use Blit Swap Chain</source>
-        <translation>Använd blit-växlingskedja</translation>
-    </message>
-    <message>
-        <source>Use Debug GPU Device</source>
-        <translation>Använda GPU-enhet för felsökning</translation>
-    </message>
-    <message>
-        <source>Use Old MDEC Routines</source>
-        <translation>Använd gamla MDEC-rutiner</translation>
-    </message>
-    <message>
-        <source>Use Separate Disc Settings</source>
-        <translation>Använd separata skivinställningar</translation>
-    </message>
-    <message>
-        <source>Use Single Card For Multi-Disc Games</source>
-        <translation>Använd ett kort för flerskivsspel</translation>
-    </message>
-    <message>
-        <source>Use Software Renderer For Readbacks</source>
-        <translation>Använd programvarurenderare för återläsning</translation>
-    </message>
-    <message>
-        <source>Uses PGXP for all instructions, not just memory operations.</source>
-        <translation>Använder PGXP för alla instruktioner, inte bara minnesoperationer.</translation>
-    </message>
-    <message>
-        <source>Uses a blit presentation model instead of flipping. This may be needed on some systems.</source>
-        <translation>Använder en blit-presentationsmodell istället för flipping. Detta kan behövas på vissa system.</translation>
-    </message>
-    <message>
-        <source>Uses game-specific settings for controllers for this game.</source>
-        <translation>Använder spelspecifika inställningar för handkontroller för detta spel.</translation>
-    </message>
-    <message>
-        <source>Uses native resolution coordinates for 2D polygons, instead of precise coordinates. Can fix misaligned UI in some games, but otherwise should be left disabled.</source>
-        <translation>Använder koordinater med inbyggd upplösning för 2D-polygoner, istället för exakta koordinater. Kan åtgärda felriktat användargränssnitt i vissa spel, men bör annars lämnas inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Uses perspective-correct interpolation for colors, which can improve visuals in some games.</source>
-        <translation>Använder perspektivkorrigerad interpolering för färger, vilket kan förbättra grafiken i vissa spel.</translation>
-    </message>
-    <message>
-        <source>Uses perspective-correct interpolation for texture coordinates, straightening out warped textures.</source>
-        <translation>Använder perspektivkorrigerad interpolering för texturkoordinater, vilket rätar ut skeva texturer.</translation>
-    </message>
-    <message>
-        <source>Uses screen positions to resolve PGXP data. May improve visuals in some games.</source>
-        <translation>Använder skärmpositioner för att lösa PGXP-data. Kan förbättra grafiken i vissa spel.</translation>
-    </message>
-    <message>
-        <source>Uses separate game settings for each disc of multi-disc games. Can only be set on the first/main disc.</source>
-        <translation>Använder separata spelinställningar för varje skiva i flerskivsspel. Kan endast ställas in på första/huvudskivan.</translation>
-    </message>
-    <message>
-        <source>Value: {} | Default: {} | Minimum: {} | Maximum: {}</source>
-        <translation>Värde: {} | Standard: {} | Minimum: {} | Maximum: {}</translation>
-    </message>
-    <message>
-        <source>Verify</source>
-        <translation>Verifiera</translation>
-    </message>
-    <message>
-        <source>Verifying Image</source>
-        <translation>Verifierar avbild</translation>
-    </message>
-    <message>
-        <source>Vertex Cache</source>
-        <translation>Vertex-cache</translation>
-    </message>
-    <message>
-        <source>Vertical Sync (VSync)</source>
-        <translation>Vertikal sync (VSync)</translation>
-    </message>
-    <message>
-        <source>WARNING: Activating cheats can cause unpredictable behavior, crashing, soft-locks, or broken saved games.</source>
-        <translation>VARNING: Aktivering av fusk kan orsaka oförutsett beteende, krascher, mjuklåsningar eller trasiga sparade spel.</translation>
-    </message>
-    <message>
-        <source>WARNING: Activating game patches can cause unpredictable behavior, crashing, soft-locks, or broken saved games.</source>
-        <translation>VARNING: Aktivering av spelpatchar kan orsaka oförutsett beteende, krascher, mjuklåsningar eller trasiga sparade spel.</translation>
-    </message>
-    <message>
-        <source>WARNING: Your game is still saving to the memory card. Continuing to {0} may IRREVERSIBLY DESTROY YOUR MEMORY CARD. We recommend resuming your game and waiting 5 seconds for it to finish saving.
-
-Do you want to {0} anyway?</source>
-        <translation>VARNING: Spelet håller fortfarande på att sparas på minneskortet. Om du fortsätter till {0} kan minneskortet förstöras på ett IRREVERSIBELT sätt. Vi rekommenderar att du återupptar spelet och väntar i 5 sekunder tills det har sparats klart.
-
-Vill du {0} ändå?</translation>
-    </message>
-    <message>
-        <source>Web Cache Size: {0} MB ({1} MB in {2} objects)</source>
-        <translation>Webbcachestorlek: {0} MB ({1} MB i {2} objekt)</translation>
-    </message>
-    <message>
-        <source>Web cache cleared.</source>
-        <translation>Webbcachen har tömts.</translation>
-    </message>
-    <message>
-        <source>When enabled and logged in, DuckStation will scan for achievements on startup.</source>
-        <translation>När aktiverat och inloggad kommer DuckStation att söka efter prestationer vid uppstart.</translation>
-    </message>
-    <message>
-        <source>When enabled, DuckStation will assume all achievements are locked and not send any unlock notifications to the server.</source>
-        <translation>När aktiverad kommer DuckStation att anta att alla prestationer är låsta och inte skicka några upplåsniingsaviseringar till servern.</translation>
-    </message>
-    <message>
-        <source>When enabled, each session will behave as if no achievements have been unlocked.</source>
-        <translation>När aktiverat kommer varje session att bete sig som att ingen prestation har låsts upp.</translation>
-    </message>
-    <message>
-        <source>When enabled, memory cards and controllers will be overwritten when save states are loaded.</source>
-        <translation>När denna funktion är aktiverad skrivs minneskort och kontroller över när sparade tillstånd läses in.</translation>
-    </message>
-    <message>
-        <source>When enabled, the legacy global save state slots will be available. These slots are independent of the current game.</source>
-        <translation>När detta är aktiverat blir de äldre globala platserna för sparade tillstånd tillgängliga. Platserna är oberoende av det aktuella spelet.</translation>
-    </message>
-    <message>
-        <source>When enabled, the minimum supported output latency will be used for the host API.</source>
-        <translation>När den är aktiverad används den minsta stödda utmatningslatensen för värd-API:et.</translation>
-    </message>
-    <message>
-        <source>When playing a multi-disc game and using per-game (title) memory cards, use a single memory card for all discs.</source>
-        <translation>När du spelar ett spel med flera skivor och använder minneskort för varje spel (titel), använd ett enda minneskort för alla skivor.</translation>
-    </message>
-    <message>
-        <source>When this option is chosen, the clock speed set below will be used.</source>
-        <translation>När detta alternativ väljs så kommer klockfrekvensen som anges nedan att användas.</translation>
-    </message>
-    <message>
-        <source>Widescreen Rendering</source>
-        <translation>Bredbildsrendering</translation>
-    </message>
-    <message>
-        <source>Wireframe Rendering</source>
-        <translation>Wireframe-rendering</translation>
-    </message>
-    <message>
-        <source>Writes backgrounds that can be replaced to the dump directory.</source>
-        <translation>Skriver bakgrunder som kan ersättas till dumpkatalogen.</translation>
-    </message>
-    <message>
-        <source>Xbox</source>
-        <translation>Xbox</translation>
-    </message>
-    <message>
-        <source>Yes, {} now and risk memory card corruption.</source>
-        <translation>Ja,  {} nu och riskera att minneskortet skadas.</translation>
-    </message>
-    <message>
-        <source>&quot;Challenge&quot; mode for achievements, including leaderboard tracking. Disables save state, cheats, and slowdown functions.</source>
-        <translation>&quot;Challenge&quot;-läget för prestationer, inklusive följa ledartavlor. Inaktiverar sparat tillstånd, fusk och funktioner för sakta körning.</translation>
-    </message>
-    <message>
-        <source>&quot;PlayStation&quot; and &quot;PSX&quot; are registered trademarks of Sony Interactive Entertainment Europe Limited. This software is not affiliated in any way with Sony Interactive Entertainment.</source>
-        <translation>&quot;PlayStation&quot; och &quot;PSX&quot; är registrerade varumärken för Sony Interactive Entertainment Europe Limited. Denna programvara har ingen koppling till Sony Interactive Entertainment på något sätt.</translation>
-    </message>
-    <message>
-        <source>change disc</source>
-        <translation>byt skiva</translation>
-    </message>
-    <message>
-        <source>shut down</source>
-        <translation>stäng av</translation>
-    </message>
-    <message>
-        <source>A cover already exists for this game. Are you sure that you want to overwrite it?</source>
-        <translation>Det finns redan ett omslag för det här spelet. Är du säker på att du vill skriva över det?</translation>
-    </message>
-    <message>
-        <source>Border Overlay</source>
-        <translation>Kantöverlägg</translation>
-    </message>
-    <message>
-        <source>Cover set.</source>
-        <translation>Omslag inställt.</translation>
-    </message>
-    <message>
-        <source>Custom</source>
-        <translation>Anpassad</translation>
-    </message>
-    <message>
-        <source>Destination Alpha Blending</source>
-        <translation>Alfablandning för destination</translation>
-    </message>
-    <message>
-        <source>Determines the area of the overlay image that the display will be drawn within.</source>
-        <translation>Bestämmer det område av överläggsbilden som skärmen ska ritas inom.</translation>
-    </message>
-    <message>
-        <source>Display Area</source>
-        <translation>Visningsområde</translation>
-    </message>
-    <message>
-        <source>Failed to copy cover: {}</source>
-        <translation>Misslyckades med att kopiera omslaget: {}</translation>
-    </message>
-    <message>
-        <source>Failed to delete existing cover: {}</source>
-        <translation>Misslyckades med att ta bort befintligt omslag: {}</translation>
-    </message>
-    <message>
-        <source>If enabled, the display will be blended with the transparency of the overlay image.</source>
-        <translation>Om den är aktiverad kommer skärmen att blandas med transparensen i överläggsbilden.</translation>
-    </message>
-    <message>
-        <source>Image Path</source>
-        <translation>Sökväg till bild</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation>Lösenord</translation>
-    </message>
-    <message>
-        <source>Select from the list of preset borders, or manually specify a custom configuration.</source>
-        <translation>Välj från listan med förvalskanter eller ange en anpassad konfiguration manuellt.</translation>
-    </message>
-    <message>
-        <source>Selected Preset</source>
-        <translation>Valt förval</translation>
-    </message>
-    <message>
-        <source>Set Cover Image</source>
-        <translation>Ställ in omslagsbild</translation>
-    </message>
-    <message>
-        <source>Sort Alphabetically</source>
-        <translation>Sortera alfabetiskt</translation>
-    </message>
-    <message>
-        <source>Sorts the cheat list alphabetically by the name of the code.</source>
-        <translation>Sorterar fusklistan i alfabetisk ordning efter kodens namn.</translation>
-    </message>
-    <message>
-        <source>AMOLED</source>
-        <translation>AMOLED</translation>
-    </message>
-    <message>
-        <source>Appearance</source>
-        <translation>Utseende</translation>
-    </message>
-    <message>
-        <source>Cobalt Sky</source>
-        <translation>Cobalt Sky</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Mörk</translation>
-    </message>
-    <message>
-        <source>Fast Forward Memory Card Access</source>
-        <translation>Snabbspolning av minneskort</translation>
-    </message>
-    <message>
-        <source>Fast forwards through memory card access, both loading and saving. Can reduce waiting times in games that frequently access memory cards.</source>
-        <translation>Snabbspolar genom minneskortsåtkomst, både inläsning och lagring. Kan minska väntetiderna i spel som ofta använder minneskort.</translation>
-    </message>
-    <message>
-        <source>Game Display</source>
-        <translation>Spelskärm</translation>
-    </message>
-    <message>
-        <source>Grey Matter</source>
-        <translation>Grå materia</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation>Språk</translation>
-    </message>
-    <message>
-        <source>Light</source>
-        <translation>Ljus</translation>
-    </message>
-    <message>
-        <source>Pinky Pals</source>
-        <translation>Pinky Pals</translation>
-    </message>
-    <message>
-        <source>Purple Rain</source>
-        <translation>Purple Rain</translation>
-    </message>
-    <message>
-        <source>Selects the color style to be used for Big Picture UI.</source>
-        <translation>Väljer den färgstil som ska användas för storbildslägets gränssnitt.</translation>
-    </message>
-    <message>
-        <source>Theme</source>
-        <translation>Tema</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to restore the default settings? Any preferences will be lost.
-
-You cannot undo this action.</source>
-        <translation>Är du säker på att du vill återställa standardinställningarna? Alla inställningar kommer att gå förlorade.
-
-Du kan inte ångra den här åtgärden.</translation>
-    </message>
-    <message>
-        <source>Automatic</source>
-        <translation>Automatiskt</translation>
-    </message>
-    <message>
-        <source>Dark Ruby</source>
-        <translation>Mörk rubin</translation>
-    </message>
-    <message>
-        <source>Open To Game List</source>
-        <translation>Öppna till spellistan</translation>
-    </message>
-    <message>
-        <source>Resets all settings to the defaults.</source>
-        <translation>Återställer alla inställningar till standardvärdena.</translation>
-    </message>
-    <message>
-        <source>Restore Defaults</source>
-        <translation>Återställ standardvärden</translation>
-    </message>
-    <message>
-        <source>Settings reset to default.</source>
-        <translation>Inställningarna återställda till standard.</translation>
-    </message>
-    <message>
-        <source>When Big Picture mode is started, the game list will be displayed instead of the main menu.</source>
-        <translation>När storbildsläget startas visas spellistan i stället för huvudmenyn.</translation>
-    </message>
-    <message>
-        <source> (%u MB on disk)</source>
-        <translation> (%u MB på disk)</translation>
-    </message>
-    <message>
-        <source>%d cycles</source>
-        <translation>%d cykler</translation>
-    </message>
-    <message>
-        <source>%u MB</source>
-        <translation>%u MB</translation>
-    </message>
-    <message>
-        <source>Achievements: </source>
-        <translation>Prestationer: </translation>
-    </message>
-    <message>
-        <source>Allows booting to continue even without a required SBI file. These games will not run correctly.</source>
-        <translation>Tillåter att uppstarten kan fortsätta även utan en nödvändig SBI-fil. Dessa spel kommer inte att köras korrekt.</translation>
-    </message>
-    <message>
-        <source>Animates windows opening/closing and changes between views in the Big Picture UI.</source>
-        <translation>Animerar fönster som öppnas/stängs och växlar mellan olika vyer i Storbildsläget.</translation>
-    </message>
-    <message>
-        <source>Controls how dithering is applied in the emulated GPU. True Color disables dithering and produces the nicest looking gradients.</source>
-        <translation>Kontrollerar hur dithering tillämpas i den emulerade GPU:n. True Color inaktiverar dithering och ger de snyggaste gradienterna.</translation>
-    </message>
-    <message>
-        <source>Disc</source>
-        <translation>Skiva</translation>
-    </message>
-    <message>
-        <source>Dithering</source>
-        <translation>Dithering</translation>
-    </message>
-    <message>
-        <source>Enable GPU-Based Validation</source>
-        <translation>Aktivera GPU-baserad validering</translation>
-    </message>
-    <message>
-        <source>Enable GPU-based validation when supported by the host&apos;s renderer API. Only for developer use.</source>
-        <translation>Aktivera GPU-baserad validering när den stöds av värdens API för rendering. Endast för användning av utvecklare.</translation>
-    </message>
-    <message>
-        <source>Enables smooth scrolling of menus in the Big Picture UI.</source>
-        <translation>Möjliggör smidig rullning av menyer i Storbildsläget.</translation>
-    </message>
-    <message>
-        <source>Frame Rate</source>
-        <translation>Bildfrekvens</translation>
-    </message>
-    <message>
-        <source>Genre: </source>
-        <translation>Genre: </translation>
-    </message>
-    <message>
-        <source>Green Giant</source>
-        <translation>Gröna jätten</translation>
-    </message>
-    <message>
-        <source>Last Played: </source>
-        <translation>Senast spelat: </translation>
-    </message>
-    <message>
-        <source>Maximum Read Speedup Cycles</source>
-        <translation>Maximala cykler för läshastighetsökning</translation>
-    </message>
-    <message>
-        <source>Maximum Seek Speedup Cycles</source>
-        <translation>Maximala cykler för sökhastighetsökning</translation>
-    </message>
-    <message>
-        <source>Release Date: </source>
-        <translation>Lanseringsdatum: </translation>
-    </message>
-    <message>
-        <source>Scaled Interlacing</source>
-        <translation>Skalad interlacing</translation>
-    </message>
-    <message>
-        <source>Scales line skipping in interlaced rendering to the internal resolution, making it less noticeable. Usually safe to enable.</source>
-        <translation>Skalerar linjeöverhoppning vid interlaced-rendering till den interna upplösningen, vilket gör det mindre märkbart. Vanligtvis säkert att aktivera.</translation>
-    </message>
-    <message>
-        <source>Select Disc for {}</source>
-        <translation>Välj skiva för {}</translation>
-    </message>
-    <message>
-        <source>Selects the backend to use for rendering the console/game visuals.</source>
-        <translation>Väljer den bakände som ska användas för att rendera konsol- och spelvisualiseringar.</translation>
-    </message>
-    <message>
-        <source>Sets the minimum delay for the &apos;Maximum&apos; read speedup level.</source>
-        <translation>Ställer in den minsta fördröjningen för läshastighetsnivån ”Maximal”.</translation>
-    </message>
-    <message>
-        <source>Sets the minimum delay for the &apos;Maximum&apos; seek speedup level.</source>
-        <translation>Ställer in den minsta fördröjningen för sökhastighetsnivån ”Maximal”.</translation>
-    </message>
-    <message>
-        <source>Time Played: </source>
-        <translation>Tid spelat: </translation>
-    </message>
-    <message>
-        <source>Upscales the game&apos;s rendering by the specified multiplier.</source>
-        <translation>Uppskalar spelets rendering med den angivna multiplikatorn.</translation>
-    </message>
-    <message>
-        <source>Utilizes the chosen frame rate regardless of the game&apos;s setting.</source>
-        <translation>Använder den valda bildfrekvensen oavsett spelets inställning.</translation>
-    </message>
-    <message>
-        <source>Window Animations</source>
-        <translation>Fönsteranimeringar</translation>
-    </message>
-    <message>
-        <source>Draws a border around the currently-selected item for readability.</source>
-        <translation>Ritar en ram runt det valda objektet för att underlätta läsbarheten.</translation>
-    </message>
-    <message>
-        <source>Menu Borders</source>
-        <translation>Menyramar</translation>
-    </message>
-    <message>
-        <source>Support for controllers that use the XInput protocol. XInput should only be used if you are using a XInput wrapper library.</source>
-        <translation>Stöd för styrenheter som använder XInput-protokollet. XInput bör endast användas om du använder ett XInput-wrapper-bibliotek.</translation>
-    </message>
-    <message>
-        <source>Automatically switches to the next disc in the game when the game stops the CD-ROM motor. Does not work for all games.</source>
-        <translation>Växlar automatiskt till nästa skiva i spelet när spelet stoppar CD-ROM-motorn. Fungerar inte för alla spel.</translation>
-    </message>
-    <message>
-        <source>Switch to Next Disc on Stop</source>
-        <translation>Växla till nästa skiva vid stopp</translation>
-    </message>
-    <message>
-        <source>Update Progress</source>
-        <translation>Uppdatera framsteg</translation>
-    </message>
-    <message>
-        <source>Default Value</source>
-        <translation>Standardvärde</translation>
-    </message>
-    <message>
-        <source>Enable Achievements to see your user summary.</source>
-        <translatorcomment>Aktivera prestationer för att se din användarsammanfattning.</translatorcomment>
-        <translation>Aktivera prestationer för att se din användarsammanfattning.</translation>
-    </message>
-    <message>
-        <source>Logging In...</source>
-        <translation>Loggar in...</translation>
-    </message>
-    <message>
-        <source>To use achievements, please log in with your retroachievements.org account.</source>
-        <translation>För att använda prestationer, logga in med ditt retroachievements.org-konto.</translation>
-    </message>
-    <message>
-        <source>Value Range</source>
-        <translation>Värdesintervall</translation>
-    </message>
-    <message>
-        <source>Bottom: </source>
-        <translation>Nederst: </translation>
-    </message>
-    <message>
-        <source>Displays only the game title in the list, instead of the title and serial/file name.</source>
-        <translation>Visar endast spelets titel i listan, istället för titeln och serienummer/filnamn.</translation>
-    </message>
-    <message>
-        <source>Includes the elapsed time since the application start in file logs.</source>
-        <translation>Inkluderar den tid som förflutit sedan programmet startades i filloggarna.</translation>
-    </message>
-    <message>
-        <source>Includes the elapsed time since the application start in window and console logs.</source>
-        <translation>Inkluderar den tid som har förflutit sedan applikationen startade i fönster- och konsolloggar.</translation>
-    </message>
-    <message>
-        <source>Left: </source>
-        <translation>Vänster: </translation>
-    </message>
-    <message>
-        <source>List Compact Mode</source>
-        <translation>Kompakt läge för lista</translation>
-    </message>
-    <message>
-        <source>Log File Timestamps</source>
-        <translation>Tidsstämplar för loggfil</translation>
-    </message>
-    <message>
-        <source>Log Timestamps</source>
-        <translation>Logga tidsstämplar</translation>
-    </message>
-    <message>
-        <source>Right: </source>
-        <translation>Höger: </translation>
-    </message>
-    <message>
-        <source>Size: </source>
-        <translation>Storlek: </translation>
-    </message>
-    <message>
-        <source>Top: </source>
-        <translation>Överst: </translation>
-    </message>
-    <message>
-        <source>${title}: Title of the game.
-${filetitle}: Name component of the game&apos;s filename.
-${serial}: Serial of the game.</source>
-        <translation>${title}: Titel på spelet.
-${filetitle}: Namnkomponenten för spelets filnamn.
-${serial}: Serienumret för spelet.</translation>
-    </message>
-    <message>
-        <source>Challenge Indicators</source>
-        <translation>Utmaningsindikatorer</translation>
-    </message>
-    <message>
-        <source>Cover Downloader</source>
-        <translation>Hämta omslagsbilder</translation>
-    </message>
-    <message>
-        <source>Determines the scaling algorithm used when 24-bit content is active, typically FMVs.</source>
-        <translation>Bestämmer skalningsalgoritmen som används när 24-bitarsinnehåll är aktivt, vanligtvis FMV.</translation>
-    </message>
-    <message>
-        <source>Disable Speedup on MDEC</source>
-        <translation>Inaktivera hastighetsökning på MDEC</translation>
-    </message>
-    <message>
-        <source>DuckStation can automatically download covers for games which do not currently have a cover set. We do not host any cover images, the user must provide their own source for images.</source>
-        <translation>DuckStation kan automatiskt hämta omslagsbilder för spel som du för närvarande inte har ett omslag för. Vi tillhandahåller inte några omslagsbilder och användaren måste tillhandahålla sin egna källa för bilder.</translation>
-    </message>
-    <message>
-        <source>Example: https://www.example-not-a-real-domain.com/covers/${serial}.jpg</source>
-        <translation>Exempel: https://www.example-not-a-real-domain.com/covers/${serial}.jpg</translation>
-    </message>
-    <message>
-        <source>FMV Scaling</source>
-        <translation>FMV-skalning</translation>
-    </message>
-    <message>
-        <source>Ignore Drive Subcode</source>
-        <translation>Ignorera enhetens underkod</translation>
-    </message>
-    <message>
-        <source>Ignores the subchannel provided by the drive when using physical discs, instead always generating subchannel data. Can improve read reliability on some drives.</source>
-        <translation>Ignorerar den underkanal som tillhandahålls av enheten vid användning av fysiska skivor och genererar istället alltid underkanaldata. Kan förbättra läsningssäkerheten på vissa enheter.</translation>
-    </message>
-    <message>
-        <source>In the form below, specify the URLs to download covers from, with one template URL per line. The following variables are available:</source>
-        <translation>I formuläret nedan anger du de URL-adresser som omslagen ska hämtas ner från, med en mall-URL per rad. Följande variabler är tillgängliga:</translation>
-    </message>
-    <message>
-        <source>Leaderboard Trackers</source>
-        <translation>Följ ledartavla</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation>Nej</translation>
-    </message>
-    <message>
-        <source>Prefer OpenGL ES Context</source>
-        <translation>Föredra OpenGL ES Context</translation>
-    </message>
-    <message>
-        <source>Progress Indicators</source>
-        <translation>Förloppsindikatorer</translation>
-    </message>
-    <message>
-        <source>Save as Serial File Names</source>
-        <translation>Spara som filnamn med serienummer</translation>
-    </message>
-    <message>
-        <source>Show Grid View Titles</source>
-        <translation>Visa titlar på rutnätsvy</translation>
-    </message>
-    <message>
-        <source>Show Localized Titles</source>
-        <translation>Visa lokalanpassade titlar</translation>
-    </message>
-    <message>
-        <source>Shows titles underneath the images in the game grid view.</source>
-        <translation>Visar titlar under bilderna i spelrutnätets vy.</translation>
-    </message>
-    <message>
-        <source>Start Download</source>
-        <translation>Starta hämtning</translation>
-    </message>
-    <message>
-        <source>Tries to detect FMVs and disable read speedup during games that don&apos;t use XA streaming audio.</source>
-        <translation>Försöker upptäcka FMV och inaktiverar läsningshastigheten under spel som inte använder XA-strömningsljud.</translation>
-    </message>
-    <message>
-        <source>Uses OpenGL ES even when desktop OpenGL is supported. May improve performance on some SBC drivers.</source>
-        <translation>Använder OpenGL ES även när OpenGL för stationära datorer stöds. Kan förbättra prestandan på vissa SBC-drivrutiner.</translation>
-    </message>
-    <message>
-        <source>Uses localized (native language) titles in the game list.</source>
-        <translation>Använder lokalanpassade (modersmål) titlar i spellistan.</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation>Ja</translation>
-    </message>
-    <message>
-        <source>Activates runahead when analog input changes, which significantly increases system requirements.</source>
-        <translation>Aktiverar runahead när analog inmatning ändras, vilket avsevärt ökar systemkraven.</translation>
-    </message>
-    <message>
-        <source>No LED</source>
-        <translation>Ingen LED</translation>
-    </message>
-    <message>
-        <source>Runahead for Analog Input</source>
-        <translation>Runahead för analog inmatning</translation>
-    </message>
-    <message>
-        <source>Automatically saves the system state when closing the game or exiting. You can then resume directly from where you left off next time.</source>
-        <translation>Sparar automatiskt systemets tillstånd  när du stänger spelet eller stänger av applikationen. Du kan sedan fortsätta direkt där du slutade nästa gång.</translation>
-    </message>
-    <message>
-        <source>Close Without Saving</source>
-        <translation>Stäng utan att spara</translation>
-    </message>
-    <message>
-        <source>Close and Save State</source>
-        <translation>Stäng och spara tillstånd</translation>
-    </message>
-    <message>
-        <source>Confirm Game Close</source>
-        <translation>Bekräfta spelavstängning</translation>
-    </message>
-    <message>
-        <source>Determines whether a prompt will be displayed to confirm closing the game.</source>
-        <translation>Bestämmer huruvid en prompt kommer att visas för att bekräfta avstängning av spelet.</translation>
-    </message>
-    <message>
-        <source>Maximum (Safer)</source>
-        <translation>Maximalt (Säkrare)</translation>
-    </message>
-    <message>
-        <source>Save State On Game Close</source>
-        <translation>Spara tillstånd vid spelavstängning</translation>
-    </message>
-    <message>
-        <source>{} of {}</source>
-        <translation>{} av {}</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n seconds remaining</source>
-        <comment>Loading time</comment>
-        <translation>
-            <numerusform>%n sekund återstår</numerusform>
-            <numerusform>%n sekunder återstår</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minutes remaining</source>
-        <comment>Loading time</comment>
-        <translation>
-            <numerusform>%n minut återstår</numerusform>
-            <numerusform>%n minuter återstår</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%g seconds</source>
-        <translation>%g sekunder</translation>
-    </message>
-    <message>
-        <source>Determines how long action confirmation messages are displayed on screen.</source>
-        <translation>Bestämmer hur länge bekräftelsemeddelanden visas på skärmen.</translation>
-    </message>
-    <message>
-        <source>Determines how long error messages are displayed on screen.</source>
-        <translation>Bestämmer hur länge felmeddelanden visas på skärmen.</translation>
-    </message>
-    <message>
-        <source>Determines how long informational messages are displayed on screen.</source>
-        <translation>Bestämmer hur länge informationsmeddelanden visas på skärmen.</translation>
-    </message>
-    <message>
-        <source>Determines how long warning messages are displayed on screen.</source>
-        <translation>Bestämmer hur länge varningsmeddelanden visas på skärmen.</translation>
-    </message>
-    <message>
-        <source>Enable Stage</source>
-        <translation>Aktivera steg</translation>
-    </message>
-    <message>
-        <source>Error Message Duration</source>
-        <translation>Visningstid för felmeddelanden</translation>
-    </message>
-    <message>
-        <source>If disabled, the shader in this stage will not be applied.</source>
-        <translation>Om inaktiverad kommer shadern i detta steg inte att tillämpas.</translation>
-    </message>
-    <message>
-        <source>Informational Message Duration</source>
-        <translation>Visningstid för informationsmeddelanden</translation>
-    </message>
-    <message>
-        <source>On-Screen Display Message Durations</source>
-        <translation>Visningstid för skärmmeddelanden</translation>
-    </message>
-    <message>
-        <source>Quick Message Duration</source>
-        <translation>Visningstid för snabbmeddelanden</translation>
-    </message>
-    <message>
-        <source>Rewind for {0} frames, lasting {1:.2f} seconds will require {2} MB of RAM and {3} MB of VRAM.</source>
-        <translation>Tillbakaspolning för {0} bildrutor, varaktighet {1:.2f} sekunder kräver upp till {2} MB RAM och {3} MB VRAM.</translation>
-    </message>
-    <message>
-        <source>Rewind for {0} frames, lasting {1:.2f} seconds will require {2} MB of RAM.</source>
-        <translation>Tillbakaspolning för {0} bildrutor, varaktighet {1:.2f} sekunder kräver upp till {2} MB RAM.</translation>
-    </message>
-    <message>
-        <source>Show Messages</source>
-        <translation>Visa meddelanden</translation>
-    </message>
-    <message>
-        <source>Shows on-screen-display messages when events occur. Errors and warnings are still displayed regardless of this setting.</source>
-        <translation>Visar meddelanden på skärmen när händelser inträffar. Fel och varningar visas alltid oavsett denna inställning.</translation>
-    </message>
-    <message>
-        <source>Use Software Renderer (Low VRAM Mode)</source>
-        <translation>Använd programvarurenderare (lågt VRAM-läge)</translation>
-    </message>
-    <message>
-        <source>Uses the software renderer when creating rewind states to prevent additional VRAM usage. Especially useful when upscaling.</source>
-        <translation>Använder programvarurenderaren när tillbakaspolningstillstånd skapas för att förhindra ytterligare VRAM-användning. Särskilt användbart vid uppskalning.</translation>
-    </message>
-    <message>
-        <source>Warning Message Duration</source>
-        <translation>Visningstid för varningsmeddelanden</translation>
-    </message>
-    <message>
-        <source>Cover Download Error</source>
-        <translation>Fel vid hämtning av omslagsbilder</translation>
-    </message>
-    <message>
-        <source>Progress database updated.</source>
-        <translation>Förloppsdatabas uppdaterad.</translation>
-    </message>
-    <message>
-        <source>Refresh Achievement Progress</source>
-        <translation>Uppdatera prestationsförlopp</translation>
-    </message>
-    <message>
-        <source>This game was not scanned by DuckStation. Some functionality is not available.</source>
-        <translation>Detta spel har inte sökts igenom av DuckStation. Viss funktionalitet är inte tillgänglig.</translation>
-    </message>
-    <message>
-        <source>Advanced Display Options</source>
-        <translation>Avancerade visningsalternativ</translation>
-    </message>
-    <message>
-        <source>Advanced Rendering Options</source>
-        <translation>Avancerade renderingsalternativ</translation>
-    </message>
-    <message>
-        <source>Crops vertex colours to 5:5:5 before modulating with the texture colour, which typically results in more visible banding.</source>
-        <translation>Beskär vertexfärgerna till 5:5:5 innan de moduleras med texturfärgen, vilket vanligtvis resulterar i mer synliga band.</translation>
-    </message>
-    <message>
-        <source>Determines how much to crop the display area.</source>
-        <translation>Bestämmer hur mycket av visningsområdet som ska beskäras.</translation>
-    </message>
-    <message>
-        <source>Disable Window Resizing</source>
-        <translation>Inaktivera ändring av fönsterstorlek</translation>
-    </message>
-    <message>
-        <source>Enables manual fine cropping of the display area, while preserving the aspect ratio of the image. Useful for removing black borders in certain games.</source>
-        <translation>Aktiverar manuell finjustering av visningsområdet, samtidigt som bildens bildförhållande bibehålls. Användbart för att ta bort svarta kanter i vissa spel.</translation>
-    </message>
-    <message>
-        <source>Fine Crop Amount</source>
-        <translation>Mängden finjusterad beskäring</translation>
-    </message>
-    <message>
-        <source>Fine Crop Mode</source>
-        <translation>Läget för finjusterad beskäring</translation>
-    </message>
-    <message>
-        <source>Plays sound effects when navigating and activating menus.</source>
-        <translation>Spelar ljudeffekter vid navigering och aktivering av menyer.</translation>
-    </message>
-    <message>
-        <source>Prevents resizing of the window while a game is running.</source>
-        <translation>Förhindrar storleksändring av fönstret medan ett spel körs.</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation>Visa alla</translation>
-    </message>
-    <message>
-        <source>Show Nearby</source>
-        <translation>Visa närliggande</translation>
-    </message>
-    <message>
-        <source>Texture Modulation Cropping (&quot;Old/v0&quot; GPU)</source>
-        <translation>Beskäring av texturmodulation (&quot;Old/v0&quot; GPU)</translation>
-    </message>
-    <message>
-        <source>Bindings</source>
-        <translation>Bindningar</translation>
-    </message>
-    <message>
-        <source>&lt;not computed&gt;</source>
-        <translation>&lt;inte beräknad&gt;</translation>
-    </message>
-    <message>
-        <source>A resume save state was found for this game, but it is corrupted and cannot be loaded:
-
-{}
-
-Do you want to delete the save state and boot the game anyway?</source>
-        <translation>Ett återupptagningsbart sparat tillstånd hittades för spelet, men det är skadat och kan inte läsas in:
-
-{}
-
-Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
-    </message>
-    <message>
-        <source>Achievement Unlocks Unconfirmed</source>
-        <translation>Prestationsupplåsningar är obekräftade</translation>
-    </message>
-    <message>
-        <source>Animate Messages</source>
-        <translation>Animera meddelanden</translation>
-    </message>
-    <message>
-        <source>Applies a blur effect to the background behind on-screen messages to improve readability.</source>
-        <translation>Lägger en oskärpeeffekt på bakgrunden bakom skärmmeddelanden för bättre läsbarhet.</translation>
-    </message>
-    <message>
-        <source>Applies a blur effect to the background when a menu is open to improve readability.</source>
-        <translation>Lägger en oskärpeeffekt på bakgrunden när en meny är öppen för bättre läsbarhet.</translation>
-    </message>
-    <message>
-        <source>Blur Backgrounds</source>
-        <translation>Gör bakgrunder oskarpa</translation>
-    </message>
-    <message>
-        <source>Blur Message Backgrounds</source>
-        <translation>Gör meddelandebakgrunder oskarpa</translation>
-    </message>
-    <message>
-        <source>Change Disc Set Title</source>
-        <translation>Ändra skivuppsättningens titel</translation>
-    </message>
-    <message>
-        <source>Change Game Serial</source>
-        <translation>Ändra spelets serienummer</translation>
-    </message>
-    <message>
-        <source>Change Game Title</source>
-        <translation>Ändra spelets titel</translation>
-    </message>
-    <message>
-        <source>Change Serial</source>
-        <translation>Ändra serienummer</translation>
-    </message>
-    <message>
-        <source>Change Title</source>
-        <translation>Ändra titel</translation>
-    </message>
-    <message>
-        <source>Clear Web Cache</source>
-        <translation>Töm webbcache</translation>
-    </message>
-    <message>
-        <source>Clears all cached images in the web cache.</source>
-        <translation>Tar bort alla cachade bilder i webbcachen.</translation>
-    </message>
-    <message>
-        <source>Compatibility</source>
-        <translation>Kompatibilitet</translation>
-    </message>
-    <message>
-        <source>Copy Serial</source>
-        <translation>Kopiera serienummer</translation>
-    </message>
-    <message>
-        <source>Copy Title</source>
-        <translation>Kopiera titel</translation>
-    </message>
-    <message>
-        <source>Custom Indicator Scale</source>
-        <translation>Anpassad indikatorskala</translation>
-    </message>
-    <message>
-        <source>Custom Notification Scale</source>
-        <translation>Anpassad aviseringsskala</translation>
-    </message>
-    <message>
-        <source>Dark Ocean</source>
-        <translation>Mörkt hav</translation>
-    </message>
-    <message>
-        <source>Database updated.</source>
-        <translation>Databasen har uppdaterats.</translation>
-    </message>
-    <message>
-        <source>Delete And Boot</source>
-        <translation>Ta bort och starta upp</translation>
-    </message>
-    <message>
-        <source>Depending on your jurisdiction, game covers may be copyrighted. You are only authorized to use this tool with your own servers and images.</source>
-        <translation>Beroende på din jurisdiktion kan spelomslag vara upphovsrättsskyddade. Du får endast använda verktyget med dina egna servrar och bilder.</translation>
-    </message>
-    <message>
-        <source>Determines the format of the screenshot file names.</source>
-        <translation>Bestämmer formatet för skärmbildernas filnamn.</translation>
-    </message>
-    <message>
-        <source>Determines the size of achievement notification popups.</source>
-        <translation>Bestämmer storleken på prestationsaviseringar.</translation>
-    </message>
-    <message>
-        <source>Determines the size of challenge/progress indicators.</source>
-        <translation>Bestämmer storleken på utmanings- och förloppsindikatorer.</translation>
-    </message>
-    <message>
-        <source>Disable Background Input</source>
-        <translation>Inaktivera bakgrundsinmatning</translation>
-    </message>
-    <message>
-        <source>Disable Textures</source>
-        <translation>Inaktivera texturer</translation>
-    </message>
-    <message>
-        <source>Disable Vertex Lighting</source>
-        <translation>Inaktivera hörnbelysning</translation>
-    </message>
-    <message>
-        <source>Disables texture emulation in the GPU, forcing all primitives to only show vertex colours.</source>
-        <translation>Inaktiverar texturemulering i grafikprocessorn och tvingar alla primitiver att endast visa hörnfärger.</translation>
-    </message>
-    <message>
-        <source>Disables vertex lighting in the GPU, forcing all primitives to only show raw texture colours.</source>
-        <translation>Inaktiverar hörnbelysning i grafikprocessorn och tvingar alla primitiver att endast visa råa texturfärger.</translation>
-    </message>
-    <message>
-        <source>Disc Set Title</source>
-        <translation>Skivuppsättningens titel</translation>
-    </message>
-    <message>
-        <source>Disc Set Title (*)</source>
-        <translation>Skivuppsättningens titel (*)</translation>
-    </message>
-    <message>
-        <source>Disc set title copied to clipboard.</source>
-        <translation>Skivuppsättningens titel kopierades till urklipp.</translation>
-    </message>
-    <message>
-        <source>Downloads all locked achievement badges while starting the game. This will reduce delays in the images being shown when unlocking achievements.</source>
-        <translation>Hämtar alla låsta prestationsmärken när spelet startas. Det minskar fördröjningen när bilder visas vid upplåsning av prestationer.</translation>
-    </message>
-    <message>
-        <source>Enable Global Save States</source>
-        <translation>Aktivera globala sparade tillstånd</translation>
-    </message>
-    <message>
-        <source>Enables animation for on-screen messages when they appear and disappear.</source>
-        <translation>Animerar skärmmeddelanden när de visas och försvinner.</translation>
-    </message>
-    <message>
-        <source>Enter a new serial for this game.</source>
-        <translation>Ange ett nytt serienummer för spelet.</translation>
-    </message>
-    <message>
-        <source>Enter a new title for this disc set.</source>
-        <translation>Ange en ny titel för skivuppsättningen.</translation>
-    </message>
-    <message>
-        <source>Enter a new title for this game.</source>
-        <translation>Ange en ny titel för spelet.</translation>
-    </message>
-    <message>
-        <source>Failed to load resume save state info.</source>
-        <translation>Det gick inte att läsa information om det återupptagningsbara sparade tillståndet.</translation>
-    </message>
-    <message>
-        <source>Failed to save custom serial.</source>
-        <translation>Det gick inte att spara det anpassade serienumret.</translation>
-    </message>
-    <message>
-        <source>Failed to save custom title.</source>
-        <translation>Det gick inte att spara den anpassade titeln.</translation>
-    </message>
-    <message>
-        <source>Font</source>
-        <translation>Teckensnitt</translation>
-    </message>
-    <message>
-        <source>Game Serial</source>
-        <translation>Spelets serienummer</translation>
-    </message>
-    <message>
-        <source>Game Title</source>
-        <translation>Spelets titel</translation>
-    </message>
-    <message>
-        <source>Game serial updated.</source>
-        <translation>Spelets serienummer har uppdaterats.</translation>
-    </message>
-    <message>
-        <source>Game title updated.</source>
-        <translation>Spelets titel har uppdaterats.</translation>
-    </message>
-    <message>
-        <source>Gamepad Button Type</source>
-        <translation>Typ av handkontrollsknappar</translation>
-    </message>
-    <message>
-        <source>Global</source>
-        <translation>Global</translation>
-    </message>
-    <message>
-        <source>Global Settings</source>
-        <translation>Globala inställningar</translation>
-    </message>
-    <message>
-        <source>Hardcore mode will not be enabled until the game is restarted. Do you want to restart the game now?</source>
-        <translation>Hardcore-läget aktiveras inte förrän spelet har startats om. Vill du starta om spelet nu?</translation>
-    </message>
-    <message>
-        <source>Hash Calculation Failed</source>
-        <translation>Beräkning av kontrollsumma misslyckades</translation>
-    </message>
-    <message>
-        <source>Hotkeys</source>
-        <translation>Snabbtangenter</translation>
-    </message>
-    <message>
-        <source>Indicator Location</source>
-        <translation>Indikatorplats</translation>
-    </message>
-    <message>
-        <source>Indicator Scale</source>
-        <translation>Indikatorskala</translation>
-    </message>
-    <message>
-        <source>Login token generated {}</source>
-        <translation>Inloggningstoken genererades {}</translation>
-    </message>
-    <message>
-        <source>Macro {}</source>
-        <translation>Makro {}</translation>
-    </message>
-    <message>
-        <source>Message Location</source>
-        <translation>Meddelandeplats</translation>
-    </message>
-    <message>
-        <source>N/A</source>
-        <translation>Inte tillgängligt</translation>
-    </message>
-    <message>
-        <source>No controller presets available.</source>
-        <translation>Inga kontrollerförval tillgängliga.</translation>
-    </message>
-    <message>
-        <source>No devices with LEDs were detected.</source>
-        <translation>Inga enheter med LED hittades.</translation>
-    </message>
-    <message>
-        <source>Notification Location</source>
-        <translation>Aviseringsplats</translation>
-    </message>
-    <message>
-        <source>Notification Size</source>
-        <translation>Aviseringsstorlek</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation>Aviseringar</translation>
-    </message>
-    <message>
-        <source>Only measured achievements can be pinned.</source>
-        <translation>Endast mätbara prestationer kan fästas.</translation>
-    </message>
-    <message>
-        <source>Open on RetroAchievements</source>
-        <translation>Öppna på RetroAchievements</translation>
-    </message>
-    <message>
-        <source>Overlay Font</source>
-        <translation>Överläggsteckensnitt</translation>
-    </message>
-    <message>
-        <source>Pin to OSD</source>
-        <translation>Fäst på OSD</translation>
-    </message>
-    <message>
-        <source>PlayStation</source>
-        <translation>PlayStation</translation>
-    </message>
-    <message>
-        <source>Prefetch Badges</source>
-        <translation>Förhämta märken</translation>
-    </message>
-    <message>
-        <source>Prevents inputs from being processed when another application is active.</source>
-        <translation>Förhindrar att inmatningar behandlas när en annan applikation är aktiv.</translation>
-    </message>
-    <message>
-        <source>Progress Tracking</source>
-        <translation>Framstegsspårning</translation>
-    </message>
-    <message>
-        <source>Refresh Achievement Database</source>
-        <translation>Uppdatera prestationsdatabas</translation>
-    </message>
-    <message>
-        <source>Refreshes the list of unlocked achievements.</source>
-        <translation>Uppdaterar listan över upplåsta prestationer.</translation>
-    </message>
-    <message>
-        <source>Reset</source>
-        <translation>Återställ</translation>
-    </message>
-    <message>
-        <source>Reset Serial</source>
-        <translation>Återställ serienummer</translation>
-    </message>
-    <message>
-        <source>Reset Title</source>
-        <translation>Återställ titel</translation>
-    </message>
-    <message>
-        <source>Reset To Default</source>
-        <translation>Återställ till standard</translation>
-    </message>
-    <message>
-        <source>Restart Game</source>
-        <translation>Starta om spelet</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>Spara</translation>
-    </message>
-    <message>
-        <source>Save Locations</source>
-        <translation>Lagringsplatser</translation>
-    </message>
-    <message>
-        <source>Save State Directory</source>
-        <translation>Katalog för sparade tillstånd</translation>
-    </message>
-    <message>
-        <source>Save state deleted.</source>
-        <translation>Det sparade tillståndet har tagits bort.</translation>
-    </message>
-    <message>
-        <source>Screenshot Directory</source>
-        <translation>Skärmbildskatalog</translation>
-    </message>
-    <message>
-        <source>Screenshot File Name Format</source>
-        <translation>Filnamnsformat för skärmbilder</translation>
-    </message>
-    <message>
-        <source>Scroll Page</source>
-        <translation>Rulla sida</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation>Sök</translation>
-    </message>
-    <message>
-        <source>Search on redump.info</source>
-        <translation>Sök på redump.info</translation>
-    </message>
-    <message>
-        <source>Selects between Xbox/PlayStation button icons in the footer and input binding.</source>
-        <translation>Väljer mellan Xbox-/PlayStation-knappikoner i sidfoten och inmatningsbindningen.</translation>
-    </message>
-    <message>
-        <source>Selects the font used for UI text.</source>
-        <translation>Väljer teckensnittet för gränssnittstext.</translation>
-    </message>
-    <message>
-        <source>Selects the font used for the performance overlay.</source>
-        <translation>Väljer teckensnittet för prestandaöverlägget.</translation>
-    </message>
-    <message>
-        <source>Selects the screen location for achievement and leaderboard notifications.</source>
-        <translation>Väljer skärmplatsen för aviseringar om prestationer och ledartavlor.</translation>
-    </message>
-    <message>
-        <source>Selects the screen location for challenge/progress indicators, and leaderboard trackers.</source>
-        <translation>Väljer skärmplats för utmanings-/framstegsindikatorer och följa ledartavlan.</translation>
-    </message>
-    <message>
-        <source>Selects which location on the screen messages are displayed.</source>
-        <translation>Väljer vilken plats på skärmen som meddelanden ska visas.</translation>
-    </message>
-    <message>
-        <source>Serial (*)</source>
-        <translation>Serienummer (*)</translation>
-    </message>
-    <message>
-        <source>Serial:</source>
-        <translation>Serienummer:</translation>
-    </message>
-    <message>
-        <source>Sets the custom scale percentage for achievement notifications.</source>
-        <translation>Anger den anpassade skalningsprocenten för prestationsaviseringar.</translation>
-    </message>
-    <message>
-        <source>Sets the custom scale percentage for challenge/progress indicators.</source>
-        <translation>Anger den anpassade skalningsprocenten för utmanings- och förloppsindikatorer.</translation>
-    </message>
-    <message>
-        <source>Shows a notification or icons in the selected location when a challenge/primed achievement is active.</source>
-        <translation>Visar en avisering eller ikoner på den valda platsen när en utmaning/förberedd prestation är aktiv.</translation>
-    </message>
-    <message>
-        <source>Shows a popup in the selected location when progress towards a measured achievement changes.</source>
-        <translation>Visar ett popup-fönster på den valda platsen när framstegen mot ett uppmätt mål förändras.</translation>
-    </message>
-    <message>
-        <source>Shows a timer in the selected location when leaderboard challenges are active.</source>
-        <translation>Visar en timer på den valda platsen när utmaningar för ledartavlan är aktiva.</translation>
-    </message>
-    <message>
-        <source>Start In Big Picture Mode</source>
-        <translation>Starta i storbildsläge</translation>
-    </message>
-    <message>
-        <source>Starts the application in Big Picture Mode instead of the desktop interface.</source>
-        <translation>Startar programmet i storbildsläge i stället för skrivbordsgränssnittet.</translation>
-    </message>
-    <message>
-        <source>Swap Gamepad Confirm/Cancel Buttons</source>
-        <translation>Byt plats på handkontrollens bekräfta-/avbrytknappar</translation>
-    </message>
-    <message>
-        <source>Swaps the confirm/cancel buttons on the gamepad, using {0} for confirming and {1} for cancelling.</source>
-        <translation>Byter plats på handkontrollens bekräfta-/avbrytknappar så att {0} bekräftar och {1} avbryter.</translation>
-    </message>
-    <message>
-        <source>The unlock state for &apos;{}&apos; will be removed. This cannot be undone.</source>
-        <translation>Upplåsningsstatusen för &apos;{}&apos; tas bort. Detta kan inte ångras.</translation>
-    </message>
-    <message>
-        <source>Title (*)</source>
-        <translation>Titel (*)</translation>
-    </message>
-    <message>
-        <source>Title:</source>
-        <translation>Titel:</translation>
-    </message>
-    <message>
-        <source>Track</source>
-        <translation>Spår</translation>
-    </message>
-    <message>
-        <source>Track Unofficial Achievements</source>
-        <translation>Spåra inofficiella prestationer</translation>
-    </message>
-    <message>
-        <source>Track hash copied to clipboard.</source>
-        <translation>Spårets kontrollsumma kopierades till urklipp.</translation>
-    </message>
-    <message>
-        <source>Unofficial achievement unlock reset.</source>
-        <translation>Inofficiell prestationsupplåsning återställd.</translation>
-    </message>
-    <message>
-        <source>Unofficial achievement unlocks reset.</source>
-        <translation>Inofficiella prestationsupplåsningar återställda.</translation>
-    </message>
-    <message>
-        <source>Unpin from OSD</source>
-        <translation>Lossa från OSD</translation>
-    </message>
-    <message>
-        <source>Update Database</source>
-        <translation>Uppdatera databas</translation>
-    </message>
-    <message>
-        <source>Updates the database for achievements shown in the game list.</source>
-        <translation>Uppdaterar databasen för prestationer som visas i spellistan.</translation>
-    </message>
-    <message>
-        <source>Use OSD Scale</source>
-        <translation>Använd OSD-skala</translation>
-    </message>
-    <message>
-        <source>Use Per-Game Hotkeys</source>
-        <translation>Använd snabbtangenter per spel</translation>
-    </message>
-    <message>
-        <source>Use Per-Game Input Sources</source>
-        <translation>Använd inmatningskällor per spel</translation>
-    </message>
-    <message>
-        <source>Use This Directory</source>
-        <translation>Använd denna katalog</translation>
-    </message>
-    <message>
-        <source>Uses game-specific configuration for hotkeys. If disabled, global hotkeys will be used.</source>
-        <translation>Använder spelspecifik konfiguration för snabbtangenter. Om den är inaktiverad används globala snabbtangenter.</translation>
-    </message>
-    <message>
-        <source>Uses game-specific configuration for input sources. If disabled, the global configuration will be used.</source>
-        <translation>Använder spelspecifik konfiguration för inmatningskällor. Om den är inaktiverad kommer den globala konfigurationen att användas.</translation>
-    </message>
-    <message>
-        <source>When enabled, DuckStation will track unofficial achievements. Unlocks will be saved locally and not sent to RetroAchievements.</source>
-        <translation>När detta är aktiverat spårar DuckStation inofficiella prestationer. Upplåsningar sparas lokalt och skickas inte till RetroAchievements.</translation>
-    </message>
-    <message>
-        <source>{0} (Missing)</source>
-        <translation>{0} (saknas)</translation>
-    </message>
-    <message>
-        <source>{} pinned.</source>
-        <translation>{} har fästs.</translation>
-    </message>
-    <message>
-        <source>{} unpinned.</source>
-        <translation>{} har lossats.</translation>
-    </message>
-    <message>
-        <source>{} | Start: {} | Length: {}</source>
-        <translation>{} | Start: {} | Längd: {}</translation>
-    </message>
-</context>
-<context>
-    <name>GPU</name>
-    <message>
-        <source>Saved screenshot to &apos;{}&apos;.</source>
-        <translation>Sparade skärmbild till &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Failed to save screenshot to &apos;{}&apos;.</source>
-        <translation>Misslyckades med att spara skärmbild till &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Saving screenshot to &apos;{}&apos;.</source>
-        <translation>Sparar skärmbild till &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Failed to start GPU trace:</source>
-        <translation>Misslyckades med att starta GPU-trace:</translation>
-    </message>
-    <message>
-        <source>Saving {0} frame GPU trace to &apos;{1}&apos;.</source>
-        <translation>Sparar {0} bildruta GPU-trace till &apos;{1}&apos;.</translation>
-    </message>
-    <message>
-        <source>Saving multi-frame frame GPU trace to &apos;{1}&apos;.</source>
-        <translation>Sparar multi-frame frame GPU-trace till &apos;{1}&apos;.</translation>
-    </message>
-    <message>
-        <source>Failed to close GPU trace:</source>
-        <translation>Misslyckades med att stänga GPU-trace:</translation>
-    </message>
-    <message>
-        <source>Saved GPU trace to &apos;{}&apos;.</source>
-        <translation>Sparade GPU-trace till &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Compressing GPU trace &apos;{}&apos;...</source>
-        <translation>Komprimerar GPU-trace &apos;{}&apos;...</translation>
-    </message>
-    <message>
-        <source>Failed to save GPU trace to &apos;{}&apos;:</source>
-        <translation>Misslyckades med att spara GPU-trace till &apos;{}&apos;:</translation>
-    </message>
-    <message>
-        <source>Failed to save screenshot:
-{}</source>
-        <translation>Misslyckades med att spara skärmbild:
-{}</translation>
-    </message>
-</context>
-<context>
-    <name>GPU_HW</name>
-    <message numerus="yes">
-        <source>%n replacement textures found.</source>
-        <comment>Replacement texture count</comment>
-        <translation>
-            <numerusform>%n replacement texture found.</numerusform>
-            <numerusform>%n replacement textures found.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>No replacement textures found.</source>
-        <translation>Inga ersättningstexturer hittades.</translation>
-    </message>
-    <message>
-        <source>Internal resolution set to {0}x ({1}x{2}).</source>
-        <translation>Intern upplösning inställd till {0}x ({1}x{2}).</translation>
-    </message>
-    <message>
-        <source>Internal resolution set to {0}x.</source>
-        <translation>Intern upplösning inställd på {0}x.</translation>
-    </message>
-    <message>
-        <source>Multisample anti-aliasing set to {}x (SSAA).</source>
-        <translation>Antialiasing för multisamplingar inställd till {}x (SSAA).</translation>
-    </message>
-    <message>
-        <source>Multisample anti-aliasing set to {}x.</source>
-        <translation>Antialiasing för multisamplingar inställd till {}x.</translation>
-    </message>
-    <message>
-        <source>{}x MSAA is not supported, using {}x instead.</source>
-        <translation>{}x MSAA stöds inte, använder {}x istället.</translation>
-    </message>
-    <message>
-        <source>SSAA is not supported, using MSAA instead.</source>
-        <translation>SSAA stöds inte, använder MSAA istället.</translation>
-    </message>
-    <message>
-        <source>Texture filter &apos;{}/{}&apos; is not supported with the current renderer.</source>
-        <translation>Texturfiltret &apos;{}/{}&apos; stöds inte med aktuell renderare.</translation>
-    </message>
-    <message>
-        <source>Geometry shaders are not supported by your GPU, and are required for wireframe rendering.</source>
-        <translation>Geometri-shaders stöds inte av din GPU och krävs för wireframe rendering.</translation>
-    </message>
-    <message>
-        <source>Resolution scale {0}x is not divisible by downsample scale {1}x, using {2}x instead.</source>
-        <translation>Upplösningsskalan {0}x är inte delbar med nersamplingsskalan {1}x, använder {2}x istället.</translation>
-    </message>
-    <message>
-        <source>Resolution scale {0}x not supported for adaptive downsampling, using {1}x.</source>
-        <translation>Upplösningsskalan {0}x stöds inte för adaptiv nersampling, använder {1}x.</translation>
-    </message>
-    <message>
-        <source>Multisample anti-aliasing is not supported when using shader blending.</source>
-        <translation>Kantutjämning med multisamplingar stöds inte när du använder shader-blandning.</translation>
-    </message>
-    <message>
-        <source>Resolution scale {0}x is not divisible by downsample scale {1}x, downsampling disabled.</source>
-        <translation>Upplösningsskalan {0}x är inte delbar med nedsamplingsskalan {1}x, nedsampling inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Failed to allocate {}x{} texture for cache:
-{}</source>
-        <translation>Det gick inte att allokera {}x{}-textur för cache:
-{}</translation>
-    </message>
-    <message>
-        <source>Compiling Shaders...</source>
-        <translation>Kompilerar shaders...</translation>
-    </message>
-    <message>
-        <source>{} of {} pipelines</source>
-        <translation>{} av {} pipelines</translation>
-    </message>
-    <message>
-        <source>Shader blending is not supported by your current GPU.</source>
-        <translation>Shader-blandning stöds inte av din aktuella GPU.</translation>
-    </message>
-    <message>
-        <source>It requires framebuffer fetch, feedback loops, or rasterizer order views.</source>
-        <translation>Det kräver framebuffer fetch, feedback loops eller rasterizer order views.</translation>
-    </message>
-    <message>
-        <source>PGXP depth buffer is not supported by your current GPU or renderer.</source>
-        <translation>PGXP-djupbuffert stöds inte av din aktuella GPU eller renderare.</translation>
-    </message>
-    <message>
-        <source>Preloading replacement textures...</source>
-        <translation>Förinläser ersättningstexturer...</translation>
-    </message>
-    <message>
-        <source>{0} of {1} textures</source>
-        <translation>{0} av {1} texturer</translation>
-    </message>
-</context>
-<context>
     <name>GameCheatCodeChoiceEditorDialog</name>
     <message>
+        <location filename="../gamecheatcodechoiceeditordialog.ui" line="14"/>
         <source>Cheat Choice Editor</source>
         <translation>Redigera fuskval</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodechoiceeditordialog.ui" line="21"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodechoiceeditordialog.ui" line="26"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodechoiceeditordialog.ui" line="42"/>
         <source>Add Cheat</source>
         <translation>Lägg till fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodechoiceeditordialog.ui" line="59"/>
         <source>Remove Cheat</source>
         <translation>Ta bort fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="1087"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="1102"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="1112"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="1087"/>
         <source>At least one option must be defined.</source>
         <translation>Minst ett alternativ måste definieras.</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="1103"/>
         <source>The option &apos;%1&apos; is defined twice.</source>
         <translation>Alternativet &apos;%1&apos; är definierat två gånger.</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="1113"/>
         <source>The option &apos;%1&apos; does not have a valid value. It must be a number.</source>
         <translation>Alternativet &apos;%1&apos; saknar giltigt värde. Det måste vara ett tal.</translation>
     </message>
@@ -9142,46 +4927,57 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>GameCheatCodeEditorDialog</name>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="14"/>
         <source>Cheat Code Editor</source>
         <translation>Redigera fuskkoder</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="23"/>
         <source>Name:</source>
         <translation>Namn:</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="33"/>
         <source>Description:</source>
         <translation>Beskrivning:</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="56"/>
         <source>Group:</source>
         <translation>Grupp:</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="66"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="76"/>
         <source>Activation:</source>
         <translation>Aktivering:</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="86"/>
         <source>Options:</source>
         <translation>Alternativ:</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="96"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="101"/>
         <source>Choice</source>
         <translation>Val</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="106"/>
         <source>Range</source>
         <translation>Omfång</translation>
     </message>
     <message>
+        <location filename="../gamecheatcodeeditordialog.ui" line="128"/>
         <source>Edit Choices...</source>
         <translation>Redigera val...</translation>
     </message>
@@ -9189,102 +4985,135 @@ Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
 <context>
     <name>GameCheatSettingsWidget</name>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="31"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="424"/>
         <source>Enable Cheats</source>
         <translation>Aktivera fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="55"/>
         <source>Sort Alphabetically</source>
         <translation>Sortera alfabetiskt</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="69"/>
         <source>Add Cheat</source>
         <translation>Lägg till fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="80"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="359"/>
         <source>Remove Cheat</source>
         <translation>Ta bort fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="91"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="364"/>
         <source>Disable All Cheats</source>
         <translation>Inaktivera alla fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="145"/>
         <source>Load Database Cheats</source>
         <translation>Läs in databasfusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="171"/>
         <source>Clear List</source>
         <translation>Töm listan</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="182"/>
         <source>Import...</source>
         <translation>Importera...</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="193"/>
         <source>Export...</source>
         <translation>Exportera...</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.ui" line="102"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="367"/>
         <source>Reload Cheats</source>
         <translation>Läs om fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="352"/>
         <source>Add Cheat...</source>
         <translation>Lägg till fusk...</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="355"/>
         <source>Edit Cheat...</source>
         <translation>Redigera fusk...</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="408"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="429"/>
         <source>Do not show again</source>
         <translation>Visa inte igen</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="564"/>
         <source>From File...</source>
         <translation>Från fil...</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="566"/>
         <source>From Text...</source>
         <translation>Från text...</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="573"/>
         <source>PCSXR/Libretro Cheat Files (*.cht *.txt);;All Files (*.*)</source>
         <translation>PCSXR/Libretro-fuskfiler (*.cht *.txt);;Alla filer (*.*)</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="575"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="593"/>
         <source>Import Cheats</source>
         <translation>Importera fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="583"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="663"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="685"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="705"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="584"/>
         <source>Failed to read file:
 %1</source>
         <translation>Misslyckades med att läsa fil:
 %1</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="593"/>
         <source>Cheat File Text:</source>
         <translation>Text för fuskfil:</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="686"/>
         <source>Failed to save file:
 %1</source>
         <translation>Misslyckades med att spara fil:
 %1</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="664"/>
         <source>This code is from the built-in cheat database, and cannot be removed. To hide this code, uncheck the &quot;Load Database Cheats&quot; option.</source>
         <translation>Denna kod är från den inbyggda fuskdatabasen och kan inte tas bort. För att dölja denna kod, avmarkera alternativet &quot;Läs in databasfusk&quot;.</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="403"/>
         <source>Enable Game Settings</source>
         <translation>Aktivera spelinställningar</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="404"/>
         <source>Game settings are currently disabled. This is NOT the default. Enabling this cheat will not have any effect until game settings are enabled.
 
 Do you want to enable game settings now?</source>
@@ -9293,6 +5122,7 @@ Do you want to enable game settings now?</source>
 Vill du aktivera spelinställningarna nu?</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="425"/>
         <source>Cheats are not currently enabled for this game. Enabling this cheat will not have any effect until cheats are enabled for this game.
 
 Do you want to enable cheats now?</source>
@@ -9301,28 +5131,35 @@ Do you want to enable cheats now?</source>
 Vill du aktivera fusk nu?</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="670"/>
+        <location filename="../gamecheatsettingswidget.cpp" line="713"/>
         <source>Confirm Removal</source>
         <translation>Bekräfta borttagning</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="671"/>
         <source>You are removing the code named &apos;%1&apos;. You cannot undo this action, are you sure you wish to delete this code?</source>
         <translation>Du tar bort koden som namnet &apos;%1&apos;. Du kan inte ångra denna åtgärd. Är du säker på att du vill ta bort denna kod?</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="696"/>
         <source>PCSXR Cheat Files (*.cht);;All Files (*.*)</source>
         <translation>PCSXR-fuskfiler (*.cht);;Alla filer (*.*)</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="698"/>
         <source>Export Cheats</source>
         <translation>Exportera fusk</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="706"/>
         <source>Failed to save cheat file:
 %1</source>
         <translation>Misslyckades med att spara fuskfil:
 %1</translation>
     </message>
     <message>
+        <location filename="../gamecheatsettingswidget.cpp" line="714"/>
         <source>You are removing all cheats manually added for this game. This action cannot be reversed.
 
 Any database cheats will still be loaded and present unless you uncheck the &quot;Load Database Cheats&quot; option.
@@ -9336,607 +5173,107 @@ Alla databasfusk kommer fortfarande att läsas in och synas såvida inte du avma
     </message>
 </context>
 <context>
-    <name>GameDatabase</name>
-    <message>
-        <source>Unknown</source>
-        <translation>Okänt</translation>
-    </message>
-    <message>
-        <source>Display cropping set to {}.</source>
-        <translation>Skärmbeskäring inställd till {}.</translation>
-    </message>
-    <message>
-        <source>CPU recompiler disabled.</source>
-        <translation>CPU-omkompilerare inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Hardware rendering disabled.</source>
-        <translation>Hårdvarurendering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Software renderer readbacks enabled.</source>
-        <translation>Återläsning av programvarurenderare aktiverad.</translation>
-    </message>
-    <message>
-        <source>Deinterlacing set to {}.</source>
-        <translation>Deinterlacing inställd till {}.</translation>
-    </message>
-    <message>
-        <source>Fast boot disabled.</source>
-        <translation>Snabb uppstart inaktiverat.</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <comment>CompatibilityRating</comment>
-        <translation>Okänd</translation>
-    </message>
-    <message>
-        <source>Doesn&apos;t Boot</source>
-        <comment>CompatibilityRating</comment>
-        <translation>Startar inte</translation>
-    </message>
-    <message>
-        <source>Crashes In Intro</source>
-        <comment>CompatibilityRating</comment>
-        <translation>Kraschar i intro</translation>
-    </message>
-    <message>
-        <source>Crashes In-Game</source>
-        <comment>CompatibilityRating</comment>
-        <translation>Kraschar i spelet</translation>
-    </message>
-    <message>
-        <source>Graphical/Audio Issues</source>
-        <comment>CompatibilityRating</comment>
-        <translation>Problem med grafik och ljud</translation>
-    </message>
-    <message>
-        <source>No Issues</source>
-        <comment>CompatibilityRating</comment>
-        <translation>Inga problem</translation>
-    </message>
-    <message>
-        <source>Force Interpreter</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga tolk</translation>
-    </message>
-    <message>
-        <source>Force Software Renderer</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga programvarurenderare</translation>
-    </message>
-    <message>
-        <source>Force Software Renderer For Readbacks</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga programvarurenderare för återläsningar</translation>
-    </message>
-    <message>
-        <source>Force Round Texture Coordinates</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga runda texturkoordinater</translation>
-    </message>
-    <message>
-        <source>Force Deinterlacing</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga deinterlacing</translation>
-    </message>
-    <message>
-        <source>Force Full Boot</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga fullständig uppstart</translation>
-    </message>
-    <message>
-        <source>Disable Automatic Analog Mode</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera automatiskt analogt läge</translation>
-    </message>
-    <message>
-        <source>Disable Multitap</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera Multitap</translation>
-    </message>
-    <message>
-        <source>Disable True Color</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera True Color</translation>
-    </message>
-    <message>
-        <source>Disable Upscaling</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera uppskalning</translation>
-    </message>
-    <message>
-        <source>Disable Texture Filtering</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera texturfiltrering</translation>
-    </message>
-    <message>
-        <source>Disable Sprite Texture Filtering</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera texturfiltrering av sprite</translation>
-    </message>
-    <message>
-        <source>Disable Scaled Dithering</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera skalad dithering</translation>
-    </message>
-    <message>
-        <source>Disable Widescreen</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera bredbild</translation>
-    </message>
-    <message>
-        <source>Disable PGXP</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera PGXP</translation>
-    </message>
-    <message>
-        <source>Disable PGXP Culling</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera PGXP Culling</translation>
-    </message>
-    <message>
-        <source>Disable PGXP Texture Correction</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera PGXP-texturkorrigering</translation>
-    </message>
-    <message>
-        <source>Disable PGXP Color Correction</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera PGXP-färgkorrigering</translation>
-    </message>
-    <message>
-        <source>Disable PGXP Depth Buffer</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera PGXP-djupbuffert</translation>
-    </message>
-    <message>
-        <source>Disable PGXP on 2D Polygons</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera PGXP på 2D-polygoner</translation>
-    </message>
-    <message>
-        <source>Force PGXP Vertex Cache</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga PGXP Vertex Cache</translation>
-    </message>
-    <message>
-        <source>Force PGXP CPU Mode</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga PGXP CPU-läge</translation>
-    </message>
-    <message>
-        <source>Force Recompiler ICache</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga ICache för omkompilerare</translation>
-    </message>
-    <message>
-        <source>Force CD-ROM SubQ Skew</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga CD-ROM SubQ Skew</translation>
-    </message>
-    <message>
-        <source>Is LibCrypt Protected</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Är LibCrypt-skyddat</translation>
-    </message>
-    <message>
-        <source>Multitap disabled.</source>
-        <translation>Multitap inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Upscaling disabled.</source>
-        <translation>Uppskalning inaktiverat.</translation>
-    </message>
-    <message>
-        <source>Texture filtering disabled.</source>
-        <translation>Texturfiltrering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Sprite texture filtering disabled.</source>
-        <translation>Sprite-texturfiltrering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Widescreen rendering disabled.</source>
-        <translation>Bredbildsrendering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP geometry correction disabled.</source>
-        <translation>PGXP-geometrikorrigering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP culling correction disabled.</source>
-        <translation>PGXP-rensningskorrigering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP perspective correct textures disabled.</source>
-        <translation>PGXP perspektiv korrekta texturer inaktiverade.</translation>
-    </message>
-    <message>
-        <source>PGXP perspective correct colors disabled.</source>
-        <translation>PGXP perspektiv korrekta färger inaktiverade.</translation>
-    </message>
-    <message>
-        <source>PGXP preserve projection precision disabled.</source>
-        <translation>PGXP bevara projektionsprecisionen inaktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP vertex cache enabled.</source>
-        <translation>PGXP vertexcache aktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP Vertex Cache is enabled, but it is not required for this game. This may cause rendering errors.</source>
-        <translation>PGXP Vertex Cache är aktiverat, men det är inte nödvändigt för detta spel. Detta kan orsaka fel i renderingen.</translation>
-    </message>
-    <message>
-        <source>PGXP CPU mode enabled.</source>
-        <translation>PGXP CPU-läge aktiverat.</translation>
-    </message>
-    <message>
-        <source>PGXP CPU mode is enabled, but it is not required for this game. This may cause rendering errors.</source>
-        <translation>PGXP CPU-läge är aktiverat men krävs inte för detta spel. Detta kan orsaka renderingsfel.</translation>
-    </message>
-    <message>
-        <source>PGXP depth buffer disabled.</source>
-        <translation>PGXP djupbuffert inaktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP disabled on 2D polygons.</source>
-        <translation>PGXP inaktiverat på 2D-polygoner.</translation>
-    </message>
-    <message>
-        <source>Compatibility settings for this game have been applied.</source>
-        <translation>Kompatibilitetsinställningar för detta spel har tillämpats.</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <translation>Inställningar</translation>
-    </message>
-    <message>
-        <source>Title</source>
-        <translation>Titel</translation>
-    </message>
-    <message>
-        <source>Serial</source>
-        <translation>Serienummer</translation>
-    </message>
-    <message>
-        <source>Languages</source>
-        <translation>Språk</translation>
-    </message>
-    <message>
-        <source>Rating</source>
-        <translation>Betyg</translation>
-    </message>
-    <message>
-        <source>Version Tested</source>
-        <translation>Version testad</translation>
-    </message>
-    <message>
-        <source>Comments</source>
-        <translation>Kommentarer</translation>
-    </message>
-    <message>
-        <source>Supported Controllers</source>
-        <translation>Kontroller som stöds</translation>
-    </message>
-    <message>
-        <source>Traits</source>
-        <translation>Egenskaper</translation>
-    </message>
-    <message>
-        <source>Display Active Start Offset</source>
-        <translation>Visa aktiv startoffset</translation>
-    </message>
-    <message>
-        <source>Display Active End Offset</source>
-        <translation>Visa aktiv slutoffset</translation>
-    </message>
-    <message>
-        <source>Display Line Start Offset</source>
-        <translation>Offset för visningens linjestart</translation>
-    </message>
-    <message>
-        <source>Display Line End Offset</source>
-        <translation>Offset för visning av linjens slut</translation>
-    </message>
-    <message>
-        <source>Display Crop Mode</source>
-        <translation>Visa beskäringsläge</translation>
-    </message>
-    <message>
-        <source>Display Deinterlacing Mode</source>
-        <translation>Visa Deinterlacing-läge</translation>
-    </message>
-    <message>
-        <source>DMA Max Slice Ticks</source>
-        <translation>DMA Max Slice Ticks</translation>
-    </message>
-    <message>
-        <source>DMA Halt Ticks</source>
-        <translation>DMA Halt Ticks</translation>
-    </message>
-    <message>
-        <source>GPU FIFO Size</source>
-        <translation>GPU FIFO-storlek</translation>
-    </message>
-    <message>
-        <source>GPU Max Runahead</source>
-        <translation>GPU Max Runahead</translation>
-    </message>
-    <message>
-        <source>Verifying Image</source>
-        <translation>Verifierar avbild</translation>
-    </message>
-    <message>
-        <source>Revision: {}</source>
-        <translation>Revision: {}</translation>
-    </message>
-    <message>
-        <source>No known dump found that matches this hash.</source>
-        <translation>Ingen känd dump som matchar denna kontrollsumma hittades.</translation>
-    </message>
-    <message>
-        <source>Serial Mismatch: Disc {} vs Hash {}</source>
-        <translation>Serienumret stämmer inte: skiva {} kontra kontrollsumma {}</translation>
-    </message>
-    <message>
-        <source>GPU Line Detect Mode</source>
-        <translation>GPU-läge för linjedetektering</translation>
-    </message>
-    <message>
-        <source>Disc Set</source>
-        <translation>Skivuppsättning</translation>
-    </message>
-    <message>
-        <source>Force Shader Blending</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga shader-blandning</translation>
-    </message>
-    <message>
-        <source>Force Full True Color</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Tvinga fullständig True Color</translation>
-    </message>
-    <message>
-        <source>Disable Full True Color</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera fullständig True Color</translation>
-    </message>
-    <message>
-        <source>Disable Scaled Interlacing</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera skalad interlacing</translation>
-    </message>
-    <message>
-        <source>Dithering set to {}.</source>
-        <translation>Dithering inställd till {}.</translation>
-    </message>
-    <message>
-        <source>Scaled interlacing disabled.</source>
-        <translation>Skalad interlacing inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Disable CD-ROM Read Speedup</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera hastighetsökning för CD-ROM-läsning</translation>
-    </message>
-    <message>
-        <source>Disable CD-ROM Seek Speedup</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera hastighetsökning för CD-ROM-sökning</translation>
-    </message>
-    <message>
-        <source>CD-ROM read speedup disabled.</source>
-        <translation>Ökad läshastighet för CD-ROM inaktiverad.</translation>
-    </message>
-    <message>
-        <source>CD-ROM seek speedup disabled.</source>
-        <translation>Ökad sökhastighet för CD-ROM inaktiverad.</translation>
-    </message>
-    <message>
-        <source>MSAA disabled.</source>
-        <translation>MSAA inaktiverad.</translation>
-    </message>
-    <message>
-        <source>CD-ROM Max Seek Speedup Cycles</source>
-        <translation>CD-ROM Max cykler för ökad sökhastighet</translation>
-    </message>
-    <message>
-        <source>CD-ROM Max Read Speedup Cycles</source>
-        <translation>CD-ROM Max cykler för ökad läshastighet</translation>
-    </message>
-    <message>
-        <source>PGXP Tolerance</source>
-        <translation>PGXP-tolerans</translation>
-    </message>
-    <message>
-        <source>PGXP Depth Clear Threshold</source>
-        <translation>Tröskelvärde för PGXP Depth Clear</translation>
-    </message>
-    <message>
-        <source>PGXP Preserve Projection Precision</source>
-        <translation>PGXP Bevara projektionsprecision</translation>
-    </message>
-    <message>
-        <source>Disable CD-ROM Speedup on MDEC</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera CD-ROM-hastighetsökning på MDEC</translation>
-    </message>
-    <message>
-        <source>Disable CD-ROM speedup on MDEC is enabled, but it is not required for this game.</source>
-        <translation>Inaktivera CD-ROM-hastighetsökning på MDEC är aktiverat, men det krävs inte för detta spel.</translation>
-    </message>
-    <message>
-        <source>Sort Title</source>
-        <translation>Sortera titel</translation>
-    </message>
-    <message>
-        <source>Localized Title</source>
-        <translation>Lokalanpassad titel</translation>
-    </message>
-    <message>
-        <source>Save Title</source>
-        <translation>Spara titel</translation>
-    </message>
-    <message>
-        <source>CPU Overclock Percent</source>
-        <translation>Överklockningsprocent för CPU</translation>
-    </message>
-    <message>
-        <source>Disable Fast Forward Memory Card Access</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera snabbspolad åtkomst till minneskort</translation>
-    </message>
-    <message>
-        <source>Fast forward memory card access disabled.</source>
-        <translation>Snabbspolning av minneskort inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Disable All Borders Crop</source>
-        <comment>GameDatabase::Trait</comment>
-        <translation>Inaktivera alla rambeskärningar</translation>
-    </message>
-    <message>
-        <source>Please configure a supported controller from the following list:</source>
-        <translation>Konfigurera en handkontroller som stöds från följande lista:</translation>
-    </message>
-    <message>
-        <source>Controller in Port {0} ({1}) is not supported for this game.</source>
-        <translation>Handkontroller i port {0} ({1}) stöds inte för detta spel.</translation>
-    </message>
-    <message>
-        <source>This game does not support multitap, but multitap is enabled.</source>
-        <translation>Detta spel har inte stöd för multitap men multitap är aktiverat.</translation>
-    </message>
-    <message>
-        <source>This may result in dropped controller inputs.</source>
-        <translation>Detta kan resultera i förlorade handkontrollerinmatningar.</translation>
-    </message>
-</context>
-<context>
     <name>GameList</name>
     <message>
-        <source>Disc</source>
-        <comment>EntryType</comment>
-        <translation>Skiva</translation>
-    </message>
-    <message>
-        <source>Disc Set</source>
-        <comment>EntryType</comment>
-        <translation>Skivuppsättning</translation>
-    </message>
-    <message>
-        <source>PS-EXE</source>
-        <comment>EntryType</comment>
-        <translation>PS-EXE</translation>
-    </message>
-    <message>
-        <source>Playlist</source>
-        <comment>EntryType</comment>
-        <translation>Spellista</translation>
-    </message>
-    <message>
-        <source>PSF</source>
-        <comment>EntryType</comment>
-        <translation>PSF</translation>
-    </message>
-    <message>
+        <location filename="../gamelistwidget.cpp" line="222"/>
         <source>Unknown</source>
         <translation>Okänt</translation>
-    </message>
-    <message>
-        <source>Scanning directory &apos;{}&apos;...</source>
-        <translation>Söker igenom katalogen &apos;{}&apos;...</translation>
-    </message>
-    <message>
-        <source>Scanning &apos;{}&apos;...</source>
-        <translation>Söker igenom &apos;{}&apos;...</translation>
-    </message>
-    <message>
-        <source>URL template must contain at least one of ${title}, ${savetitle}, ${filetitle}, or ${serial}.</source>
-        <translation>URL-mallen måste innehålla minst ett av följande: ${title}, ${savetitle}, ${filetitle} eller ${serial}.</translation>
-    </message>
-    <message>
-        <source>No URLs to download enumerated.</source>
-        <translation>Inga URLer för att hämta ner uppräknat.</translation>
     </message>
 </context>
 <context>
     <name>GameListModel</name>
     <message>
+        <location filename="../gamelistwidget.cpp" line="89"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="90"/>
         <source>File Title</source>
         <translation>Filtitel</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="96"/>
         <source>Time Played</source>
         <translation>Tid spelat</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="97"/>
         <source>Last Played</source>
         <translation>Senast spelat</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="98"/>
         <source>Size</source>
         <translation>Storlek</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="100"/>
         <source>Region</source>
         <translation>Region</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="102"/>
         <source>Compatibility</source>
         <translation>Kompatibilitet</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="87"/>
         <source>Icon</source>
         <translation>Ikon</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="88"/>
         <source>Serial</source>
         <translation>Serienummer</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="91"/>
         <source>Developer</source>
         <translation>Utvecklare</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="92"/>
         <source>Publisher</source>
         <translation>Utgivare</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="93"/>
         <source>Genre</source>
         <translation>Genre</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="94"/>
         <source>Year</source>
         <translation>År</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="95"/>
         <source>Players</source>
         <translation>Spelare</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="101"/>
         <source>Achievements</source>
         <translation>Prestationer</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="1088"/>
         <source>No Achievements</source>
         <translation>Inga prestationer</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="1090"/>
         <source>%1/%2 achievements unlocked</source>
         <translation>%1/%2 prestationer upplåsta</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="1094"/>
         <source>%1 unlocked in hardcore mode</source>
         <translation>%1 upplåst i hardcore-läget</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="99"/>
         <source>Data Size</source>
         <translation>Datastorlek</translation>
     </message>
@@ -9944,10 +5281,12 @@ Alla databasfusk kommer fortfarande att läsas in och synas såvida inte du avma
 <context>
     <name>GameListSearchDirectoriesModel</name>
     <message>
+        <location filename="../gamelistsettingswidget.cpp" line="80"/>
         <source>Search Directory</source>
         <translation>Sökkatalog</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.cpp" line="82"/>
         <source>Scan Recursively</source>
         <translation>Sök  rekursivt</translation>
     </message>
@@ -9955,50 +5294,64 @@ Alla databasfusk kommer fortfarande att läsas in och synas såvida inte du avma
 <context>
     <name>GameListSettingsWidget</name>
     <message>
+        <location filename="../gamelistsettingswidget.ui" line="31"/>
         <source>Search Directories (will be scanned for games)</source>
         <translation>Sökkataloger (kommer att genomsökas efter spel)</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.ui" line="57"/>
         <source>Add</source>
         <translation>Lägg till</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.ui" line="74"/>
+        <location filename="../gamelistsettingswidget.ui" line="174"/>
+        <location filename="../gamelistsettingswidget.cpp" line="291"/>
         <source>Remove</source>
         <translation>Ta bort</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.ui" line="114"/>
         <source>Excluded Paths (will not be scanned)</source>
         <translation>Exkluderade sökvägar (kommer inte sökas igenom)</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.ui" line="157"/>
         <source>Folder...</source>
         <translation>Mapp...</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.ui" line="140"/>
         <source>File...</source>
         <translation>Fil...</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.ui" line="218"/>
         <source>Scan For New Games</source>
         <translation>Leta efter nya spel</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.ui" line="235"/>
         <source>Rescan All Games</source>
         <translation>Sök igenom alla spel igen</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.cpp" line="294"/>
         <source>Open Directory...</source>
         <translation>Öppna katalog...</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.cpp" line="302"/>
         <source>Select Search Directory</source>
         <translation>Välj sökkatalog</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.cpp" line="308"/>
         <source>Scan Recursively?</source>
         <translation>Sök igenom rekursivt?</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.cpp" line="309"/>
         <source>Would you like to scan the directory &quot;%1&quot; recursively?
 
 Scanning recursively takes more time, but will identify files in subdirectories.</source>
@@ -10007,10 +5360,12 @@ Scanning recursively takes more time, but will identify files in subdirectories.
 Söka igenom den rekursivt tar längre tid men identifierar filer i underkataloger.</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.cpp" line="336"/>
         <source>Select Path</source>
         <translation>Välj sökväg</translation>
     </message>
     <message>
+        <location filename="../gamelistsettingswidget.cpp" line="346"/>
         <source>Select Directory</source>
         <translation>Välj katalog</translation>
     </message>
@@ -10018,38 +5373,47 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GameListWidget</name>
     <message>
+        <location filename="../gamelistwidget.ui" line="55"/>
         <source>Game List</source>
         <translation>Spellista</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.ui" line="74"/>
         <source>Game Grid</source>
         <translation>Spelrutnät</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.ui" line="93"/>
         <source>Merge Multi-Disc Games</source>
         <translation>Slå ihop spel på flera skivor</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.ui" line="112"/>
         <source>Show Localized Titles</source>
         <translation>Visa lokalanpassade titlar</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.ui" line="150"/>
         <source>Show Titles</source>
         <translation>Visa titlar</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.ui" line="205"/>
         <source>All Types</source>
         <translation>Alla typer</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.ui" line="218"/>
         <source>All Regions</source>
         <translation>Alla regioner</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.ui" line="131"/>
         <source>Show Game Icons</source>
         <translation>Visa spelikoner</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="78"/>
         <source>.cue (Cue Sheets)
 .iso (Single Track Image)
 .ecm (Error Code Modeling Image)
@@ -10066,10 +5430,12 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 .pbp (PlayStation Portable, endast dekrypterad)</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="2338"/>
         <source>Cover scale: %1%</source>
         <translation>Omslagsskala: %1%</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="2340"/>
         <source>Icon size: %1%</source>
         <translation>Ikonstorlek: %1%</translation>
     </message>
@@ -10077,30 +5443,37 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GamePatchDetailsWidget</name>
     <message>
+        <location filename="../gamepatchdetailswidget.ui" line="67"/>
         <source>Patch Title</source>
         <translation>Patchtitel</translation>
     </message>
     <message>
+        <location filename="../gamepatchdetailswidget.ui" line="29"/>
         <source>Enabled</source>
         <translation>Aktiverad</translation>
     </message>
     <message>
+        <location filename="../gamepatchdetailswidget.ui" line="48"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Author: &lt;/span&gt;Patch Author&lt;/p&gt;&lt;p&gt;Description would go here&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Upphovsperson: &lt;/span&gt;Patch Author&lt;/p&gt;&lt;p&gt;Beskrivning anges här&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../gamepatchsettingswidget.cpp" line="34"/>
         <source>Unknown</source>
         <translation>Okänt</translation>
     </message>
     <message>
+        <location filename="../gamepatchsettingswidget.cpp" line="37"/>
         <source>No description provided.</source>
         <translation>Ingen beskrivning angavs.</translation>
     </message>
     <message>
+        <location filename="../gamepatchsettingswidget.cpp" line="33"/>
         <source>&lt;strong&gt;Author: &lt;/strong&gt;%1%2&lt;br&gt;%3</source>
         <translation>&lt;strong&gt;Upphovsperson:  &lt;/strong&gt;%1%2&lt;br&gt;%3</translation>
     </message>
     <message>
+        <location filename="../gamepatchsettingswidget.cpp" line="35"/>
         <source>&lt;br&gt;&lt;strong&gt;Not permitted in RetroAchievements hardcore mode.&lt;/strong&gt;</source>
         <translation>&lt;br&gt;&lt;strong&gt;Inte tillåtet i RetroAchievements hardcore-läge.&lt;/strong&gt;</translation>
     </message>
@@ -10108,14 +5481,17 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GamePatchSettingsWidget</name>
     <message>
+        <location filename="../gamepatchsettingswidget.ui" line="71"/>
         <source>Reload Patches</source>
         <translation>Läs om patchar</translation>
     </message>
     <message>
+        <location filename="../gamepatchsettingswidget.ui" line="47"/>
         <source>Disable All Patches</source>
         <translation>Inaktivera alla patchar</translation>
     </message>
     <message>
+        <location filename="../gamepatchsettingswidget.cpp" line="126"/>
         <source>No patches are available for this game.</source>
         <translation>Det finns inga patchar tillgängliga för detta spel.</translation>
     </message>
@@ -10123,198 +5499,248 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GameSummaryWidget</name>
     <message>
+        <location filename="../gamesummarywidget.ui" line="43"/>
         <source>Title:</source>
         <translation>Titel:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="29"/>
         <source>Image Path:</source>
         <translation>Avbildssökväg:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="352"/>
         <source>Length</source>
         <translation>Längd</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="357"/>
         <source>Hash</source>
         <translation>Kontrollsumma</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="260"/>
         <source>Controllers:</source>
         <translation>Handkontroller:</translation>
     </message>
     <message>
-        <source>Tracks:</source>
-        <translation>Spår:</translation>
-    </message>
-    <message>
+        <location filename="../gamesummarywidget.ui" line="274"/>
         <source>Controller Preset:</source>
         <translation>Handkontrollerförval:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="246"/>
         <source>Release Info:</source>
         <translation>Utgivet den:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="147"/>
         <source>Languages:</source>
         <translation>Språk:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="206"/>
         <source>Uses separate game settings for each disc of multi-disc games. Can only be set on the first/main disc.</source>
         <translation>Använder separata spelinställningar för varje skiva i flerskivsspel. Kan endast ställas in på första/huvudskivan.</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="209"/>
         <source>Use Separate Disc Settings</source>
         <translation>Använd separata skivinställningar</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="286"/>
         <source>Edit...</source>
         <translation>Redigera...</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="91"/>
         <source>Serial:</source>
         <translation>Serienummer:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="190"/>
         <source>Type:</source>
         <translation>Typ:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="116"/>
         <source>Region:</source>
         <translation>Region:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="105"/>
         <source>Change Serial</source>
         <translation>Ändra serienummer</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="168"/>
         <source>Compatibility:</source>
         <translation>Kompatibilitet:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="218"/>
         <source>Hashes:</source>
         <translation>Kontrollsummor:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="232"/>
         <source>Metadata:</source>
         <translation>Metadata:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="311"/>
         <source>Verify</source>
         <translation>Verifiera</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="337"/>
         <source>#</source>
         <translation>#</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="342"/>
         <source>Mode</source>
         <translation>Läge</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="347"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="362"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="502"/>
         <source>&lt;not computed&gt;</source>
         <translation>&lt;inte beräknad&gt;</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="65"/>
         <source>Show Default Flag</source>
         <translation>Visa standardflagga</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="142"/>
         <source>%1 (Custom)</source>
         <translation>%1 (anpassad)</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="143"/>
+        <location filename="../gamesummarywidget.cpp" line="215"/>
+        <location filename="../gamesummarywidget.cpp" line="245"/>
+        <location filename="../gamesummarywidget.cpp" line="263"/>
+        <location filename="../gamesummarywidget.cpp" line="270"/>
+        <location filename="../gamesummarywidget.cpp" line="271"/>
+        <location filename="../gamesummarywidget.cpp" line="272"/>
         <source>Unknown</source>
         <translation>Okänt</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="195"/>
         <source> by </source>
         <translation> av </translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="196"/>
         <source>%1 (published by %2)</source>
         <translation>%1 (utgivet av %2)</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="210"/>
         <source>published by %1</source>
         <translation>utgivet av %1</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="697"/>
         <source>Search on redump.info</source>
         <translation>Sök på redump.info</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="222"/>
         <source>Released %1</source>
         <translation>Utgivet %1</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="229"/>
         <source>%1-%2 players</source>
         <translation>%1-%2 spelare</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="238"/>
         <source>%1-%2 memory card blocks</source>
         <translation>%1-%2 minneskortsblock</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="299"/>
         <source>Use Global Settings</source>
         <translation>Använd globala inställningar</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="301"/>
         <source>Game Specific Configuration</source>
         <translation>Spelspecifik konfiguration</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="308"/>
+        <source>Game ID: %1</source>
+        <translation>Spel-ID: %1</translation>
+    </message>
+    <message>
+        <location filename="../gamesummarywidget.cpp" line="498"/>
         <source>Track %1</source>
         <translation>Spår %1</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="542"/>
         <source>Compatibility Report</source>
         <translation>Kompatibilitetsrapport</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="584"/>
         <source>Per-game controller configuration initialized with global settings.</source>
         <translation>Kontrollerkonfiguration per-spel initierades med globala inställningar.</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="151"/>
         <source>N/A</source>
         <translation>Inte tillgängligt</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="56"/>
         <source>Restore Title</source>
         <translation>Återställ titel</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="136"/>
         <source>Restore Region</source>
         <translation>Återställ region</translation>
     </message>
     <message>
-        <source>Verifying Image</source>
-        <translation>Verifierar avbild</translation>
-    </message>
-    <message>
+        <location filename="../gamesummarywidget.cpp" line="654"/>
         <source>Hash Calculation Failed</source>
         <translation>Beräkning av kontrollsumma misslyckades</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.cpp" line="529"/>
         <source>This game was not scanned by DuckStation. Some functionality is not available.</source>
         <translation>Detta spel har inte sökts igenom av DuckStation. Viss funktionalitet är inte tillgänglig.</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="67"/>
         <source>Disc Set Title:</source>
         <translation>Titel för skivuppsättning:</translation>
     </message>
     <message>
+        <location filename="../gamesummarywidget.ui" line="80"/>
         <source>Restore Disc Set Title</source>
         <translation>Återställ titel för skivuppsättning</translation>
     </message>
     <message numerus="yes">
+        <location filename="../gamesummarywidget.cpp" line="231"/>
         <source>%n player(s)</source>
         <translation>
             <numerusform>%n spelare</numerusform>
@@ -10322,6 +5748,7 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../gamesummarywidget.cpp" line="240"/>
         <source>%n memory card block(s)</source>
         <translation>
             <numerusform>%n minneskortsblock</numerusform>
@@ -10332,936 +5759,1151 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>GraphicsSettingsWidget</name>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="35"/>
         <source>Renderer:</source>
         <translation>Renderare:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="45"/>
         <source>Adapter:</source>
         <translation>Adapter:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="137"/>
         <source>Down-Sampling:</source>
         <translation>Nersampling:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="226"/>
         <source>:</source>
         <translation>:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="255"/>
         <source>Scaling:</source>
         <translation>Skalning:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="305"/>
+        <location filename="../graphicssettingswidget.cpp" line="400"/>
         <source>Widescreen Rendering</source>
         <translation>Bredbildsrendering</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="291"/>
+        <location filename="../graphicssettingswidget.cpp" line="412"/>
         <source>Force 4:3 For FMVs</source>
         <translation>Tvinga 4:3 för FMVs</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="298"/>
+        <location filename="../graphicssettingswidget.cpp" line="414"/>
         <source>FMV Chroma Smoothing</source>
         <translation>FMV Chroma-utjämning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="277"/>
+        <location filename="../graphicssettingswidget.cpp" line="404"/>
         <source>PGXP Geometry Correction</source>
         <translation>Korrigering av PGXP-geometri</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="284"/>
         <source>PGXP Depth Buffer (Low Compatibility)</source>
         <translation>PGXP djupbuffert (låg kompatibilitet)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="174"/>
         <source>Sprite Texture Filtering:</source>
         <translation>Filtrering av sprite-textur:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="356"/>
         <source>Display Options</source>
         <translation>Skärmalternativ</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="362"/>
         <source>Exclusive Fullscreen:</source>
         <translation>Exklusiv helskärm:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="379"/>
         <source>Screen Position:</source>
         <translation>Skärmposition:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="539"/>
+        <location filename="../graphicssettingswidget.ui" line="1016"/>
         <source>Rendering Options</source>
         <translation>Renderingsalternativ</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="545"/>
         <source>Multi-Sampling:</source>
         <translation>Multisampling:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="555"/>
         <source>Line Detection:</source>
         <translation>Linjedetektering:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="312"/>
+        <location filename="../graphicssettingswidget.cpp" line="417"/>
         <source>Round Upscaled Texture Coordinates</source>
         <translation>Avrunda uppskalade texturkoordinater</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="606"/>
+        <location filename="../graphicssettingswidget.cpp" line="465"/>
         <source>Software Renderer Readbacks</source>
         <translation>Återläsning för programvarurenderare</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="576"/>
         <source>Max Queued Frames:</source>
         <translation>Max köade bildrutor:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="632"/>
         <source>PGXP</source>
         <translation>PGXP</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="656"/>
         <source>Geometry Tolerance:</source>
         <translation>Geometritolerans:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="700"/>
         <source>Depth Clear Threshold:</source>
         <translation>Tröskelvärde för djuptömning:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="738"/>
+        <location filename="../graphicssettingswidget.cpp" line="483"/>
         <source>Perspective Correct Colors</source>
         <translation>Korrekta färger för perspektiv</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="766"/>
+        <location filename="../graphicssettingswidget.cpp" line="496"/>
         <source>Vertex Cache</source>
         <translation>Vertex-cache</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="731"/>
+        <location filename="../graphicssettingswidget.cpp" line="479"/>
         <source>Perspective Correct Textures</source>
         <translation>Korrekta texturer för perspektiv</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="759"/>
+        <location filename="../graphicssettingswidget.cpp" line="492"/>
         <source>CPU Mode</source>
         <translation>CPU-läge</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="752"/>
+        <location filename="../graphicssettingswidget.cpp" line="490"/>
         <source>Preserve Projection Precision</source>
         <translation>Bevara projektionens precision</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="745"/>
+        <location filename="../graphicssettingswidget.cpp" line="486"/>
         <source>Culling Correction</source>
         <translation>Rensningskorrigering</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="773"/>
+        <location filename="../graphicssettingswidget.cpp" line="499"/>
         <source>Disable on 2D Polygons</source>
         <translation>Inaktivera för 2D-polygoner</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="780"/>
+        <location filename="../graphicssettingswidget.cpp" line="503"/>
         <source>Depth Test Transparent Polygons</source>
         <translation>Transparenta polygoner för djuptest</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="824"/>
         <source>General Settings</source>
         <translation>Allmänna inställningar</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="830"/>
+        <location filename="../graphicssettingswidget.cpp" line="510"/>
         <source>Enable Texture Cache</source>
         <translation>Aktivera texturcache</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="922"/>
+        <location filename="../graphicssettingswidget.cpp" line="533"/>
         <source>Use Old MDEC Routines</source>
         <translation>Använd gamla MDEC-rutiner</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1162"/>
+        <location filename="../graphicssettingswidget.cpp" line="579"/>
         <source>Disable Compute Shaders</source>
         <translation>Inaktivera beräkningsshaders</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1113"/>
+        <location filename="../graphicssettingswidget.cpp" line="582"/>
         <source>Disable Compressed Textures</source>
         <translation>Inaktivera komprimerade texturer</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="516"/>
         <source>Enable Texture Replacements</source>
         <translation>Aktivera texturersättningar</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="837"/>
+        <location filename="../graphicssettingswidget.cpp" line="513"/>
         <source>Preload Texture Replacements</source>
         <translation>Förinläs texturersättningar</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="862"/>
+        <location filename="../graphicssettingswidget.cpp" line="524"/>
         <source>Enable Texture Dumping</source>
         <translation>Aktivera texturdumpning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="892"/>
+        <location filename="../graphicssettingswidget.cpp" line="526"/>
         <source>Dump Replaced Textures</source>
         <translation>Dumpa ersatta texturer</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="885"/>
+        <location filename="../graphicssettingswidget.cpp" line="519"/>
         <source>Always Track Uploads</source>
         <translation>Spåra alltid uppladdningar</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="902"/>
         <source>VRAM Write (Background) Replacement</source>
         <translation>Ersättning för VRAM-skrivning (bakgrund)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="908"/>
+        <location filename="../graphicssettingswidget.cpp" line="529"/>
         <source>Enable VRAM Write Replacement</source>
         <translation>Aktivera VRAM-skrivningsersättning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="915"/>
+        <location filename="../graphicssettingswidget.cpp" line="531"/>
         <source>Enable VRAM Write Dumping</source>
         <translation>Aktivera VRAM-skrivdumpning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="932"/>
         <source>Textures Directory</source>
         <translation>Texturkatalog</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="938"/>
         <source>Directory to load replacement textures from, and save dumps to.</source>
         <translation>Katalog att läsa in ersättande texturer från och spara dumpar till.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="998"/>
         <source>Debugging</source>
         <translation>Felsökning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1022"/>
         <source>Wireframe Mode:</source>
         <translation>Wireframe-läge:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="567"/>
+        <location filename="../graphicssettingswidget.cpp" line="454"/>
         <source>Threaded Rendering</source>
         <translation>Trådad rendering</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1034"/>
+        <location filename="../graphicssettingswidget.cpp" line="543"/>
         <source>Disable Textures</source>
         <translation>Inaktivera texturer</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1041"/>
+        <location filename="../graphicssettingswidget.cpp" line="546"/>
         <source>Disable Vertex Lighting</source>
         <translation>Inaktivera hörnbelysning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1053"/>
         <source>GPU Dump Recording/Playback</source>
         <translation>Inspelning/Uppspelning av GPU-dump</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1059"/>
         <source>Dump Compression Mode:</source>
         <translation>Komprimeringsläge för dump:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1069"/>
         <source>Fast Dump Playback</source>
         <translation>Snabb dumpuppspelning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1079"/>
         <source>Device Options</source>
         <translation>Enhetsalternativ</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1141"/>
         <source>Disable Texture Copy To Self</source>
         <translation>Inaktivera texturkopia till själv</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1120"/>
+        <location filename="../graphicssettingswidget.cpp" line="560"/>
         <source>Disable Dual-Source Blending</source>
         <translation>Inaktivera blandning med dubbla källor</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1134"/>
+        <location filename="../graphicssettingswidget.cpp" line="567"/>
         <source>Disable Texture Buffers</source>
         <translation>Inaktivera texturbuffertar</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1148"/>
+        <location filename="../graphicssettingswidget.cpp" line="573"/>
         <source>Disable Memory Import</source>
         <translation>Inaktivera minnesimport</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1155"/>
+        <location filename="../graphicssettingswidget.cpp" line="576"/>
         <source>Disable Rasterizer Order Views</source>
         <translation>Inaktivera vyer för rastrerarordning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="204"/>
         <source>Aspect Ratio:</source>
         <translation>Bildförhållande:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="394"/>
+        <location filename="../graphicssettingswidget.cpp" line="397"/>
         <source>Bilinear (Smooth)</source>
         <translation>Bilinjär (mjuk)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="245"/>
         <source>Crop:</source>
         <translation>Beskär:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="443"/>
+        <location filename="../graphicssettingswidget.ui" line="463"/>
+        <location filename="../graphicssettingswidget.ui" line="483"/>
+        <location filename="../graphicssettingswidget.ui" line="503"/>
+        <location filename="../graphicssettingswidget.ui" line="668"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="349"/>
         <source>Internal Resolution</source>
         <translation>Intern upplösning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="65"/>
         <source>Rendering</source>
         <translation>Rendering</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="106"/>
         <source>Internal Resolution:</source>
         <translation>Intern upplösning:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="164"/>
         <source>Texture Filtering:</source>
         <translation>Texturfiltrering:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="194"/>
         <source>Deinterlacing:</source>
         <translation>Deinterlacing:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="687"/>
         <source>Reset Geometry Tolerance</source>
         <translation>Återställ geometritolerans</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="716"/>
         <source>Reset Depth Clear Threshold</source>
         <translation>Återställ tröskelvärde för djupnollställning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="806"/>
+        <location filename="../graphicssettingswidget.ui" line="847"/>
         <source>Texture Replacement</source>
         <translation>Texturersättning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="853"/>
         <source>Enable Texture Replacement</source>
         <translation>Aktivera texturersättningar</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="948"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="959"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="970"/>
         <source>Reset</source>
         <translation>Nollställ</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="520"/>
+        <location filename="../graphicssettingswidget.cpp" line="435"/>
         <source>Disable Mailbox Presentation</source>
         <translation>Inaktivera presentation av brevlåda</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1106"/>
+        <location filename="../graphicssettingswidget.cpp" line="558"/>
         <source>Disable Shader Cache</source>
         <translation>Inaktivera shadercache</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="149"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="338"/>
         <source>Advanced</source>
         <translation>Avancerat</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="527"/>
+        <location filename="../graphicssettingswidget.cpp" line="439"/>
         <source>Use Blit Swap Chain</source>
         <translation>Använd blit-växlingskedja</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1085"/>
+        <location filename="../graphicssettingswidget.cpp" line="549"/>
         <source>Use Debug Device</source>
         <translation>Använd felsökningsenhet</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1127"/>
+        <location filename="../graphicssettingswidget.cpp" line="563"/>
         <source>Disable Framebuffer Fetch</source>
         <translation>Inaktivera framebuffer-hämtning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="400"/>
+        <location filename="../graphicssettingswidget.cpp" line="404"/>
+        <location filename="../graphicssettingswidget.cpp" line="408"/>
+        <location filename="../graphicssettingswidget.cpp" line="412"/>
+        <location filename="../graphicssettingswidget.cpp" line="414"/>
+        <location filename="../graphicssettingswidget.cpp" line="417"/>
+        <location filename="../graphicssettingswidget.cpp" line="435"/>
+        <location filename="../graphicssettingswidget.cpp" line="439"/>
+        <location filename="../graphicssettingswidget.cpp" line="458"/>
+        <location filename="../graphicssettingswidget.cpp" line="465"/>
+        <location filename="../graphicssettingswidget.cpp" line="483"/>
+        <location filename="../graphicssettingswidget.cpp" line="490"/>
+        <location filename="../graphicssettingswidget.cpp" line="492"/>
+        <location filename="../graphicssettingswidget.cpp" line="496"/>
+        <location filename="../graphicssettingswidget.cpp" line="499"/>
+        <location filename="../graphicssettingswidget.cpp" line="503"/>
+        <location filename="../graphicssettingswidget.cpp" line="510"/>
+        <location filename="../graphicssettingswidget.cpp" line="513"/>
+        <location filename="../graphicssettingswidget.cpp" line="516"/>
+        <location filename="../graphicssettingswidget.cpp" line="519"/>
+        <location filename="../graphicssettingswidget.cpp" line="524"/>
+        <location filename="../graphicssettingswidget.cpp" line="526"/>
+        <location filename="../graphicssettingswidget.cpp" line="529"/>
+        <location filename="../graphicssettingswidget.cpp" line="531"/>
+        <location filename="../graphicssettingswidget.cpp" line="533"/>
+        <location filename="../graphicssettingswidget.cpp" line="543"/>
+        <location filename="../graphicssettingswidget.cpp" line="546"/>
+        <location filename="../graphicssettingswidget.cpp" line="549"/>
+        <location filename="../graphicssettingswidget.cpp" line="552"/>
+        <location filename="../graphicssettingswidget.cpp" line="555"/>
+        <location filename="../graphicssettingswidget.cpp" line="558"/>
+        <location filename="../graphicssettingswidget.cpp" line="560"/>
+        <location filename="../graphicssettingswidget.cpp" line="563"/>
+        <location filename="../graphicssettingswidget.cpp" line="567"/>
+        <location filename="../graphicssettingswidget.cpp" line="570"/>
+        <location filename="../graphicssettingswidget.cpp" line="573"/>
+        <location filename="../graphicssettingswidget.cpp" line="576"/>
+        <location filename="../graphicssettingswidget.cpp" line="579"/>
+        <location filename="../graphicssettingswidget.cpp" line="582"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="354"/>
+        <location filename="../graphicssettingswidget.cpp" line="451"/>
+        <location filename="../graphicssettingswidget.cpp" line="539"/>
+        <location filename="../graphicssettingswidget.cpp" line="789"/>
         <source>Disabled</source>
         <translation>Inaktiverad</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="511"/>
         <source>Enables caching of guest textures, required for texture replacement. &lt;strong&gt;The texture cache is currently experimental, and may cause rendering errors in some games.&lt;/strong&gt;</source>
         <translation>Aktiverar cachelagring av gästtexturer, vilket krävs för texturersättningar. &lt;strong&gt;Texturcachen är för närvarande experimentell och kan orsaka renderingsfel i vissa spel.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="520"/>
         <source>Forces texture upload tracking to be enabled regardless of whether it is needed. Reduces performance, but allows toggling replacements on and off. &lt;strong&gt;Not required for replacements to load, &lt;/strong&gt;normally tracking is automatically enabled when needed.</source>
         <translation>Tvingar spårning av texturuppladdning att aktiveras oavsett om det behövs eller inte. Minskar prestandan, men gör det möjligt att växla mellan på- och avstängning av ersättningar. &lt;strong&gt;Krävs inte för att ersättningar ska läsas in &lt;/strong&gt;, normalt aktiveras spårning automatiskt när det behövs.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="862"/>
         <source>%1x Native</source>
         <translation>%1x inbyggd</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="454"/>
+        <location filename="../graphicssettingswidget.cpp" line="461"/>
+        <location filename="../graphicssettingswidget.cpp" line="479"/>
+        <location filename="../graphicssettingswidget.cpp" line="486"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="378"/>
         <source>Aspect Ratio</source>
         <translation>Bildförhållande</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="383"/>
         <source>Deinterlacing</source>
         <translation>Deinterlacing</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="423"/>
         <source>Fullscreen Mode</source>
         <translation>Helskärmsläge</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="423"/>
+        <location filename="../graphicssettingswidget.cpp" line="741"/>
         <source>Borderless Fullscreen</source>
         <translation>Ramfri helskärm</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="424"/>
         <source>Chooses the fullscreen resolution and frequency.</source>
         <translation>Väljer helskärmsupplösningen och frekvens.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="361"/>
         <source>Texture Filtering</source>
         <translation>Texturfiltrering</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="440"/>
         <source>Uses a blit presentation model instead of flipping when using the Direct3D 11 renderer. This usually results in slower performance, but may be required for some streaming applications, or to uncap framerates on some systems.</source>
         <translation>Använder en blit-presentationsmodell istället för flipping när Direct3D 11-renderaren används. Detta resulterar vanligtvis i långsammare prestanda, men kan vara nödvändigt för vissa strömningsprogram eller för att frigöra bildfrekvenser på vissa system.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="700"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="436"/>
         <source>Forces the use of FIFO over Mailbox presentation, i.e. double buffering instead of triple buffering. Usually results in worse frame pacing.</source>
         <translation>Tvingar fram användning av FIFO i stället för brevlådepresentation, dvs. dubbelbuffring i stället för trippelbuffring. Detta resulterar vanligen i sämre bildrytm.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="264"/>
         <source>Select Textures Directory</source>
         <translation>Välj texturkatalog</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="339"/>
         <source>Renderer</source>
         <translation>Renderare</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="344"/>
         <source>Adapter</source>
         <translation>Adapter</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="344"/>
         <source>(Default)</source>
         <translation>(standard)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="345"/>
         <source>If your system contains multiple GPUs or adapters, you can select which GPU you wish to use for the hardware renderers. &lt;br&gt;This option is only supported in Direct3D and Vulkan. OpenGL will always use the default device.</source>
         <translation>Om ditt system innehåller flera GPU:er eller adaptrar kan du välja vilken GPU du vill använda för hårdvarurenderingarna. &lt;br&gt;Det här alternativet stöds endast i Direct3D och Vulkan. OpenGL kommer alltid att använda standardenheten.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="350"/>
         <source>Setting this beyond 1x will enhance the resolution of rendered 3D polygons and lines. Only applies to the hardware backends. &lt;br&gt;This option is usually safe, with most games looking fine at higher resolutions. Higher resolutions require a more powerful GPU.</source>
         <translation>Om du ställer in detta värde till mer än 1x förbättras upplösningen för renderade 3D-polygoner och linjer. Gäller endast för hårdvarubakändar. &lt;br&gt;Det här alternativet är vanligtvis säkert, och de flesta spel ser bra ut i högre upplösningar. Högre upplösningar kräver en kraftfullare GPU.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="354"/>
         <source>Down-Sampling</source>
         <translation>Nersampling</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="355"/>
         <source>Downsamples the rendered image prior to displaying it. Can improve overall image quality in mixed 2D/3D games, but should be disabled for pure 3D games.</source>
         <translation>Samplar ner den renderade bilden innan den visas. Kan förbättra den övergripande bildkvaliteten i blandade 2D/3D-spel, men bör inaktiveras för rena 3D-spel.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="357"/>
         <source>Down-Sampling Display Scale</source>
         <translation>Skala för skärmnedsampling</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="357"/>
         <source>1x</source>
         <translation>1x</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="358"/>
         <source>Selects the resolution scale that will be applied to the final image. 1x will downsample to the original console resolution.</source>
         <translation>Väljer den upplösningsskala som ska tillämpas på den slutliga bilden. 1x innebär nedskalning till den ursprungliga konsolupplösningen.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="363"/>
         <source>Smooths out the blockiness of magnified textures on 3D objects by using filtering. &lt;br&gt;Will have a greater effect on higher resolution scales.</source>
         <translation>Utjämnar blockigheten i förstorade texturer på 3D-objekt med hjälp av filtrering. &lt;br&gt;Effekten blir större på skalor med högre upplösning.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="366"/>
         <source>Sprite Texture Filtering</source>
         <translation>Filtrering av sprite-textur</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="368"/>
         <source>Smooths out the blockiness of magnified textures on 2D objects by using filtering. This filter only applies to sprites and other 2D elements, such as the HUD.</source>
         <translation>Utjämnar blockigheten i förstorade texturer på 2D-objekt med hjälp av filtrering. Detta filter gäller endast sprites och andra 2D-element, t.ex. HUD.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="380"/>
         <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is Auto (Game Native) which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era.</source>
         <translation>Ändrar det bildförhållande som används för att visa konsolens utdata på skärmen. Standardinställningen är Automatiskt (spelets inbyggda) som automatiskt justerar bildförhållandet så att det motsvarar hur ett spel skulle visas på en typisk TV för den tiden.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="385"/>
         <source>Determines which algorithm is used to convert interlaced frames to progressive for display on your system. Using progressive rendering provides the best quality output, but some games require interlaced rendering.</source>
         <translation>Bestämmer vilken algoritm som används för att konvertera sammanflätade (interlaced) bildrutor till progressiva för visning på ditt system. Progressiv rendering ger den bästa kvaliteten, men vissa spel kräver interlaced rendering.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="388"/>
         <source>Crop</source>
         <translation>Beskär</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="390"/>
         <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide. Some games display content in the overscan area, or use it for screen effects. May not display correctly with the &quot;All Borders&quot; setting. &quot;Only Overscan&quot; offers a good compromise between stability and hiding black borders.</source>
         <translation>Bestämmer hur stor del av det område som normalt inte syns på en konsument-TV-apparat som ska beskäras/döljas. Vissa spel visar innehåll i overscan-området eller använder det för skärmeffekter. Visas kanske inte korrekt med inställningen &quot;Alla kanter&quot;. &quot;Endast överskanning&quot; är en bra kompromiss mellan stabilitet och att dölja svarta kanter.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="394"/>
         <source>Scaling</source>
         <translation>Skalning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="395"/>
         <source>Determines how the emulated console&apos;s output is upscaled or downscaled to your monitor&apos;s resolution.</source>
         <translation>Bestämmer hur den emulerade konsolens utdata ska upp- eller nedskalas till din bildskärms upplösning.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="401"/>
         <source>Scales vertex positions in screen-space to a widescreen aspect ratio, essentially increasing the field of view from 4:3 to the chosen display aspect ratio in 3D games. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Skalar vertexpositioner i skärmrymden till ett bredbildsförhållande, vilket i princip ökar synfältet från 4:3 till det valda bildförhållandet i 3D-spel. &lt;b&gt;&lt;u&gt;Kanske inte kompatibel med alla spel.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="405"/>
         <source>Reduces &quot;wobbly&quot; polygons and &quot;warping&quot; textures that are common in PS1 games. &lt;strong&gt;May not be compatible with all games.&lt;/strong&gt;</source>
         <translation>Reducerar &quot;vingliga&quot; polygoner och &quot;skeva&quot; texturer som är vanliga i PS1-spel. &lt;strong&gt;Kanske inte kompatibel med alla spel.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="408"/>
         <source>PGXP Depth Buffer</source>
         <translation>PGXP-djupbuffert</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="409"/>
         <source>Attempts to reduce polygon Z-fighting by testing pixels against the depth values from PGXP. Low compatibility, but can work well in some games. Other games may need a threshold adjustment.</source>
         <translation>Försöker minska polygonernas Z-fighting genom att testa bildpunkter mot djupvärdena från PGXP. Låg kompatibilitet, men kan fungera bra i vissa spel. Andra spel kan behöva en tröskeljustering.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="413"/>
         <source>Switches back to 4:3 display aspect ratio when displaying 24-bit content, usually FMVs.</source>
         <translation>Växlar tillbaka till bildförhållandet 4:3 vid visning av 24-bitars innehåll, vanligtvis FMV.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="415"/>
         <source>Smooths out blockyness between colour transitions in 24-bit content, usually FMVs.</source>
         <translation>Utjämnar blockighet mellan färgövergångar i 24-bitars innehåll, vanligtvis FMV.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="425"/>
         <source>Exclusive Fullscreen Control</source>
         <translation>Exklusiv helskärmskontroll</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="425"/>
         <source>Automatic</source>
         <translation>Automatisk</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="426"/>
         <source>Controls whether exclusive fullscreen can be utilized by Vulkan drivers.</source>
         <translation>Kontrollerar om exklusiv helskärm kan användas av Vulkan-drivrutiner.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="428"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="430"/>
         <source>Determines the position on the screen when black borders must be added.</source>
         <translation>Bestämmer positionen på skärmen när svarta sorgkanter måste läggas till.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="446"/>
         <source>Line Detection</source>
         <translation>Linjedetektion</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="448"/>
         <source>Attempts to detect one pixel high/wide lines that rely on non-upscaled rasterization behavior, filling in gaps introduced by upscaling.</source>
         <translation>Försök att upptäcka en bildpunkt höga/breda linjer som förlitar sig på icke-uppskalad rastrering och fyller i luckor som uppstått genom uppskalning.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="451"/>
         <source>Multi-Sampling</source>
         <translation>Multi-sampling</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="452"/>
         <source>Uses multi-sampled anti-aliasing when rendering 3D polygons. Can improve visuals with a lower performance requirement compared to upscaling, &lt;strong&gt;but often introduces rendering errors.&lt;/strong&gt;</source>
         <translation>Använder multi-samplad anti-aliasing vid rendering av 3D-polygoner. Kan förbättra grafiken med ett lägre prestandakrav jämfört med uppskalning, &lt;strong&gt;men ger ofta upphov till renderingsfel.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="455"/>
         <source>Uses a second thread for drawing graphics. Provides a significant speed improvement particularly with the software renderer, and is safe to use.</source>
         <translation>Använder en andra tråd för att rita grafik. Ger en betydande hastighetsförbättring, särskilt med programvarurenderaren och är säker att använda.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="466"/>
         <source>Runs the software renderer in parallel for VRAM readbacks. On some systems, this may result in greater performance when using graphical enhancements with the hardware renderer.</source>
         <translation>Kör programvarurenderingen parallellt för VRAM-återläsningar. På vissa system kan detta resultera i bättre prestanda när du använder grafiska förbättringar med maskinvarurenderingen.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="418"/>
         <source>Rounds texture coordinates instead of flooring when upscaling. Can fix misaligned textures in some games, but break others, and is incompatible with texture filtering.</source>
         <translation>Avrundar texturkoordinater istället för flooring vid uppskalning. Kan fixa feljusterade texturer i vissa spel, men förstöra andra, och är inkompatibel med texturfiltrering.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="472"/>
         <source>Geometry Tolerance</source>
         <translation>Geometritolerans</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="472"/>
         <source>-1.00px (Disabled)</source>
         <translation>-1.00px (Inaktiverad)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="473"/>
         <source>Discards precise geometry when it is found to be offset past the specified threshold. This can help with games that have vertices significantly moved by PGXP, but is still a hack/workaround.</source>
         <translation>Kasserar exakt geometri när det upptäcks att den är förskjuten över det angivna tröskelvärdet. Detta kan hjälpa till med spel där hörnpunkter flyttas avsevärt av PGXP, men det är fortfarande ett hack/temporärlösning.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="475"/>
         <source>Depth Clear Threshold</source>
         <translation>Tröskelvärde för djuptömning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="477"/>
         <source>Determines the increase in depth that will result in the depth buffer being cleared. Can help with depth issues in some games, but is still a hack/workaround.</source>
         <translation>Bestämmer den ökning av djupet som leder till att djupbufferten rensas. Kan hjälpa till med djupproblem i vissa spel, men är fortfarande ett hack/temporärlösning.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="480"/>
         <source>Uses perspective-correct interpolation for texture coordinates, straightening out warped textures. Requires geometry correction enabled.</source>
         <translation>Använder perspektivkorrigerad interpolering för texturkoordinater, vilket rätar ut skeva texturer. Kräver att geometrikorrigering är aktiverad.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="484"/>
         <source>Uses perspective-correct interpolation for vertex colors, which can improve visuals in some games, but cause rendering errors in others. Requires geometry correction enabled.</source>
         <translation>Använder perspektivkorrigerad interpolering för vertexfärger, vilket kan förbättra grafiken i vissa spel, men orsaka renderingsfel i andra. Kräver att geometrikorrigering är aktiverad.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="487"/>
         <source>Increases the precision of polygon culling, reducing the number of holes in geometry. Requires geometry correction enabled.</source>
         <translation>Ökar precisionen i polygonutrensningen, vilket minskar antalet hål i geometrin. Kräver att geometrikorrigering är aktiverad.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="491"/>
         <source>Adds additional precision to PGXP data post-projection. May improve visuals in some games.</source>
         <translation>Lägger till ytterligare precision till PGXP-data efterprojicering. Kan förbättra grafiken i vissa spel.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="493"/>
         <source>Uses PGXP for all instructions, not just memory operations. Required for PGXP to correct wobble in some games, but has a high performance cost.</source>
         <translation>Använder PGXP för alla instruktioner, inte bara minnesoperationer. Krävs för att PGXP ska korrigera wobble i vissa spel, men har en hög prestandakostnad.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="497"/>
         <source>Uses screen-space vertex positions to obtain precise positions, instead of tracking memory accesses. Can provide PGXP compatibility for some games, but &lt;strong&gt;generally provides no benefit.&lt;/strong&gt;</source>
         <translation>Använder vertexpositioner i skärmrymden för att få exakta positioner, istället för att spåra minnesåtkomst. Kan ge PGXP-kompatibilitet för vissa spel, men &lt;strong&gt;ger i allmänhet inga fördelar.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="500"/>
         <source>Uses native resolution coordinates for 2D polygons, instead of precise coordinates. Can fix misaligned UI in some games, but otherwise should be left disabled. The game database will enable this automatically when needed.</source>
         <translation>Använder koordinater med inbyggd upplösning för 2D-polygoner, istället för exakta koordinater. Kan åtgärda felriktat användargränssnitt i vissa spel, men bör annars lämnas inaktiverat. Speldatabasen kommer att aktivera detta automatiskt när det behövs.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="534"/>
         <source>Enables the older, less accurate MDEC decoding routines. May be required for old replacement backgrounds to match/load.</source>
         <translation>Aktiverar de äldre, mindre exakta MDEC-avkodningsrutinerna. Kan krävas för att gamla ersättningsbakgrunder ska matcha/läsas in.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="517"/>
         <source>Enables loading of replacement textures. Not compatible with all games.</source>
         <translation>Aktiverar inläsning av ersättningstexturer. Inte kompatibelt med alla spel.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="514"/>
         <source>Loads all replacement texture to RAM, reducing stuttering at runtime.</source>
         <translation>Läser in alla ersättningstexturer till RAM-minnet, vilket gör att det går snabbare att köra.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="525"/>
         <source>Enables dumping of textures to image files, which can be replaced. Not compatible with all games.</source>
         <translation>Aktiverar dumpning av texturer till bildfiler, som kan ersättas. Inte kompatibel med alla spel.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="527"/>
         <source>Dumps textures that have replacements already loaded.</source>
         <translation>Dumpar texturer som har ersättningar redan inlästa.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="530"/>
         <source>Enables the replacement of background textures in supported games.</source>
         <translation>Aktiverar ersättning av bakgrundstexturer i spel som stöds.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="532"/>
         <source>Writes backgrounds that can be replaced to the dump directory.</source>
         <translation>Skriver bakgrunder som kan ersättas till dumpkatalogen.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="539"/>
         <source>Wireframe Mode</source>
         <translation>Ramverksläge</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="540"/>
         <source>Draws a wireframe outline of the triangles rendered by the console&apos;s GPU, either as a replacement or an overlay.</source>
         <translation>Ritar en wireframe-kontur av de trianglar som renderas av konsolens GPU, antingen som en ersättning eller ett överlägg.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="544"/>
         <source>Disables texture emulation in the GPU, forcing all primitives to only show vertex colours.</source>
         <translation>Inaktiverar texturemulering i grafikprocessorn och tvingar alla primitiver att endast visa hörnfärger.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="547"/>
         <source>Disables vertex lighting in the GPU, forcing all primitives to only show raw texture colours.</source>
         <translation>Inaktiverar hörnbelysning i grafikprocessorn och tvingar alla primitiver att endast visa råa texturfärger.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="550"/>
         <source>Enable debugging when supported by the host&apos;s renderer API. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Aktivera felsökning när detta stöds av värdens API för rendering. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="559"/>
         <source>Forces shaders to be compiled for every run of the program. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Tvingar shaders att kompileras för varje körning av programmet. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="561"/>
         <source>Prevents dual-source blending from being used. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Förhindrar att blandning med dubbla källor används. Användbar för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="564"/>
         <source>Prevents the framebuffer fetch extensions from being used. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Förhindrar att tilläggen för hämtning av framebufferten används. Användbart för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="568"/>
         <source>Forces VRAM updates through texture updates, instead of texture buffers and draws. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Tvingar VRAM-uppdateringar genom texturuppdateringar, istället för texturbuffertar och draws. Användbart för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="570"/>
         <source>Disable Texture Copies To Self</source>
         <translation>Inaktivera texturkopior till själv</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="571"/>
         <source>Disables the use of self-copy updates for the VRAM texture. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användning av självkopieuppdateringar för VRAM-texturen. Användbar för tester av trasiga grafikdrivrutiner. &lt;strong&gt;Endast för utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="574"/>
         <source>Disables the use of host memory importing. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användning av värdminnesimport. Användbar för tester av trasiga grafikdrivrutiner. &lt;strong&gt;Endast för utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="577"/>
         <source>Disables the use of rasterizer order views. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användning av rasterizer order views. Användbar för tester av trasiga grafikdrivrutiner. &lt;strong&gt;Endast för utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="580"/>
         <source>Disables the use of compute shaders. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användningen av compute shaders. Användbart för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="583"/>
         <source>Disables the use of compressed textures. Useful for testing broken graphics drivers. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Inaktiverar användningen av komprimerade texturer. Användbar för att testa trasiga grafikdrivrutiner. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="725"/>
         <source>%1 [Unavailable]</source>
         <translation>%1 [inte tillgänglig]</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="843"/>
         <source>PGXP is not enabled. Increasing the resolution without enabling PGXP will result in visible polygon glitches.</source>
         <translation>PGXP är inte aktiverat. Om upplösningen höjs utan att PGXP aktiveras uppstår synliga polygonfel.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="850"/>
         <source>Automatic (Based on Window Size)</source>
         <translation>Automatisk (baserat på fönsterstorlek)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="851"/>
         <source>1x Native (Default)</source>
         <translation>1x inbyggd (Standard)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="852"/>
         <source>3x Native (for 720p)</source>
         <translation>3x inbyggd (för 720p)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="853"/>
         <source>5x Native (for 1080p)</source>
         <translation>5x inbyggd (för 1080p)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="854"/>
         <source>6x Native (for 1440p)</source>
         <translation>6x inbyggd (för 1440p)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="855"/>
         <source>9x Native (for 4K)</source>
         <translation>9x inbyggd (för 4K)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="1046"/>
         <source>&lt;h3&gt;Changing the renderer is not recommended!&lt;/h3&gt;&lt;p&gt;The &lt;strong&gt;Automatic&lt;/strong&gt; option provides the best experience, selecting the optimal renderer for your graphics adapter. There is &lt;strong&gt;no visual or performance advantage&lt;/strong&gt; to using a different renderer, and you risk the application breaking due to driver bugs.&lt;br&gt;&lt;br&gt;If you continue with changing the renderer, &lt;strong&gt;do not ask for support&lt;/strong&gt;.&lt;br&gt;&lt;br&gt;Are you sure you want to change the renderer?&lt;/p&gt;</source>
         <translation>&lt;h3&gt;Det rekommenderas inte att byta renderare!&lt;/h3&gt;&lt;p&gt;Alternativet &lt;strong&gt;Automatisk&lt;/strong&gt; ger den bästa upplevelsen genom att välja den optimala renderaren för ditt grafikkort. Det finns &lt;strong&gt;ingen visuell eller prestandamässig fördel&lt;/strong&gt; med att använda en annan renderare, och drivrutinsfel kan få programmet att sluta fungera.&lt;br&gt;&lt;br&gt;Om du fortsätter att byta renderare ska du &lt;strong&gt;inte be om support&lt;/strong&gt;.&lt;br&gt;&lt;br&gt;Är du säker på att du vill byta renderare?&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="786"/>
         <source>Use Global Setting</source>
         <translation>Använd global inställning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="791"/>
         <source>%1x MSAA</source>
         <translation>%1x MSAA</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="793"/>
         <source>%1x SSAA</source>
         <translation>%1x SSAA</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="184"/>
         <source>Dithering:</source>
         <translation>Dithering:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="599"/>
+        <location filename="../graphicssettingswidget.cpp" line="461"/>
         <source>Scaled Interlacing</source>
         <translation>Skalad interlacing</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1092"/>
+        <location filename="../graphicssettingswidget.cpp" line="552"/>
         <source>Use GPU-Based Validation</source>
         <translation>Använd GPU-baserad validering</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="340"/>
         <source>Selects the backend to use for rendering the console/game visuals. &lt;br&gt;Depending on your system and hardware, Direct3D 11 and OpenGL hardware backends may be available. &lt;br&gt;The software renderer offers the best compatibility, but is the slowest and does not offer any enhancements.</source>
         <translation>Väljer den bakände som ska användas för att rendera konsol- och spelgrafiken. &lt;br&gt;Beroende på system och maskinvara kan Direct3D 11- och OpenGL-hårdvarubakändar finnas tillgängliga. &lt;br&gt;Programvarurenderingen erbjuder den bästa kompatibiliteten, men är långsammast och erbjuder inga förbättringar.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="371"/>
         <source>Dithering</source>
         <translation>Dithering</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="373"/>
         <source>Controls how dithering is applied in the emulated GPU. True Color disables dithering and produces the nicest looking gradients. Scaled options make the dither pattern less noticeable at higher resolutions. Shader Blending options perform blending in software, and are more accurate but have a &lt;strong&gt;significant&lt;/strong&gt; performance penalty.</source>
         <translation>Kontrollerar hur dithering tillämpas i den emulerade GPU:n. True Color inaktiverar dithering och ger de snyggaste gradienterna. Med skalade alternativ blir dithermönstret mindre märkbart i högre upplösningar. Alternativet Shader-blandning utför blandning i programvara och är mer exakt, men har en &lt;strong&gt;betydande&lt;/strong&gt; prestandaförlust.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="462"/>
         <source>Scales line skipping in interlaced rendering to the internal resolution. This makes the combing less obvious at higher resolutions. Usually safe to enable.</source>
         <translation>Skalar linjeöverhoppning vid interlaced-rendering till den interna upplösningen. Detta gör kamningen mindre uppenbar i högre upplösningar. Vanligtvis säkert att aktivera.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="553"/>
         <source>Enable GPU-based validation when supported by the renderer API. &lt;strong&gt;Only for developer use.&lt;/strong&gt;</source>
         <translation>Aktivera GPU-baserad validering när detta stöds av renderarens API. &lt;strong&gt;Endast för användning av utvecklare.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="504"/>
         <source>Enables depth testing for semi-transparent polygons. Usually these include shadows, and tend to clip through the ground when depth testing is enabled. Depth writes for semi-transparent polygons are disabled regardless of this setting.</source>
         <translation>Aktiverar djupkontroll för halvtransparenta polygoner. Dessa inkluderar vanligtvis skuggor och tenderar att klippa igenom marken när djupkontroll är aktiverat. Djupskrivningar för halvtransparenta polygoner är inaktiverade oavsett denna inställning.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="265"/>
         <source>FMV Scaling:</source>
         <translation>FMV-skalning:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="1099"/>
+        <location filename="../graphicssettingswidget.cpp" line="555"/>
         <source>Prefer OpenGL ES Context</source>
         <translation>Föredra OpenGL ES Context</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="397"/>
         <source>FMV Scaling</source>
         <translation>FMV-skalning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="398"/>
         <source>Determines the scaling algorithm used when 24-bit content is active, typically FMVs.</source>
         <translation>Bestämmer skalningsalgoritmen som används när 24-bitarsinnehåll är aktivt, vanligtvis FMV.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="556"/>
         <source>Uses OpenGL ES even when desktop OpenGL is supported. May improve performance on some SBC drivers.</source>
         <translation>Använder OpenGL ES även när OpenGL för stationära datorer stöds. Kan förbättra prestandan på vissa SBC-drivrutiner.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="897"/>
         <source>Custom</source>
         <translation>Anpassad</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="396"/>
         <source>Fine Crop Mode:</source>
         <translation>Läget för finjusterad beskäring:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="414"/>
         <source>Reset Fine Cropping</source>
         <translation>Återställ finjusterad beskäring</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="427"/>
         <source>Fine Crop Size:</source>
         <translation>Storlek för finjusterad beskäring:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="436"/>
         <source>Left:</source>
         <translation>Vänster:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="456"/>
         <source>Top:</source>
         <translation>Överst:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="476"/>
         <source>Right:</source>
         <translation>Höger:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="496"/>
         <source>Bottom:</source>
         <translation>Nederst:</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.ui" line="592"/>
         <source>Texture Modulation Cropping (&quot;Old/v0 GPU&quot;)</source>
         <translation>Beskäring av texturmodulation (&quot;Old/v0&quot; GPU)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="431"/>
         <source>Fine Crop Mode</source>
         <translation>Läget för finjusterad beskäring</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="431"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="432"/>
         <source>Enables manual fine cropping of the display area, while preserving the aspect ratio of the image. Useful for removing black borders in certain games.</source>
         <translation>Aktiverar manuell finjustering av visningsområdet, samtidigt som bildens bildförhållande bibehålls. Användbart för att ta bort svarta kanter i vissa spel.</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="458"/>
         <source>Texture Modulation Cropping (&quot;Old/v0&quot; GPU)</source>
         <translation>Beskäring av texturmodulation (&quot;Old/v0&quot; GPU)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="459"/>
         <source>Crops vertex colours to 5:5:5 before modulating with the texture colour, which typically results in more visible banding. This is a characteristic of the &quot;old&quot; GPUs found in early model consoles.</source>
         <translation>Beskär vertexfärgerna till 5:5:5 innan de moduleras med texturfärgen, vilket vanligtvis resulterar i mer synliga band. Detta är ett kännetecken för de ”gamla” GPU:erna som finns i tidiga konsolmodeller.</translation>
     </message>
 </context>
 <context>
-    <name>GunCon</name>
-    <message>
-        <source>Pointer/Aiming</source>
-        <translation>Pekare/Sikte</translation>
-    </message>
-    <message>
-        <source>Trigger</source>
-        <translation>Skjutknapp</translation>
-    </message>
-    <message>
-        <source>Shoot Offscreen</source>
-        <translation>Skjut utanför skärm</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <source>Relative Left</source>
-        <translation>Relativ vänster</translation>
-    </message>
-    <message>
-        <source>Relative Right</source>
-        <translation>Relativ höger</translation>
-    </message>
-    <message>
-        <source>Relative Up</source>
-        <translation>Relativ upp</translation>
-    </message>
-    <message>
-        <source>Relative Down</source>
-        <translation>Relativ ner</translation>
-    </message>
-    <message>
-        <source>Crosshair Image Path</source>
-        <translation>Sökväg till korssiktesbild</translation>
-    </message>
-    <message>
-        <source>Path to an image to use as a crosshair/cursor.</source>
-        <translation>Sökväg till en bild att använda som ett korssikte/markör.</translation>
-    </message>
-    <message>
-        <source>Crosshair Image Scale</source>
-        <translation>Skala för korssiktesbild</translation>
-    </message>
-    <message>
-        <source>Scale of crosshair image on screen.</source>
-        <translation>Skala för korssiktesbilden på skärmen.</translation>
-    </message>
-    <message>
-        <source>Cursor Color</source>
-        <translation>Markörfärg</translation>
-    </message>
-    <message>
-        <source>Applies a color to the chosen crosshair images, can be used for multiple players. Specify in HTML/CSS format (e.g. #aabbcc)</source>
-        <translation>Tillämpar en färg till valda korssiktesbilder och kan användas av flera spelare. Ange i HTML/CSS-format (t.ex. #aabbcc)</translation>
-    </message>
-    <message>
-        <source>X Scale</source>
-        <translation>X-skala</translation>
-    </message>
-    <message>
-        <source>Scales X coordinates relative to the center of the screen.</source>
-        <translation>Skalar X-koordinater relativt till centrum av skärmen.</translation>
-    </message>
-    <message>
-        <source>Line Offset</source>
-        <translation>Linjeförskjutning</translation>
-    </message>
-    <message>
-        <source>Offset applied to lightgun vertical position.</source>
-        <translation>Förskjutning som tillämpas på ljuspistolens vertikala position.</translation>
-    </message>
-    <message>
-        <source>Tick Offset</source>
-        <translation>Tick-förskjutning</translation>
-    </message>
-    <message>
-        <source>Offset applied to lightgun horizontal position.</source>
-        <translation>Förskjutning som tillämpas på ljuspistolens horisontella position.</translation>
-    </message>
-</context>
-<context>
     <name>Host</name>
     <message numerus="yes">
+        <location filename="../gamelistwidget.cpp" line="2511"/>
         <source>%n seconds</source>
         <translation>
             <numerusform>%n sekund</numerusform>
@@ -11269,6 +6911,7 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../gamelistwidget.cpp" line="2512"/>
         <source>%n minutes</source>
         <translation>
             <numerusform>%n minut</numerusform>
@@ -11276,6 +6919,7 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../gamelistwidget.cpp" line="2513"/>
         <source>%n hours</source>
         <translation>
             <numerusform>%n timme</numerusform>
@@ -11283,719 +6927,187 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
         </translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="2518"/>
         <source>Today</source>
         <translation>Idag</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="2519"/>
         <source>Yesterday</source>
         <translation>Igår</translation>
     </message>
     <message>
+        <location filename="../gamelistwidget.cpp" line="2520"/>
         <source>Never</source>
         <translation>Aldrig</translation>
-    </message>
-    <message>
-        <source>today</source>
-        <translation>idag</translation>
-    </message>
-    <message>
-        <source>yesterday</source>
-        <translation>igår</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n days ago</source>
-        <comment>Date difference</comment>
-        <translation>
-            <numerusform>%n dag sedan</numerusform>
-            <numerusform>%n dagar sedan</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>on {}</source>
-        <translation>den {}</translation>
-    </message>
-    <message>
-        <source>Now</source>
-        <translation>Nu</translation>
-    </message>
-    <message>
-        <source>now</source>
-        <translation>nu</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n seconds ago</source>
-        <comment>Time difference</comment>
-        <translation>
-            <numerusform>%n sekund sedan</numerusform>
-            <numerusform>%n sekunder sedan</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minutes ago</source>
-        <comment>Time difference</comment>
-        <translation>
-            <numerusform>%n minut sedan</numerusform>
-            <numerusform>%n minuter sedan</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hours ago</source>
-        <comment>Time difference</comment>
-        <translation>
-            <numerusform>%n timme sedan</numerusform>
-            <numerusform>%n timmar sedan</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n weeks ago</source>
-        <comment>Time difference</comment>
-        <translation>
-            <numerusform>%n vecka sedan</numerusform>
-            <numerusform>%n veckor sedan</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n months ago</source>
-        <comment>Time difference</comment>
-        <translation>
-            <numerusform>%n månad sedan</numerusform>
-            <numerusform>%n månader sedan</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n years ago</source>
-        <comment>Time difference</comment>
-        <translation>
-            <numerusform>%n år sedan</numerusform>
-            <numerusform>%n år sedan</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>{} at {}</source>
-        <translation>{} kl. {}</translation>
-    </message>
-    <message>
-        <source>{}h {}m</source>
-        <translation>{}h {}m</translation>
-    </message>
-    <message>
-        <source>{}h {}m {}s</source>
-        <translation>{}h {}m {}s</translation>
-    </message>
-    <message>
-        <source>{}m {}s</source>
-        <translation>{}m {}s</translation>
-    </message>
-    <message>
-        <source>{}s</source>
-        <translation>{}s</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Ingen</translation>
-    </message>
-</context>
-<context>
-    <name>Hotkeys</name>
-    <message>
-        <source>Graphics</source>
-        <translation>Grafik</translation>
-    </message>
-    <message>
-        <source>System</source>
-        <translation>System</translation>
-    </message>
-    <message>
-        <source>Toggle Fullscreen</source>
-        <translation>Växla helskärm</translation>
-    </message>
-    <message>
-        <source>Toggle Pause</source>
-        <translation>Växla paus</translation>
-    </message>
-    <message>
-        <source>Power Off System</source>
-        <translation>Stäng av systemet</translation>
-    </message>
-    <message>
-        <source>Open Pause Menu</source>
-        <translation>Öppna pausmenyn</translation>
-    </message>
-    <message>
-        <source>Open Cheat Settings</source>
-        <translation>Öppna fuskinställningar</translation>
-    </message>
-    <message>
-        <source>Save Screenshot</source>
-        <translation>Spara skärmbild</translation>
-    </message>
-    <message>
-        <source>Record Single Frame GPU Trace</source>
-        <translation>Spela in en bildruta med GPU Trace</translation>
-    </message>
-    <message>
-        <source>Record Multi-Frame GPU Trace</source>
-        <translation>Spela in flera bildrutor med GPU Trace</translation>
-    </message>
-    <message>
-        <source>Toggle Media Capture</source>
-        <translation>Växla mediafångst</translation>
-    </message>
-    <message>
-        <source>Open Achievement List</source>
-        <translation>Öppna lista över prestationer</translation>
-    </message>
-    <message>
-        <source>Open Leaderboard List</source>
-        <translation>Öppna ledartavlelistan</translation>
-    </message>
-    <message>
-        <source>Change Disc</source>
-        <translation>Byt skiva</translation>
-    </message>
-    <message>
-        <source>Swap Memory Card Slots</source>
-        <translation>Byt minneskortsplatser</translation>
-    </message>
-    <message>
-        <source>Frame Step</source>
-        <translation>Stega bildruta</translation>
-    </message>
-    <message>
-        <source>Rewind</source>
-        <translation>Spola tillbaka</translation>
-    </message>
-    <message>
-        <source>Toggle Clock Speed Control (Overclocking)</source>
-        <translation>Växla klockfrekvensstyrning (överklockning)</translation>
-    </message>
-    <message>
-        <source>Increase Emulation Speed</source>
-        <translation>Öka emuleringshastighet</translation>
-    </message>
-    <message>
-        <source>Decrease Emulation Speed</source>
-        <translation>Sänk emuleringshastighet</translation>
-    </message>
-    <message>
-        <source>Reset Emulation Speed</source>
-        <translation>Nollställ emuleringshastighet</translation>
-    </message>
-    <message>
-        <source>Toggle Software Rendering</source>
-        <translation>Växla programvarurendering</translation>
-    </message>
-    <message>
-        <source>Toggle PGXP</source>
-        <translation>Växla PGXP</translation>
-    </message>
-    <message>
-        <source>Increase Resolution Scale</source>
-        <translation>Öka upplösningsskala</translation>
-    </message>
-    <message>
-        <source>Decrease Resolution Scale</source>
-        <translation>Sänk upplösningsskala</translation>
-    </message>
-    <message>
-        <source>Toggle Post-Processing</source>
-        <translation>Växla efterbehandling</translation>
-    </message>
-    <message>
-        <source>Reload Post Processing Shaders</source>
-        <translation>Läs om shaders för efterbehandling</translation>
-    </message>
-    <message>
-        <source>Reload Texture Replacements</source>
-        <translation>Läs om texturersättningar</translation>
-    </message>
-    <message>
-        <source>Toggle Widescreen</source>
-        <translation>Växla bredbild</translation>
-    </message>
-    <message>
-        <source>Toggle PGXP Depth Buffer</source>
-        <translation>Växla PGXP-djupbuffert</translation>
-    </message>
-    <message>
-        <source>Toggle PGXP CPU Mode</source>
-        <translation>Växla CPU-läge för PGXP</translation>
-    </message>
-    <message>
-        <source>Toggle On-Screen Display</source>
-        <translation>Växla On-Screen Display</translation>
-    </message>
-    <message>
-        <source>Restart Game</source>
-        <translation>Starta om spelet</translation>
-    </message>
-    <message>
-        <source>Toggle Audio Capture</source>
-        <translation>Växla ljudfångst</translation>
-    </message>
-    <message>
-        <source>Toggle Video Capture</source>
-        <translation>Växla videofångst</translation>
-    </message>
-    <message>
-        <source>Rotate Display Clockwise</source>
-        <translation>Rotera skärmen medurs</translation>
-    </message>
-    <message>
-        <source>Rotate Display Counterclockwise</source>
-        <translation>Rotera skärmen moturs</translation>
-    </message>
-    <message>
-        <source>Freecam Toggle</source>
-        <translation>Fri kamera växla</translation>
-    </message>
-    <message>
-        <source>Freecam Reset</source>
-        <translation>Fri kamera nollställ</translation>
-    </message>
-    <message>
-        <source>Freecam Move Left</source>
-        <translation>Fri kamera flytta vänster</translation>
-    </message>
-    <message>
-        <source>Freecam Move Right</source>
-        <translation>Fri kamera flytta vänster</translation>
-    </message>
-    <message>
-        <source>Freecam Move Up</source>
-        <translation>Fri kamera flytta upp</translation>
-    </message>
-    <message>
-        <source>Freecam Move Down</source>
-        <translation>Fri kamera flytta ner</translation>
-    </message>
-    <message>
-        <source>Freecam Move Forward</source>
-        <translation>Fri kamera flytta framåt</translation>
-    </message>
-    <message>
-        <source>Freecam Move Backward</source>
-        <translation>Fri kamera flytta bakåt</translation>
-    </message>
-    <message>
-        <source>Freecam Rotate Left</source>
-        <translation>Fri kamera rotera vänster</translation>
-    </message>
-    <message>
-        <source>Freecam Rotate Right</source>
-        <translation>Fri kamera rotera höger</translation>
-    </message>
-    <message>
-        <source>Freecam Rotate Forward</source>
-        <translation>Fri kamera rotera framåt</translation>
-    </message>
-    <message>
-        <source>Freecam Rotate Backward</source>
-        <translation>Fri kamera rotera bakåt</translation>
-    </message>
-    <message>
-        <source>Freecam Roll Left</source>
-        <translation>Fri kamera rulla vänster</translation>
-    </message>
-    <message>
-        <source>Freecam Roll Right</source>
-        <translation>Fri kamera rulla höger</translation>
-    </message>
-    <message>
-        <source>Audio</source>
-        <translation>Ljud</translation>
-    </message>
-    <message>
-        <source>Toggle Mute</source>
-        <translation>Växla tyst ljud</translation>
-    </message>
-    <message>
-        <source>Toggle CD Audio Mute</source>
-        <translation>Växla volym för cd-ljud</translation>
-    </message>
-    <message>
-        <source>Volume Up</source>
-        <translation>Höj volym</translation>
-    </message>
-    <message>
-        <source>Volume Down</source>
-        <translation>Sänk volym</translation>
-    </message>
-    <message>
-        <source>Save States</source>
-        <translation>Sparade tillstånd</translation>
-    </message>
-    <message>
-        <source>Load From Selected Slot</source>
-        <translation>Läs in från vald plats</translation>
-    </message>
-    <message>
-        <source>Save To Selected Slot</source>
-        <translation>Spara till vald plats</translation>
-    </message>
-    <message>
-        <source>Select Previous Save Slot</source>
-        <translation>Välj föregående sparningsplats</translation>
-    </message>
-    <message>
-        <source>Select Next Save Slot</source>
-        <translation>Välj nästa sparningsplats</translation>
-    </message>
-    <message>
-        <source>Save State and Select Next Slot</source>
-        <translation>Spara tillstånd och välj nästa plats</translation>
-    </message>
-    <message>
-        <source>Select Next Slot and Save State</source>
-        <translation>Välj nästa plats och spara tillstånd</translation>
-    </message>
-    <message>
-        <source>Undo Load State</source>
-        <translation>Ångra inläst tillstånd</translation>
-    </message>
-    <message>
-        <source>Load Game State 1</source>
-        <translation>Läs in speltillstånd 1</translation>
-    </message>
-    <message>
-        <source>Save Game State 1</source>
-        <translation>Spara speltillstånd 1</translation>
-    </message>
-    <message>
-        <source>Load Game State 2</source>
-        <translation>Läs in speltillstånd 2</translation>
-    </message>
-    <message>
-        <source>Save Game State 2</source>
-        <translation>Spara speltillstånd 2</translation>
-    </message>
-    <message>
-        <source>Load Game State 3</source>
-        <translation>Läs in speltillstånd 3</translation>
-    </message>
-    <message>
-        <source>Save Game State 3</source>
-        <translation>Spara speltillstånd 3</translation>
-    </message>
-    <message>
-        <source>Load Game State 4</source>
-        <translation>Läs in speltillstånd 4</translation>
-    </message>
-    <message>
-        <source>Save Game State 4</source>
-        <translation>Spara speltillstånd 4</translation>
-    </message>
-    <message>
-        <source>Load Game State 5</source>
-        <translation>Läs in speltillstånd 5</translation>
-    </message>
-    <message>
-        <source>Save Game State 5</source>
-        <translation>Spara speltillstånd 5</translation>
-    </message>
-    <message>
-        <source>Load Game State 6</source>
-        <translation>Läs in speltillstånd 6</translation>
-    </message>
-    <message>
-        <source>Save Game State 6</source>
-        <translation>Spara speltillstånd 6</translation>
-    </message>
-    <message>
-        <source>Load Game State 7</source>
-        <translation>Läs in speltillstånd 7</translation>
-    </message>
-    <message>
-        <source>Save Game State 7</source>
-        <translation>Spara speltillstånd 7</translation>
-    </message>
-    <message>
-        <source>Load Game State 8</source>
-        <translation>Läs in speltillstånd 8</translation>
-    </message>
-    <message>
-        <source>Save Game State 8</source>
-        <translation>Spara speltillstånd 8</translation>
-    </message>
-    <message>
-        <source>Load Game State 9</source>
-        <translation>Läs in speltillstånd 9</translation>
-    </message>
-    <message>
-        <source>Save Game State 9</source>
-        <translation>Spara speltillstånd 9</translation>
-    </message>
-    <message>
-        <source>Load Game State 10</source>
-        <translation>Läs in speltillstånd 10</translation>
-    </message>
-    <message>
-        <source>Save Game State 10</source>
-        <translation>Spara speltillstånd 10</translation>
-    </message>
-    <message>
-        <source>Load Global State 1</source>
-        <translation>Läs in globalt tillstånd 1</translation>
-    </message>
-    <message>
-        <source>Save Global State 1</source>
-        <translation>Spara globalt tillstånd 1</translation>
-    </message>
-    <message>
-        <source>Load Global State 2</source>
-        <translation>Läs in globalt tillstånd 2</translation>
-    </message>
-    <message>
-        <source>Save Global State 2</source>
-        <translation>Spara globalt tillstånd 2</translation>
-    </message>
-    <message>
-        <source>Load Global State 3</source>
-        <translation>Läs in globalt tillstånd 3</translation>
-    </message>
-    <message>
-        <source>Save Global State 3</source>
-        <translation>Spara globalt tillstånd 3</translation>
-    </message>
-    <message>
-        <source>Load Global State 4</source>
-        <translation>Läs in globalt tillstånd 4</translation>
-    </message>
-    <message>
-        <source>Save Global State 4</source>
-        <translation>Spara globalt tillstånd 4</translation>
-    </message>
-    <message>
-        <source>Load Global State 5</source>
-        <translation>Läs in globalt tillstånd 5</translation>
-    </message>
-    <message>
-        <source>Save Global State 5</source>
-        <translation>Spara globalt tillstånd 5</translation>
-    </message>
-    <message>
-        <source>Load Global State 6</source>
-        <translation>Läs in globalt tillstånd 6</translation>
-    </message>
-    <message>
-        <source>Save Global State 6</source>
-        <translation>Spara globalt tillstånd 6</translation>
-    </message>
-    <message>
-        <source>Load Global State 7</source>
-        <translation>Läs in globalt tillstånd 7</translation>
-    </message>
-    <message>
-        <source>Save Global State 7</source>
-        <translation>Spara globalt tillstånd 7</translation>
-    </message>
-    <message>
-        <source>Load Global State 8</source>
-        <translation>Läs in globalt tillstånd 8</translation>
-    </message>
-    <message>
-        <source>Save Global State 8</source>
-        <translation>Spara globalt tillstånd 8</translation>
-    </message>
-    <message>
-        <source>Load Global State 9</source>
-        <translation>Läs in globalt tillstånd 9</translation>
-    </message>
-    <message>
-        <source>Save Global State 9</source>
-        <translation>Spara globalt tillstånd 9</translation>
-    </message>
-    <message>
-        <source>Load Global State 10</source>
-        <translation>Läs in globalt tillstånd 10</translation>
-    </message>
-    <message>
-        <source>Save Global State 10</source>
-        <translation>Spara globalt tillstånd 10</translation>
-    </message>
-    <message>
-        <source>Interface</source>
-        <translation>Gränssnitt</translation>
-    </message>
-    <message>
-        <source>Fast Forward (Hold)</source>
-        <translation>Snabbspola (Håll)</translation>
-    </message>
-    <message>
-        <source>Fast Forward (Toggle)</source>
-        <translation>Snabbspola (Växla)</translation>
-    </message>
-    <message>
-        <source>Turbo (Hold)</source>
-        <translation>Turbo (Håll)</translation>
-    </message>
-    <message>
-        <source>Turbo (Toggle)</source>
-        <translation>Turbo (Växla)</translation>
-    </message>
-    <message>
-        <source>Free Camera</source>
-        <translation>Fri kamera</translation>
-    </message>
-    <message>
-        <source>Debugging</source>
-        <translation>Felsökning</translation>
-    </message>
-    <message>
-        <source>Toggle PGXP Preserve Projection Precision</source>
-        <translation>Växla PGXP bevara projektionsprecision</translation>
-    </message>
-    <message>
-        <source>Toggle VRAM View</source>
-        <translation>Växla VRAM-vy</translation>
-    </message>
-    <message>
-        <source>Switch to Previous Disc</source>
-        <translation>Växla till föregående skiva</translation>
-    </message>
-    <message>
-        <source>Switch to Next Disc</source>
-        <translation>Växla till nästa skiva</translation>
-    </message>
-    <message>
-        <source>Toggle Texture Modulation Cropping</source>
-        <translation>Växla beskäring av texturmodulation</translation>
     </message>
 </context>
 <context>
     <name>ISOBrowserWindow</name>
     <message>
+        <location filename="../isobrowserwindow.ui" line="14"/>
         <source>ISO Browser</source>
         <translation>ISO-bläddrare</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="26"/>
         <source>File:</source>
         <translation>Fil:</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="64"/>
+        <location filename="../isobrowserwindow.ui" line="80"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="85"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="90"/>
         <source>Size</source>
         <translation>Storlek</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="114"/>
         <source>Extract</source>
         <translation>Extrahera</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="121"/>
         <source>Extract (XA)</source>
         <translation>Extrahera (XA)</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="128"/>
         <source>Extract (Raw)</source>
         <translation>Extrahera (Raw)</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="135"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="83"/>
         <source>ISO Browser - %1</source>
         <translation>ISO-bläddrare - %1</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="93"/>
         <source>Select File</source>
         <translation>Välj fil</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="168"/>
         <source>&amp;Open</source>
         <translation>Ö&amp;ppna</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="173"/>
         <source>&amp;Extract</source>
         <translation>&amp;Extrahera</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="175"/>
         <source>Extract (&amp;XA)</source>
         <translation>Extrahera (&amp;XA)</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="177"/>
         <source>Extract (&amp;Raw)</source>
         <translation>Extrahera (&amp;Raw)</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="189"/>
         <source>Extract File</source>
         <translation>Extrahera fil</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="337"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.cpp" line="345"/>
         <source>&lt;Parent Directory&gt;</source>
         <translation>&lt;föräldrakatalog&gt;</translation>
     </message>
     <message>
+        <location filename="../isobrowserwindow.ui" line="40"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
-    </message>
-    <message>
-        <source>Extracting {}...</source>
-        <translation>Extraherar {}...</translation>
     </message>
 </context>
 <context>
     <name>InputBindingDialog</name>
     <message>
+        <location filename="../inputbindingdialog.ui" line="14"/>
         <source>Edit Bindings</source>
         <translation>Redigera bindningar</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="20"/>
         <source>Bindings for Controller0/ButtonCircle</source>
         <translation>Bindningar för Kontroller0/ButtonCircle</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="74"/>
         <source>Sensitivity:</source>
         <translation>Känslighet:</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="87"/>
+        <location filename="../inputbindingdialog.ui" line="107"/>
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="94"/>
         <source>Deadzone:</source>
         <translation>Dödläge:</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="148"/>
         <source>Add Binding</source>
         <translation>Lägg till bindning</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="159"/>
         <source>Remove Binding</source>
         <translation>Ta bort bindning</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="170"/>
         <source>Clear Bindings</source>
         <translation>Töm bindningar</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.cpp" line="33"/>
         <source>Bindings for %1:</source>
         <translation>Bindningar för %1:</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.cpp" line="176"/>
+        <location filename="../inputbindingdialog.cpp" line="193"/>
         <source>Push Button/Axis... [%1]</source>
         <translation>Tryckknapp/Axlar... [%1]</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.cpp" line="362"/>
+        <location filename="../inputbindingdialog.cpp" line="386"/>
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="114"/>
         <source>Reset Sensitivity</source>
         <translation>Nollställ känslighet</translation>
     </message>
     <message>
+        <location filename="../inputbindingdialog.ui" line="125"/>
         <source>Reset Deadzone</source>
         <translation>Nollställ dödzon</translation>
     </message>
@@ -12003,20 +7115,24 @@ Söka igenom den rekursivt tar längre tid men identifierar filer i underkatalog
 <context>
     <name>InputBindingWidget</name>
     <message>
+        <location filename="../inputbindingwidgets.cpp" line="116"/>
         <source>Left-click to change binding.
 Shift-click to set multiple bindings.</source>
         <translation>Vänsterklicka för att ändra bindning.
 Skift-klicka för att ställa in flera bindningar.</translation>
     </message>
     <message>
+        <location filename="../inputbindingwidgets.cpp" line="117"/>
         <source>Right-click to remove binding.</source>
         <translation>Högerklicka för att ta bort bindning.</translation>
     </message>
     <message>
+        <location filename="../inputbindingwidgets.cpp" line="123"/>
         <source>No binding set.</source>
         <translation>Ingen bindning inställd.</translation>
     </message>
     <message numerus="yes">
+        <location filename="../inputbindingwidgets.cpp" line="145"/>
         <source>%n bindings</source>
         <translation>
             <numerusform>%n bindning</numerusform>
@@ -12024,575 +7140,384 @@ Skift-klicka för att ställa in flera bindningar.</translation>
         </translation>
     </message>
     <message>
+        <location filename="../inputbindingwidgets.cpp" line="361"/>
+        <location filename="../inputbindingwidgets.cpp" line="378"/>
         <source>Push Button/Axis... [%1]</source>
         <translation>Tryckknapp/Axlar... [%1]</translation>
     </message>
     <message>
+        <location filename="../inputbindingwidgets.cpp" line="499"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../inputbindingwidgets.cpp" line="501"/>
         <source>No devices with vibration motors were detected.</source>
         <translation>Inga enheter med vibrationsmotorer hittades.</translation>
     </message>
     <message>
+        <location filename="../inputbindingwidgets.cpp" line="502"/>
         <source>No devices with LEDs were detected.</source>
         <translation>Inga enheter med LED hittades.</translation>
     </message>
     <message>
+        <location filename="../inputbindingwidgets.cpp" line="519"/>
         <source>&lt;strong&gt;%1&lt;/strong&gt;&lt;br&gt;Select the device and effect to map this bind to.</source>
         <translation>&lt;strong&gt;%1&lt;/strong&gt;&lt;br&gt;Välj enheten och effekten som denna bindning ska mappas till.</translation>
     </message>
 </context>
 <context>
-    <name>InputManager</name>
-    <message>
-        <source>Multiple Devices</source>
-        <translation>Flera enheter</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>Ingen</translation>
-    </message>
-    <message>
-        <source>Keyboard</source>
-        <translation>Tangentbord</translation>
-    </message>
-    <message>
-        <source>Mouse</source>
-        <translation>Mus</translation>
-    </message>
-    <message>
-        <source>Controller {} connected.</source>
-        <translation>Handkontroller {} ansluten.</translation>
-    </message>
-    <message>
-        <source>X</source>
-        <translation>X</translation>
-    </message>
-    <message>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <source>WheelX</source>
-        <translation>HjulX</translation>
-    </message>
-    <message>
-        <source>WheelY</source>
-        <translation>HjulY</translation>
-    </message>
-    <message>
-        <source>LeftButton</source>
-        <translation>Vänsterknapp</translation>
-    </message>
-    <message>
-        <source>RightButton</source>
-        <translation>Högerknapp</translation>
-    </message>
-    <message>
-        <source>MiddleButton</source>
-        <translation>Mittknapp</translation>
-    </message>
-    <message>
-        <source>Keyboard/{}</source>
-        <translation>Tangentbord/{}</translation>
-    </message>
-    <message>
-        <source>Pointer-{0}/{1}</source>
-        <translation>Pekare-{0}/{1}</translation>
-    </message>
-    <message>
-        <source>System paused because controller {} was disconnected.</source>
-        <translation>Systemet pausade därför att kontroller {} kopplades från.</translation>
-    </message>
-</context>
-<context>
     <name>InterfaceSettingsWidget</name>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="29"/>
         <source>Behavior</source>
         <translation>Beteende</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="63"/>
+        <location filename="../interfacesettingswidget.cpp" line="171"/>
         <source>Pause On Focus Loss</source>
         <translation>Pausa när fokus tappas</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="49"/>
+        <location filename="../interfacesettingswidget.cpp" line="167"/>
         <source>Inhibit Screensaver</source>
         <translation>Förhindra skärmsläckare</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="84"/>
+        <location filename="../interfacesettingswidget.cpp" line="179"/>
         <source>Enable Discord Presence</source>
         <translation>Aktivera Discord-närvaro</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="56"/>
+        <location filename="../interfacesettingswidget.cpp" line="174"/>
         <source>Pause On Controller Disconnection</source>
         <translation>Pausa när handkontroller kopplas från</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="77"/>
+        <location filename="../interfacesettingswidget.cpp" line="177"/>
         <source>Start In Big Picture Mode</source>
         <translation>Starta i storbildsläge</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="94"/>
         <source>Game Display</source>
         <translation>Spelskärm</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="100"/>
+        <location filename="../interfacesettingswidget.cpp" line="182"/>
         <source>Start Fullscreen</source>
         <translation>Starta helskärm</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="107"/>
+        <location filename="../interfacesettingswidget.cpp" line="184"/>
         <source>Double-Click Toggles Fullscreen</source>
         <translation>Dubbelklick växlar helskärm</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="114"/>
+        <location filename="../interfacesettingswidget.cpp" line="187"/>
         <source>Render To Separate Window</source>
         <translation>Renderera till separat fönster</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="128"/>
+        <location filename="../interfacesettingswidget.cpp" line="193"/>
         <source>Hide Main Window When Running</source>
         <translation>Dölj huvudmenyn vid körning</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="142"/>
+        <location filename="../interfacesettingswidget.cpp" line="197"/>
         <source>Disable Window Resizing</source>
         <translation>Inaktivera ändring av fönsterstorlek</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="121"/>
+        <location filename="../interfacesettingswidget.cpp" line="190"/>
         <source>Hide Cursor In Fullscreen</source>
         <translation>Dölj markör i helskärm</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="159"/>
         <source>Appearance</source>
         <translation>Utseende</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="188"/>
         <source>Updates</source>
         <translation>Uppdateringar</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="165"/>
         <source>Language:</source>
         <translation>Språk:</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="175"/>
         <source>Theme:</source>
         <translation>Tema:</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="194"/>
         <source>Update Channel:</source>
         <translation>Uppdateringskanal:</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="204"/>
         <source>Current Version:</source>
         <translation>Aktuell version:</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="220"/>
+        <location filename="../interfacesettingswidget.cpp" line="238"/>
         <source>Enable Automatic Update Check</source>
         <translation>Aktivera automatisk uppdateringskontroll</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="240"/>
         <source>Check for Updates...</source>
         <translation>Leta efter uppdateringar...</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="161"/>
+        <location filename="../interfacesettingswidget.cpp" line="163"/>
+        <location filename="../interfacesettingswidget.cpp" line="167"/>
+        <location filename="../interfacesettingswidget.cpp" line="184"/>
+        <location filename="../interfacesettingswidget.cpp" line="187"/>
+        <location filename="../interfacesettingswidget.cpp" line="190"/>
+        <location filename="../interfacesettingswidget.cpp" line="238"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="188"/>
         <source>Renders the display of the simulated console to the main window of the application, over the game list. If checked, the display will render in a separate window.</source>
         <translation>Renderar skärmen för den simulerade konsolen till huvudfönstret för programmet, över spellistan. Om markerad kommer skärmen att rendera i ett separat fönster.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="239"/>
         <source>Automatically checks for updates to the program on startup. Updates can be deferred until later or skipped entirely.</source>
         <translation>Letar automatiskt efter uppdateringar till programmet vid uppstart. Uppdateringar kan fördröjas till senare eller hoppas över helt.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="133"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="168"/>
         <source>Prevents the screen saver from activating and the host from sleeping while emulation is running.</source>
         <translation>Förhindrar att skärmsläckaren aktiveras och att värden går in i viloläge när emulatorn körs.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="176"/>
         <source>Pauses the emulator when a controller with bindings is disconnected.</source>
         <translation>Pausar emulatorn när en handkontoller med bindningar kopplas från.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="110"/>
+        <location filename="../interfacesettingswidget.cpp" line="119"/>
+        <location filename="../interfacesettingswidget.cpp" line="169"/>
+        <location filename="../interfacesettingswidget.cpp" line="171"/>
+        <location filename="../interfacesettingswidget.cpp" line="175"/>
+        <location filename="../interfacesettingswidget.cpp" line="177"/>
+        <location filename="../interfacesettingswidget.cpp" line="179"/>
+        <location filename="../interfacesettingswidget.cpp" line="182"/>
+        <location filename="../interfacesettingswidget.cpp" line="193"/>
+        <location filename="../interfacesettingswidget.cpp" line="195"/>
+        <location filename="../interfacesettingswidget.cpp" line="197"/>
+        <location filename="../interfacesettingswidget.cpp" line="199"/>
+        <location filename="../interfacesettingswidget.cpp" line="205"/>
+        <location filename="../interfacesettingswidget.cpp" line="210"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="172"/>
         <source>Pauses the emulator when you minimize the window or switch to another application, and unpauses when you switch back.</source>
         <translation>Pausar emulatorn när du minimerar fönstret eller byter till ett annat program samt avpausar när du växlar tillbaka.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="183"/>
         <source>Automatically switches to fullscreen mode when a game is started.</source>
         <translation>Ändrar automatiskt till fullskärm när spelet startar.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="191"/>
         <source>Hides the mouse pointer/cursor when the emulator is in fullscreen mode.</source>
         <translation>Döljer muspekaren/markören när emulatorn är i helskärmsläge.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="180"/>
         <source>Shows the game you are currently playing as part of your profile in Discord.</source>
         <translation>Visar spelet som du för närvarande spelar som en del av din profil i Discord.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="35"/>
+        <location filename="../interfacesettingswidget.cpp" line="161"/>
         <source>Confirm Game Close</source>
         <translation>Bekräfta spelavstängning</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="42"/>
+        <location filename="../interfacesettingswidget.cpp" line="163"/>
         <source>Save State On Game Close</source>
         <translation>Spara tillstånd vid spelavstängning</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="162"/>
         <source>Determines whether a prompt will be displayed to confirm closing the game.</source>
         <translation>Bestämmer huruvid en prompt kommer att visas för att bekräfta avstängning av spelet.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="164"/>
         <source>Automatically saves the system state when closing the game or exiting. You can then resume directly from where you left off next time.</source>
         <translation>Sparar automatiskt systemets tillstånd  när du stänger spelet eller stänger av applikationen. Du kan sedan fortsätta direkt där du slutade nästa gång.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="178"/>
         <source>Starts the application in Big Picture Mode instead of the desktop interface.</source>
         <translation>Startar programmet i storbildsläge i stället för skrivbordsgränssnittet.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="185"/>
         <source>Switches between full screen and windowed when the window is double-clicked.</source>
         <translation>Växlar mellan helskärm och fönsterläge när fönstret dubbelklickas.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="194"/>
         <source>Hides the main window of the application while the game is displayed in a separate window.</source>
         <translation>Döljer programmets huvudfönster medan spelet visas i ett separat fönster.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="198"/>
         <source>Prevents resizing of the window while a game is running.</source>
         <translation>Förhindrar storleksändring av fönstret medan ett spel körs.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="216"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="216"/>
         <source>System Language</source>
         <translation>Systemspråk</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="217"/>
         <source>Selects the language for the application. Please note that not all parts of the application may be translated for a given language.</source>
         <translation>Väljer språk för applikationen. Observera att inte alla delar av applikationen kanske är översatta till ett visst språk.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="230"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="231"/>
         <source>Selects the theme for the application.</source>
         <translation>Väljer temat för applikationen.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="233"/>
         <source>Update Channel</source>
         <translation>Uppdateringskanal</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="235"/>
         <source>Selects the channel that will be checked for updates to the application. The &lt;strong&gt;preview&lt;/strong&gt; channel contains the latest changes, and may be unstable. The &lt;strong&gt;latest&lt;/strong&gt; channel tracks the latest release.</source>
         <translation>Väljer den kanal som ska kontrolleras för uppdateringar av applikationen. Kanalen &lt;strong&gt;preview&lt;/strong&gt; innehåller de senaste ändringarna och kan vara instabil. Kanalen &lt;strong&gt;latest&lt;/strong&gt; följer den senaste versionen.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="135"/>
+        <location filename="../interfacesettingswidget.cpp" line="195"/>
         <source>Display System Log In Main Window</source>
         <translation>Visa systemlogg i huvudfönstret</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="149"/>
+        <location filename="../interfacesettingswidget.cpp" line="199"/>
         <source>Automatically Resize Window</source>
         <translation>Storleksändra fönstret automatiskt</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="79"/>
+        <location filename="../interfacesettingswidget.cpp" line="205"/>
         <source>Disable Window Rounded Corners</source>
         <translation>Inaktivera fönster med rundade hörn</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="85"/>
+        <location filename="../interfacesettingswidget.cpp" line="210"/>
         <source>Use Fractional Window Scale</source>
         <translation>Använd fraktionell fönsterskalning</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="104"/>
+        <location filename="../interfacesettingswidget.cpp" line="110"/>
         <source>Use System Font</source>
         <translation>Använd systemteckensnitt</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="111"/>
         <source>Uses the system font for the interface, instead of the bundled Roboto font. Enabling this option may cause some UI elements to not fit within windows.</source>
         <translation>Använder systemets teckensnitt i gränssnittet i stället för det medföljande Roboto-teckensnittet. Alternativet kan göra att vissa gränssnittselement inte ryms i fönstren.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="115"/>
+        <location filename="../interfacesettingswidget.cpp" line="119"/>
         <source>Disable Style Sheets</source>
         <translation>Inaktivera stilmallar</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="120"/>
         <source>Disables the use of style sheets in the application, reverting to the original &apos;Fusion&apos; style but retaining the color scheme.</source>
         <translation>Inaktiverar stilmallar i programmet och återgår till den ursprungliga Fusion-stilen, men behåller färgschemat.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="196"/>
         <source>Displays the log in the main window of the application while a game is running.</source>
         <translation>Visar loggen i huvudfönstret för applikationen när ett spel körs.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="200"/>
         <source>Automatically resizes the window to match the internal resolution. &lt;strong&gt;For high internal resolutions, this will create very large windows.&lt;/strong&gt;</source>
         <translation>Ändrar automatiskt storlek på fönstret så att det matchar den interna upplösningen. &lt;strong&gt;För höga interna upplösningar kommer detta att skapa mycket stora fönster.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="206"/>
         <source>Disables the rounding of windows automatically applied in Windows 11, which may obscure parts of the content.</source>
         <translation>Inaktiverar den automatiska avrundningen av fönster i Windows 11, som kan dölja delar av innehållet.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="211"/>
         <source>Calculates the true scaling factor for your display, avoiding the downsampling applied by MacOS.</source>
         <translation>Beräknar den verkliga skalningsfaktorn för din skärm och undviker den nedsampling som tillämpas av MacOS.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.ui" line="70"/>
+        <location filename="../interfacesettingswidget.cpp" line="169"/>
         <source>Disable Background Input</source>
         <translation>Inaktivera bakgrundsinmatning</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="170"/>
         <source>Prevents inputs from being processed when another application is active.</source>
         <translation>Förhindrar att inmatningar behandlas när en annan applikation är aktiv.</translation>
     </message>
 </context>
 <context>
-    <name>JogCon</name>
-    <message>
-        <source>Failed to create force feedback device for Port {}:
-{}</source>
-        <translation>Misslyckades med att skapa force feedback-enhet för port {}:
-{}</translation>
-    </message>
-    <message>
-        <source>D-Pad Up</source>
-        <translation>Riktningsknapp upp</translation>
-    </message>
-    <message>
-        <source>D-Pad Right</source>
-        <translation>Riktningsknapp höger</translation>
-    </message>
-    <message>
-        <source>D-Pad Down</source>
-        <translation>Riktningsknapp ner</translation>
-    </message>
-    <message>
-        <source>D-Pad Left</source>
-        <translation>Riktningsknapp vänster</translation>
-    </message>
-    <message>
-        <source>Triangle</source>
-        <translation>Triangel</translation>
-    </message>
-    <message>
-        <source>Circle</source>
-        <translation>Cirkel</translation>
-    </message>
-    <message>
-        <source>Cross</source>
-        <translation>Kryss</translation>
-    </message>
-    <message>
-        <source>Square</source>
-        <translation>Fyrkant</translation>
-    </message>
-    <message>
-        <source>Select</source>
-        <translation>Select</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>L1</source>
-        <translation>L1</translation>
-    </message>
-    <message>
-        <source>R1</source>
-        <translation>R1</translation>
-    </message>
-    <message>
-        <source>L2</source>
-        <translation>L2</translation>
-    </message>
-    <message>
-        <source>R2</source>
-        <translation>R2</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>Läge</translation>
-    </message>
-    <message>
-        <source>Steering Left</source>
-        <translation>Styrning vänster</translation>
-    </message>
-    <message>
-        <source>Steering Right</source>
-        <translation>Styrning höger</translation>
-    </message>
-    <message>
-        <source>Vibration Motor</source>
-        <translation>Vibrationsmotor</translation>
-    </message>
-    <message>
-        <source>Force Feedback Device</source>
-        <translation>Force Feedback-enhet</translation>
-    </message>
-    <message>
-        <source>Analog Deadzone</source>
-        <translation>Analogt dödläge</translation>
-    </message>
-    <message>
-        <source>Sets the analog stick deadzone, i.e. the fraction of the stick movement which will be ignored.</source>
-        <translation>Ställer in dödläget för analoga spaken, alltså den del av spakrörelser som kommer att ignoreras.</translation>
-    </message>
-    <message>
-        <source>Analog Sensitivity</source>
-        <translation>Analog känslighet</translation>
-    </message>
-    <message>
-        <source>Sets the analog stick axis scaling factor. A value between 130% and 140% is recommended when using recent controllers, e.g. DualShock 4, Xbox One Controller.</source>
-        <translation>Ställer in skalningsfaktorn för den analoga spakens axlar. Ett värde mellan 130% och 140% rekommenderas när senare handkontroller används, t.ex. DualShock 4, Xbox One-handkontroller.</translation>
-    </message>
-    <message>
-        <source>Button/Trigger Deadzone</source>
-        <translation>Dödläge för knapp/skjutknapp</translation>
-    </message>
-    <message>
-        <source>Sets the deadzone for activating buttons/triggers, i.e. the fraction of the trigger which will be ignored.</source>
-        <translation>Ställer in dödläget för aktivering av knappar/skjutknappar, alltså den del av knappen som kommer att ignoreras.</translation>
-    </message>
-    <message>
-        <source>Steering Hold Deadzone</source>
-        <translation>Dödläge för styrningshållning</translation>
-    </message>
-    <message>
-        <source>Sets the deadzone for holding the wheel at the set position, i.e. when it will not trigger an effect.</source>
-        <translation>Ställer in dödläget för när ratten hålls på inställd position, t.ex när den inte ska utlösa en effekt.</translation>
-    </message>
-    <message>
-        <source>Mode LED</source>
-        <translation>Mode LED</translation>
-    </message>
-</context>
-<context>
-    <name>Justifier</name>
-    <message>
-        <source>Pointer/Aiming</source>
-        <translation>Pekare/Sikte</translation>
-    </message>
-    <message>
-        <source>Trigger</source>
-        <translation>Skjutknapp</translation>
-    </message>
-    <message>
-        <source>Shoot Offscreen</source>
-        <translation>Skjut utanför skärm</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>Back</source>
-        <translation>Bakåt</translation>
-    </message>
-    <message>
-        <source>Relative Left</source>
-        <translation>Relativ vänster</translation>
-    </message>
-    <message>
-        <source>Relative Right</source>
-        <translation>Relativ höger</translation>
-    </message>
-    <message>
-        <source>Relative Up</source>
-        <translation>Relativ upp</translation>
-    </message>
-    <message>
-        <source>Relative Down</source>
-        <translation>Relativ ner</translation>
-    </message>
-    <message>
-        <source>Crosshair Image Path</source>
-        <translation>Sökväg till korssiktesbild</translation>
-    </message>
-    <message>
-        <source>Path to an image to use as a crosshair/cursor.</source>
-        <translation>Sökväg till en bild att använda som ett korssikte/markör.</translation>
-    </message>
-    <message>
-        <source>Crosshair Image Scale</source>
-        <translation>Skala för korssiktesbild</translation>
-    </message>
-    <message>
-        <source>Scale of crosshair image on screen.</source>
-        <translation>Skala för korssiktesbilden på skärmen.</translation>
-    </message>
-    <message>
-        <source>Cursor Color</source>
-        <translation>Markörfärg</translation>
-    </message>
-    <message>
-        <source>Applies a color to the chosen crosshair images, can be used for multiple players. Specify in HTML/CSS format (e.g. #aabbcc)</source>
-        <translation>Tillämpar en färg till valda korssiktesbilder och kan användas av flera spelare. Ange i HTML/CSS-format (t.ex. #aabbcc)</translation>
-    </message>
-    <message>
-        <source>X Scale</source>
-        <translation>X-skala</translation>
-    </message>
-    <message>
-        <source>Scales X coordinates relative to the center of the screen.</source>
-        <translation>Skalar X-koordinater relativt till centrum av skärmen.</translation>
-    </message>
-    <message>
-        <source>Line Start Offset</source>
-        <translation>Offset för linjestart</translation>
-    </message>
-    <message>
-        <source>Offset applied to lightgun vertical position that the Justifier will first trigger on.</source>
-        <translation>Offset som tillämpas på ljuspistolens vertikala position som din Justifier först kommer att avfyra på.</translation>
-    </message>
-    <message>
-        <source>Line End Offset</source>
-        <translation>Offset för linjeslut</translation>
-    </message>
-    <message>
-        <source>Offset applied to lightgun vertical position that the Justifier will last trigger on.</source>
-        <translation>Offset som tillämpas på ljuspistolens vertikala position som din Justifier senast avfyrar på.</translation>
-    </message>
-    <message>
-        <source>Tick Offset</source>
-        <translation>Tick-offset</translation>
-    </message>
-    <message>
-        <source>Offset applied to lightgun horizontal position that the Justifier will trigger on.</source>
-        <translation>Offset som tillämpas på ljuspistolens horisontella position som din Justifier kommer att avfyras på.</translation>
-    </message>
-    <message>
-        <source>Off-Screen Out-Of-Bounds Frames</source>
-        <translation>Bildruto utanför skärmen utanför gränserna</translation>
-    </message>
-    <message>
-        <source>Number of frames that the Justifier is pointed out-of-bounds for an off-screen shot.</source>
-        <translation>Antal bildrutor som din Justifier siktas på utanför spelplanen för ett skott utanför skärmen.</translation>
-    </message>
-    <message>
-        <source>Off-Screen Trigger Frames</source>
-        <translation>Avtryckarbilder utanför skärmen</translation>
-    </message>
-    <message>
-        <source>Number of frames that the trigger is held for an off-screen shot.</source>
-        <translation>Antal bildrutor som avtryckaren hålls inne för en avfyrning utanför skärmen.</translation>
-    </message>
-    <message>
-        <source>Number of frames that the Justifier is pointed out-of-bounds after the trigger is released, for an off-screen shot.</source>
-        <translation>Antal bildrutor som Justifieraren siktas på utanför gränserna efter att avtryckaren har släppts, för ett skott utanför skärmen.</translation>
-    </message>
-</context>
-<context>
     <name>LogWidget</name>
     <message>
+        <location filename="../logwindow.cpp" line="64"/>
         <source>Dropped %1 log messages, please use file or system console logging.
 </source>
         <translation>Släppte %1 loggmeddelanden, använd loggning till fil eller systemkonsol.
@@ -12602,62 +7527,77 @@ Skift-klicka för att ställa in flera bindningar.</translation>
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../logwindow.cpp" line="301"/>
         <source>Log Window - %1 [%2]</source>
         <translation>Loggfönster - %1 [%2]</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="305"/>
         <source>Log Window</source>
         <translation>Loggfönster</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="328"/>
         <source>&amp;Clear</source>
         <translation>&amp;Töm</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="330"/>
         <source>&amp;Save...</source>
         <translation>&amp;Spara...</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="333"/>
         <source>&amp;Settings</source>
         <translation>I&amp;nställningar</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="336"/>
         <source>Log To &amp;System Console</source>
         <translation>Logga till &amp;systemkonsoll</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="340"/>
         <source>Log To &amp;Debug Console</source>
         <translation>Logga till &amp;felsökningskonsoll</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="344"/>
         <source>Log To &amp;File</source>
         <translation>Logga till &amp;fil</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="350"/>
         <source>Attach To &amp;Main Window</source>
         <translation>Fäst till &amp;huvudfönstret</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="354"/>
         <source>Show &amp;Timestamps</source>
         <translation>Visa &amp;tidsstämplar</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="360"/>
         <source>&amp;Log Level</source>
         <translation>&amp;Loggnivå</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="370"/>
         <source>&amp;Channels</source>
         <translation>&amp;Kanaler</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="413"/>
         <source>Select Log File</source>
         <translation>Välj loggfil</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="413"/>
         <source>Log Files (*.txt)</source>
         <translation>Loggfiler (*.txt)</translation>
     </message>
     <message>
+        <location filename="../logwindow.cpp" line="429"/>
         <source>Log was written to %1.
 </source>
         <translation>Loggen skrevs till %1.
@@ -12667,30 +7607,37 @@ Skift-klicka för att ställa in flera bindningar.</translation>
 <context>
     <name>MAC_APPLICATION_MENU</name>
     <message>
+        <location filename="../qthost.cpp" line="95"/>
         <source>Services</source>
         <translation>Tjänster</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="96"/>
         <source>Hide %1</source>
         <translation>Dölj %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="97"/>
         <source>Hide Others</source>
         <translation>Dölj övriga</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="98"/>
         <source>Show All</source>
         <translation>Visa alla</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="99"/>
         <source>Preferences...</source>
         <translation>Inställningar...</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="100"/>
         <source>Quit %1</source>
         <translation>Avsluta %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="101"/>
         <source>About %1</source>
         <translation>Om %1</translation>
     </message>
@@ -12698,526 +7645,689 @@ Skift-klicka för att ställa in flera bindningar.</translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="../mainwindow.ui" line="23"/>
         <source>&amp;System</source>
         <translation>&amp;System</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="671"/>
+        <location filename="../mainwindow.cpp" line="1392"/>
+        <location filename="../mainwindow.cpp" line="1759"/>
         <source>Change Disc</source>
         <translation>Byt skiva</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="683"/>
         <source>Cheats</source>
         <translation>Fusk</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="897"/>
+        <location filename="../mainwindow.cpp" line="1252"/>
         <source>Load State</source>
         <translation>Läs in tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="83"/>
         <source>S&amp;ettings</source>
         <translation>&amp;Inställningar</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="112"/>
         <source>&amp;Help</source>
         <translation>&amp;Hjälp</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="125"/>
         <source>&amp;Debug</source>
         <translation>Fe&amp;lsök</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="129"/>
         <source>Switch GPU Renderer</source>
         <translation>Byt GPU-renderare</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="134"/>
         <source>Switch CPU Emulation Mode</source>
         <translation>Byt CPU-emuleringsläge</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="139"/>
         <source>Switch Crop Mode</source>
         <translation>Byt beskäringsläge</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="144"/>
         <source>Log Level</source>
         <translation>Loggnivå</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="149"/>
         <source>Log Channels</source>
         <translation>Loggkanaler</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="45"/>
+        <location filename="../mainwindow.ui" line="438"/>
         <source>&amp;Load State</source>
         <translation>&amp;Läs in tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="450"/>
         <source>&amp;Save State</source>
         <translation>&amp;Spara tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="486"/>
         <source>C&amp;onsole</source>
         <translation>K&amp;onsol</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="633"/>
         <source>View Third-Party Notices...</source>
         <translation>Tredjepartslicenser...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="656"/>
         <source>&amp;About DuckStation...</source>
         <translation>&amp;Om DuckStation...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="731"/>
         <source>&amp;Interface</source>
         <translation>&amp;Gränssnitt</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="840"/>
         <source>Show VRAM</source>
         <translation>Visa VRAM</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="848"/>
         <source>Dump CPU to VRAM Copies</source>
         <translation>Dumpa CPU till VRAM-kopior</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="856"/>
         <source>Dump VRAM to CPU Copies</source>
         <translation>Dumpa VRAM till CPU-kopior</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="869"/>
         <source>Dump RAM...</source>
         <translation>Dumpa RAM...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="874"/>
         <source>Dump VRAM...</source>
         <translation>Dumpa VRAM...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="879"/>
         <source>Dump SPU RAM...</source>
         <translation>Dumpa SPU RAM...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="887"/>
         <source>Show GPU State</source>
         <translation>Visa GPU-tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="895"/>
         <source>Show CD-ROM State</source>
         <translation>Visa cd-rom-tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="903"/>
         <source>Show SPU State</source>
         <translation>Visa SPU-tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="911"/>
         <source>Show Timers State</source>
         <translation>Visa tillstånd för timers</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="919"/>
         <source>Show MDEC State</source>
         <translation>Visa MDEC-tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="927"/>
         <source>Show DMA State</source>
         <translation>Visa DMA-tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="894"/>
         <source>Resume</source>
         <translation>Återuppta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="963"/>
         <source>Resumes the last save state created.</source>
         <translation>Återupptar senaste sparade tillståndet som skapats.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1089"/>
         <source>Memory &amp;Card Editor</source>
         <translation>Minneskorts&amp;redigerare</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1101"/>
         <source>CPU D&amp;ebugger</source>
         <translation>CPU-felsöka&amp;re</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1242"/>
+        <location filename="../mainwindow.cpp" line="1462"/>
         <source>Big Picture</source>
         <translation>Storbild</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1266"/>
         <source>Memory &amp;Scanner</source>
         <translation>Minness&amp;kanner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1299"/>
         <source>Media Ca&amp;pture</source>
         <translation>Mediafångs&amp;t</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="193"/>
         <source>&amp;View</source>
         <translation>&amp;Visa</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="154"/>
         <source>CD-ROM Lid Control</source>
         <translation>Styrning av CD-ROM-lucka</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="197"/>
         <source>&amp;Window Size</source>
         <translation>&amp;Fönsterstorlek</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="253"/>
         <source>&amp;Tools</source>
         <translation>Ver&amp;ktyg</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="330"/>
         <source>Start &amp;File...</source>
         <translation>Starta &amp;fil...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="342"/>
         <source>Start &amp;Disc...</source>
         <translation>Starta s&amp;kiva...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="357"/>
         <source>Start &amp;BIOS</source>
         <translation>Starta &amp;BIOS</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="381"/>
         <source>&amp;Rescan All Games</source>
         <translation>Sök ig&amp;enom alla spel igen</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="426"/>
         <source>&amp;Pause</source>
         <translation>&amp;Paus</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="462"/>
         <source>E&amp;xit</source>
         <translation>Avs&amp;luta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="510"/>
         <source>&amp;Controllers</source>
         <translation>Handko&amp;ntroller</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="534"/>
         <source>&amp;Graphics</source>
         <translation>&amp;Grafik</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="597"/>
         <source>&amp;GitHub Repository...</source>
         <translation>&amp;GitHub-förråd...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="609"/>
         <source>&amp;Discord Server...</source>
         <translation>&amp;Discord-server...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="621"/>
         <source>Check for &amp;Updates...</source>
         <translation>Leta e&amp;fter uppdateringar...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="645"/>
         <source>About &amp;Qt...</source>
         <translation>Om &amp;Qt...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="779"/>
+        <location filename="../mainwindow.ui" line="794"/>
         <source>&amp;Settings</source>
         <translation>I&amp;nställningar</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="805"/>
         <source>From File...</source>
         <translation>Från fil...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="813"/>
         <source>From Device...</source>
         <translation>Från enhet...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="821"/>
         <source>From Game List...</source>
         <translation>Från spellista...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="829"/>
         <source>Remove Disc</source>
         <translation>Ta bort skiva</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="936"/>
         <source>&amp;Screenshot</source>
         <translation>&amp;Skärmbild</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="948"/>
         <source>&amp;Memory Cards</source>
         <translation>Minn&amp;eskort</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="215"/>
         <source>&amp;Toolbar</source>
         <translation>Ve&amp;rktygsrad</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2167"/>
         <source>Lock Toolbar</source>
         <translation>Lås verktygsrad</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1029"/>
         <source>&amp;Status Bar</source>
         <translation>Statusra&amp;d</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="719"/>
+        <location filename="../mainwindow.ui" line="1044"/>
         <source>Game &amp;List</source>
         <translation>Spellis&amp;ta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1062"/>
         <source>System &amp;Display</source>
         <translation>Systemskä&amp;rm</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1077"/>
         <source>Game &amp;Properties</source>
         <translation>Spele&amp;genskaper</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1116"/>
         <source>Game &amp;Grid</source>
         <translation>Spelr&amp;utnät</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1155"/>
         <source>Show Titles (Grid View)</source>
         <translation>Visa titlar (rutnätsvy)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1349"/>
         <source>Log Timestamps</source>
         <translation>Logga tidsstämplar</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1365"/>
         <source>Log To System Console</source>
         <translation>Logga till systemkonsol</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1373"/>
         <source>Log To Window</source>
         <translation>Logga till fönster</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1381"/>
         <source>Log To File</source>
         <translation>Logga till fil</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1461"/>
         <source>Start Big Picture Mode</source>
         <translation>Starta storbildsläge</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1993"/>
         <source>%1x Scale</source>
         <translation>%1x skala</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3482"/>
         <source>No containers are available for the current backend.</source>
         <translation>Inga containrar är tillgängliga för den aktuella bakänden.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3499"/>
         <source>%1 Files (*.%2)</source>
         <translation>%1 filer (*.%2)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3164"/>
         <source>Save State For Resume</source>
         <translation>Spara tillstånd för att återuppta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1182"/>
+        <location filename="../mainwindow.cpp" line="1271"/>
+        <location filename="../mainwindow.cpp" line="1367"/>
+        <location filename="../mainwindow.cpp" line="1657"/>
+        <location filename="../mainwindow.cpp" line="3430"/>
+        <location filename="../mainwindow.cpp" line="3447"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="111"/>
         <source>All File Types (*.bin *.img *.iso *.cue *.chd *.cpe *.ecm *.mds *.pbp *.ccd *.elf *.exe *.psexe *.ps-exe *.psx *.psf *.minipsf *.m3u *.psxgpu);;Single-Track Raw Images (*.bin *.img *.iso);;Cue Sheets (*.cue);;MAME CHD Images (*.chd);;Error Code Modeler Images (*.ecm);;Media Descriptor Sidecar Images (*.mds);;CloneCD Images (*.ccd);;PlayStation EBOOTs (*.pbp *.PBP);;PlayStation Executables (*.cpe *.elf *.exe *.psexe *.ps-exe, *.psx);;Portable Sound Format Files (*.psf *.minipsf);;Playlists (*.m3u);;PSX GPU Dumps (*.psxgpu *.psxgpu.zst *.psxgpu.xz)</source>
         <translation>Alla filtyper (*.bin *.img *.iso *.cue *.chd *.cpe *.ecm *.mds *.pbp *.ccd *.elf *.exe *.psexe *.ps-exe *.psx *.psf *.minipsf *.m3u *.psxgpu);;Råa enkelspårsavbilder (*.bin *.img *.iso);;Cue-ark (*.cue);;MAME CHD-avbilder (*.chd);;Error Code Modeler-avbilder (*.ecm);;Media Descriptor-sidofiler (*.mds);;CloneCD-avbilder (*.ccd);;PlayStation EBOOT-filer (*.pbp *.PBP);;Körbara PlayStation-filer (*.cpe *.elf *.exe *.psexe *.ps-exe, *.psx);;Portable Sound Format-filer (*.psf *.minipsf);;Spellistor (*.m3u);;PSX GPU-dumpar (*.psxgpu *.psxgpu.zst *.psxgpu.xz)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="723"/>
         <source>Could not find any CD-ROM devices. Please ensure you have a CD-ROM drive connected and sufficient permissions to access it.</source>
         <translation>Kunde inte hitta några cd-rom-enheter. Försäkra dig om att du har en cd-rom-enhet ansluten och tillräckliga rättigheter att komma åt den.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="737"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="913"/>
         <source>Resume (%1)</source>
         <translation>Återuppta (%1)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="920"/>
+        <location filename="../mainwindow.cpp" line="1009"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Game Save %1 (%2)</source>
         <translation>Sparat spel %1 (%2)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="932"/>
         <source>Edit Memory Cards...</source>
         <translation>Redigera minneskort...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="955"/>
         <source>Confirm Save State Deletion</source>
         <translation>Bekräfta borttagning av sparat tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="990"/>
+        <location filename="../mainwindow.cpp" line="1043"/>
         <source>Save States (*.sav)</source>
         <translation>Sparade tillstånd (*.sav)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1009"/>
+        <location filename="../mainwindow.cpp" line="1055"/>
         <source>Game Save %1 (Empty)</source>
         <translation>Sparat spel %1 (Tom)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1018"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Global Save %1 (%2)</source>
         <translation>Globalt sparat spel %1 (%2)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1018"/>
+        <location filename="../mainwindow.cpp" line="1064"/>
         <source>Global Save %1 (Empty)</source>
         <translation>Globalt sparat spel %1 (Tom)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1071"/>
         <source>Select Cheats...</source>
         <translation>Välj fusk...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1090"/>
         <source>Cheats are not enabled.</source>
         <translation>Fusk har inte aktiverats.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1095"/>
         <source>&amp;Apply Cheat</source>
         <translation>Tilläm&amp;pa fusk</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1219"/>
         <source>Save was created %1.</source>
         <translation>Sparningen skapades %1.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1462"/>
         <source>Exit Big Picture</source>
         <translation>Avsluta storbildsläge</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1657"/>
         <source>You must select a disc to change discs.</source>
         <translation>Du måste välja en skiva för att byta skivor.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1687"/>
+        <location filename="../mainwindow.cpp" line="1768"/>
         <source>Properties...</source>
         <translation>Egenskaper...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1697"/>
         <source>Open Containing Directory...</source>
         <translation>Öppna överliggande katalog...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1704"/>
         <source>Browse ISO...</source>
         <translation>Bläddra ISO...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1715"/>
+        <location filename="../mainwindow.cpp" line="1776"/>
         <source>Set Cover Image...</source>
         <translation>Ange omslagsbild...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1796"/>
         <source>Exclude From List</source>
         <translation>Exkludera från lista</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1801"/>
         <source>Reset Play Time</source>
         <translation>Nollställ spelad tid</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2734"/>
+        <location filename="../mainwindow.cpp" line="2742"/>
+        <location filename="../mainwindow.cpp" line="2750"/>
         <source>Destination File</source>
         <translation>Målfil</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2734"/>
+        <location filename="../mainwindow.cpp" line="2750"/>
         <source>Binary Files (*.bin)</source>
         <translation>Binärfiler (*.bin)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2742"/>
         <source>Binary Files (*.bin);;PNG Images (*.png)</source>
         <translation>Binärfiler (*.bin);;PNG-bilder (*.png)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3270"/>
+        <location filename="../mainwindow.cpp" line="3281"/>
+        <location filename="../mainwindow.cpp" line="3305"/>
+        <location filename="../mainwindow.cpp" line="3314"/>
         <source>Memory Card Not Found</source>
         <translation>Minneskortet hittades inte</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3271"/>
         <source>Memory card &apos;%1&apos; does not exist. Do you want to create an empty memory card?</source>
         <translation>Minneskortet &apos;%1&apos; finns inte. Vill du skapa ett tomt minneskort?</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3282"/>
         <source>Failed to create memory card &apos;%1&apos;: %2</source>
         <translation>Misslyckades med att skapa minneskort &apos;%1&apos;: %2</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3306"/>
+        <location filename="../mainwindow.cpp" line="3315"/>
         <source>Memory card &apos;%1&apos; could not be found. Try starting the game and saving to create it.</source>
         <translation>Minneskortet &apos;%1&apos; kunde inte hittas. Prova att starta spelet och spara för att skapa det.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3332"/>
         <source>RA: Logged in as %1 (%2 points, %3 casual). %4 unread messages.</source>
         <translation>RA: Inloggad som %1 (%2 poäng, %3 avslappnat). %4 olästa meddelanden.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3432"/>
         <source>RA: Updated achievement game database.</source>
         <translation>RA: Prestationsdatabasen har uppdaterats.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3511"/>
         <source>Media Capture</source>
         <translation>Mediafångst</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1729"/>
         <source>Default Boot</source>
         <translation>Standarduppstart</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1733"/>
         <source>Fast Boot</source>
         <translation>Snabb uppstart</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1739"/>
         <source>Full Boot</source>
         <translation>Fullständig uppstart</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1747"/>
         <source>Boot and Debug</source>
         <translation>Uppstart och felsökning</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1814"/>
         <source>Add Search Directory...</source>
         <translation>Lägg till sökkatalog...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="345"/>
+        <location filename="../mainwindow.cpp" line="1352"/>
         <source>Start Disc</source>
         <translation>Starta skiva</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="709"/>
+        <location filename="../mainwindow.cpp" line="1377"/>
         <source>Select Disc Image</source>
         <translation>Välj skivavbild</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="618"/>
         <source>Paused</source>
         <translation>Pausad</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1461"/>
         <source>Stop Big Picture Mode</source>
         <translation>Stoppa storbildsläge</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="741"/>
         <source>Select disc drive:</source>
         <translation>Välj skivenhet:</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1823"/>
         <source>Select Cover Image</source>
         <translation>Välj skivomslag</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1842"/>
         <source>Cover Already Exists</source>
         <translation>Omslaget finns redan</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1843"/>
         <source>A cover image for this game already exists, do you wish to replace it?</source>
         <translation>En omslagsbild för detta spel finns redan. Vill du ersätta den?</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1837"/>
+        <location filename="../mainwindow.cpp" line="1852"/>
+        <location filename="../mainwindow.cpp" line="1858"/>
+        <location filename="../mainwindow.cpp" line="1864"/>
         <source>Copy Error</source>
         <translation>Kopieringsfel</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1853"/>
         <source>Failed to remove existing cover &apos;%1&apos;</source>
         <translation>Misslyckades med att ta bort befintligt omslag &apos;%1&apos;</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1859"/>
         <source>Failed to copy &apos;%1&apos; to &apos;%2&apos;</source>
         <translation>Misslyckades med att kopiera &apos;%1&apos; till &apos;%2&apos;</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1865"/>
         <source>Failed to remove &apos;%1&apos;</source>
         <translation>Misslyckades med att ta bort &apos;%1&apos;</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1875"/>
         <source>Confirm Reset</source>
         <translation>Bekräfta omstart</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1838"/>
         <source>You must select a different file to the current cover image.</source>
         <translation>Du måste välja en annan fil för den aktuella omslagsbilden.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1876"/>
         <source>Are you sure you want to reset the play time for &apos;%1&apos;?
 
 This action cannot be undone.</source>
@@ -13226,34 +8336,47 @@ This action cannot be undone.</source>
 Denna åtgärd kan inte ångras.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1199"/>
         <source>Load Resume State</source>
         <translation>Läs in återställt tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1170"/>
+        <location filename="../mainwindow.cpp" line="1253"/>
         <source>Fresh Boot</source>
         <translation>Fräsch uppstart</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1171"/>
+        <location filename="../mainwindow.cpp" line="1254"/>
         <source>Delete And Boot</source>
         <translation>Ta bort och starta upp</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1183"/>
+        <location filename="../mainwindow.cpp" line="1272"/>
         <source>Failed to delete save state file &apos;%1&apos;.</source>
         <translation>Misslyckades med att ta bort sparad tillståndfil: &apos;%1&apos;.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="988"/>
         <source>Load From File...</source>
         <translation>Läs in från fil...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="990"/>
+        <location filename="../mainwindow.cpp" line="1043"/>
         <source>Select Save State File</source>
         <translation>Välj fil för sparat tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1000"/>
         <source>Undo Load State</source>
         <translation>Ångra inläst tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="956"/>
         <source>Are you sure you want to delete all save states for %1?
 
 The saves will not be recoverable.</source>
@@ -13262,98 +8385,122 @@ The saves will not be recoverable.</source>
 Detta går inte att ångra.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1038"/>
         <source>Save To File...</source>
         <translation>Spara till fil...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1327"/>
         <source>Confirm Disc Change</source>
         <translation>Bekräfta skivbyte</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1331"/>
         <source>Swap Disc</source>
         <translation>Växla skiva</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="22"/>
         <source>Native</source>
         <translation>Inbyggd</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="24"/>
         <source>Classic Windows</source>
         <translation>Classic Windows</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="26"/>
         <source>Fusion</source>
         <translation>Fusion</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="27"/>
         <source>Dark Fusion (Gray)</source>
         <translation>Dark Fusion (Grå)</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="28"/>
         <source>Dark Fusion (Blue)</source>
         <translation>Dark Fusion (Blå)</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="31"/>
         <source>Cobalt Sky</source>
         <translation>Cobalt Sky</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="32"/>
         <source>Grey Matter</source>
         <translation>Grey Matter</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="35"/>
         <source>Dark Ocean</source>
         <translation>Mörkt hav</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="36"/>
         <source>Dark Ruby</source>
         <translation>Dark Ruby</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="37"/>
         <source>Purple Rain</source>
         <translation>Purple Rain</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="38"/>
         <source>QDarkStyle</source>
         <translation>QDarkStyle</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="34"/>
         <source>Pinky Pals</source>
         <translation>Pinky Pals</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="30"/>
         <source>AMOLED</source>
         <translation>AMOLED</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="33"/>
         <source>Green Giant</source>
         <translation>Gröna jätten</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="119"/>
         <source>Images (*.jpg *.jpeg *.png *.webp)</source>
         <translation>Bilder (*.jpg *.jpeg *.png *.webp)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2931"/>
         <source>Select Background Image</source>
         <translation>Välj bakgrundsbild</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1468"/>
         <source>Refresh Achievement &amp;Progress</source>
         <translation>Uppdatera prestationsfra&amp;msteg</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3449"/>
         <source>RA: Updated achievement progress database.</source>
         <translation>RA: Framstegsdatabasen för prestationer uppdaterades.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="949"/>
         <source>Delete Save States</source>
         <translation>Ta bort sparade tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="997"/>
         <source>Undo Load State (%1)</source>
         <translation>Ångra inläsning av tillstånd (%1)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>A resume save state was found for this game, but it is corrupted and cannot be loaded:
 
 %1
@@ -13366,950 +8513,926 @@ Do you want to delete the save state and boot the game anyway?</source>
 Vill du ta bort det sparade tillståndet och starta spelet ändå?</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1328"/>
         <source>Do you want to swap discs or boot the new image via system restart?</source>
         <translation>Vill du byta skiva eller starta den nya avbilden genom att starta om systemet?</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1367"/>
         <source>No resume save state found.</source>
         <translation>Inget återupptagningsbart sparat tillstånd hittades.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1791"/>
         <source>Select Disc...</source>
         <translation>Välj skiva...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2172"/>
         <source>Small Icons</source>
         <translation>Små ikoner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2177"/>
         <source>Show Labels</source>
         <translation>Visa etiketter</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2182"/>
         <source>Labels Beside Icons</source>
         <translation>Etiketter bredvid ikoner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1357"/>
         <source>Log File Timestamps</source>
         <translation>Tidsstämplar för loggfil</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="71"/>
         <source>Top</source>
         <translation>Överst</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="72"/>
         <source>Bottom</source>
         <translation>Nederst</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="73"/>
         <source>Left</source>
         <translation>Vänster</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="74"/>
         <source>Right</source>
         <translation>Höger</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="2188"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1167"/>
         <source>Zoom &amp;In</source>
         <translation>Zooma &amp;in</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1179"/>
         <source>Zoom &amp;Out</source>
         <translation>Zooma &amp;ut</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="206"/>
         <source>Sort B&amp;y</source>
         <translation>Sortera e&amp;fter</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="27"/>
         <source>Cha&amp;nge Disc</source>
         <translation>&amp;Byt skiva</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="36"/>
         <source>&amp;Cheats</source>
         <translation>&amp;Fusk</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="54"/>
         <source>Sa&amp;ve State</source>
         <translation>Spara &amp;tillstånd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="257"/>
         <source>Allows you to record audio and/or video from the content.</source>
         <translation>Gör det möjligt att spela in ljud och/eller video från innehållet.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="260"/>
         <source>Media Capt&amp;ure</source>
         <translation>Mediafån&amp;gst</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="333"/>
         <source>Starts a new session using the selected file.</source>
         <translation>Startar en ny session med den valda filen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="348"/>
         <source>Starts a new session from a physical disc.</source>
         <translation>Startar en ny session från en fysisk skiva.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="360"/>
         <source>Starts a new session without any disc inserted.</source>
         <translation>Startar en ny session utan att någon skiva är isatt.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="369"/>
         <source>Scan &amp;For New Games</source>
         <translation>Sök &amp;efter nya spel</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="372"/>
         <source>Searches for new games added since the last refresh.</source>
         <translation>Söker efter nya spel som lagts till sedan senaste uppdateringen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="384"/>
         <source>Rescans all games, discarding any cached information.</source>
         <translation>Söker igenom alla spel igen och raderar all cachad information.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="399"/>
         <source>Ends the current session.</source>
         <translation>Avslutar den aktuella sessionen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="408"/>
         <source>&amp;Restart Game</source>
         <translation>&amp;Starta om spelet</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="411"/>
+        <location filename="../mainwindow.cpp" line="1332"/>
         <source>Restart</source>
         <translation>Starta om</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="414"/>
         <source>Restarts the emulated system.</source>
         <translation>Startar om det emulerade systemet.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="429"/>
         <source>Pauses/resumes the session.</source>
         <translation>Pausar/återupptar sessionen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="441"/>
         <source>Restores the session state from the selected slot.</source>
         <translation>Återställer sessionens tillstånd från den valda platsen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="465"/>
         <source>Exits the application.</source>
         <translation>Avslutar applikationen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="474"/>
         <source>&amp;BIOS</source>
         <translation>&amp;BIOS</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="477"/>
         <source>Configures where the system firmware is located.</source>
         <translation>Konfigurerar var systemets fasta programvara finns.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="489"/>
         <source>Configures options related to the simulated console.</source>
         <translation>Konfigurerar alternativ relaterade till den simulerade konsolen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="498"/>
         <source>&amp;Emulation</source>
         <translation>&amp;Emulering</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="501"/>
         <source>Configures options related to the simulation.</source>
         <translation>Konfigurerar alternativ relaterade till simuleringen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="513"/>
         <source>Configures options and bindings for the emulated controllers.</source>
         <translation>Konfigurerar alternativ och bindningar för de emulerade kontrollerna.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="522"/>
         <source>Hot&amp;keys</source>
         <translation>Snabb&amp;tangenter</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="525"/>
         <source>Configures shortcut keys for actions related to the session.</source>
         <translation>Konfigurerar genvägstangenter för åtgärder relaterade till sessionen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="537"/>
         <source>Configures options related to how the session content is displayed.</source>
         <translation>Konfigurerar alternativ relaterade till hur sessionens innehåll visas.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="546"/>
         <source>Post-Processi&amp;ng</source>
         <translation>Efterbehandli&amp;ng</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="549"/>
         <source>Configures post-processing effects applied after rendering the content.</source>
         <translation>Konfigurerar efterbearbetningseffekter som tillämpas efter rendering av innehållet.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="558"/>
         <source>On-&amp;Screen Display</source>
         <translation>&amp;Skärmvisning</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="561"/>
         <source>These options determine the behavior of the messages that are displayed while content is running.</source>
         <translation>Dessa alternativ bestämmer hur meddelanden som visas medan innehåll körs ska fungera.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="570"/>
         <source>Capt&amp;ure</source>
         <translation>Fån&amp;ga</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="573"/>
         <source>These options determine how screenshots and videos are captured by the application.</source>
         <translation>Dessa alternativ bestämmer hur programmet tar skärmbilder och spelar in video.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="585"/>
         <source>&amp;Fullscreen</source>
         <translation>&amp;Helskärm</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="588"/>
         <source>Switches between fullscreen and windowed modes.</source>
         <translation>Växlar mellan helskärm och fönsterlägen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="600"/>
         <source>Opens a link to the GitHub repository for the application.</source>
         <translation>Öppnar en länk till GitHub-arkivet för applikationen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="612"/>
         <source>Opens a link to the Discord server for the application.</source>
         <translation>Öppnar en länk till Discord-servern för applikationen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="624"/>
         <source>Checks if any application updates are available for download.</source>
         <translation>Kontrollerar om det finns några programuppdateringar tillgängliga att hämta ner.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="636"/>
         <source>Shows copyright and license notices for third-party libraries included with the application.</source>
         <translation>Visar upphovsrätts- och licensmeddelanden för tredjepartsbibliotek som ingår i applikationen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="648"/>
         <source>Displays copyright and license notices for Qt.</source>
         <translation>Visar upphovsrätts- och licensmeddelanden för Qt.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="659"/>
         <source>Displays copyright and license notices for the application.</source>
         <translation>Visar upphovsrätts- och licensmeddelanden för applikationen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="674"/>
         <source>Swaps the currently-inserted disc with another disc or game.</source>
         <translation>Byter ut den skiva som för närvarande är isatt mot en annan skiva eller ett annat spel.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="686"/>
         <source>Shows the list of cheats available for this game.</source>
         <translation>Visar listan över fusk tillgängliga för detta spel.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="695"/>
         <source>&amp;Audio</source>
         <translation>&amp;Ljud</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="698"/>
         <source>Configures options related to how audio from the content is played.</source>
         <translation>Konfigurerar alternativ relaterade till hur ljud från innehållet spelas upp.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="707"/>
         <source>Ac&amp;hievements</source>
         <translation>Pres&amp;tationer</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="710"/>
         <source>Configures options related to RetroAchievements.</source>
         <translation>Konfigurerar alternativ relaterade till RetroAchievements.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="722"/>
         <source>Configures the locations where the application will search for game files.</source>
         <translation>Konfigurerar de platser där programmet ska söka efter spelfiler.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="734"/>
         <source>Configures options related to the apperance and behavior of the application.</source>
         <translation>Konfigurerar alternativ relaterade till applikationens utseende och beteende.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="746"/>
         <source>Configures advanced options for the application.</source>
         <translation>Konfigurerar avancerade alternativ för applikationen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="758"/>
         <source>Configures internal options for the application.</source>
         <translation>Konfigurerar programmets interna alternativ.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="767"/>
         <source>Add Game Director&amp;y...</source>
         <translation>Lägg till spel&amp;katalog...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="770"/>
         <source>Adds a new directory that will be searched for game files.</source>
         <translation>Lägger till en ny katalog som kommer att sökas igenom efter spelfiler.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="782"/>
+        <location filename="../mainwindow.ui" line="797"/>
         <source>Opens the settings window.</source>
         <translation>Öppnar inställningsfönstret.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="808"/>
         <source>Manually selects the disc image file to switch to.</source>
         <translation>Väljer manuellt den skivavbildningsfil som ska växlas till.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="816"/>
         <source>Switches to a physical disc.</source>
         <translation>Växlar till en fysisk skiva.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="824"/>
         <source>Switches to a disc in the game list.</source>
         <translation>Växlar till en skiva i spellistan.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="832"/>
         <source>Removes the disc from the emulated system.</source>
         <translation>Tar bort skivan från det emulerade systemet.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="939"/>
         <source>Takes a screenshot of the current content.</source>
         <translation>Tar en skärmbild på aktuellt innehåll.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="951"/>
         <source>Configures options related to the emulated memory cards.</source>
         <translation>Konfigurerar alternativ relaterade till emulerade minneskort.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="974"/>
         <source>Controls whether the toolbar is visible.</source>
         <translation>Kontrollerar om verktygsfältet ska visas.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="982"/>
         <source>Loc&amp;k Toolbar</source>
         <translation>Lå&amp;s verktygsrad</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="985"/>
         <source>Controls whether the toolbar can be moved.</source>
         <translation>Kontrollerar om verktygsfältet kan flyttas.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="996"/>
         <source>Controls whether the smaller toolbar icons are displayed.</source>
         <translation>Kontrollerar om de mindre verktygsfältikonerna visas.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1007"/>
         <source>Controls whether labels are displayed alongside toolbar icons.</source>
         <translation>Kontrollerar om etiketter visas bredvid verktygsfältets ikoner.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1018"/>
         <source>Controls whether labels are displayed next to or under toolbar icons.</source>
         <translation>Kontrollerar om etiketter visas bredvid eller under verktygsfältets ikoner.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1032"/>
         <source>Controls whether the status bar is visible.</source>
         <translation>Kontrollerar om statusfältet är synligt.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1047"/>
         <source>Switches to the list of available games in table view.</source>
         <translation>Växlar till listan över tillgängliga spel i tabellvy.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1065"/>
         <source>Switches back to the game currently running.</source>
         <translation>Växlar tillbaka till det spel som för närvarande körs.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1080"/>
         <source>Opens the configuration for the game currently running.</source>
         <translation>Öppnar konfigurationen för spelet som körs för närvarande.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1092"/>
         <source>Opens the memory card editor.</source>
         <translation>Öppnar minneskortsredigeraren.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1104"/>
         <source>Opens the debugger for the emulated CPU.</source>
         <translation>Öppnar felsökaren för den emulerade CPU:n.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1119"/>
         <source>Switches to the list of available games in grid/cover view.</source>
         <translation>Växlar till listan över tillgängliga spel i rutnät-/omslagsvy.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1134"/>
         <source>&amp;Merge Multi-Disc Games</source>
         <translation>Slå samman spel &amp;på flera skivor</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1137"/>
         <source>Merges multiple discs that belong to the same game into a single item in the game list.</source>
         <translation>Slår samman flera skivor som tillhör samma spel till ett enda objekt i spellistan.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1453"/>
         <source>Clear List Backgro&amp;und</source>
         <translation>Töm listbakgr&amp;und</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1483"/>
         <source>Refresh &amp;Achievement Database</source>
         <translation>Uppdatera &amp;prestationsdatabas</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1528"/>
         <source>&amp;Animate Game Icons</source>
         <translation>&amp;Animera spelikoner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1543"/>
         <source>Prefer Ac&amp;hievement Icons</source>
         <translation>Föredra prestations&amp;ikoner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1561"/>
         <source>Syst&amp;em Log</source>
         <translation>System&amp;logg</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1573"/>
         <source>Start &amp;Capture</source>
         <translation>Starta &amp;fångst</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1576"/>
         <source>Starts recording audio and video.</source>
         <translation>Startar inspelning av ljud och video.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1585"/>
         <source>Stop &amp;Capture</source>
         <translation>Stoppa &amp;fångst</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1597"/>
         <source>Start &amp;Video-Only Capture</source>
         <translation>Starta &amp;videofångst (endast video)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1600"/>
         <source>Starts a video-only recording.</source>
         <translation>Startar en inspelning med endast video.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1612"/>
         <source>Start &amp;Audio-Only Capture</source>
         <translation>Starta &amp;ljudfångst (endast ljud)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1615"/>
         <source>Starts an audio-only recording.</source>
         <translation>Startar en inspelning med endast ljud.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1627"/>
         <source>Automatic</source>
         <translation>Automatisk</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1635"/>
         <source>Closed</source>
         <translation>Stängd</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1643"/>
         <source>Open</source>
         <translation>Öppen</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1158"/>
         <source>Shows captions under the game cover in grid view.</source>
         <translation>Visar bildtexter under spelomslaget i rutnätvy.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="743"/>
         <source>Ad&amp;vanced</source>
         <translation>Avance&amp;rat</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="755"/>
         <source>&amp;Debugging</source>
         <translation>&amp;Felsökning</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="864"/>
         <source>Enable &amp;Safe Mode</source>
         <translation>Aktivera &amp;säkert läge</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="960"/>
         <source>Res&amp;ume</source>
         <translation>Återup&amp;pta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="971"/>
         <source>&amp;Show Toolbar</source>
         <translation>&amp;Visa verktygsrad</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="993"/>
         <source>S&amp;mall Icons</source>
         <translation>S&amp;må ikoner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1004"/>
         <source>Show &amp;Labels</source>
         <translation>Visa &amp;etiketter</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1015"/>
         <source>Show Labels &amp;Beside Icons</source>
         <translation>Visa etiketter &amp;bredvid ikoner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1152"/>
         <source>Show Grid Ca&amp;ptions</source>
         <translation>Visa rutnätste&amp;xter</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1170"/>
         <source>Increases the size of game icons or covers.</source>
         <translation>Ökar storleken på spelikonerna eller omslag.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1182"/>
         <source>Decreases the size of game icons or covers.</source>
         <translation>Minskar storleken på spelikonerna eller omslag.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1191"/>
         <source>&amp;Refresh Grid Covers</source>
         <translation>&amp;Uppdatera rutnätsomslag</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1194"/>
         <source>Invalidates the cache of game covers, allowing new images to be discovered.</source>
         <translation>Invaliderar cachen för spelomslag, vilket gör det möjligt att upptäcka nya bilder.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1203"/>
         <source>&amp;Open Data Directory...</source>
         <translation>&amp;Öppna datakatalog...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1206"/>
         <source>Opens the directory containing application data in your file browser.</source>
         <translation>Öppnar katalogen som innehåller programdata i din filbläddrare.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1221"/>
         <source>Ends the current session without the option to save state.</source>
         <translation>Avslutar den aktuella sessionen utan möjlighet att spara tillståndet.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1230"/>
         <source>Start Bi&amp;g Picture Mode</source>
         <translation>Starta s&amp;torbildsläge</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1233"/>
+        <location filename="../mainwindow.ui" line="1245"/>
         <source>Opens or closes the controller-based &quot;big picture&quot; mode.</source>
         <translation>Öppnar eller stänger det kontrollerbaserade ”storbildsläget”.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1254"/>
         <source>Cover &amp;Downloader</source>
         <translation>Hämta &amp;omslagsbilder</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1257"/>
         <source>Opens the cover downloader window.</source>
         <translation>Öppnar fönstret för hämtningar av omslag.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1272"/>
         <source>Opens the memory scanner window.</source>
         <translation>Öppnar fönstret för minnesskanner.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1290"/>
         <source>Shows icons from the memory card of each game in list view.</source>
         <translation>Visar ikoner från minneskortet för varje spel i listvy.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1305"/>
         <source>Starts or stops capture of video and audio from the content.</source>
         <translation>Startar eller stoppar inspelning av video och ljud från innehållet.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1314"/>
         <source>Open Te&amp;xture Directory...</source>
         <translation>Öppna te&amp;xturkatalog...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1317"/>
         <source>Opens the directory used to store texture replacements.</source>
         <translation>Öppnar katalogen som används för att lagra texturersättningar.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1326"/>
         <source>&amp;Reload Texture Replacements</source>
         <translation>&amp;Läs om texturersättningar</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1329"/>
         <source>Invalidates the cache of available replacement textures.</source>
         <translation>Invaliderar cachen med tillgängliga ersättningstexturer.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1338"/>
         <source>Capture &amp;GPU Frame</source>
         <translation>Fånga &amp;GPU-bildruta</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1341"/>
         <source>Saves the emulated GPU commands to a file that can be later replayed.</source>
         <translation>Sparar emulerade GPU-kommandona i en fil som senare kan spelas upp igen.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1390"/>
         <source>&amp;ISO Browser</source>
         <translation>&amp;ISO-bläddrare</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1393"/>
         <source>Opens the ISO browser window.</source>
         <translation>Öppnar fönstret för ISO-bläddraren.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1405"/>
         <source>&amp;Free Camera</source>
         <translation>&amp;Fri kamera</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1408"/>
         <source>Allows you to freely move the camera in supported games.</source>
         <translation>Gör det möjligt att fritt flytta kameran i spel som stöder denna funktion.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1417"/>
         <source>Controller &amp;Test</source>
         <translation>Handkontroller&amp;test</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1420"/>
         <source>Allows you to test emulated controller mappings.</source>
         <translation>Gör det möjligt att testa emulerade kontrollermappningar.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1429"/>
         <source>Controller Prese&amp;ts</source>
         <translation>Handkontrollsför&amp;val</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1432"/>
         <source>Creates or edits controller presets that can be applied to games.</source>
         <translation>Skapar eller redigerar förval för kontroller som kan användas i spel.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1441"/>
         <source>&amp;Change List Background...</source>
         <translation>Ä&amp;ndra listbakgrund...</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1444"/>
         <source>Changes the background image shown in the game list/grid.</source>
         <translation>Ändrar bakgrundsbilden som visas i spellistan/rutnätet.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1456"/>
         <source>Removes the background image shown in the game list/grid.</source>
         <translation>Tar bort bakgrundsbilden som visas i spellistan/rutnätet.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1471"/>
         <source>Refreshes the list of unlocked achievements.</source>
         <translation>Uppdaterar listan över upplåsta prestationer.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1486"/>
         <source>Updates the database for achievements shown in the game list.</source>
         <translation>Uppdaterar databasen för prestationer som visas i spellistan.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1498"/>
         <source>Show Locali&amp;zed Titles</source>
         <translation>Visa lokalan&amp;passade titlar</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1501"/>
         <source>Shows titles for games in their native language.</source>
         <translation>Visar titlar på spel på deras ursprungliga språk.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1974"/>
         <source>&amp;Ascending</source>
         <translation>S&amp;tigande</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1982"/>
         <source>&amp;Descending</source>
         <translation>&amp;Fallande</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="453"/>
         <source>Saves the session state to the selected slot.</source>
         <translation>Sparar sessionstillståndet till vald plats.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1510"/>
         <source>Memory &amp;Editor</source>
         <translation>Minnesr&amp;edigerare</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1516"/>
         <source>Opens the memory editor window.</source>
         <translation>Öppnar fönstret för minnesredigeraren.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1531"/>
         <source>Animates icons in the list view when selected.</source>
         <translation>Animerar ikoner i listvyn när de väljs.</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="29"/>
         <source>Darker Fusion</source>
         <translation>Darker Fusion</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="1213"/>
         <source>&lt;strong&gt;Resume Game&lt;/strong&gt;&lt;br&gt;Do you want to load this state, or start from a fresh boot?</source>
         <translation>&lt;strong&gt;Återuppta spel&lt;/strong&gt;&lt;br&gt;Vill du läsa  in detta tillstånd eller starta om från början?</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="393"/>
         <source>Cl&amp;ose Game</source>
         <translation>S&amp;täng spel</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="396"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1215"/>
         <source>Close Game &amp;Without Saving</source>
         <translation>Stäng spelet &amp;utan att spara</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1218"/>
         <source>Close (No Save)</source>
         <translation>Stäng (spara inte)</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1287"/>
         <source>Show Game Ico&amp;ns</source>
         <translation>Visa speliko&amp;ner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1546"/>
         <source>Prioritizes the games badges used for RetroAchievements over memory card icons.</source>
         <translation>Prioriterar spelmärken som används för RetroAchievements istället för minneskortsikoner.</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3159"/>
         <source>Confirm Exit</source>
         <translation>Bekräfta avslut</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3159"/>
         <source>Confirm Close</source>
         <translation>Bekräfta stängning</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3160"/>
         <source>Are you sure you want to exit the application?</source>
         <translation>Är du säker på att du vill avsluta applikationen?</translation>
     </message>
     <message>
+        <location filename="../mainwindow.cpp" line="3161"/>
         <source>Are you sure you want to close the current game?</source>
         <translation>Är du säker på att du vill stänga det aktuella spelet?</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1269"/>
         <source>Scanner</source>
         <translation>Skanner</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1302"/>
         <source>Capture</source>
         <translation>Fånga</translation>
     </message>
     <message>
+        <location filename="../mainwindow.ui" line="1513"/>
         <source>Editor</source>
         <translation>Redigerare</translation>
     </message>
     <message>
+        <location filename="../interfacesettingswidget.cpp" line="312"/>
+        <location filename="../mainwindow.cpp" line="3616"/>
         <source>Checking for updates...</source>
         <translation>Letar efter uppdateringar...</translation>
-    </message>
-    <message>
-        <source>Refresh Achievement Progress</source>
-        <translation>Uppdatera prestationsförlopp</translation>
-    </message>
-</context>
-<context>
-    <name>MediaCapture</name>
-    <message>
-        <source>H.264 with Software Encoding</source>
-        <comment>VideoCodec</comment>
-        <translation>H.264 med programvarukodning</translation>
-    </message>
-    <message>
-        <source>H.264 with Hardware Encoding</source>
-        <comment>VideoCodec</comment>
-        <translation>H.264 med maskinvarukodning</translation>
-    </message>
-    <message>
-        <source>HEVC with Software Encoding</source>
-        <comment>VideoCodec</comment>
-        <translation>HEVC med programvarukodning</translation>
-    </message>
-    <message>
-        <source>HEVC with Hardware Encoding</source>
-        <comment>VideoCodec</comment>
-        <translation>HEVC med maskinvarukodning</translation>
-    </message>
-    <message>
-        <source>Advanced Audio Coding</source>
-        <comment>AudioCodec</comment>
-        <translation>Avancerad ljudkodning</translation>
-    </message>
-    <message>
-        <source>MPEG-2 Audio Layer III</source>
-        <comment>AudioCodec</comment>
-        <translation>MPEG-2 ljudlager III</translation>
-    </message>
-    <message>
-        <source>Uncompressed PCM</source>
-        <comment>AudioCodec</comment>
-        <translation>Okomprimerad PCM</translation>
-    </message>
-    <message>
-        <source>Failed to load Media Foundation libraries: </source>
-        <translation>Misslyckades med att läsa in Media Foundation-bibliotek: </translation>
-    </message>
-    <message>
-        <source>Audio Video Interleave</source>
-        <comment>ContainerFormat</comment>
-        <translation>Audio Video Interleave</translation>
-    </message>
-    <message>
-        <source>MPEG-4 Part 14</source>
-        <comment>ContainerFormat</comment>
-        <translation>MPEG-4 del 14</translation>
-    </message>
-    <message>
-        <source>MPEG-2 Audio Layer III</source>
-        <comment>ContainerFormat</comment>
-        <translation>MPEG-2 ljudlager III</translation>
-    </message>
-    <message>
-        <source>Waveform Audio File Format</source>
-        <comment>ContainerFormat</comment>
-        <translation>Waveform-ljudfilformat</translation>
-    </message>
-    <message>
-        <source>FFmpeg was not found, or is not the correct version.
-You can download FFmpeg from {}.
-This build of DuckStation requires FFmpeg v{}, with library versions:
-  libavcodec: {}
-  libavformat: {}
-  libavutil: {}
-  libswscale: {}
-  libswresample: {}
-</source>
-        <translation>FFmpeg hittades inte eller är inte rätt version.
-Du kan ladda ner FFmpeg från {}.
-Denna version av DuckStation kräver FFmpeg v{}, med följande biblioteksversioner:
-libavcodec: {}
-libavformat: {}
-libavutil: {}
-libswscale: {}
-libswresample: {}
-</translation>
-    </message>
-    <message>
-        <source>Audio codec &apos;{0}&apos; does not support {1} Hz samples, using {2} Hz.</source>
-        <translation>Ljudkodeken &apos;{0}&apos; stöder inte sampling med {1} Hz, använder {2} Hz.</translation>
-    </message>
-    <message>
-        <source>Matroska Media Container</source>
-        <comment>ContainerFormat</comment>
-        <translation>Matroska-mediecontainer</translation>
-    </message>
-    <message>
-        <source>QuickTime File Format</source>
-        <comment>ContainerFormat</comment>
-        <translation>QuickTime-filformat</translation>
-    </message>
-    <message>
-        <source>Media Foundation</source>
-        <comment>MediaCaptureBackend</comment>
-        <translation>Media Foundation</translation>
-    </message>
-    <message>
-        <source>FFmpeg</source>
-        <comment>MediaCaptureBackend</comment>
-        <translation>FFmpeg</translation>
-    </message>
-</context>
-<context>
-    <name>MemoryCard</name>
-    <message>
-        <source>Buffer is empty.</source>
-        <translation>Bufferten är tom.</translation>
-    </message>
-    <message>
-        <source>Insufficient free blocks, {} blocks are needed, but only have {}.</source>
-        <translation>Otillräckligt antal lediga block, {} block behövs men har endast {}.</translation>
-    </message>
-    <message>
-        <source>File name must be at maximum {} characters long.</source>
-        <translation>Filnamn får endast vara maximalt {} tecken långa.</translation>
-    </message>
-    <message>
-        <source>Save file with the same name &apos;{}&apos; already exists in memory card.</source>
-        <translation>Sparad fil med samma namn &apos;{}&apos; finns redan på minneskortet.</translation>
-    </message>
-    <message>
-        <source>File is incorrect size, expected {} bytes, got {} bytes.</source>
-        <translation>Filen har felaktig storlek, förväntade {} bytes, fick {} bytes.</translation>
-    </message>
-    <message>
-        <source>File is incorrect size, expected at least {} bytes, got {} bytes.</source>
-        <translation>Filen har felaktig storlek, förväntade minst {} bytes, fick {} bytes.</translation>
-    </message>
-    <message>
-        <source>Incorrect header.</source>
-        <translation>Felaktig header.</translation>
-    </message>
-    <message>
-        <source>File must have an extension.</source>
-        <translation>Filen måste ha en filändelse.</translation>
-    </message>
-    <message>
-        <source>Unknown extension &apos;{}&apos;.</source>
-        <translation>Okänd filändelse &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Invalid size for save file.</source>
-        <translation>Ogiltig storlek för sparad fil.</translation>
-    </message>
-    <message>
-        <source>Failed to read directory frame: </source>
-        <translation>Misslyckades med att läsa directory frame: </translation>
-    </message>
-    <message>
-        <source>Invalid size ({} bytes) reported by directory frame.</source>
-        <translation>Ogiltig storlek ({} bytes) rapporterades av directory frame.</translation>
-    </message>
-    <message>
-        <source>Failed to read block bytes: </source>
-        <translation>Misslyckades med att läsa blockbytes: </translation>
-    </message>
-    <message>
-        <source>Insufficient free blocks.</source>
-        <translation>Otillräckligt antal lediga block.</translation>
-    </message>
-    <message>
-        <source>Invalid filename.</source>
-        <translation>Ogiltigt filnamn.</translation>
-    </message>
-    <message>
-        <source>Insufficient free blocks, needs {} blocks, but only have {}.</source>
-        <translation>Otillräckligt antal lediga block, behöver {} block men har endast {}.</translation>
-    </message>
-    <message>
-        <source>File does not exist, or is empty.</source>
-        <translation>Filen finns inte eller är tom.</translation>
-    </message>
-    <message>
-        <source>Unknown save format.</source>
-        <translation>Okänt sparformat.</translation>
-    </message>
-    <message>
-        <source>Memory Card {} could not be read.</source>
-        <translation>Minneskort {} kunde inte läsas.</translation>
-    </message>
-    <message>
-        <source>File: {0}
-Error: {1}
-The memory card will NOT be saved.
-You must delete the memory card manually if you want to save.</source>
-        <translation>Fil: {0}
-Fel: {1}
-Minneskortet kommer INTE att sparas.
-Du måste ta bort minneskortet manuellt om du vill spara.</translation>
-    </message>
-    <message>
-        <source>Failed to save memory card {}.</source>
-        <translation>Misslyckades med att spara minneskort {}.</translation>
-    </message>
-    <message>
-        <source>File: {0}:
-Error: {1}</source>
-        <translation>Fil: {0}:
-Fel: {1}</translation>
-    </message>
-    <message>
-        <source>Memory Card Slot {}</source>
-        <translation>Minneskortsplats {}</translation>
-    </message>
-    <message>
-        <source>Saved card to &apos;{}&apos;.</source>
-        <translation>Sparade kort till &apos;{}&apos;.</translation>
     </message>
 </context>
 <context>
     <name>MemoryCardEditorDialog</name>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="14"/>
         <source>Memory Card Editor</source>
         <translation>Redigera minneskort</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="48"/>
+        <location filename="../memorycardeditorwindow.ui" line="248"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="53"/>
+        <location filename="../memorycardeditorwindow.ui" line="253"/>
         <source>File Name</source>
         <translation>Filnamn</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="58"/>
+        <location filename="../memorycardeditorwindow.ui" line="258"/>
         <source>Blocks</source>
         <translation>Block</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="82"/>
+        <location filename="../memorycardeditorwindow.ui" line="200"/>
         <source>New...</source>
         <translation>Ny...</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="93"/>
+        <location filename="../memorycardeditorwindow.ui" line="211"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="43"/>
+        <location filename="../memorycardeditorwindow.ui" line="243"/>
         <source>Icon</source>
         <translation>Ikon</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="68"/>
         <source>Memory Card 2:</source>
         <translation>Minneskort 2:</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="190"/>
         <source>Memory Card 1:</source>
         <translation>Minneskort 1:</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.ui" line="129"/>
+        <location filename="../memorycardeditorwindow.ui" line="170"/>
         <source>Card Modified</source>
         <translation>Kortet ändrat</translation>
     </message>
@@ -14317,164 +9440,225 @@ Fel: {1}</translation>
 <context>
     <name>MemoryCardEditorWindow</name>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="40"/>
         <source>Single Save Files (*.mcs);;All Files (*.*)</source>
         <translation>Enstaka sparade filer (*.mcs);;Alla filer (*.*)</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="142"/>
+        <location filename="../memorycardeditorwindow.cpp" line="941"/>
         <source>Delete File</source>
         <translation>Ta bort fil</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="144"/>
+        <location filename="../memorycardeditorwindow.cpp" line="944"/>
         <source>Undelete File</source>
         <translation>Ångra filborttagning</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="146"/>
+        <location filename="../memorycardeditorwindow.cpp" line="947"/>
         <source>Rename File</source>
         <translation>Byt namn på fil</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="148"/>
+        <location filename="../memorycardeditorwindow.cpp" line="950"/>
         <source>Export File</source>
         <translation>Exportera fil</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="193"/>
         <source>New Card...</source>
         <translation>Nytt kort...</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="194"/>
         <source>Open Card...</source>
         <translation>Öppna kort...</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="275"/>
         <source>Format Card</source>
         <translation>Formatera kort</translation>
     </message>
     <message>
-        <source>Import File...</source>
-        <translation>Importera fil...</translation>
-    </message>
-    <message>
-        <source>Import Card...</source>
-        <translation>Importera kort...</translation>
-    </message>
-    <message>
+        <location filename="../memorycardeditorwindow.cpp" line="274"/>
         <source>Save</source>
         <translation>Spara</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="559"/>
+        <location filename="../memorycardeditorwindow.cpp" line="628"/>
+        <location filename="../memorycardeditorwindow.cpp" line="638"/>
+        <location filename="../memorycardeditorwindow.cpp" line="701"/>
+        <location filename="../memorycardeditorwindow.cpp" line="766"/>
+        <location filename="../memorycardeditorwindow.cpp" line="797"/>
+        <location filename="../memorycardeditorwindow.cpp" line="825"/>
+        <location filename="../memorycardeditorwindow.cpp" line="865"/>
+        <location filename="../memorycardeditorwindow.cpp" line="917"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="560"/>
         <source>Failed to load memory card: %1</source>
         <translation>Misslyckades med att läsa in minneskort: %1</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="434"/>
         <source> (Deleted)</source>
         <translation> (borttaget)</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="42"/>
         <source>PNG Images (*.png);;JPEG Images (*.jpg *.jpeg);;WebP Images (*.webp)</source>
         <translation>PNG-bilder (*.png);;JPEG-bilder (*.jpg *.jpeg);;WebP-bilder (*.webp)</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="44"/>
         <source>Animated PNG Images (*.png)</source>
         <translation>Animerade PNG-bilder (*.png)</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="150"/>
+        <location filename="../memorycardeditorwindow.cpp" line="740"/>
+        <location filename="../memorycardeditorwindow.cpp" line="755"/>
+        <location filename="../memorycardeditorwindow.cpp" line="953"/>
         <source>Extract Icon</source>
         <translation>Extrahera ikon</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="276"/>
+        <source>Import...</source>
+        <translation>Importera...</translation>
+    </message>
+    <message>
+        <location filename="../memorycardeditorwindow.cpp" line="525"/>
+        <location filename="../memorycardeditorwindow.cpp" line="552"/>
         <source>Select Memory Card</source>
         <translation>Välj minneskort</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="605"/>
         <source>Save memory card?</source>
         <translation>Spara minneskort?</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="606"/>
         <source>Memory card &apos;%1&apos; is not saved, do you want to save before closing?</source>
         <translation>Minneskortet &apos;%1&apos; har inte sparats. Vill du spara det innan du stänger?</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="629"/>
         <source>Destination memory card already contains a save file with the same name (%1) as the one you are attempting to copy. Please delete this file from the destination memory card before copying.</source>
         <translation>Minneskortsmålet innehåller redan en sparad fil med samma namn (%1) som den som du försöker att kopiera. Ta bort denna fil från minneskortsmålet innan du kopierar.</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="639"/>
         <source>Insufficient blocks, this file needs %1 but only %2 are available.</source>
         <translation>Otillräckliga block, denna fil behöver %1 men endast %2 finns tillgängliga.</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="702"/>
         <source>Failed to undelete file %1. The file may have been partially overwritten by another save.</source>
         <translation>Misslyckades med att återställa borttagna filen %1. Filen kan delvis ha skrivits över av en annan sparning.</translation>
     </message>
     <message>
-        <source>Select Single Savefile</source>
-        <translation>Välj enstaka sparad fil</translation>
+        <location filename="../memorycardeditorwindow.cpp" line="717"/>
+        <source>Select Single Save File</source>
+        <translation>Välj en enskild sparfil</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="742"/>
+        <location filename="../memorycardeditorwindow.cpp" line="781"/>
+        <location filename="../memorycardeditorwindow.cpp" line="956"/>
         <source>Extract Animated Icon</source>
         <translation>Extrahera animerad ikon</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="767"/>
         <source>Failed to extract icon from save file %1:
 %2</source>
         <translation>Misslyckades med att extrahera ikon från sparfilen %1:
 %2</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="798"/>
         <source>Failed to extract animated icon from save file %1:
 %2</source>
         <translation>Misslyckades med att extrahera animerad ikon från sparfilen %1:
 %2</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="826"/>
         <source>Failed to rename save file %1:
 %2</source>
         <translation>Misslyckades med att byta namn på sparade filen %1:
 %2</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="845"/>
+        <source>Import Single Save File...</source>
+        <translation>Importera en enskild sparfil...</translation>
+    </message>
+    <message>
+        <location filename="../memorycardeditorwindow.cpp" line="847"/>
+        <source>Import Entire Memory Card...</source>
+        <translation>Importera hela minneskortet...</translation>
+    </message>
+    <message>
+        <location filename="../memorycardeditorwindow.cpp" line="857"/>
         <source>Select Import File</source>
         <translation>Välj importfil</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="866"/>
         <source>Failed to import memory card from %1:
 %2</source>
         <translation>Misslyckades med att importa minneskort från %1:
 %2</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="887"/>
         <source>Format memory card?</source>
         <translation>Formatera minneskort?</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="888"/>
         <source>Formatting the memory card will destroy all saves, and they will not be recoverable. The memory card which will be formatted is located at &apos;%1&apos;.</source>
         <translation>Formatering av minneskortet kommer att förstöra alla sparningar och det går inte att ångra. Minneskortet som kommer att formateras finns på &apos;%1&apos;.</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="909"/>
         <source>Select Save File</source>
         <translation>Välj sparad fil</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="918"/>
         <source>Failed to import save from %1:
 %2</source>
         <translation>Misslyckades med att importera sparning från %1:
 %2</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="959"/>
         <source>Copy File</source>
         <translation>Kopiera fil</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="35"/>
         <source>DuckStation Memory Card (*.mcd)</source>
         <translation>DuckStation-minneskort (*.mcd)</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="36"/>
         <source>All Importable Memory Card Types (*.mcd *.mcr *.mc *.gme *.srm *.psm *.ps *.ddf *.mem *.vgs *.psx)</source>
         <translation>Alla importerbara minneskortstyper (*.mcd *.mcr *.mc *.gme *.srm *.psm *.ps *.ddf *.mem *.vgs *.psx)</translation>
     </message>
     <message numerus="yes">
+        <location filename="../memorycardeditorwindow.cpp" line="502"/>
         <source>%n block(s) free</source>
         <translation>
             <numerusform>%n block ledigt</numerusform>
@@ -14485,34 +9669,42 @@ Fel: {1}</translation>
 <context>
     <name>MemoryCardRenameFileDialog</name>
     <message>
+        <location filename="../memorycardrenamefiledialog.ui" line="14"/>
         <source>Rename Memory Card File</source>
         <translation>Byt namn på minneskortsfilen</translation>
     </message>
     <message>
+        <location filename="../memorycardrenamefiledialog.ui" line="44"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;WARNING: &lt;/span&gt;Renaming memory card files may result in saves becoming inaccessible or corrupted. Be sure to make backups first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;VARNING: &lt;/span&gt;Byta namn på minneskortsfiler kan orsaka att sparningar inte blir nåbara eller skadade. Försäkra dig om att göra säkerhetskopior först.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../memorycardrenamefiledialog.ui" line="62"/>
         <source>Original Name:</source>
         <translation>Ursprungligt namn:</translation>
     </message>
     <message>
+        <location filename="../memorycardrenamefiledialog.ui" line="76"/>
         <source>Region:</source>
         <translation>Region:</translation>
     </message>
     <message>
+        <location filename="../memorycardrenamefiledialog.ui" line="86"/>
         <source>Serial:</source>
         <translation>Serienummer:</translation>
     </message>
     <message>
+        <location filename="../memorycardrenamefiledialog.ui" line="96"/>
         <source>File Name:</source>
         <translation>Filnamn:</translation>
     </message>
     <message>
+        <location filename="../memorycardrenamefiledialog.ui" line="106"/>
         <source>Full File Name:</source>
         <translation>Fullständigt filnamn:</translation>
     </message>
     <message>
+        <location filename="../memorycardeditorwindow.cpp" line="1075"/>
         <source>Unknown (%1)</source>
         <translation>Okänt (%1)</translation>
     </message>
@@ -14520,98 +9712,130 @@ Fel: {1}</translation>
 <context>
     <name>MemoryCardSettingsWidget</name>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="84"/>
+        <location filename="../memorycardsettingswidget.cpp" line="112"/>
+        <location filename="../memorycardsettingswidget.cpp" line="254"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="87"/>
+        <location filename="../memorycardsettingswidget.cpp" line="115"/>
         <source>Open...</source>
         <translation>Öppna...</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="61"/>
         <source>The number of memory cards that can be used is dependent on multitap and game support.</source>
         <translation>Antalet minneskort som kan användas beror på multitap- och spelstöd.</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="74"/>
         <source>Save Locations</source>
         <translation>Lagringsplatser</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="80"/>
         <source>Memory Cards:</source>
         <translation>Minneskort:</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="102"/>
         <source>Memory Cards Location</source>
         <translation>Minneskortens lagringsplats</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="102"/>
+        <location filename="../memorycardsettingswidget.cpp" line="130"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="103"/>
         <source>Specifies the directory where memory cards will be saved.</source>
         <translation>Anger katalogen där minneskort ska sparas.</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="108"/>
         <source>Save States:</source>
         <translation>Sparade tillstånd:</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="127"/>
         <source>Select Save States Directory</source>
         <translation>Välj katalog för sparade tillstånd</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="130"/>
         <source>Save States Location</source>
         <translation>Lagringsplats för sparade tillstånd</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="131"/>
         <source>Specifies the directory where save states will be saved.</source>
         <translation>Anger katalogen där sparade tillstånd ska sparas.</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="136"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="140"/>
+        <location filename="../memorycardsettingswidget.cpp" line="145"/>
         <source>Create Save State Backups</source>
         <translation>Skapa säkerhetskopior av sparade tillstånd</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="146"/>
         <source>Backs up any previous save state when creating a new save state, with a .bak extension.</source>
         <translation>Säkerhetskopierar alla tidigare sparade tillstånd när ett nytt sparat tillstånd skapas, med filändelsen .bak.</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="148"/>
+        <location filename="../memorycardsettingswidget.cpp" line="152"/>
         <source>Enable Global Save States</source>
         <translation>Aktivera globala sparade tillstånd</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="152"/>
         <source>Unchecked</source>
         <translation>Avmarkerad</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="153"/>
         <source>When enabled, the legacy global save state slots will be available. These slots are independent of the current game.</source>
         <translation>När detta är aktiverat blir de äldre globala platserna för sparade tillstånd tillgängliga. Platserna är oberoende av det aktuella spelet.</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="156"/>
+        <location filename="../memorycardsettingswidget.cpp" line="161"/>
         <source>Use Single Card For Multi-Disc Games</source>
         <translation>Använd ett kort för flerskivsspel</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="162"/>
         <source>When playing a multi-disc game and using per-game (title) memory cards, a single memory card will be used for all discs. If unchecked, a separate card will be used for each disc.</source>
         <translation>När du spelar ett spel på flera skivor och använder minneskort per-spel (titel) kommer ett enstaka minneskort att användas för alla skivor. Om avmarkerad kommer ett enstaka kort att användas för varje skiva.</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="167"/>
+        <location filename="../memorycardsettingswidget.cpp" line="178"/>
         <source>Memory Card Editor</source>
         <translation>Redigera minneskort</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="172"/>
         <source>The memory card editor enables you to move saves between cards, as well as import cards of other formats.</source>
         <translation>Redigeraren för minneskort låter dig att flytta sparningar mellan kort såväl som att importera kort av andra format.</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="210"/>
         <source>Port %1</source>
         <translation>Port %1</translation>
     </message>
     <message numerus="yes">
+        <location filename="../memorycardsettingswidget.cpp" line="215"/>
         <source>Current Multitap Mode: %1 (%n Cards)</source>
         <comment>Card Count</comment>
         <translation>
@@ -14620,26 +9844,33 @@ Fel: {1}</translation>
         </translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="99"/>
         <source>Select Memory Card Directory</source>
         <translation>Välj katalog för minneskort</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="238"/>
         <source>Memory Card Type:</source>
         <translation>Minneskortstyp:</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="266"/>
         <source>Shared Memory Card Path:</source>
         <translation>Sökväg för delat minneskort:</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="290"/>
         <source>Select path to memory card image</source>
         <translation>Välj sökväg till minneskortsavbild</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="145"/>
+        <location filename="../memorycardsettingswidget.cpp" line="161"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
+        <location filename="../memorycardsettingswidget.cpp" line="36"/>
         <source>All Memory Card Types (*.mcd *.mcr *.mc)</source>
         <translation>Alla minneskortstyper (*.mcd *.mcr *.mc)</translation>
     </message>
@@ -14647,130 +9878,164 @@ Fel: {1}</translation>
 <context>
     <name>MemoryEditorWindow</name>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="14"/>
         <source>Memory Editor</source>
         <translation>Minnesredigerare</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="28"/>
+        <location filename="../memoryeditorwindow.ui" line="344"/>
         <source>Address:</source>
         <translation>Adress:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="52"/>
         <source>RAM</source>
         <translation>RAM</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="65"/>
         <source>Scratchpad</source>
         <translation>Skissblock</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="75"/>
         <source>EXP1</source>
         <translation>EXP1</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="85"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="95"/>
         <source>VRAM</source>
         <translation>VRAM</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="105"/>
         <source>SPU RAM</source>
         <translation>SPU-RAM</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="131"/>
         <source>Search</source>
         <translation>Sök</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="142"/>
         <source>Data Inspector</source>
         <translation>Datainspekterare</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="148"/>
         <source>ASCII Character:</source>
         <translation>ASCII-tecken:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="176"/>
         <source>Signed Byte:</source>
         <translation>Signerad byte:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="192"/>
         <source>Decimal</source>
         <translation>Decimal</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="202"/>
         <source>Hexadecimal</source>
         <translation>Hexadecimal</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="212"/>
         <source>Octal</source>
         <translation>Oktal</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="237"/>
         <source>Unsigned Byte:</source>
         <translation>Osignerad byte:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="246"/>
         <source>Little Endian</source>
         <translation>Little Endian</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="256"/>
         <source>Big Endian</source>
         <translation>Big Endian</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="281"/>
         <source>Unsigned Halfword:</source>
         <translation>Osignerad halfword:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="288"/>
         <source>32-Bit Float:</source>
         <translation>32-bitars flyttal:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="309"/>
         <source>Unsigned Doubleword:</source>
         <translation>Osignerad doubleword:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="358"/>
         <source>UTF-8 String:</source>
         <translation>UTF-8-sträng:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="365"/>
         <source>64-Bit Float:</source>
         <translation>64-bitars flyttal:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="379"/>
         <source>Unsigned Word:</source>
         <translation>Osignerad word:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="386"/>
         <source>Signed Word:</source>
         <translation>Signerad word:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="406"/>
         <source>Signed Halfword:</source>
         <translation>Signerad halfword:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.ui" line="413"/>
         <source>Signed Doubleword:</source>
         <translation>Signerad doubleword:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.cpp" line="95"/>
         <source>Enter memory address:</source>
         <translation>Ange minnesadress:</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.cpp" line="172"/>
+        <location filename="../memoryeditorwindow.cpp" line="199"/>
         <source>Invalid search pattern. It should contain hex digits or question marks.</source>
         <translation>Ogiltigt sökmönster. Det bör innehålla hexadecimala siffror eller frågetecken.</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.cpp" line="211"/>
         <source>Pattern not found in memory.</source>
         <translation>Mönstret hittades inte i minnet.</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.cpp" line="228"/>
         <source>Pattern found at 0x%1 (passed the end of memory).</source>
         <translation>Mönster hittades vid 0x%1 (passerat minnets slut).</translation>
     </message>
     <message>
+        <location filename="../memoryeditorwindow.cpp" line="235"/>
         <source>Pattern found at 0x%1.</source>
         <translation>Mönster hittades vid 0x%1.</translation>
     </message>
@@ -14778,254 +10043,289 @@ Fel: {1}</translation>
 <context>
     <name>MemoryScannerWindow</name>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="14"/>
         <source>Memory Scanner</source>
         <translation>Minnesskanner</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="46"/>
+        <location filename="../memoryscannerwindow.ui" line="389"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="51"/>
+        <location filename="../memoryscannerwindow.ui" line="399"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="56"/>
         <source>Previous Value</source>
         <translation>Föregående värde</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="69"/>
         <source>Search Parameters</source>
         <translation>Sökparametrar</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="75"/>
         <source>Value:</source>
         <translation>Värde:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="91"/>
         <source>Signed</source>
         <translation>Signerad</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="96"/>
         <source>Unsigned</source>
         <translation>Osignerad</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="108"/>
         <source>Decimal</source>
         <translation>Decimal</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="113"/>
         <source>Hex</source>
         <translation>Hex</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="123"/>
         <source>Data Size:</source>
         <translation>Datastorlek:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="134"/>
         <source>Byte (1 byte)</source>
         <translation>Byte (1 byte)</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="139"/>
         <source>Halfword (2 bytes)</source>
         <translation>Halvord (2 byte)</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="144"/>
         <source>Word (4 bytes)</source>
         <translation>Ord (4 byte)</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="152"/>
         <source>Operator:</source>
         <translation>Operator:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="160"/>
         <source>Any Value (&apos;New Search&apos; or &apos;Reset Result Value&apos;)</source>
         <translation>Valfritt värde (&quot;Ny sökning&quot; eller &quot;Återställ resultatvärde&quot;)</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="165"/>
         <source>Less Than Previous Result</source>
         <translation>Mindre än tidigare resultat</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="170"/>
         <source>Less or Equal to Previous Result</source>
         <translation>Mindre eller lika med föregående resultat</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="175"/>
         <source>Greater Than Previous Result</source>
         <translation>Större än tidigare resultat</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="180"/>
         <source>Greater or Equal to Previous Result</source>
         <translation>Större eller lika med föregående resultat</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="185"/>
         <source>Not Equal to Previous Result (Changed Value)</source>
         <translation>Inte lika med föregående resultat (ändrat värde)</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="190"/>
         <source>Equal to Previous Result (Unchanged Value)</source>
         <translation>Lika med föregående resultat (oförändrat värde)</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="195"/>
         <source>Decreased By Value</source>
         <translation>Minskas med värde</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="200"/>
         <source>Increased By Value</source>
         <translation>Ökas med värde</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="205"/>
         <source>Changed By Value</source>
         <translation>Ändras med värde</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="210"/>
         <source>Equal to Value</source>
         <translation>Lika med värdet</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="215"/>
         <source>Not Equal to Value</source>
         <translation>Inte lika med värdet</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="220"/>
         <source>Less Than Value</source>
         <translation>Mindre än värdet</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="225"/>
         <source>Less or Equal to Value</source>
         <translation>Mindre än eller lika med värdet</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="230"/>
         <source>Greater Than Value</source>
         <translation>Större än värdet</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="235"/>
         <source>Greater or Equal to Value</source>
         <translation>Större än eller lika med värdet</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="243"/>
         <source>Start Address:</source>
         <translation>Startadress:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="253"/>
         <source>End Address:</source>
         <translation>Slutadress:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="263"/>
         <source>Preset Range:</source>
         <translation>Förvalsintervall:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="271"/>
         <source>RAM</source>
         <translation>RAM</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="276"/>
         <source>Scratchpad</source>
         <translation>Skissblock</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="281"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="289"/>
         <source>Result Count:</source>
         <translation>Resultatantal:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="296"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="305"/>
         <source>New Search</source>
         <translation>Ny sökning</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="315"/>
         <source>Search Again</source>
         <translation>Sök igen</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="325"/>
         <source>Clear Results</source>
         <translation>Töm resultat</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="337"/>
         <source>Add Selected Results To Watch List</source>
         <translation>Lägg till valda resultat i bevakningslistan</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="384"/>
         <source>Simple Cheat Code or Description</source>
         <translation>Enkel fuskkod eller Beskrivning</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="394"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="404"/>
         <source>Freeze</source>
         <translation>Frys</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="420"/>
         <source>Load Watch</source>
         <translation>Lägg till bevakning</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="433"/>
         <source>Save Watch</source>
         <translation>Spara bevakning</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="440"/>
         <source>Add Manual Address</source>
         <translation>Lägg till manuell adress</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="450"/>
         <source>Freeze Selected Entries</source>
         <translation>Frys valda poster</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="460"/>
         <source>Remove Selected Entries</source>
         <translation>Ta bort markerade poster</translation>
     </message>
     <message>
-        <source>Byte</source>
-        <translation>Byte</translation>
-    </message>
-    <message>
-        <source>Halfword</source>
-        <translation>Halvord</translation>
-    </message>
-    <message>
-        <source>Word</source>
-        <translation>Word</translation>
-    </message>
-    <message>
-        <source>Signed Byte</source>
-        <translation>Signerad byte</translation>
-    </message>
-    <message>
-        <source>Signed Halfword</source>
-        <translation>Signerat halvord</translation>
-    </message>
-    <message>
-        <source>Signed Word</source>
-        <translation>Signerat ord</translation>
-    </message>
-    <message>
+        <location filename="../memoryscannerwindow.cpp" line="98"/>
         <source>Address of RAM for HxD Usage: 0x%1</source>
         <translation>Adress till RAM för HxD-användning: 0x%1</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.cpp" line="331"/>
         <source>Enter manual address:</source>
         <translation>Ange manuell adress:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.cpp" line="341"/>
         <source>Select data size:</source>
         <translation>Välj datastorlek:</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.cpp" line="560"/>
         <source>%1 (only showing first %2)</source>
         <translation>%1 (visar endast första %2)</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.ui" line="61"/>
         <source>First Value</source>
         <translation>Första värdet</translation>
     </message>
     <message>
+        <location filename="../memoryscannerwindow.cpp" line="406"/>
         <source>Failed to open memory editor at specified address.</source>
         <translation>Misslyckades med att öppna minnesredigeraren vid angiven adress.</translation>
     </message>
@@ -15033,945 +10333,408 @@ Fel: {1}</translation>
 <context>
     <name>MultipleDeviceAutobindDialog</name>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="1031"/>
         <source>Select the devices from the list below that you want to bind to this controller.</source>
         <translation>Välj de enheter i listan nedan som du vill binda till den här kontrollern.</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="1081"/>
+        <location filename="../controllerbindingwidgets.cpp" line="1096"/>
         <source>Automatic Mapping Failed</source>
         <translation>Automatisk mappning misslyckades</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="1082"/>
         <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
         <translation>Inga generiska bindningar genererades för enheten &apos;%1&apos;. Handkontrollern/källan kanske inte har stöd för automatisk mappning.</translation>
     </message>
     <message>
+        <location filename="../controllerbindingwidgets.cpp" line="1097"/>
         <source>No devices were selected.</source>
         <translation>Inga enheter valdes.</translation>
     </message>
 </context>
 <context>
-    <name>NeGcon</name>
-    <message>
-        <source>D-Pad Up</source>
-        <translation>Riktningsknapp upp</translation>
-    </message>
-    <message>
-        <source>D-Pad Right</source>
-        <translation>Riktningsknapp höger</translation>
-    </message>
-    <message>
-        <source>D-Pad Down</source>
-        <translation>Riktningsknapp ner</translation>
-    </message>
-    <message>
-        <source>D-Pad Left</source>
-        <translation>Riktningsknapp vänster</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>A Button</source>
-        <translation>A-knapp</translation>
-    </message>
-    <message>
-        <source>B Button</source>
-        <translation>B-knapp</translation>
-    </message>
-    <message>
-        <source>I Button</source>
-        <translation>I-knapp</translation>
-    </message>
-    <message>
-        <source>II Button</source>
-        <translation>II-knapp</translation>
-    </message>
-    <message>
-        <source>Left Trigger</source>
-        <translation>Vänster skjutknapp</translation>
-    </message>
-    <message>
-        <source>Right Trigger</source>
-        <translation>Höger skjutknapp</translation>
-    </message>
-    <message>
-        <source>Steering (Twist) Left</source>
-        <translation>Styrning (Trist) vänster</translation>
-    </message>
-    <message>
-        <source>Steering (Twist) Right</source>
-        <translation>Styrning (Twist) höger</translation>
-    </message>
-    <message>
-        <source>Disable Simultaneous Opposing Cardinal Directions</source>
-        <translation>Inaktivera samtidiga motsatta riktningar</translation>
-    </message>
-    <message>
-        <source>Prevents concurrent left/right or up/down inputs from being presented to the game.</source>
-        <translation>Förhindrar att samtidiga inmatningar åt vänster/höger eller upp/ner presenteras för spelet.</translation>
-    </message>
-    <message>
-        <source>Steering Axis Deadzone</source>
-        <translation>Dödläge för styraxlar</translation>
-    </message>
-    <message>
-        <source>Sets deadzone for steering axis.</source>
-        <translation>Ställer in dödläge för styraxlar.</translation>
-    </message>
-    <message>
-        <source>Steering Axis Saturation</source>
-        <translation>Mättnad av styraxel</translation>
-    </message>
-    <message>
-        <source>Sets saturation for steering axis.</source>
-        <translation>Ställer in mättnad för styraxel.</translation>
-    </message>
-    <message>
-        <source>Steering Axis Linearity</source>
-        <translation>Linjäritet för styraxel</translation>
-    </message>
-    <message>
-        <source>Sets linearity for steering axis.</source>
-        <translation>Ställer in linjäriteten för styraxeln.</translation>
-    </message>
-    <message>
-        <source>Steering Scaling</source>
-        <translation>Styrningsskalning</translation>
-    </message>
-    <message>
-        <source>Sets scaling for steering axis.</source>
-        <translation>Ställer in skalning för styraxel.</translation>
-    </message>
-    <message>
-        <source>I Button Deadzone</source>
-        <translation>Dödzon för I-knapp</translation>
-    </message>
-    <message>
-        <source>Sets deadzone for button I.</source>
-        <translation>Ställer in dödzon för knapp I.</translation>
-    </message>
-    <message>
-        <source>I Button Saturation</source>
-        <translation>Mättnad för I-knapp</translation>
-    </message>
-    <message>
-        <source>Sets saturation for button I.</source>
-        <translation>Ställer in mättnad för knapp I.</translation>
-    </message>
-    <message>
-        <source>I Button Linearity</source>
-        <translation>Linjäritet för I-knapp</translation>
-    </message>
-    <message>
-        <source>Sets linearity for button I.</source>
-        <translation>Ställer in linjäritet för knapp I.</translation>
-    </message>
-    <message>
-        <source>I Scaling</source>
-        <translation>I skalning</translation>
-    </message>
-    <message>
-        <source>Sets scaling for button I.</source>
-        <translation>Ställer in skalning för knapp I.</translation>
-    </message>
-    <message>
-        <source>II Button Deadzone</source>
-        <translation>Dödzon för II-knapp</translation>
-    </message>
-    <message>
-        <source>Sets deadzone for button II.</source>
-        <translation>Ställer in dödzon för knapp II.</translation>
-    </message>
-    <message>
-        <source>II Button Saturation</source>
-        <translation>Mättnad för II-knapp</translation>
-    </message>
-    <message>
-        <source>Sets saturation for button II.</source>
-        <translation>Ställer in mättnad för knapp II.</translation>
-    </message>
-    <message>
-        <source>II Button Linearity</source>
-        <translation>Linjäritet för II-knapp</translation>
-    </message>
-    <message>
-        <source>Sets linearity for button II.</source>
-        <translation>Ställer in linjäritet för knapp II.</translation>
-    </message>
-    <message>
-        <source>II Scaling</source>
-        <translation>II skalning</translation>
-    </message>
-    <message>
-        <source>Sets scaling for button II.</source>
-        <translation>Ställer in skalning för knapp II.</translation>
-    </message>
-    <message>
-        <source>Left Trigger Deadzone</source>
-        <translation>Dödzon för vänster avtryckare</translation>
-    </message>
-    <message>
-        <source>Sets deadzone for left trigger.</source>
-        <translation>Ställer in dödzon för vänster avtryckare.</translation>
-    </message>
-    <message>
-        <source>Left Trigger Saturation</source>
-        <translation>Mättnad för vänster avtryckare</translation>
-    </message>
-    <message>
-        <source>Sets saturation for left trigger.</source>
-        <translation>Ställer in mättnad för vänster avtryckare.</translation>
-    </message>
-    <message>
-        <source>Left Trigger Linearity</source>
-        <translation>Linjäritet för vänster avtryckare</translation>
-    </message>
-    <message>
-        <source>Sets linearity for left trigger.</source>
-        <translation>Ställer in linjäritet för vänster avtryckare.</translation>
-    </message>
-    <message>
-        <source>Left Trigger Scaling</source>
-        <translation>Skalning för vänster avtryckare</translation>
-    </message>
-    <message>
-        <source>Sets scaling for left trigger.</source>
-        <translation>Ställer in skalning för vänster avtryckare.</translation>
-    </message>
-</context>
-<context>
-    <name>NeGconRumble</name>
-    <message>
-        <source>D-Pad Up</source>
-        <translation>Riktningsknapp upp</translation>
-    </message>
-    <message>
-        <source>D-Pad Right</source>
-        <translation>Riktningsknapp höger</translation>
-    </message>
-    <message>
-        <source>D-Pad Down</source>
-        <translation>Riktningsknapp ner</translation>
-    </message>
-    <message>
-        <source>D-Pad Left</source>
-        <translation>Riktningsknapp vänster</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>A Button</source>
-        <translation>A-knapp</translation>
-    </message>
-    <message>
-        <source>B Button</source>
-        <translation>B-knapp</translation>
-    </message>
-    <message>
-        <source>I Button</source>
-        <translation>I-knapp</translation>
-    </message>
-    <message>
-        <source>II Button</source>
-        <translation>II-knapp</translation>
-    </message>
-    <message>
-        <source>Left Trigger</source>
-        <translation>Vänster skjutknapp</translation>
-    </message>
-    <message>
-        <source>Right Trigger</source>
-        <translation>Höger skjutknapp</translation>
-    </message>
-    <message>
-        <source>Steering (Twist) Left</source>
-        <translation>Styrning (Trist) vänster</translation>
-    </message>
-    <message>
-        <source>Steering (Twist) Right</source>
-        <translation>Styrning (Twist) höger</translation>
-    </message>
-    <message>
-        <source>Analog Toggle</source>
-        <translation>Analog växlingsknapp</translation>
-    </message>
-    <message>
-        <source>Disable Simultaneous Opposing Cardinal Directions</source>
-        <translation>Inaktivera samtidiga motsatta riktningar</translation>
-    </message>
-    <message>
-        <source>Prevents concurrent left/right or up/down inputs from being presented to the game.</source>
-        <translation>Förhindrar att samtidiga inmatningar åt vänster/höger eller upp/ner presenteras för spelet.</translation>
-    </message>
-    <message>
-        <source>Steering Axis Deadzone</source>
-        <translation>Dödläge för styraxlar</translation>
-    </message>
-    <message>
-        <source>Sets deadzone size for steering axis.</source>
-        <translation>Ställer in dödlägets storlek för styrande axlar.</translation>
-    </message>
-    <message>
-        <source>Steering Axis Sensitivity</source>
-        <translation>Känslighet för styrande axlar</translation>
-    </message>
-    <message>
-        <source>Sets the steering axis scaling factor.</source>
-        <translation>Ställer in skalningsfaktorn för styrande axlar.</translation>
-    </message>
-    <message>
-        <source>Large Motor Vibration Bias</source>
-        <translation>Vibrationsjustering för stor motor</translation>
-    </message>
-    <message>
-        <source>Sets the bias value for the large vibration motor. If vibration in some games is too weak or not functioning, try increasing this value. Negative values will decrease the intensity of vibration.</source>
-        <translation>Anger justeringsvärdet för stor vibrationsmotor. Om vibrationen i vissa spel är för svag eller inte fungerar så prova att öka detta värde. Negativa värden kommer att sänka intensiteten för vibrationen.</translation>
-    </message>
-    <message>
-        <source>Small Motor Vibration Bias</source>
-        <translation>Vibrationsjustering för liten  motor</translation>
-    </message>
-    <message>
-        <source>Sets the bias value for the small vibration motor. If vibration in some games is too weak or not functioning, try increasing this value. Negative values will decrease the intensity of vibration.</source>
-        <translation>Anger justeringsvärdet för liten vibrationsmotor. Om vibrationen i vissa spel är för svag eller inte fungerar så prova att öka detta värde. Negativa värden kommer att sänka intensiteten för vibrationen.</translation>
-    </message>
-</context>
-<context>
-    <name>OSDMessage</name>
-    <message>
-        <source>CPU clock speed control enabled ({:.3f} MHz).</source>
-        <translation>Hastighetskontroll för CPU-klocka aktiverad ({:.3f} MHz).</translation>
-    </message>
-    <message>
-        <source>CPU clock speed control disabled ({:.3f} MHz).</source>
-        <translation>Hastighetskontroll för CPU-klocka inaktiverad ({:.3f} MHz).</translation>
-    </message>
-    <message>
-        <source>Emulation speed set to {}%.</source>
-        <translation>Emuleringshastighet inställd till {}%.</translation>
-    </message>
-    <message>
-        <source>PGXP is now enabled.</source>
-        <translation>PGXP är nu aktiverat.</translation>
-    </message>
-    <message>
-        <source>PGXP is now disabled.</source>
-        <translation>PGXP är nu inaktiverat.</translation>
-    </message>
-    <message>
-        <source>PGXP Depth Buffer is now enabled.</source>
-        <translation>PGXP Depth Buffer är nu aktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP Depth Buffer is now disabled.</source>
-        <translation>PGXP Depth Buffer är nu inaktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP CPU mode is now enabled.</source>
-        <translation>PGXP CPU-läge är nu aktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP CPU mode is now disabled.</source>
-        <translation>PGXP CPU-läge är nu inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Volume: Muted</source>
-        <translation>Volym: Tyst</translation>
-    </message>
-    <message>
-        <source>Rewinding is disabled while runahead is enabled.</source>
-        <translation>Tillbakaspolning är inaktiverad när runahead är aktiverat.</translation>
-    </message>
-    <message>
-        <source>Rewinding is disabled while safe mode is enabled.</source>
-        <translation>Tillbakaspolning är inaktiverad när säkert läge är aktiverat.</translation>
-    </message>
-    <message>
-        <source>Rewinding unavailable.</source>
-        <translation>Tillbakaspolning är inte tillgänglig.</translation>
-    </message>
-    <message>
-        <source>Volume: {}%</source>
-        <translation>Volym: {}%</translation>
-    </message>
-    <message>
-        <source>CD Audio Muted.</source>
-        <translation>CD-ljud tystat.</translation>
-    </message>
-    <message>
-        <source>CD Audio Unmuted.</source>
-        <translation>CD-ljud aktiverat.</translation>
-    </message>
-    <message>
-        <source>Rewinding is not enabled.</source>
-        <translation>Tillbakaspolning är inte aktiverad.</translation>
-    </message>
-    <message>
-        <source>Swapped memory card ports. Both ports have a memory card.</source>
-        <translation>Växlade minneskortsportar. Båda portarna har ett minneskort.</translation>
-    </message>
-    <message>
-        <source>Swapped memory card ports. Port 2 has a memory card, Port 1 is empty.</source>
-        <translation>Växlade minneskortsportar. Port 2 har ett minneskort. Port 1 är tomt.</translation>
-    </message>
-    <message>
-        <source>Swapped memory card ports. Port 1 has a memory card, Port 2 is empty.</source>
-        <translation>Växlade minneskortsportar. Port 1 har ett minneskort. Port 2 är tomt.</translation>
-    </message>
-    <message>
-        <source>Swapped memory card ports. Neither port has a memory card.</source>
-        <translation>Växlade minneskortsportar. Ingen av portarna har ett minneskort.</translation>
-    </message>
-    <message>
-        <source>Failed to open disc image &apos;{}&apos;: {}.</source>
-        <translation>Misslyckades med att öpnna skivavbilden &apos;{}&apos;: {}.</translation>
-    </message>
-    <message>
-        <source>Inserted disc &apos;{}&apos; ({}).</source>
-        <translation>Matade in skivan &apos;{}&apos; ({}).</translation>
-    </message>
-    <message>
-        <source>Switching to {}{} GPU renderer.</source>
-        <translation>Växlar till {}{} GPU-renderare.</translation>
-    </message>
-    <message>
-        <source>Switching to {} audio backend.</source>
-        <translation>Växlar till ljudbakänden {}.</translation>
-    </message>
-    <message>
-        <source>Game restarted.</source>
-        <translation>Spelet har startats om.</translation>
-    </message>
-    <message>
-        <source>Switching to {} CPU execution mode.</source>
-        <translation>Växlar till CPU-körningsläget {}.</translation>
-    </message>
-    <message>
-        <source>Recompiler options changed, flushing all blocks.</source>
-        <translation>Alternativ för omkompilerare ändrades. Spolar alla block.</translation>
-    </message>
-    <message>
-        <source>Failed to save undo load state:
-{}</source>
-        <translation>Misslyckades med att spara ångrat inläst tillstånd:
-{}</translation>
-    </message>
-    <message>
-        <source>Switching to {} renderer...</source>
-        <translation>Växlar till {}-renderare...</translation>
-    </message>
-    <message>
-        <source>CD image preloading not available for multi-disc image &apos;{}&apos;</source>
-        <translation>Förinläsning av cd-avbild är inte tillgängligt för flerskivsavbilden &apos;{}&apos;</translation>
-    </message>
-    <message>
-        <source>Precaching CD image failed, it may be unreliable.</source>
-        <translation>Förcachning av cd-avbild misslyckades, kan orsaka något problem.</translation>
-    </message>
-    <message>
-        <source>Disabling PCDrv because no root directory is specified.</source>
-        <translation>Inaktiverar PCDrv därför att ingen rotkatalog har angivits.</translation>
-    </message>
-    <message>
-        <source>PGXP is incompatible with the software renderer, disabling PGXP.</source>
-        <translation>PGXP är inte kompatibel med programvarurenderaren, inaktiverar PGXP.</translation>
-    </message>
-    <message>
-        <source>No post-processing shaders are selected.</source>
-        <translation>Inga shaders för efterbehandling har valts.</translation>
-    </message>
-    <message>
-        <source>Post-processing is now enabled.</source>
-        <translation>Efterbehandling är nu aktiverad.</translation>
-    </message>
-    <message>
-        <source>Post-processing is now disabled.</source>
-        <translation>Efterbehandling är nu inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Post-processing shaders reloaded.</source>
-        <translation>Shaders för efterbehandling lästes om.</translation>
-    </message>
-    <message>
-        <source>Failed to initialize hardware renderer, falling back to software renderer.</source>
-        <translation>Det gick inte att initiera hårdvarurenderaren. Växlar till programvarurenderaren.</translation>
-    </message>
-    <message>
-        <source>Failed to create {} GPU device, reverting to {}.
-{}</source>
-        <translation>Misslyckades med att skapa {} GPU-enhet, återgår till {}.
-{}</translation>
-    </message>
-    <message>
-        <source>Failed to switch to exclusive fullscreen, using borderless instead.</source>
-        <translation>Misslyckades med att växla till exklusiv helskärm, använder kantlöst fönster istället.</translation>
-    </message>
-    <message>
-        <source>PGXP Preserve Projection Precision is now enabled.</source>
-        <translation>PGXP bevara projektionsprecisionen är nu aktiverat.</translation>
-    </message>
-    <message>
-        <source>PGXP Preserve Projection Precision is now disabled.</source>
-        <translation>PGXP bevara projektionsprecisionen är nu inaktiverat.</translation>
-    </message>
-    <message>
-        <source>Now showing VRAM.</source>
-        <translation>Nu visas VRAM.</translation>
-    </message>
-    <message>
-        <source>Now showing display.</source>
-        <translation>Nu visas skärmen.</translation>
-    </message>
-    <message>
-        <source>Widescreen rendering is now enabled, and aspect ratio is set to {}.</source>
-        <translation>Bredbildsrendering är nu aktiverad och bildförhållandet är inställt på {}.</translation>
-    </message>
-    <message>
-        <source>Widescreen rendering is now disabled, and aspect ratio is set to {}.</source>
-        <translation>Bredbildsrendering är nu inaktiverad och bildförhållandet är inställt på {}.</translation>
-    </message>
-    <message>
-        <source>Failed to load post-processing chain.</source>
-        <translation>Det gick inte att läsa in efterbehandlingskedjan.</translation>
-    </message>
-    <message>
-        <source>Texture modulation cropping is now enabled.</source>
-        <translation>Beskäring av texturmodulation är nu aktiverad.</translation>
-    </message>
-    <message>
-        <source>Texture modulation cropping is now disabled.</source>
-        <translation>Beskäring av texturmodulation är nu inaktiverad.</translation>
-    </message>
-</context>
-<context>
     <name>OSDSettingsWidget</name>
     <message>
+        <location filename="../osdsettingswidget.ui" line="29"/>
         <source>Display</source>
         <translation>Skärm</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="35"/>
         <source>Display Scale:</source>
         <translation>Visningsskala:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="42"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="55"/>
         <source>Display Margins:</source>
         <translation>Visningsmarginaler:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="62"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="72"/>
         <source>Theme:</source>
         <translation>Tema:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="82"/>
         <source>Font:</source>
         <translation>Teckensnitt:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="92"/>
         <source>Overlay Font:</source>
         <translation>Överläggsteckensnitt:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="105"/>
         <source>Messages</source>
         <translation>Meddelanden</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="111"/>
+        <location filename="../osdsettingswidget.cpp" line="117"/>
         <source>Show Messages</source>
         <translation>Visa meddelanden</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="118"/>
+        <location filename="../osdsettingswidget.cpp" line="120"/>
         <source>Show Status Indicators</source>
         <translation>Visa statusindikatorer</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="125"/>
+        <location filename="../osdsettingswidget.cpp" line="123"/>
         <source>Animate Messages</source>
         <translation>Animera meddelanden</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="132"/>
+        <location filename="../osdsettingswidget.cpp" line="126"/>
         <source>Blur Message Backgrounds</source>
         <translation>Gör meddelandebakgrunder oskarpa</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="139"/>
         <source>Error Duration:</source>
         <translation>Fellängd:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="146"/>
+        <location filename="../osdsettingswidget.ui" line="172"/>
+        <location filename="../osdsettingswidget.ui" line="198"/>
+        <location filename="../osdsettingswidget.ui" line="224"/>
         <source> seconds</source>
         <translation> sekunder</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="165"/>
         <source>Warning Duration:</source>
         <translation>Varningslängd:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="191"/>
         <source>Information Duration:</source>
         <translation>Informationslängd:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="217"/>
         <source>Action Duration:</source>
         <translation>Åtgärdslängd:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="243"/>
         <source>Display Location:</source>
         <translation>Visningsplats:</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="256"/>
         <source>Overlays</source>
         <translation>Överlägg</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="267"/>
+        <location filename="../osdsettingswidget.cpp" line="137"/>
         <source>Show FPS</source>
         <translation>Visa bilder/s</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="274"/>
+        <location filename="../osdsettingswidget.cpp" line="135"/>
         <source>Show Emulation Speed</source>
         <translation>Visa emuleringshastighet</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="281"/>
+        <location filename="../osdsettingswidget.cpp" line="140"/>
         <source>Show CPU Usage</source>
         <translation>Visa CPU-användning</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="288"/>
+        <location filename="../osdsettingswidget.cpp" line="142"/>
         <source>Show GPU Usage</source>
         <translation>Visa GPU-användning</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="295"/>
+        <location filename="../osdsettingswidget.cpp" line="132"/>
         <source>Show Resolution</source>
         <translation>Visa upplösning</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="302"/>
+        <location filename="../osdsettingswidget.cpp" line="144"/>
         <source>Show GPU Statistics</source>
         <translation>Visa GPU-statistik</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="309"/>
+        <location filename="../osdsettingswidget.cpp" line="150"/>
         <source>Show Frame Times</source>
         <translation>Visa bildrutetider</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="316"/>
+        <location filename="../osdsettingswidget.cpp" line="147"/>
         <source>Show Latency Statistics</source>
         <translation>Visa latensstatistik</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="323"/>
+        <location filename="../osdsettingswidget.cpp" line="153"/>
         <source>Show Controller Input</source>
         <translation>Visa kontrollerinmatning</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.ui" line="330"/>
+        <location filename="../osdsettingswidget.cpp" line="155"/>
         <source>Show Settings</source>
         <translation>Visa inställningar</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="97"/>
         <source>Display Scale</source>
         <translation>Visningsskala</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="98"/>
         <source>Changes the size at which on-screen elements, including status and messages are displayed.</source>
         <translation>Ändrar storleken för vilken OSD-element, inklusive status och meddelanden, visas med.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="99"/>
         <source>Display Margins</source>
         <translation>Visningsmarginaler</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="101"/>
         <source>Determines the margin between the edge of the screen and on-screen messages.</source>
         <translation>Bestämmer marginalen mellan skärmkanten och skärmmeddelanden.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="104"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="104"/>
         <source>Automatic</source>
         <translation>Automatisk</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="105"/>
         <source>Determines the theme to use for on-screen display elements and the Big Picture UI.</source>
         <translation>Bestämmer vilket tema som ska användas för visningselement på skärmen och storbildsgränssnittet.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="107"/>
         <source>Font</source>
         <translation>Teckensnitt</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="109"/>
         <source>Determines the font to use for on-screen display elements and the Big Picture UI.</source>
         <translation>Bestämmer teckensnittet för skärmvisningselement och storbildsgränssnittet.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="111"/>
         <source>Overlay Font</source>
         <translation>Överläggsteckensnitt</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="114"/>
         <source>Determines the font to use for the performance overlay.</source>
         <translation>Bestämmer teckensnittet för prestandaöverlägget.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="117"/>
+        <location filename="../osdsettingswidget.cpp" line="120"/>
+        <location filename="../osdsettingswidget.cpp" line="123"/>
+        <location filename="../osdsettingswidget.cpp" line="126"/>
         <source>Checked</source>
         <translation>Markerat</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="118"/>
         <source>Shows on-screen-display messages when events occur such as save states being created/loaded, screenshots being taken, etc. Errors and warnings are still displayed regardless of this setting.</source>
         <translation>Visar meddelanden på skärmen när händelser inträffar, till exempel när spartillstånd skapas/läses in, skärmbilder fångas osv. Fel och varningar visas fortfarande oavsett denna inställning.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="121"/>
         <source>Shows indicators on screen when the system is not running in its &quot;normal&quot; state. For example, fast forwarding, or being paused.</source>
         <translation>Visar indikatorer på skärmen när systemet inte körs i sitt &quot;normala&quot; tillstånd. Till exempel snabbspolning framåt eller vid paus.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="124"/>
         <source>Enables animation for on-screen messages when they appear and disappear.</source>
         <translation>Animerar skärmmeddelanden när de visas och försvinner.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="127"/>
         <source>Enables a blur effect on the background behind on-screen messages to improve readability.</source>
         <translation>Aktiverar oskärpa i bakgrunden bakom skärmmeddelanden för bättre läsbarhet.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="129"/>
         <source>Message Location</source>
         <translation>Meddelandeplats</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="131"/>
         <source>Selects which location on the screen messages are displayed.</source>
         <translation>Väljer vilken plats på skärmen som meddelanden ska visas.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="132"/>
+        <location filename="../osdsettingswidget.cpp" line="135"/>
+        <location filename="../osdsettingswidget.cpp" line="137"/>
+        <location filename="../osdsettingswidget.cpp" line="140"/>
+        <location filename="../osdsettingswidget.cpp" line="142"/>
+        <location filename="../osdsettingswidget.cpp" line="144"/>
+        <location filename="../osdsettingswidget.cpp" line="147"/>
+        <location filename="../osdsettingswidget.cpp" line="150"/>
+        <location filename="../osdsettingswidget.cpp" line="153"/>
+        <location filename="../osdsettingswidget.cpp" line="155"/>
         <source>Unchecked</source>
         <translation>Avmarkerad</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="133"/>
         <source>Shows the resolution of the game in the top-right corner of the display.</source>
         <translation>Visar spelets upplösning längst upp i högra hörnet av skärmen.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="136"/>
         <source>Shows the current emulation speed of the system in the top-right corner of the display as a percentage.</source>
         <translation>Visar aktuell emuleringshastighet för systemet i övre högra hörnet av skärmen som ett procenttal.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="138"/>
         <source>Shows the internal frame rate of the game in the top-right corner of the display.</source>
         <translation>Visar den interna bildfrekvensen för spelet i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="141"/>
         <source>Shows the host&apos;s CPU usage of each system thread in the top-right corner of the display.</source>
         <translation>Visar värdens CPU-användning för varje systemtråd i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="143"/>
         <source>Shows the host&apos;s GPU usage in the top-right corner of the display.</source>
         <translation>Visar värdens GPU-användning i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="145"/>
         <source>Shows information about the emulated GPU in the top-right corner of the display.</source>
         <translation>Visar information om emulerad GPU i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="148"/>
         <source>Shows information about input and audio latency in the top-right corner of the display.</source>
         <translation>Visar information om inmatnings- och ljudlatens i övre högra hörnet av skärmen.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="151"/>
         <source>Shows the history of frame rendering times as a graph in the top-right corner of the display.</source>
         <translation>Visar historiken för bildrenderingstider som en graf i det övre högra hörnet av skärmen.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="154"/>
         <source>Shows the current controller state of the system in the bottom-left corner of the display.</source>
         <translation>Visar aktuellt tillstånd för handkontroller för systemet i nedre vänstra hörnet av skärmen.</translation>
     </message>
     <message>
+        <location filename="../osdsettingswidget.cpp" line="156"/>
         <source>Shows a summary of current settings in the bottom-right corner of the display.</source>
         <translation>Visar ett sammandrag av aktuella inställningar i nedre högra hörnet av skärmen.</translation>
     </message>
 </context>
 <context>
-    <name>Pad</name>
-    <message>
-        <source>Save state contains controller type {0} in Port {1}.</source>
-        <translation>Sparat tillstånd innehåller kontrollertypen {0} i Port {1}.</translation>
-    </message>
-    <message>
-        <source>Leaving {0} connected.</source>
-        <translation>Lämnar {0} anslutet.</translation>
-    </message>
-    <message>
-        <source>Memory card {} present in save state but not in system.</source>
-        <translation>Minneskort {} finns i sparat tillstånd men inte i systemet.</translation>
-    </message>
-    <message>
-        <source>Creating temporary card.</source>
-        <translation>Skapar temporärt kort.</translation>
-    </message>
-    <message>
-        <source>Memory card {} from save state does not match current card data.</source>
-        <translation>Minneskort {} från sparat tillstånd matchar inte aktuellt kortdata.</translation>
-    </message>
-    <message>
-        <source>Simulating replugging. The game may not be able to handle this.</source>
-        <translation>Simulerar återanslutning. Spelet kanske inte kan hantera detta.</translation>
-    </message>
-    <message>
-        <source>Ignoring card.</source>
-        <translation>Ignorerar kort.</translation>
-    </message>
-    <message>
-        <source>Memory card {} present in system but not in save state.</source>
-        <translation>Minneskort {} finns i systemet men inte i sparat tillstånd.</translation>
-    </message>
-    <message>
-        <source>Removing card.</source>
-        <translation>Tar bort kort.</translation>
-    </message>
-    <message>
-        <source>Replugging card.</source>
-        <translation>Återansluter kort.</translation>
-    </message>
-</context>
-<context>
-    <name>PlayStationMouse</name>
-    <message>
-        <source>Pointer</source>
-        <translation>Pekare</translation>
-    </message>
-    <message>
-        <source>Left Button</source>
-        <translation>Vänster knapp</translation>
-    </message>
-    <message>
-        <source>Right Button</source>
-        <translation>Höger knapp</translation>
-    </message>
-    <message>
-        <source>Horizontal Sensitivity</source>
-        <translation>Horisontell känslighet</translation>
-    </message>
-    <message>
-        <source>Adjusts the correspondance between physical and virtual mouse movement.</source>
-        <translation>Justerar korrespondansen mellan fysiska och virtuella musrörelser.</translation>
-    </message>
-    <message>
-        <source>Vertical Sensitivity</source>
-        <translation>Vertikal känslighet</translation>
-    </message>
-</context>
-<context>
-    <name>PopnController</name>
-    <message>
-        <source>Left White</source>
-        <translation>Vänster vit</translation>
-    </message>
-    <message>
-        <source>Left Yellow</source>
-        <translation>Vänster gul</translation>
-    </message>
-    <message>
-        <source>Left Green</source>
-        <translation>Vänster grön</translation>
-    </message>
-    <message>
-        <source>Left Blue/Sel</source>
-        <translation>Vänster blå/Sel</translation>
-    </message>
-    <message>
-        <source>Middle Red/Okay</source>
-        <translation>Mitten röd/Okay</translation>
-    </message>
-    <message>
-        <source>Right Blue/Sel</source>
-        <translation>Höger blå/Sel</translation>
-    </message>
-    <message>
-        <source>Right Green</source>
-        <translation>Höger grön</translation>
-    </message>
-    <message>
-        <source>Right Yellow</source>
-        <translation>Höger gul</translation>
-    </message>
-    <message>
-        <source>Right White</source>
-        <translation>Höger vit</translation>
-    </message>
-    <message>
-        <source>Select</source>
-        <translation>Select</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-</context>
-<context>
-    <name>PostProcessing</name>
-    <message>
-        <source>Unknown Error</source>
-        <translation>Okänt fel</translation>
-    </message>
-    <message>
-        <source>GLSL</source>
-        <translation>GLSL</translation>
-    </message>
-    <message>
-        <source>ReShade</source>
-        <translation>ReShade</translation>
-    </message>
-    <message>
-        <source>Slang</source>
-        <translation>Slang</translation>
-    </message>
-    <message>
-        <source>Failed to compile post-processing shader &apos;{}&apos;.</source>
-        <translation>Misslyckades med att kompilera efterbehandlingsshadern &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>Failed to resize post-processing shader &apos;{}&apos;.</source>
-        <translation>Misslyckades med att storleksändra efterbehandlingsshadern &apos;{}&apos;.</translation>
-    </message>
-</context>
-<context>
     <name>PostProcessingChainConfigWidget</name>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="31"/>
         <source>Enable Post Processing</source>
         <translation>Aktivera efterbehandling</translation>
     </message>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="62"/>
         <source>&amp;Reload Shaders</source>
         <translation>&amp;Uppdatera shaders</translation>
     </message>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="75"/>
         <source>Post Processing Chain</source>
         <translation>Efterbehandlingskedja</translation>
     </message>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="103"/>
         <source>Add</source>
         <translation>Lägg till</translation>
     </message>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="120"/>
         <source>Remove</source>
         <translation>Ta bort</translation>
     </message>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="137"/>
         <source>Clear</source>
         <translation>Töm</translation>
     </message>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="154"/>
         <source>Move Up</source>
         <translation>Flytta upp</translation>
     </message>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="171"/>
         <source>Move Down</source>
         <translation>Flytta ner</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="242"/>
         <source>Are you sure you want to clear all shader stages?</source>
         <translation>Är du säker på att du vill tömma alla shader stages?</translation>
     </message>
     <message>
+        <location filename="../postprocessingchainconfigwidget.ui" line="51"/>
         <source>Open Directory</source>
         <translation>Öppna katalog</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="241"/>
         <source>Clear Shader Stages</source>
         <translation>Töm shader-steg</translation>
     </message>
@@ -15979,126 +10742,166 @@ Fel: {1}</translation>
 <context>
     <name>PostProcessingOverlayConfigWidget</name>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="29"/>
         <source>Basic Configuration</source>
         <translation>Grundinställning</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="45"/>
         <source>Selected Preset:</source>
         <translation>Valt förval:</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="35"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A border overlay is an image that is drawn around the system display. Border overlays are applied after post-processing. You can choose from the border list below, or manually configure a custom border.&lt;/p&gt;&lt;p&gt;Additional preset borders can be added to the &lt;span style=&quot; font-weight:700;&quot;&gt;resources\overlays&lt;/span&gt; folder within in the data directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ett kantöverlägg är en bild som ritas runt systemskärmen. Kantöverlägg appliceras efter efterbearbetning. Du kan välja från listan nedan eller manuellt konfigurera en anpassad kant.&lt;/p&gt;&lt;p&gt;Fler förval för kanter kan läggas till i mappen &lt;span style=&quot; font-weight:700;&quot;&gt;resources\overlays&lt;/span&gt; i datakatalogen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="61"/>
         <source>Refresh Overlay List</source>
         <translation>Uppdatera överläggslista</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="75"/>
         <source>Custom Configuration</source>
         <translation>Anpassad konfiguration</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="81"/>
         <source>Image Path:</source>
         <translation>Bildsökväg:</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="93"/>
         <source>Browse...</source>
         <translation>Bläddra…</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="106"/>
         <source>Display Start:</source>
         <translation>Skärmstart:</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="115"/>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="160"/>
         <source>X:</source>
         <translation>X:</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="122"/>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="139"/>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="167"/>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="184"/>
         <source> pixels</source>
         <translation> pixlar</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="132"/>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="177"/>
         <source>Y:</source>
         <translation>Y:</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="198"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="595"/>
         <source>Destination Alpha Blending</source>
         <translation>Alfablandning för destination</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="205"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="592"/>
         <source>Alpha Blending</source>
         <translation>Alfa-blandning</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="227"/>
         <source>Export...</source>
         <translation>Exportera...</translation>
     </message>
     <message>
+        <location filename="../postprocessingoverlayconfigwidget.ui" line="151"/>
         <source>Display End:</source>
         <translation>Skärmslut:</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="607"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="608"/>
         <source>Custom...</source>
         <translation>Anpassad...</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="582"/>
         <source>Image Path</source>
         <translation>Sökväg till bild</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="582"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="585"/>
         <source>Unspecified</source>
         <translation>Ospecificerad</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="583"/>
         <source>Defines the path of the custom overlay image that will be loaded.</source>
         <translation>Definierar sökvägen för den anpassade överlagringsbild som ska läsas in.</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="584"/>
         <source>Display Rectangle</source>
         <translation>Visa rektangel</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="586"/>
         <source>Defines the area in the overlay image that the game image will be drawn into.</source>
         <translation>Definierar det område i överläggsbilden som spelbilden ska ritas in i.</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="592"/>
+        <location filename="../postprocessingsettingswidget.cpp" line="595"/>
         <source>Unchecked</source>
         <translation>Omarkerad</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="593"/>
         <source>If checked, the overlay image will be alpha blended with the framebuffer, i.e. transparency will be applied.</source>
         <translation>Om den är markerad kommer överlagringsbilden att alfablandas med framebufferten, dvs. transparens kommer att tillämpas.</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="596"/>
         <source>If checked, the game image will be blended with the inverse amount of alpha in the overlay image. For example, an image with alpha of 0.75 will draw the game image at 25% brightness.</source>
         <translation>Om den är markerad kommer spelbilden att blandas med den omvända mängden alfa i överläggsbilden. Till exempel kommer en bild med alfa på 0,75 att rita spelbilden med 25% ljusstyrka.</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="640"/>
         <source>Select Image</source>
         <translation>Välj bild</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="641"/>
         <source>All Cover Image Types (*.jpg *.jpeg *.png *.webp)</source>
         <translation>Alla omslagsbildtyper (*.jpg *.jpeg *.png *.webp)</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="651"/>
         <source>Export to YAML</source>
         <translation>Exportera till YAML</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="651"/>
         <source>YAML Files (*.yml)</source>
         <translation>YAML-filer (*.yml)</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="674"/>
         <source>Export Error</source>
         <translation>Exportfel</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="675"/>
         <source>Failed to save file: %1</source>
         <translation>Misslyckades med att spara filen: %1</translation>
     </message>
@@ -16106,26 +10909,32 @@ Fel: {1}</translation>
 <context>
     <name>PostProcessingSelectShaderDialog</name>
     <message>
+        <location filename="../postprocessingselectshaderdialog.ui" line="14"/>
         <source>Select Shader</source>
         <translation>Välj shader</translation>
     </message>
     <message>
+        <location filename="../postprocessingselectshaderdialog.ui" line="51"/>
         <source>All</source>
         <translation>Alla</translation>
     </message>
     <message>
+        <location filename="../postprocessingselectshaderdialog.ui" line="64"/>
         <source>GLSL</source>
         <translation>GLSL</translation>
     </message>
     <message>
+        <location filename="../postprocessingselectshaderdialog.ui" line="74"/>
         <source>Reshade</source>
         <translation>Reshade</translation>
     </message>
     <message>
+        <location filename="../postprocessingselectshaderdialog.ui" line="84"/>
         <source>Slang</source>
         <translation>Slang</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="691"/>
         <source>Add</source>
         <translation>Lägg till</translation>
     </message>
@@ -16133,14 +10942,17 @@ Fel: {1}</translation>
 <context>
     <name>PostProcessingSettingsWidget</name>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="36"/>
         <source>Display</source>
         <translation>Skärm</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="38"/>
         <source>Internal</source>
         <translation>Intern</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="39"/>
         <source>Border Overlay</source>
         <translation>Kantöverlägg</translation>
     </message>
@@ -16148,22 +10960,27 @@ Fel: {1}</translation>
 <context>
     <name>PostProcessingShaderConfigWidget</name>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="462"/>
         <source>Red</source>
         <translation>Röd</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="462"/>
         <source>Green</source>
         <translation>Grön</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="462"/>
         <source>Blue</source>
         <translation>Blå</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="462"/>
         <source>Alpha</source>
         <translation>Alfa</translation>
     </message>
     <message>
+        <location filename="../postprocessingsettingswidget.cpp" line="463"/>
         <source>%1 (%2)</source>
         <translation>%1 (%2)</translation>
     </message>
@@ -16171,74 +10988,53 @@ Fel: {1}</translation>
 <context>
     <name>QtHost</name>
     <message>
+        <location filename="../qthost.cpp" line="3540"/>
+        <location filename="../qthost.cpp" line="3567"/>
+        <location filename="../qthost.cpp" line="3586"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <source>An error occurred while deleting empty game settings:
-{}</source>
-        <translation>Ett fel inträffade vid borttagning av tomma spelinställningar:
-{}</translation>
-    </message>
-    <message>
-        <source>An error occurred while saving game settings:
-{}</source>
-        <translation>Ett fel inträffade vid sparandet  av spelinställningar:
-{}</translation>
-    </message>
-    <message>
-        <source>Download failed: Data is empty.</source>
-        <translation>Hämtning misslyckades: Data är tomt.</translation>
-    </message>
-    <message>
-        <source>Yes</source>
-        <translation>Ja</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation>Nej</translation>
-    </message>
-    <message>
-        <source>Controller {} disconnected.</source>
-        <translation>Handkontroller {} frånkopplad.</translation>
-    </message>
-    <message>
+        <location filename="../qthost.cpp" line="3541"/>
         <source>File &apos;%1&apos; does not exist.</source>
         <translation>Filen &apos;%1&apos; finns inte.</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="3568"/>
         <source>The specified save state does not exist.</source>
         <translation>Det angivna sparade tillståndet finns inte.</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="3588"/>
         <source>Cannot use no-gui mode, because no boot filename was specified.</source>
         <translation>Kan inte använda no-gui-läget därför att inget uppstartsfilnamn angavs.</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="3589"/>
         <source>Cannot use batch mode, because no boot filename was specified.</source>
         <translation>Kan inte använda batch-läget därför att inget uppstartsfilnamn angavs.</translation>
     </message>
     <message>
-        <source>Unfortunately, the virtual machine has abnormally shut down and cannot be recovered. Please use the available support options for further assistance, and provide information about what you were doing when the error occurred, as well as the details below:
-
-{}</source>
-        <translation>Tyvärr har den virtuella maskinen stängts av på ett onormalt sätt och kan inte återställas. Använd de tillgängliga supportalternativen för ytterligare hjälp och lämna information om vad du gjorde när felet inträffade, samt detaljerna nedan:
-
-{}</translation>
-    </message>
-    <message>
+        <location filename="../qthost.cpp" line="2627"/>
         <source>System Language</source>
         <translation>Systemspråk</translation>
     </message>
     <message>
-        <source>Unknown</source>
-        <translation>Okänt</translation>
+        <location filename="../qthost.cpp" line="434"/>
+        <source>We have detected that LD_LIBRARY_PATH has been set to the following value:
+
+%1
+
+This will likely prevent DuckStation from working correctly. You should modify your environment to leave LD_LIBRARY_PATH unset.</source>
+        <translation>Miljövariabeln LD_LIBRARY_PATH är satt till:\n%1\n\nDetta kommer sannolikt att hindra DuckStation från att fungera korrekt. Ändra din miljö så att LD_LIBRARY_PATH inte är satt.</translation>
     </message>
     <message>
-        <source>Downloading {}...</source>
-        <translation>Hämtar {}...</translation>
+        <location filename="../qthost.cpp" line="440"/>
+        <source>Don&apos;t show again</source>
+        <translation>Visa inte igen</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="590"/>
         <source>Would you like to create a launcher shortcut for DuckStation?
 
 This will add DuckStation to your application menu, allowing you to launch it more easily.
@@ -16253,16 +11049,19 @@ Genvägen skapas på:
 %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="597"/>
         <source>Don&apos;t ask again</source>
         <translation>Fråga inte igen</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="620"/>
         <source>Failed to create launcher shortcut shortcut:
 %1</source>
         <translation>Det gick inte att skapa startgenvägen:
 %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="626"/>
         <source>Launcher shortcut created successfully.
 
 You can find DuckStation in your application menu.</source>
@@ -16271,6 +11070,7 @@ You can find DuckStation in your application menu.</source>
 Du hittar DuckStation i programmenyn.</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="650"/>
         <source>The existing launcher shortcut points to a different location:
 
 Current: %1
@@ -16285,412 +11085,29 @@ Genväg: %2
 Vill du uppdatera genvägen så att den pekar på den aktuella platsen?</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="666"/>
         <source>Failed to remove old launcher shortcut:
 %1</source>
         <translation>Det gick inte att ta bort den gamla startgenvägen:
 %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="675"/>
         <source>Failed to create updated launcher shortcut:
 %1</source>
         <translation>Det gick inte att skapa den uppdaterade startgenvägen:
 %1</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="681"/>
         <source>Launcher shortcut updated successfully.</source>
         <translation>Startgenvägen har uppdaterats.</translation>
-    </message>
-    <message>
-        <source>File Download</source>
-        <translation>Filhämtning</translation>
-    </message>
-</context>
-<context>
-    <name>SDLInputSource</name>
-    <message>
-        <source>LeftX</source>
-        <translation>LeftX</translation>
-    </message>
-    <message>
-        <source>LeftY</source>
-        <translation>LeftY</translation>
-    </message>
-    <message>
-        <source>RightX</source>
-        <translation>RightX</translation>
-    </message>
-    <message>
-        <source>RightY</source>
-        <translation>RightY</translation>
-    </message>
-    <message>
-        <source>LeftTrigger</source>
-        <translation>LeftTrigger</translation>
-    </message>
-    <message>
-        <source>RightTrigger</source>
-        <translation>RightTrigger</translation>
-    </message>
-    <message>
-        <source>L2</source>
-        <translation>L2</translation>
-    </message>
-    <message>
-        <source>R2</source>
-        <translation>R2</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <source>X</source>
-        <translation>X</translation>
-    </message>
-    <message>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <source>Back</source>
-        <translation>Back</translation>
-    </message>
-    <message>
-        <source>Guide</source>
-        <translation>Guide</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>LeftStick</source>
-        <translation>LeftStick</translation>
-    </message>
-    <message>
-        <source>RightStick</source>
-        <translation>RightStick</translation>
-    </message>
-    <message>
-        <source>LeftShoulder</source>
-        <translation>LeftShoulder</translation>
-    </message>
-    <message>
-        <source>RightShoulder</source>
-        <translation>RightShoulder</translation>
-    </message>
-    <message>
-        <source>DPadUp</source>
-        <translation>DPadUp</translation>
-    </message>
-    <message>
-        <source>DPadDown</source>
-        <translation>DPadDown</translation>
-    </message>
-    <message>
-        <source>DPadLeft</source>
-        <translation>DPadLeft</translation>
-    </message>
-    <message>
-        <source>DPadRight</source>
-        <translation>DPadRight</translation>
-    </message>
-    <message>
-        <source>Misc1</source>
-        <translation>Misc1</translation>
-    </message>
-    <message>
-        <source>RightPaddle1</source>
-        <translation>RightPaddle1</translation>
-    </message>
-    <message>
-        <source>LeftPaddle1</source>
-        <translation>LeftPaddle1</translation>
-    </message>
-    <message>
-        <source>RightPaddle2</source>
-        <translation>RightPaddle2</translation>
-    </message>
-    <message>
-        <source>LeftPaddle2</source>
-        <translation>LeftPaddle2</translation>
-    </message>
-    <message>
-        <source>Touchpad</source>
-        <translation>Touchpad</translation>
-    </message>
-    <message>
-        <source>Misc2</source>
-        <translation>Misc2</translation>
-    </message>
-    <message>
-        <source>Misc3</source>
-        <translation>Misc3</translation>
-    </message>
-    <message>
-        <source>Misc4</source>
-        <translation>Misc4</translation>
-    </message>
-    <message>
-        <source>Misc5</source>
-        <translation>Misc5</translation>
-    </message>
-    <message>
-        <source>Misc6</source>
-        <translation>Misc6</translation>
-    </message>
-    <message>
-        <source>Cross</source>
-        <translation>Cross</translation>
-    </message>
-    <message>
-        <source>Circle</source>
-        <translation>Circle</translation>
-    </message>
-    <message>
-        <source>Square</source>
-        <translation>Square</translation>
-    </message>
-    <message>
-        <source>Triangle</source>
-        <translation>Triangle</translation>
-    </message>
-    <message>
-        <source>Create</source>
-        <translation>Create</translation>
-    </message>
-    <message>
-        <source>PS</source>
-        <translation>PS</translation>
-    </message>
-    <message>
-        <source>Options</source>
-        <translation>Options</translation>
-    </message>
-    <message>
-        <source>L3</source>
-        <translation>L3</translation>
-    </message>
-    <message>
-        <source>R3</source>
-        <translation>R3</translation>
-    </message>
-    <message>
-        <source>L1</source>
-        <translation>L1</translation>
-    </message>
-    <message>
-        <source>R1</source>
-        <translation>R1</translation>
-    </message>
-    <message>
-        <source>North</source>
-        <translation>North</translation>
-    </message>
-    <message>
-        <source>East</source>
-        <translation>East</translation>
-    </message>
-    <message>
-        <source>South</source>
-        <translation>South</translation>
-    </message>
-    <message>
-        <source>West</source>
-        <translation>West</translation>
-    </message>
-    <message>
-        <source>Turn</source>
-        <translation>Turn</translation>
-    </message>
-    <message>
-        <source>Tilt</source>
-        <translation>Tilt</translation>
-    </message>
-    <message>
-        <source>Enable XBox HIDAPI Driver</source>
-        <translation>Aktivera XBox HIDAPI-drivrutin</translation>
-    </message>
-    <message>
-        <source>Enables the HIDAPI driver for XBox controllers.</source>
-        <translation>Aktiverar HIDAPI-drivrutinen för XBox-kontroller.</translation>
-    </message>
-    <message>
-        <source>Enable Raw Input Drivers</source>
-        <translation>Aktivera drivrutiner för råinmatning</translation>
-    </message>
-    <message>
-        <source>Enables raw input joystick drivers which can improve handling of XInput-capable devices.</source>
-        <translation>Aktiverar råa styrenhetsdrivrutiner som kan förbättra hanteringen av XInput-kompatibla enheter.</translation>
-    </message>
-    <message>
-        <source>Enable DirectInput Driver</source>
-        <translation>Aktivera DirectInput-drivrutin</translation>
-    </message>
-    <message>
-        <source>Enables compatibility with DirectInput controllers.</source>
-        <translation>Aktiverar kompatibilitet med DirectInput-kontroller.</translation>
-    </message>
-    <message>
-        <source>Enable XInput Driver</source>
-        <translation>Aktivera XInput-drivrutin</translation>
-    </message>
-    <message>
-        <source>Enables compatibility with XInput controllers.</source>
-        <translation>Aktiverar kompatibilitet med XInput-kontroller.</translation>
-    </message>
-    <message>
-        <source>Enable WGI Driver</source>
-        <translation>Aktivera WGI-drivrutin</translation>
-    </message>
-    <message>
-        <source>Enables compatibility with Windows.Gaming.Input controllers.</source>
-        <translation>Aktiverar kompatibilitet med Windows.Gaming.Input-kontroller.</translation>
-    </message>
-    <message>
-        <source>Enable GameInput Driver</source>
-        <translation>Aktivera GameInput-drivrutin</translation>
-    </message>
-    <message>
-        <source>Enables compatibility with GameInput controllers.</source>
-        <translation>Aktiverar kompatibilitet med GameInput-kontroller.</translation>
-    </message>
-    <message>
-        <source>Enable IOKit Driver</source>
-        <translation>Aktivera IOKit-drivrutin</translation>
-    </message>
-    <message>
-        <source>Allows the use of IOKit for controller handling.</source>
-        <translation>Tillåter användning av IOKit för hantering av styrenheter.</translation>
-    </message>
-    <message>
-        <source>Enable MFI Driver</source>
-        <translation>Aktivera MFI-drivrutin</translation>
-    </message>
-    <message>
-        <source>Allows the use of GCController/MFI for controller handling.</source>
-        <translation>Tillåter användning av GCController/MFI för hantering av kontroller.</translation>
-    </message>
-    <message>
-        <source>Force Digital Hat Inputs</source>
-        <translation>Tvinga digitala hatt-inmatningar</translation>
-    </message>
-    <message>
-        <source>Forces joysticks to always treat &apos;hat&apos; axis inputs (ABS_HAT0X - ABS_HAT3Y) as 8-way digital hats without checking whether they may be analog.</source>
-        <translation>Tvingar styrenheter att alltid behandla ”hat”-axelinmatningar (ABS_HAT0X - ABS_HAT3Y) som 8-vägs digitala hats utan att kontrollera om de kan vara analoga.</translation>
-    </message>
-    <message>
-        <source>SDL-{0}  {1}</source>
-        <translation>SDL-{0}  {1}</translation>
-    </message>
-    <message>
-        <source>SDL-{0}/{1}</source>
-        <translation>SDL-{0}/{1}</translation>
-    </message>
-    <message>
-        <source>SDL-{0}/Hat{1}{2}</source>
-        <translation>SDL-{0}/Hat{1}{2}</translation>
-    </message>
-    <message>
-        <source>SmallMotor</source>
-        <translation>SmallMotor</translation>
-    </message>
-    <message>
-        <source>LargeMotor</source>
-        <translation>LargeMotor</translation>
-    </message>
-    <message>
-        <source>Haptic</source>
-        <translation>Haptic</translation>
-    </message>
-    <message>
-        <source>MuteLED</source>
-        <translation>MuteLED</translation>
-    </message>
-    <message>
-        <source>RGBLED</source>
-        <translation>RGBLED</translation>
-    </message>
-    <message>
-        <source>SDL-{0}/{1}{2}{3}</source>
-        <translation>SDL-{0}/{1}{2}{3}</translation>
-    </message>
-</context>
-<context>
-    <name>SPU</name>
-    <message>
-        <source>Failed to create or configure audio stream, falling back to null output. The error was:
-{}</source>
-        <translation>Misslyckades med att skapa eller konfigurera ljudström, faller tillbaka till null-utdata. Felet var:
-{}</translation>
-    </message>
-</context>
-<context>
-    <name>SaveStateSelectorUI</name>
-    <message>
-        <source>No save state slots available.</source>
-        <translation>Inga platser för sparade tillstånd är tillgängliga.</translation>
-    </message>
-    <message>
-        <source>Load</source>
-        <translation>Läs in</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>Spara</translation>
-    </message>
-    <message>
-        <source>Select Previous</source>
-        <translation>Välj föregående</translation>
-    </message>
-    <message>
-        <source>Select Next</source>
-        <translation>Välj nästa</translation>
-    </message>
-    <message>
-        <source>{} ({})</source>
-        <translation>{} ({})</translation>
-    </message>
-    <message>
-        <source>Saved {}</source>
-        <translation>Sparat {}</translation>
-    </message>
-    <message>
-        <source>No save present in this slot.</source>
-        <translation>Ingen sparning finns på denna plats.</translation>
-    </message>
-    <message>
-        <source>Unknown error.</source>
-        <translation>Okänt fel.</translation>
-    </message>
-    <message>
-        <source>Global Slot {}</source>
-        <translation>Global plats {}</translation>
-    </message>
-    <message>
-        <source>Game Slot {}</source>
-        <translation>Spelplats {}</translation>
-    </message>
-    <message>
-        <source>No save in this slot.</source>
-        <translation>Ingen sparning i denna plats.</translation>
-    </message>
-    <message>
-        <source>Global Save Slot {} selected.</source>
-        <translation>Global sparningsplats {} vald.</translation>
-    </message>
-    <message>
-        <source>Save Slot {0} selected.</source>
-        <translation>Sparningsplats {0} vald.</translation>
     </message>
 </context>
 <context>
     <name>SearchBox</name>
     <message>
+        <location filename="../searchbox.cpp" line="13"/>
         <source>Search...</source>
         <translation>Sök...</translation>
     </message>
@@ -16698,30 +11115,37 @@ Vill du uppdatera genvägen så att den pekar på den aktuella platsen?</transla
 <context>
     <name>SelectDiscDialog</name>
     <message>
+        <location filename="../selectdiscdialog.ui" line="20"/>
         <source>Select the disc that you want to boot.</source>
         <translation>Välj skivan som du vill starta upp.</translation>
     </message>
     <message>
+        <location filename="../selectdiscdialog.ui" line="31"/>
         <source>Disc</source>
         <translation>Skiva</translation>
     </message>
     <message>
+        <location filename="../selectdiscdialog.ui" line="36"/>
         <source>File Name</source>
         <translation>Filnamn</translation>
     </message>
     <message>
+        <location filename="../selectdiscdialog.ui" line="41"/>
         <source>Last Played</source>
         <translation>Senast spelat</translation>
     </message>
     <message>
+        <location filename="../selectdiscdialog.ui" line="64"/>
         <source>Select</source>
         <translation>Välj</translation>
     </message>
     <message>
+        <location filename="../selectdiscdialog.ui" line="74"/>
         <source>Cancel</source>
         <translation>Avbryt</translation>
     </message>
     <message>
+        <location filename="../selectdiscdialog.cpp" line="90"/>
         <source>Select Disc for %1</source>
         <translation>Välj skiva för %1</translation>
     </message>
@@ -16729,22 +11153,28 @@ Vill du uppdatera genvägen så att den pekar på den aktuella platsen?</transla
 <context>
     <name>SettingWidgetBinder</name>
     <message>
+        <location filename="../settingwidgetbinder.h" line="145"/>
         <source>Use Global Setting [Enabled]</source>
         <translation>Använd global inställning [aktiverad]</translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="146"/>
         <source>Use Global Setting [Disabled]</source>
         <translation>Använd global inställning [inaktiverad]</translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="421"/>
+        <location filename="../settingwidgetbinder.h" line="557"/>
         <source>Global: </source>
         <translation>Globalt: </translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="1290"/>
         <source>Confirm Folder</source>
         <translation>Bekräfta mapp</translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="1291"/>
         <source>The chosen directory does not currently exist:
 
 %1
@@ -16757,967 +11187,245 @@ Do you want to create this directory?</source>
 Vill du skapa denna katalog?</translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="1314"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="1315"/>
         <source>Folder path cannot be empty.</source>
         <translation>Mappsökvägen får inte vara tom.</translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="1382"/>
         <source>%1 [incompatible]</source>
         <translation>%1 [inkompatibel]</translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="1404"/>
         <source>%1 [forced]</source>
         <translation>%1 [tvingad]</translation>
     </message>
     <message>
+        <location filename="../settingwidgetbinder.h" line="1374"/>
+        <location filename="../settingwidgetbinder.h" line="1378"/>
         <source>Incompatible with this game</source>
         <translation>Inkompatibelt med detta spel</translation>
     </message>
     <message>
+        <location filename="../achievementsettingswidget.cpp" line="168"/>
+        <location filename="../graphicssettingswidget.cpp" line="887"/>
+        <location filename="../settingwidgetbinder.h" line="154"/>
+        <location filename="../settingwidgetbinder.h" line="170"/>
         <source>Use Global Setting [%1]</source>
         <translation>Använd global inställning [%1]</translation>
     </message>
 </context>
 <context>
-    <name>Settings</name>
-    <message>
-        <source>None</source>
-        <comment>LogLevel</comment>
-        <translation>Ingen</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <comment>LogLevel</comment>
-        <translation>Fel</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <comment>LogLevel</comment>
-        <translation>Varning</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <comment>LogLevel</comment>
-        <translation>Information</translation>
-    </message>
-    <message>
-        <source>Verbose</source>
-        <comment>LogLevel</comment>
-        <translation>Utförlig</translation>
-    </message>
-    <message>
-        <source>Developer</source>
-        <comment>LogLevel</comment>
-        <translation>Utvecklare</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <comment>LogLevel</comment>
-        <translation>Felsök</translation>
-    </message>
-    <message>
-        <source>Trace</source>
-        <comment>LogLevel</comment>
-        <translation>Spåra</translation>
-    </message>
-    <message>
-        <source>Auto-Detect</source>
-        <comment>ConsoleRegion</comment>
-        <translation>Identifiera automatiskt</translation>
-    </message>
-    <message>
-        <source>NTSC-J (Japan)</source>
-        <comment>ConsoleRegion</comment>
-        <translation>NTSC-J (Japan)</translation>
-    </message>
-    <message>
-        <source>NTSC-U/C (US, Canada)</source>
-        <comment>ConsoleRegion</comment>
-        <translation>NTSC-U/C (USA, Kanada)</translation>
-    </message>
-    <message>
-        <source>PAL (Europe, Australia)</source>
-        <comment>ConsoleRegion</comment>
-        <translation>PAL (Europa, Australien)</translation>
-    </message>
-    <message>
-        <source>NTSC-J (Japan)</source>
-        <comment>DiscRegion</comment>
-        <translation>NTSC-J (Japan)</translation>
-    </message>
-    <message>
-        <source>NTSC-U/C (US, Canada)</source>
-        <comment>DiscRegion</comment>
-        <translation>NTSC-U/C (USA, Kanada)</translation>
-    </message>
-    <message>
-        <source>PAL (Europe, Australia)</source>
-        <comment>DiscRegion</comment>
-        <translation>PAL (Europa, Australien)</translation>
-    </message>
-    <message>
-        <source>Other</source>
-        <comment>DiscRegion</comment>
-        <translation>Annat</translation>
-    </message>
-    <message>
-        <source>Non-PS1</source>
-        <comment>DiscRegion</comment>
-        <translation>Icke-PS1</translation>
-    </message>
-    <message>
-        <source>Interpreter (Slowest)</source>
-        <comment>CPUExecutionMode</comment>
-        <translation>Tolk (långsammast)</translation>
-    </message>
-    <message>
-        <source>Cached Interpreter (Faster)</source>
-        <comment>CPUExecutionMode</comment>
-        <translation>Cachad tolk (snabbare)</translation>
-    </message>
-    <message>
-        <source>Recompiler (Fastest)</source>
-        <comment>CPUExecutionMode</comment>
-        <translation>Omkompilerare (snabbaste)</translation>
-    </message>
-    <message>
-        <source>Disabled (Slowest)</source>
-        <comment>CPUFastmemMode</comment>
-        <translation>Inaktiverad (långsammast)</translation>
-    </message>
-    <message>
-        <source>MMap (Hardware, Fastest, 64-Bit Only)</source>
-        <comment>CPUFastmemMode</comment>
-        <translation>MMap (hårdvara, snabbast, endast 64 bitar)</translation>
-    </message>
-    <message>
-        <source>LUT (Faster)</source>
-        <comment>CPUFastmemMode</comment>
-        <translation>LUT (snabbare)</translation>
-    </message>
-    <message>
-        <source>Automatic</source>
-        <comment>GPURenderer</comment>
-        <translation>Automatiskt</translation>
-    </message>
-    <message>
-        <source>Direct3D 11</source>
-        <comment>GPURenderer</comment>
-        <translation>Direct3D 11</translation>
-    </message>
-    <message>
-        <source>Direct3D 12</source>
-        <comment>GPURenderer</comment>
-        <translation>Direct3D 12</translation>
-    </message>
-    <message>
-        <source>Metal</source>
-        <comment>GPURenderer</comment>
-        <translation>Metall</translation>
-    </message>
-    <message>
-        <source>Vulkan</source>
-        <comment>GPURenderer</comment>
-        <translation>Vulkan</translation>
-    </message>
-    <message>
-        <source>OpenGL</source>
-        <comment>GPURenderer</comment>
-        <translation>OpenGL</translation>
-    </message>
-    <message>
-        <source>Software</source>
-        <comment>GPURenderer</comment>
-        <translation>Programvara</translation>
-    </message>
-    <message>
-        <source>Nearest-Neighbor</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>Närmaste granne</translation>
-    </message>
-    <message>
-        <source>Bilinear</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>Bilinjär</translation>
-    </message>
-    <message>
-        <source>Bilinear (No Edge Blending)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>Bilinjär (ingen kantblandning)</translation>
-    </message>
-    <message>
-        <source>JINC2 (Slow)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>JINC2 (långsam)</translation>
-    </message>
-    <message>
-        <source>JINC2 (Slow, No Edge Blending)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>JINC2 (Långsam, ingen kantblandning)</translation>
-    </message>
-    <message>
-        <source>xBR (Very Slow)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>xBR (mycket långsam)</translation>
-    </message>
-    <message>
-        <source>xBR (Very Slow, No Edge Blending)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>xBR (mycket långsam, ingen kantblandning)</translation>
-    </message>
-    <message>
-        <source>MMPX Advanced (Very Slow)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>MMPX avancerad (mycket långsam)</translation>
-    </message>
-    <message>
-        <source>Disabled</source>
-        <comment>GPULineDetectMode</comment>
-        <translation>Inaktiverad</translation>
-    </message>
-    <message>
-        <source>Quads</source>
-        <comment>GPULineDetectMode</comment>
-        <translation>Kvadrater</translation>
-    </message>
-    <message>
-        <source>Triangles (Basic)</source>
-        <comment>GPULineDetectMode</comment>
-        <translation>Trianglar (grundläggande)</translation>
-    </message>
-    <message>
-        <source>Triangles (Aggressive)</source>
-        <comment>GPULineDetectMode</comment>
-        <translation>Trianglar (Aggressiv)</translation>
-    </message>
-    <message>
-        <source>Disabled</source>
-        <comment>GPUDownsampleMode</comment>
-        <translation>Inaktiverad</translation>
-    </message>
-    <message>
-        <source>Box (Downsample 3D/Smooth All)</source>
-        <comment>GPUDownsampleMode</comment>
-        <translation>Box (nedsampling 3D/utjämna alla)</translation>
-    </message>
-    <message>
-        <source>Adaptive (Preserve 3D/Smooth 2D)</source>
-        <comment>GPUDownsampleMode</comment>
-        <translation>Adaptiv (bevara 3D/utjämna 2D)</translation>
-    </message>
-    <message>
-        <source>Disabled</source>
-        <comment>GPUWireframeMode</comment>
-        <translation>Inaktiverad</translation>
-    </message>
-    <message>
-        <source>Overlay Wireframe</source>
-        <comment>GPUWireframeMode</comment>
-        <translation>Överlägg Wireframe</translation>
-    </message>
-    <message>
-        <source>Only Wireframe</source>
-        <comment>GPUWireframeMode</comment>
-        <translation>Endast Wireframe</translation>
-    </message>
-    <message>
-        <source>Disabled</source>
-        <comment>GPUDumpCompressionMode</comment>
-        <translation>Inaktiverad</translation>
-    </message>
-    <message>
-        <source>Zstandard (Low)</source>
-        <comment>GPUDumpCompressionMode</comment>
-        <translation>Zstandard (låg)</translation>
-    </message>
-    <message>
-        <source>Zstandard (Default)</source>
-        <comment>GPUDumpCompressionMode</comment>
-        <translation>Zstandard (standard)</translation>
-    </message>
-    <message>
-        <source>Zstandard (High)</source>
-        <comment>GPUDumpCompressionMode</comment>
-        <translation>Zstandard (hög)</translation>
-    </message>
-    <message>
-        <source>XZ (Low)</source>
-        <comment>GPUDumpCompressionMode</comment>
-        <translation>XZ (låg)</translation>
-    </message>
-    <message>
-        <source>XZ (Default)</source>
-        <comment>GPUDumpCompressionMode</comment>
-        <translation>XZ (standard)</translation>
-    </message>
-    <message>
-        <source>XZ (High)</source>
-        <comment>GPUDumpCompressionMode</comment>
-        <translation>XZ (hög)</translation>
-    </message>
-    <message>
-        <source>Disabled (Flickering)</source>
-        <comment>DisplayDeinterlacingMode</comment>
-        <translation>Inaktiverad (flimrande)</translation>
-    </message>
-    <message>
-        <source>Weave (Combing)</source>
-        <comment>DisplayDeinterlacingMode</comment>
-        <translation>Weave (kamning)</translation>
-    </message>
-    <message>
-        <source>Blend (Blur)</source>
-        <comment>DisplayDeinterlacingMode</comment>
-        <translation>Blanda (oskärpa)</translation>
-    </message>
-    <message>
-        <source>Adaptive (FastMAD)</source>
-        <comment>DisplayDeinterlacingMode</comment>
-        <translation>Adaptiv (FastMAD)</translation>
-    </message>
-    <message>
-        <source>Progressive (Optimal)</source>
-        <comment>DisplayDeinterlacingMode</comment>
-        <translation>Progressiv (optimal)</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <comment>DisplayCropMode</comment>
-        <translation>Ingen</translation>
-    </message>
-    <message>
-        <source>Only Overscan Area</source>
-        <comment>DisplayCropMode</comment>
-        <translation>Endast överskanningsområde</translation>
-    </message>
-    <message>
-        <source>Only Overscan Area (Aspect Uncorrected)</source>
-        <comment>DisplayCropMode</comment>
-        <translation>Endast överskanningsområde (bildförhållande inte korrigerat)</translation>
-    </message>
-    <message>
-        <source>All Borders</source>
-        <comment>DisplayCropMode</comment>
-        <translation>Alla kanter</translation>
-    </message>
-    <message>
-        <source>All Borders (Aspect Uncorrected)</source>
-        <comment>DisplayCropMode</comment>
-        <translation>Alla kanter (bildförhållande inte korrigerat)</translation>
-    </message>
-    <message>
-        <source>Auto (Game Native)</source>
-        <comment>DisplayAspectRatio</comment>
-        <translation>Automatiskt (spelets inbyggda)</translation>
-    </message>
-    <message>
-        <source>Stretch To Fill</source>
-        <comment>DisplayAspectRatio</comment>
-        <translation>Sträck ut för att fylla</translation>
-    </message>
-    <message>
-        <source>Left / Top</source>
-        <comment>DisplayAlignment</comment>
-        <translation>Vänster / Överst</translation>
-    </message>
-    <message>
-        <source>Center</source>
-        <comment>DisplayAlignment</comment>
-        <translation>Centrera</translation>
-    </message>
-    <message>
-        <source>Right / Bottom</source>
-        <comment>DisplayAlignment</comment>
-        <translation>Höger / Nederst</translation>
-    </message>
-    <message>
-        <source>No Rotation</source>
-        <comment>DisplayRotation</comment>
-        <translation>Ingen rotation</translation>
-    </message>
-    <message>
-        <source>Rotate 90° (Clockwise)</source>
-        <comment>DisplayRotation</comment>
-        <translation>Rotera 90° (medurs)</translation>
-    </message>
-    <message>
-        <source>Rotate 180° (Vertical Flip)</source>
-        <comment>DisplayRotation</comment>
-        <translation>Rotera 180° (vertikal vändning)</translation>
-    </message>
-    <message>
-        <source>Rotate 270° (Clockwise)</source>
-        <comment>DisplayRotation</comment>
-        <translation>Rotera 270° (medurs)</translation>
-    </message>
-    <message>
-        <source>Nearest-Neighbor</source>
-        <comment>DisplayScalingMode</comment>
-        <translation>Närmaste granne</translation>
-    </message>
-    <message>
-        <source>Nearest-Neighbor (Integer)</source>
-        <comment>DisplayScalingMode</comment>
-        <translation>Närmaste granne (heltal)</translation>
-    </message>
-    <message>
-        <source>Bilinear (Smooth)</source>
-        <comment>DisplayScalingMode</comment>
-        <translation>Bilinjär (mjuk)</translation>
-    </message>
-    <message>
-        <source>Bilinear (Sharp)</source>
-        <comment>DisplayScalingMode</comment>
-        <translation>Bilinjär (skarp)</translation>
-    </message>
-    <message>
-        <source>Bilinear (Integer)</source>
-        <comment>DisplayScalingMode</comment>
-        <translation>Bilinjär (heltal)</translation>
-    </message>
-    <message>
-        <source>Lanczos (Sharp)</source>
-        <comment>DisplayScalingMode</comment>
-        <translation>Lanczos (skarp)</translation>
-    </message>
-    <message>
-        <source>Automatic</source>
-        <comment>DisplayExclusiveFullscreenControl</comment>
-        <translation>Automatiskt</translation>
-    </message>
-    <message>
-        <source>Disallowed</source>
-        <comment>DisplayExclusiveFullscreenControl</comment>
-        <translation>Inte tillåten</translation>
-    </message>
-    <message>
-        <source>Allowed</source>
-        <comment>DisplayExclusiveFullscreenControl</comment>
-        <translation>Tillåten</translation>
-    </message>
-    <message>
-        <source>Screen Resolution</source>
-        <comment>DisplayScreenshotMode</comment>
-        <translation>Skärmupplösning</translation>
-    </message>
-    <message>
-        <source>Internal Resolution</source>
-        <comment>DisplayScreenshotMode</comment>
-        <translation>Intern upplösning</translation>
-    </message>
-    <message>
-        <source>Internal Resolution (Aspect Uncorrected)</source>
-        <comment>DisplayScreenshotMode</comment>
-        <translation>Intern upplösning (bildförhållande okorrigerad)</translation>
-    </message>
-    <message>
-        <source>PNG</source>
-        <comment>DisplayScreenshotFormat</comment>
-        <translation>PNG</translation>
-    </message>
-    <message>
-        <source>JPEG</source>
-        <comment>DisplayScreenshotFormat</comment>
-        <translation>JPEG</translation>
-    </message>
-    <message>
-        <source>WebP</source>
-        <comment>DisplayScreenshotFormat</comment>
-        <translation>WebP</translation>
-    </message>
-    <message>
-        <source>Timestamp</source>
-        <comment>CaptureFileNameFormat</comment>
-        <translation>Tidsstämpel</translation>
-    </message>
-    <message>
-        <source>Game and Timestamp</source>
-        <comment>CaptureFileNameFormat</comment>
-        <translation>Spel och tidsstämpel</translation>
-    </message>
-    <message>
-        <source>Timestamp in Game Folder</source>
-        <comment>CaptureFileNameFormat</comment>
-        <translation>Tidsstämpel i spelmapp</translation>
-    </message>
-    <message>
-        <source>Game and Timestamp in Game Folder</source>
-        <comment>CaptureFileNameFormat</comment>
-        <translation>Spel och tidsstämpel i spelmapp</translation>
-    </message>
-    <message>
-        <source>Disabled</source>
-        <comment>AchievementProgressIndicatorMode</comment>
-        <translation>Inaktiverad</translation>
-    </message>
-    <message>
-        <source>Show Icon</source>
-        <comment>AchievementProgressIndicatorMode</comment>
-        <translation>Visa ikon</translation>
-    </message>
-    <message>
-        <source>Show Icon and Title</source>
-        <comment>AchievementProgressIndicatorMode</comment>
-        <translation>Visa ikon och titel</translation>
-    </message>
-    <message>
-        <source>No Memory Card</source>
-        <comment>MemoryCardType</comment>
-        <translation>Inget minneskort</translation>
-    </message>
-    <message>
-        <source>Shared Between All Games</source>
-        <comment>MemoryCardType</comment>
-        <translation>Delat mellan alla spel</translation>
-    </message>
-    <message>
-        <source>Separate Card Per Game (Serial)</source>
-        <comment>MemoryCardType</comment>
-        <translation>Separat kort per spel (serienummer)</translation>
-    </message>
-    <message>
-        <source>Separate Card Per Game (Title)</source>
-        <comment>MemoryCardType</comment>
-        <translation>Separat kort per spel (titel)</translation>
-    </message>
-    <message>
-        <source>Separate Card Per Game (File Title)</source>
-        <comment>MemoryCardType</comment>
-        <translation>Separat kort per spel (filtitel)</translation>
-    </message>
-    <message>
-        <source>Non-Persistent Card (Do Not Save)</source>
-        <comment>MemoryCardType</comment>
-        <translation>Icke beständigt kort (spara inte)</translation>
-    </message>
-    <message>
-        <source>Disabled</source>
-        <comment>MultitapMode</comment>
-        <translation>Inaktiverad</translation>
-    </message>
-    <message>
-        <source>Enable on Port 1 Only</source>
-        <comment>MultitapMode</comment>
-        <translation>Aktivera endast på port 1</translation>
-    </message>
-    <message>
-        <source>Enable on Port 2 Only</source>
-        <comment>MultitapMode</comment>
-        <translation>Aktivera endast på port 2</translation>
-    </message>
-    <message>
-        <source>Enable on Ports 1 and 2</source>
-        <comment>MultitapMode</comment>
-        <translation>Aktivera på port 1 och 2</translation>
-    </message>
-    <message>
-        <source>Uncompressed</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>Okomprimerad</translation>
-    </message>
-    <message>
-        <source>Deflate (Low)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>Deflate (låg)</translation>
-    </message>
-    <message>
-        <source>Deflate (Default)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>Deflate (standard)</translation>
-    </message>
-    <message>
-        <source>Deflate (High)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>Deflate (hög)</translation>
-    </message>
-    <message>
-        <source>Zstandard (Low)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>Zstandard (låg)</translation>
-    </message>
-    <message>
-        <source>Zstandard (Default)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>Zstandard (standard)</translation>
-    </message>
-    <message>
-        <source>Zstandard (High)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>Zstandard (hög)</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <comment>PIODeviceType</comment>
-        <translation>Ingen</translation>
-    </message>
-    <message>
-        <source>Xplorer/Xploder Cartridge</source>
-        <comment>PIODeviceType</comment>
-        <translation>Xplorer/Xploder-kassett</translation>
-    </message>
-    <message>
-        <source>Null (No Output)</source>
-        <comment>AudioBackend</comment>
-        <translation>Null (ingen utmatning)</translation>
-    </message>
-    <message>
-        <source>Cubeb</source>
-        <comment>AudioBackend</comment>
-        <translation>Cubeb</translation>
-    </message>
-    <message>
-        <source>SDL</source>
-        <comment>AudioBackend</comment>
-        <translation>SDL</translation>
-    </message>
-    <message>
-        <source>XAudio2</source>
-        <comment>AudioBackend</comment>
-        <translation>XAudio2</translation>
-    </message>
-    <message>
-        <source>Off (Noisy)</source>
-        <comment>AudioStretchMode</comment>
-        <translation>Av (brusigt)</translation>
-    </message>
-    <message>
-        <source>Resampling (Pitch Shift)</source>
-        <comment>AudioStretchMode</comment>
-        <translation>Omsampling (tonhöjdsändring)</translation>
-    </message>
-    <message>
-        <source>Time Stretch (Tempo Change, Best Sound)</source>
-        <comment>AudioStretchMode</comment>
-        <translation>Tidsutsträckning (tempoväxling, bästa ljud)</translation>
-    </message>
-    <message>
-        <source>Unscaled</source>
-        <comment>GPUDitheringMode</comment>
-        <translation>Oskalad</translation>
-    </message>
-    <message>
-        <source>Unscaled (Shader Blending)</source>
-        <comment>GPUDitheringMode</comment>
-        <translation>Oskalad (Shader-blandning)</translation>
-    </message>
-    <message>
-        <source>Scaled</source>
-        <comment>GPUDitheringMode</comment>
-        <translation>Skalad</translation>
-    </message>
-    <message>
-        <source>Scaled (Shader Blending)</source>
-        <comment>GPUDitheringMode</comment>
-        <translation>Skalad (Shader-blandning)</translation>
-    </message>
-    <message>
-        <source>True Color</source>
-        <comment>GPUDitheringMode</comment>
-        <translation>True Color</translation>
-    </message>
-    <message>
-        <source>True Color (Full)</source>
-        <comment>GPUDitheringMode</comment>
-        <translation>True Color (Fullständig)</translation>
-    </message>
-    <message>
-        <source>Auto-Detect</source>
-        <comment>ForceVideoTiming</comment>
-        <translation>Identifiera automatiskt</translation>
-    </message>
-    <message>
-        <source>Scale2x (EPX)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>Scale2x (EPX)</translation>
-    </message>
-    <message>
-        <source>Scale3x (Slow)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>Scale3x (Långsam)</translation>
-    </message>
-    <message>
-        <source>MMPX (Slow)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>MMPX (Långsam)</translation>
-    </message>
-    <message>
-        <source>MMPX Enhanced (Slow)</source>
-        <comment>GPUTextureFilter</comment>
-        <translation>MMPX förbättrad (Långsam)</translation>
-    </message>
-    <message>
-        <source>NTSC (60 Hz)</source>
-        <comment>ForceVideoTiming</comment>
-        <translation>NTSC (60 Hz)</translation>
-    </message>
-    <message>
-        <source>PAL (50 Hz)</source>
-        <comment>ForceVideoTiming</comment>
-        <translation>PAL (50 Hz)</translation>
-    </message>
-    <message>
-        <source>Disabled</source>
-        <comment>AchievementChallengeIndicatorMode</comment>
-        <translation>Inaktiverad</translation>
-    </message>
-    <message>
-        <source>Show Persistent Icons</source>
-        <comment>AchievementChallengeIndicatorMode</comment>
-        <translation>Visa bestående ikoner</translation>
-    </message>
-    <message>
-        <source>Show Temporary Icons</source>
-        <comment>AchievementChallengeIndicatorMode</comment>
-        <translation>Visa temporära ikoner</translation>
-    </message>
-    <message>
-        <source>Show Notifications</source>
-        <comment>AchievementChallengeIndicatorMode</comment>
-        <translation>Visa aviseringar</translation>
-    </message>
-    <message>
-        <source>XZ (Low)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>XZ (låg)</translation>
-    </message>
-    <message>
-        <source>XZ (Default)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>XZ (standard)</translation>
-    </message>
-    <message>
-        <source>XZ (High)</source>
-        <comment>SaveStateCompressionMode</comment>
-        <translation>XZ (hög)</translation>
-    </message>
-    <message>
-        <source>Bilinear (Hybrid)</source>
-        <comment>DisplayScalingMode</comment>
-        <translation>Bilinjär (Hybrid)</translation>
-    </message>
-    <message>
-        <source>PAR 1:1</source>
-        <comment>DisplayAspectRatio</comment>
-        <translation>PAR 1:1</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <comment>DisplayFineCropMode</comment>
-        <translation>Ingen</translation>
-    </message>
-    <message>
-        <source>Video Resolution</source>
-        <comment>DisplayFineCropMode</comment>
-        <translation>Videoupplösning</translation>
-    </message>
-    <message>
-        <source>Internal Resolution</source>
-        <comment>DisplayFineCropMode</comment>
-        <translation>Intern upplösning</translation>
-    </message>
-    <message>
-        <source>Window Resolution</source>
-        <comment>DisplayFineCropMode</comment>
-        <translation>Fönsterupplösning</translation>
-    </message>
-    <message>
-        <source>Top Left</source>
-        <comment>NotificationLocation</comment>
-        <translation>Överst till vänster</translation>
-    </message>
-    <message>
-        <source>Top Center</source>
-        <comment>NotificationLocation</comment>
-        <translation>Överst i mitten</translation>
-    </message>
-    <message>
-        <source>Top Right</source>
-        <comment>NotificationLocation</comment>
-        <translation>Överst till höger</translation>
-    </message>
-    <message>
-        <source>Bottom Left</source>
-        <comment>NotificationLocation</comment>
-        <translation>Nederst till vänster</translation>
-    </message>
-    <message>
-        <source>Bottom Center</source>
-        <comment>NotificationLocation</comment>
-        <translation>Nederst i mitten</translation>
-    </message>
-    <message>
-        <source>Bottom Right</source>
-        <comment>NotificationLocation</comment>
-        <translation>Nederst till höger</translation>
-    </message>
-</context>
-<context>
     <name>SettingsWindow</name>
     <message>
+        <location filename="../settingswindow.ui" line="96"/>
         <source>Restore Defaults</source>
         <translation>Återställ standardvärden</translation>
     </message>
     <message>
+        <location filename="../settingswindow.ui" line="103"/>
         <source>Copy Global Settings</source>
         <translation>Kopiera globala inställningar</translation>
     </message>
     <message>
+        <location filename="../settingswindow.ui" line="110"/>
         <source>Clear Settings</source>
         <translation>Töm inställningar</translation>
     </message>
     <message>
+        <location filename="../settingswindow.ui" line="117"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="68"/>
         <source>Summary</source>
         <translation>Sammandrag</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="70"/>
         <source>&lt;strong&gt;Summary&lt;/strong&gt;&lt;hr&gt;This page shows information about the selected game, and allows you to validate your disc was dumped correctly.</source>
         <translation>&lt;strong&gt;Sammandrag&lt;/strong&gt;&lt;hr&gt;Denna sida visar information om det valda spelet och låter dig validera att din skiva dumpades korrekt.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="100"/>
         <source>&lt;strong&gt;Interface Settings&lt;/strong&gt;&lt;hr&gt;These options control how the emulator looks and behaves.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Gränssnittsinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr hur emulatorn ser ut och uppför sig.&lt;br&gt;&lt;br&gt;Hovra över ett alternativ för ytterligare information, och Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="108"/>
         <source>&lt;strong&gt;Game List Settings&lt;/strong&gt;&lt;hr&gt;The list above shows the directories which will be searched by DuckStation to populate the game list. Search directories can be added, removed, and switched to recursive/non-recursive.</source>
         <translation>&lt;strong&gt;Inställningar för spellista&lt;/strong&gt;&lt;hr&gt;Listan ovanför visar katalogerna som kommer att sökas igenom av DuckStation för att fylla upp spellistan. Sökkataloger kan läggas till, tas bort och växlas mellan rekursiv/icke-rekursiv sökninig.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="117"/>
         <source>Console</source>
         <translation>Konsol</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="119"/>
         <source>&lt;strong&gt;Console Settings&lt;/strong&gt;&lt;hr&gt;These options determine the configuration of the simulated console.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Konsolinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ bestämmer konfigurationen för den simulerade konsolen.&lt;br&gt;&lt;br&gt;Hovra över ett alternativ för ytterligare information samt Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="124"/>
         <source>&lt;strong&gt;Emulation Settings&lt;/strong&gt;&lt;hr&gt;These options determine the speed and runahead behavior of the system.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Emuleringsinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ bestämmer hastighet och runahead-beteende för systemet.&lt;br&gt;&lt;br&gt;Hovra över ett alternativ för ytterligare information samt Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="131"/>
         <source>&lt;strong&gt;Patches&lt;/strong&gt;&lt;hr&gt;This section allows you to select optional patches to apply to the game, which may provide performance, visual, or gameplay improvements. Activating game patches can cause unpredictable behavior, crashing, soft-locks, or broken saved games. Use patches at your own risk, no support will be provided to users who have enabled game patches.</source>
         <translation>&lt;strong&gt;Patchar&lt;/strong&gt;&lt;hr&gt;Denna sektion låter dig att välja valfria patchar att använda för spelet som kan tillhandahålla ökad prestanda, visuellt bätte eller ökat spelvärde. Aktivering av spelpatchar kan orsaka oförutsedda problem, krascher, låsningar eller trasiga sparade tillstånd. Använd patchar på egen risk, ingen support kan tillhandahållas till användare som har aktiverat spelpatchar.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="137"/>
         <source>&lt;strong&gt;Cheats&lt;/strong&gt;&lt;hr&gt;This section allows you to select which cheats you wish to enable. &lt;strong&gt;Using cheats can have unpredictable effects on games, causing crashes, graphical glitches, and corrupted saves.&lt;/strong&gt; Cheats also persist through save states even after being disabled, please remember to reset/reboot the game after turning off any codes.</source>
         <translation>&lt;strong&gt;Fusk&lt;/strong&gt;&lt;hr&gt;Denna sektion låter dig välja vilka fusk som du vill aktivera. &lt;strong&gt;Användning av fusk har oförutsedda effekter på spel, kan orsaka krascher, grafiska problem och skadade sparade spel.&lt;/strong&gt; Fusk är också bestående genom sparade tillstånd även efter de inaktiverats. Kom ihåg att starta om spelet efter att koderna har stängts av.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="146"/>
         <source>&lt;strong&gt;Memory Card Settings&lt;/strong&gt;&lt;hr&gt;This page lets you control what mode the memory card emulation will function in, and where the images for these cards will be stored on disk.</source>
         <translation>&lt;strong&gt;Inställningar för minneskort&lt;/strong&gt;&lt;hr&gt;Denna sida låter dig stura vilket läge som minneskortsemulering ska använda och var avbilderna för dessa kort kommer att lagras på disk.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="150"/>
         <source>&lt;strong&gt;Graphics Settings&lt;/strong&gt;&lt;hr&gt;These options control how the graphics of the emulated console are rendered. Not all options are available for the software renderer. Mouse over each option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Grafikinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr hur grafiken för den emulerade konsolen renderas. Inte alla alternativ finns tillgängliga för programvarurenderaren. Hovra över ett alternativ för ytterligare information samt Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="154"/>
         <source>On-Screen Display</source>
         <extracomment>Translators may want to shorten On-Screen Display to &quot;OSD&quot;.</extracomment>
         <translation>On-Screen Display</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="156"/>
         <source>&lt;strong&gt;On-Screen Display Settings&lt;/strong&gt;&lt;hr&gt;These options determine the behavior of the messages that are displayed while content is running.</source>
         <translation>&lt;strong&gt;Inställningar för skärmvisning&lt;/strong&gt;&lt;hr&gt;Dessa alternativ bestämmer hur meddelanden som visas medan innehåll körs ska fungera.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="159"/>
         <source>Post-Processing</source>
         <translation>Efterbehandling</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="161"/>
         <source>&lt;strong&gt;Post-Processing Settings&lt;/strong&gt;&lt;hr&gt;Post processing allows you to alter the appearance of the image displayed on the screen with various filters. Shaders will be executed in sequence. Additional shaders can be downloaded from &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;.</source>
         <translation>&lt;strong&gt;Inställningar för efterbehandling&lt;/strong&gt;&lt;hr&gt;Efterbehandling låter dig ändra utseendet för bilden som visas på skärmen med olika filter. Shaders kommer att köras i sekvens. Ytterligare shaders kan hämtas från &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="167"/>
         <source>&lt;strong&gt;Audio Settings&lt;/strong&gt;&lt;hr&gt;These options control the audio output of the console. Mouse over an option for additional information.</source>
         <translation>&lt;strong&gt;Ljudinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr ljudutmatningen för konsolen. Hovra över ett alternativ för ytterligare information.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="187"/>
         <source>&lt;strong&gt;Advanced Settings&lt;/strong&gt;&lt;hr&gt;These options control logging and internal behavior of the emulator. Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Avancerade inställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr loggning och interna beteendet för emulatorn. Hovra över ett alternativ för ytterligare information samt Skift+Hjul för att rulla i panelen.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="202"/>
         <source>Unchecked</source>
         <translation>Inte markerat</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="203"/>
         <source>Disables all enhancement options, simulating the system as accurately as possible. Use to quickly determine whether an enhancement is responsible for game bugs.</source>
         <translation>Inaktiverar alla alternativ för förbättringar, simulerar systemet så precist som möjligt. Använd för att snabbt bestämma huruvida en förbättringar orsakar vissa spelbuggar.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="713"/>
         <source>%1 [%2]</source>
         <translation>%1 [%2]</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="98"/>
         <source>Interface</source>
         <translation>Gränssnitt</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="106"/>
         <source>Game List</source>
         <translation>Spellista</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="113"/>
         <source>BIOS</source>
         <translation>BIOS</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="122"/>
         <source>Emulation</source>
         <translation>Emulering</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="129"/>
         <source>Patches</source>
         <translation>Patchar</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="135"/>
         <source>Cheats</source>
         <translation>Fusk</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="148"/>
         <source>Graphics</source>
         <translation>Grafik</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="166"/>
         <source>Audio</source>
         <translation>Ljud</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="144"/>
         <source>Memory Cards</source>
         <translation>Minneskort</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="170"/>
         <source>Achievements</source>
         <translation>Prestationer</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="178"/>
         <source>Capture</source>
         <translation>Fånga</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="180"/>
         <source>&lt;strong&gt;Capture Settings&lt;/strong&gt;&lt;hr&gt;These options determine how screenshots and videos are captured by the application.</source>
         <translation>&lt;strong&gt;Fångstinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ bestämmer hur programmet tar skärmbilder och spelar in video.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="185"/>
         <source>Advanced</source>
         <translation>Avancerat</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="194"/>
         <source>Debugging</source>
         <translation>Felsökning</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="196"/>
         <source>&lt;strong&gt;Debugging Settings&lt;/strong&gt;&lt;hr&gt;These options control internal behavior of the emulator. You should not modify anything on this page without a good reason to do so.</source>
         <translation>&lt;strong&gt;Felsökningsinställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr emulatorns interna funktion. Ändra inget på den här sidan utan ett gott skäl.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="333"/>
         <source>Confirm Restore Defaults</source>
         <translation>Bekräfta återställ standardvärden</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="350"/>
         <source>The configuration for this game will be replaced by the current global settings.
 
 Any current setting values will be overwritten.
@@ -17730,10 +11438,12 @@ Alla aktuella inställningsvärden kommer att skrivas över.
 Vill du fortsätta?</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="368"/>
         <source>Per-game configuration copied from global settings.</source>
         <translation>Konfiguration per-spel har kopierats från globala inställningar.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="378"/>
         <source>The configuration for this game will be cleared.
 
 Any current setting values will be lost.
@@ -17746,26 +11456,37 @@ Alla aktuella inställningsvärden kommer att förloras.
 Vill du fortsätta?</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="390"/>
         <source>Per-game configuration cleared.</source>
         <translation>Konfiguration per-spel har tömts.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="417"/>
         <source>Recommended Value</source>
         <translation>Rekommenderat värde</translation>
     </message>
     <message>
+        <location filename="../settingswindow.ui" line="20"/>
+        <location filename="../settingswindow.cpp" line="349"/>
+        <location filename="../settingswindow.cpp" line="367"/>
+        <location filename="../settingswindow.cpp" line="377"/>
+        <location filename="../settingswindow.cpp" line="389"/>
         <source>DuckStation Settings</source>
         <translation>Inställningar för DuckStation</translation>
     </message>
     <message>
+        <location filename="../settingswindow.ui" line="76"/>
+        <location filename="../settingswindow.cpp" line="202"/>
         <source>Safe Mode</source>
         <translation>Säkert läge</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="114"/>
         <source>&lt;strong&gt;BIOS Settings&lt;/strong&gt;&lt;hr&gt;These options control which BIOS and expansion port is used.&lt;br&gt;&lt;br&gt;Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;BIOS-inställningar&lt;/strong&gt;&lt;hr&gt;Dessa alternativ styr vilken BIOS och expansionsport som används.&lt;br&gt;&lt;br&gt;Hovra över ett alternativ för ytterligare information och Shift+mushjul för att bläddra i panelen.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="334"/>
         <source>Are you sure you want to restore the default settings? Any preferences will be lost.
 
 You cannot undo this action.</source>
@@ -17774,6 +11495,7 @@ You cannot undo this action.</source>
 Du kan inte ångra den här åtgärden.</translation>
     </message>
     <message>
+        <location filename="../settingswindow.cpp" line="172"/>
         <source>&lt;strong&gt;Achievement Settings&lt;/strong&gt;&lt;hr&gt;DuckStation uses RetroAchievements as an achievement database and for tracking progress. To use achievements, please sign up for an account at &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;. To view the achievement list in-game, press the hotkey for &lt;strong&gt;Open Pause Menu&lt;/strong&gt; and select &lt;strong&gt;Achievements&lt;/strong&gt; from the menu. Mouse over an option for additional information, and Shift+Wheel to scroll this panel.</source>
         <translation>&lt;strong&gt;Inställningar för prestationer&lt;/strong&gt;&lt;hr&gt;DuckStation använder RetroAchievements som prestationsdatabas och för att spåra framsteg. För att använda prestationer, registrera ett konto på &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;. För att visa prestationslistan i spelet, tryck på snabbtangenten för &lt;strong&gt;Öppna pausmenyn&lt;/strong&gt; och välj &lt;strong&gt;Prestationer&lt;/strong&gt; från menyn. Håll muspekaren över ett alternativ för ytterligare information och tryck på Skift+hjul för att bläddra i panelen.</translation>
     </message>
@@ -17781,70 +11503,87 @@ Du kan inte ångra den här åtgärden.</translation>
 <context>
     <name>SetupWizardDialog</name>
     <message>
+        <location filename="../setupwizarddialog.ui" line="85"/>
         <source>Language</source>
         <translation>Språk</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="92"/>
         <source>BIOS Image</source>
         <translation>BIOS-avbild</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="99"/>
         <source>Game Directories</source>
         <translation>Spelkataloger</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="106"/>
         <source>Controller Setup</source>
         <translation>Handkontroller</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="127"/>
         <source>Interface Selection</source>
         <translation>Val av gränssnitt</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="134"/>
         <source>View Selection</source>
         <translation>Val av vy</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="141"/>
         <source>Complete</source>
         <translation>Färdig</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="252"/>
         <source>Language:</source>
         <translation>Språk:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="269"/>
         <source>Theme:</source>
         <translation>Tema:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="279"/>
         <source>Enable Automatic Updates</source>
         <translation>Aktivera automatiska uppdateringar</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="397"/>
         <source>NTSC-J (Japan):</source>
         <translation>NTSC-J (Japan):</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="414"/>
         <source>NTSC-U/C (US/Canada):</source>
         <translation>NTSC-U/C (US, Kanada):</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="431"/>
         <source>PAL (Europe, Australia):</source>
         <translation>PAL (Europa, Australien):</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="465"/>
         <source>Open in Explorer...</source>
         <translation>Öppna i Utforskaren...</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1165"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation supports earning achievements and leaderboard tracking with RetroAchievements.&lt;/p&gt;&lt;p&gt;If you have a RetroAchievements account, you can use the form below to log in. If not, you can register by clicking the Register button below.&lt;/p&gt;&lt;p&gt;A RetroAchievements account is &lt;span style=&quot; font-weight:700;&quot;&gt;not&lt;/span&gt; required to use DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation har stöd för att låsa upp prestationer och följa ledartavlor med RetroAchievements.&lt;/p&gt;&lt;p&gt;Om du har ett RetroAchievements-konto kan du logga in med formuläret nedan. Annars kan du registrera dig genom att klicka på knappen Registrera nedan.&lt;/p&gt;&lt;p&gt;Ett RetroAchievements-konto är &lt;span style=&quot; font-weight:700;&quot;&gt;inte&lt;/span&gt; nödvändigt för att använda DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1213"/>
         <source>Register</source>
         <translation>Registrera</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1315"/>
         <source>Choose the interface DuckStation should show when it starts. Desktop Mode is designed for mouse and keyboard use, while Big Picture Mode is optimized for navigation with a controller on a TV.
 
 You can change this at a later time by toggling the &quot;Start In Big Picture Mode&quot; setting in Interface Settings.</source>
@@ -17853,14 +11592,17 @@ You can change this at a later time by toggling the &quot;Start In Big Picture M
 Du kan ändra detta senare genom att växla inställningen &quot;Starta i storbildsläge&quot; i gränssnittsinställningarna.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1335"/>
         <source>Desktop Mode</source>
         <translation>Skrivbordsläge</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1355"/>
         <source>Big Picture Mode</source>
         <translation>Storbildsläge</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1409"/>
         <source>Choose how games should initially be displayed in both Desktop and Big Picture Mode. List View shows detailed information in columns, while Grid View shows game cover art.
 
 You can change this option at a later time by using the toolbar in Desktop Mode or shortcuts in Big Picture Mode.</source>
@@ -17869,102 +11611,133 @@ You can change this option at a later time by using the toolbar in Desktop Mode 
 Du kan ändra detta senare med verktygsfältet i skrivbordsläget eller snabbkommandon i storbildsläget.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1429"/>
         <source>List View</source>
         <translation>Listvy</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1449"/>
         <source>Grid View</source>
         <translation>Rutnätsvy</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1500"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Setup Complete!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;You are now ready to run games.&lt;/p&gt;&lt;p&gt;Further options are available under the settings menu. You can also use the Big Picture UI for navigation entirely with a gamepad.&lt;/p&gt;&lt;p&gt;We hope you enjoy using DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Konfigurationen är färdig!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;Du är nu klar för att starta spel.&lt;/p&gt;&lt;p&gt;Ytterligare alternativ finns tillgängliga i inställningsmenyn. Du kan även använda Storbildsläget för att navigera helt med en handkontroller.&lt;/p&gt;&lt;p&gt;Vi hoppas att du har kul med DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="361"/>
         <source>BIOS Directory:</source>
         <translation>BIOS-katalog:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="317"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation requires a PS1 or PS2 BIOS in order to run.&lt;/p&gt;&lt;p&gt;For legal reasons, you must obtain a BIOS &lt;span style=&quot; font-weight:700;&quot;&gt;from an actual PS1/PS2 unit that you own&lt;/span&gt; (borrowing doesn&apos;t count). You should use Caetla or another utility to create an image from your console&apos;s BIOS ROM on your PC.&lt;/p&gt;&lt;p&gt;Once you have dumped the BIOS from your console, you can click the &amp;quot;Install BIOS&amp;quot; button below to add this image to DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation kräver ett PS1- eller PS2-BIOS för att köras.&lt;/p&gt;&lt;p&gt;Av juridiska skäl måste du skaffa ett BIOS &lt;span style=&quot; font-weight:700;&quot;&gt;från en faktisk PS1-/PS2-enhet som du äger&lt;/span&gt; (det räknas inte att låna en). Du bör använda Caetla eller ett annat verktyg för att skapa en avbild från konsolens BIOS-ROM på datorn.&lt;/p&gt;&lt;p&gt;När du har dumpat BIOS från konsolen kan du klicka på knappen &amp;quot;Installera BIOS&amp;quot; nedan för att lägga till avbilden i DuckStation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="339"/>
         <source>Install BIOS...</source>
         <translation>Installera BIOS...</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="353"/>
         <source>Advanced Settings</source>
         <translation>Avancerade inställningar</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="371"/>
         <source>Browse...</source>
         <translation>Bläddra...</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="382"/>
         <source>Reset</source>
         <translation>Nollställ</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="476"/>
         <source>Refresh List</source>
         <translation>Uppdatera lista</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="521"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation will automatically scan and identify games from the selected directories below, and populate the game list. These games should be dumped from discs you own. Utilities such as ImgBurn can be used to create images of game discs in .bin/.cue format.&lt;/p&gt;&lt;p&gt;Supported formats for dumps include: %1&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DuckStation söker automatiskt igenom och identifierar spel i de valda katalogerna nedan och fyller spellistan. Spelen ska ha dumpats från skivor som du äger. Verktyg som ImgBurn kan användas för att skapa avbilder av spelskivor i .bin/.cue-format.&lt;/p&gt;&lt;p&gt;Dumpformat som stöds: %1&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="536"/>
         <source>Search Directories (will be scanned for games)</source>
         <translation>Sökkataloger (kommer att genomsökas efter spel)</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="562"/>
         <source>Add...</source>
         <translation>Lägg till...</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="579"/>
+        <location filename="../setupwizarddialog.cpp" line="307"/>
         <source>Remove</source>
         <translation>Ta bort</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="646"/>
         <source>Controller Port 1</source>
         <translation>Kontrollerport 1</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="662"/>
+        <location filename="../setupwizarddialog.ui" line="723"/>
         <source>Controller Mapped To:</source>
         <translation>Handkontroll ansluten till:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="652"/>
+        <location filename="../setupwizarddialog.ui" line="713"/>
         <source>Controller Type:</source>
         <translation>Kontrollertyp:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="636"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By default, DuckStation will map your keyboard to the virtual controller. &lt;span style=&quot; font-weight:700;&quot;&gt;To use an external controller, you must map it first. &lt;/span&gt;On this screen, you can automatically map any controller which is currently connected. If your controller is not currently connected, you can plug it in now.&lt;/p&gt;&lt;p&gt;To change controller bindings in more detail, or use multi-tap, open the Settings menu and choose Controllers once you have completed the Setup Wizard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Som standard mappar DuckStation tangentbordet till den virtuella handkontrollen. &lt;span style=&quot; font-weight:700;&quot;&gt;För att använda en extern handkontroll måste du först mappa den. &lt;/span&gt;På den här skärmen kan du automatiskt mappa en ansluten handkontroll. Om handkontrollen inte är ansluten kan du ansluta den nu.&lt;/p&gt;&lt;p&gt;Om du vill ändra handkontrollsbindningarna mer ingående eller använda multitap öppnar du menyn Inställningar och väljer Handkontroller när du har slutfört installationsguiden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="671"/>
+        <location filename="../setupwizarddialog.ui" line="732"/>
         <source>Default (Keyboard)</source>
         <translation>Standard (tangentbord)</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="691"/>
+        <location filename="../setupwizarddialog.ui" line="752"/>
         <source>Automatic Mapping</source>
         <translation>Automatisk mappning</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="707"/>
         <source>Controller Port 2</source>
         <translation>Kontrollerport 2</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="183"/>
         <source>&amp;Back</source>
         <translation>&amp;Bakåt</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="190"/>
+        <location filename="../setupwizarddialog.cpp" line="139"/>
         <source>&amp;Next</source>
         <translation>&amp;Nästa</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="200"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Avbryt</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="60"/>
         <source>No BIOS images were found. DuckStation WILL NOT be able to run games without a BIOS image.
 
 Are you sure you wish to continue without selecting a BIOS image?</source>
@@ -17973,6 +11746,7 @@ Are you sure you wish to continue without selecting a BIOS image?</source>
 Är du säker på att du vill fortsätta utan att välja en BIOS-avbild?</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="75"/>
         <source>No game directories have been selected. You will have to manually open any game dumps you want to play, DuckStation&apos;s list will be empty.
 
 Are you sure you want to continue?</source>
@@ -17981,6 +11755,7 @@ Are you sure you want to continue?</source>
 Är du säker på att du vill fortsätta?</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="147"/>
         <source>Are you sure you want to cancel DuckStation setup?
 
 Any changes have been saved, and the wizard will run again next time you start DuckStation.</source>
@@ -17989,22 +11764,27 @@ Any changes have been saved, and the wizard will run again next time you start D
 Ändringar har sparats och konfígurationsguiden kommer att köras nästa gång du startar DuckStation.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="224"/>
         <source>Select BIOS Directory</source>
         <translation>Välj BIOS-katalog</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="139"/>
         <source>&amp;Finish</source>
         <translation>&amp;Färdig</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="146"/>
         <source>Cancel Setup</source>
         <translation>Avbryt konfiguration</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="262"/>
         <source>No BIOS images found. Please install one to continue.</source>
         <translation>Inga BIOS-avbilder hittades. Installera en för att fortsätta.</translation>
     </message>
     <message numerus="yes">
+        <location filename="../setupwizarddialog.cpp" line="271"/>
         <source>%n BIOS images found. You can install additional BIOS images if desired.</source>
         <comment>BIOS Count</comment>
         <translation>
@@ -18013,18 +11793,22 @@ Any changes have been saved, and the wizard will run again next time you start D
         </translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="310"/>
         <source>Open Directory...</source>
         <translation>Öppna katalog...</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="318"/>
         <source>Select Search Directory</source>
         <translation>Välj sökkatalog</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="324"/>
         <source>Scan Recursively?</source>
         <translation>Sök igenom rekursivt?</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="325"/>
         <source>Would you like to scan the directory &quot;%1&quot; recursively?
 
 Scanning recursively takes more time, but will identify files in subdirectories.</source>
@@ -18033,181 +11817,225 @@ Scanning recursively takes more time, but will identify files in subdirectories.
 Söka igenom den rekursivt tar längre tid men identifierar filer i underkataloger.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="407"/>
         <source>Open Pause Menu</source>
         <translation>Öppna pausmenyn</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="436"/>
         <source>Multiple Devices...</source>
         <translation>Flera enheter...</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="441"/>
         <source>No devices available</source>
         <translation>Inga enheter tillgängliga</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="491"/>
         <source>PGXP is not enabled. Increasing the resolution without enabling PGXP will result in visible polygon glitches.</source>
         <translation>PGXP är inte aktiverat. Om upplösningen höjs utan att PGXP aktiveras uppstår synliga polygonfel.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="628"/>
         <source>Logged in as %1
 Token generated %2</source>
         <translation>Inloggad som: %1
 Token genererades %2</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="455"/>
         <source>No generic bindings were generated for device &apos;%1&apos;. The controller/source may not support automatic mapping.</source>
         <translation>Inga generiska bindningar genererades för enheten &apos;%1&apos;. Handkontrollen/källan kanske inte har stöd för automatisk mappning.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="14"/>
         <source>DuckStation Setup Wizard</source>
         <translation>Konfigurationsguide för DuckStation</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="231"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Welcome to DuckStation!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;This wizard will help guide you through the configuration steps required to use the application. It is recommended if this is your first time installing DuckStation that you view the setup guide at &lt;a href=&quot;https://github.com/stenzek/duckstation#downloading-and-running&quot;&gt;https://github.com/stenzek/duckstation#downloading-and-running&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;By default, DuckStation will connect to the server at &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt; to check for updates, and if available and confirmed, download update packages from &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt;. If you do not wish for DuckStation to make any network connections on startup, you should uncheck the Automatic Updates option now. The Automatic Update setting can be changed later at any time in Interface Settings.&lt;/p&gt;&lt;p&gt;Please choose a language and theme to begin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;h1 style=&quot; margin-top:18px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:xx-large; font-weight:700;&quot;&gt;Välkommen till DuckStation!&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;Denna guide hjälper dig genom konfigurationen som krävs för att kunna använda programmet. Om det är första gången du installerar DuckStation så rekommenderas det att du tittar på guiden &lt;a href=&quot;https://github.com/stenzek/duckstation#downloading-and-running&quot;&gt;https://github.com/stenzek/duckstation#downloading-and-running&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;DuckStation kommer som standard att ansluta till servern på &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt; för att leta efter uppdateringar och, om tillgängligt och bekräftat, hämta uppdateringspaket från &lt;a href=&quot;https://github.com/&quot;&gt;github.com&lt;/a&gt;. Om du inte vill att DuckStation ska göra några nätverksanslutningar vid uppstart så kan du inaktivera automatiska uppdateringar nu. Inställningen för automatiska uppdateringar kan ändras senare i användargränssnittet.&lt;/p&gt;&lt;p&gt;Välj ett språk och tema för att börja.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="113"/>
         <source>Graphics Setup</source>
         <translation>Grafikkonfiguration</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="120"/>
         <source>RetroAchievements</source>
         <translation>RetroAchievements</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="896"/>
         <source>Internal Resolution:</source>
         <translation>Intern upplösning:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="931"/>
         <source>Texture Filtering:</source>
         <translation>Texturfiltrering:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="945"/>
         <source>Sprite Texture Filtering:</source>
         <translation>Filtrering av sprite-textur:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="973"/>
         <source>Aspect Ratio:</source>
         <translation>Bildförhållande:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="999"/>
         <source>:</source>
         <translation>:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1018"/>
         <source>Crop:</source>
         <translation>Beskär:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1032"/>
         <source>Scaling:</source>
         <translation>Skalning:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1071"/>
         <source>Widescreen Rendering</source>
         <translation>Bredbildsrendering</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1061"/>
         <source>PGXP Geometry Correction</source>
         <translation>PGXP geometrikorrigering</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1260"/>
         <source>Settings</source>
         <translation>Inställningar</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1266"/>
         <source>Enable Achievements</source>
         <translation>Aktivera prestationer</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1273"/>
         <source>Enable Hardcore Mode</source>
         <translation>Aktivera hardcore-läge</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1224"/>
         <source>View Profile...</source>
         <translation>Visa profil...</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1235"/>
         <source>Login...</source>
         <translation>Logga in...</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1246"/>
         <source>Logout</source>
         <translation>Logga ut</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="634"/>
         <source>Not Logged In.</source>
         <translation>Inte inloggad.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="924"/>
         <source>Setting this beyond 1x will enhance the resolution of rendered 3D polygons and lines. Only applies to the hardware backends. &lt;br&gt;This option is usually safe, with most games looking fine at higher resolutions. Higher resolutions require a more powerful GPU.</source>
         <translation>Om du ställer in detta värde till mer än 1x förbättras upplösningen för renderade 3D-polygoner och linjer. Gäller endast för hårdvarubackends. &lt;br&gt;Det här alternativet är vanligtvis säkert, och de flesta spel ser bra ut i högre upplösningar. Högre upplösningar kräver en kraftfullare GPU.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="938"/>
         <source>Smooths out the blockiness of magnified textures on 3D objects by using filtering. &lt;br&gt;Will have a greater effect on higher resolution scales.</source>
         <translation>Utjämnar blockigheten i förstorade texturer på 3D-objekt med hjälp av filtrering. &lt;br&gt;Har större effekt på skalor med högre upplösning.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="952"/>
         <source>Smooths out the blockiness of magnified textures on 2D objects by using filtering. This filter only applies to sprites and other 2D elements, such as the HUD.</source>
         <translation>Utjämnar blockigheten i förstorade texturer på 2D-objekt med hjälp av filtrering. Detta filter gäller endast sprites och andra 2D-element, t.ex. HUD.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="982"/>
         <source>Changes the aspect ratio used to display the console&apos;s output to the screen. The default is Auto (Game Native) which automatically adjusts the aspect ratio to match how a game would be shown on a typical TV of the era.</source>
         <translation>Ändrar det bildförhållande som används för att visa konsolens utdata på skärmen. Standardinställningen är Automatiskt (spelets inbyggda) som automatiskt justerar bildförhållandet så att det motsvarar hur ett spel skulle visas på en typisk TV för den tiden.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1025"/>
         <source>Determines how much of the area typically not visible on a consumer TV set to crop/hide. Some games display content in the overscan area, or use it for screen effects. May not display correctly with the &quot;All Borders&quot; setting. &quot;Only Overscan&quot; offers a good compromise between stability and hiding black borders.</source>
         <translation>Bestämmer hur stor del av det område som normalt inte syns på en konsument-TV-apparat som ska beskäras/döljas. Vissa spel visar innehåll i overscan-området eller använder det för skärmeffekter. Visas kanske inte korrekt med inställningen ”Alla kanter. ”Endast överskanning” är en bra kompromiss mellan stabilitet och att dölja svarta kanter.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1039"/>
         <source>Determines how the emulated console&apos;s output is upscaled or downscaled to your monitor&apos;s resolution.</source>
         <translation>Bestämmer hur den emulerade konsolens utdata ska upp- eller nedskalas till din bildskärms upplösning.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1068"/>
         <source>Scales vertex positions in screen-space to a widescreen aspect ratio, essentially increasing the field of view from 4:3 to the chosen display aspect ratio in 3D games. &lt;b&gt;&lt;u&gt;May not be compatible with all games.&lt;/u&gt;&lt;/b&gt;</source>
         <translation>Skalar vertexpositioner i skärmrymden till ett bredbildsförhållande, vilket i princip ökar synfältet från 4:3 till det valda bildförhållandet i 3D-spel. &lt;b&gt;&lt;u&gt;Kanske inte är kompatibel med alla spel.&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1058"/>
         <source>Reduces &quot;wobbly&quot; polygons and &quot;warping&quot; textures that are common in PS1 games. &lt;strong&gt;May not be compatible with all games.&lt;/strong&gt;</source>
         <translation>Reducerar &quot;vingliga&quot; polygoner och &quot;skeva&quot; texturer som är vanliga i PS1-spel. &lt;strong&gt;Kanske inte är kompatibel med alla spel.&lt;/strong&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="768"/>
         <source>Pause Menu Hotkey</source>
         <translation>Snabbtangent för pausmeny</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="774"/>
         <source>Pressing this key will open the pause menu when ingame, allowing you to load/save state, change settings, and perform other functions without needing to use a mouse. Click the button to change the trigger.</source>
         <translation>När du trycker på tangenten öppnas pausmenyn under spelet. Där kan du läsa in eller spara tillstånd, ändra inställningar och utföra andra åtgärder utan mus. Klicka på knappen för att ändra utlösaren.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="855"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This page includes some of the commonly set graphics options in DuckStation.&lt;/p&gt;&lt;p&gt;These options are generally safe to enable, and compatible with most games. Changing the internal resolution and enabling PGXP geometry correction will significantly improve the graphical fidelity of most games.&lt;/p&gt;&lt;p&gt;You can change these options and others in &lt;span style=&quot; font-weight:700;&quot;&gt;Graphics Settings &lt;/span&gt;after completing setup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Den här sidan innehåller några av de vanligaste grafikinställningarna i DuckStation.&lt;/p&gt;&lt;p&gt;Alternativen är i allmänhet säkra att aktivera och kompatibla med de flesta spel. En högre intern upplösning och PGXP-geometrikorrigering förbättrar grafikkvaliteten avsevärt i de flesta spel.&lt;/p&gt;&lt;p&gt;Du kan ändra dessa och andra alternativ under &lt;span style=&quot; font-weight:700;&quot;&gt;Grafikinställningar &lt;/span&gt;när installationen är klar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="959"/>
         <source>Dithering:</source>
         <translation>Dithering:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="966"/>
         <source>Controls how dithering is applied in the emulated GPU. True Color disables dithering and produces the nicest looking gradients. Scaled options make the dither pattern less noticeable at higher resolutions. Shader Blending options perform blending in software, and are more accurate but have a &lt;strong&gt;significant&lt;/strong&gt; performance penalty.</source>
         <translation>Kontrollerar hur dithering tillämpas i den emulerade GPU:n. True Color inaktiverar dithering och ger de snyggaste gradienterna. Med skalade alternativ blir dithermönstret mindre märkbart i högre upplösningar. Alternativet Shader-blandning utför blandning i programvara och är mer exakt, men har en &lt;strong&gt;betydande&lt;/strong&gt; prestandaförlust.</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1153"/>
         <source>RetroAchievements</source>
         <comment>Header text</comment>
         <translation>RetroAchievements</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.ui" line="1046"/>
         <source>FMV Scaling:</source>
         <translation>FMV-skalning:</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="59"/>
         <source>No BIOS Image Found</source>
         <translation>Ingen BIOS-avbild hittades</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="74"/>
         <source>No Game Directories Selected</source>
         <translation>Inga spelkataloger valda</translation>
     </message>
     <message>
+        <location filename="../setupwizarddialog.cpp" line="454"/>
         <source>Automatic Binding Failed</source>
         <translation>Automatisk bindning misslyckades</translation>
     </message>
@@ -18215,733 +12043,171 @@ Token genererades %2</translation>
 <context>
     <name>System</name>
     <message>
-        <source>Failed to boot system:</source>
-        <translation>Misslyckades med att starta systemet:</translation>
-    </message>
-    <message>
+        <location filename="../qthost.cpp" line="1100"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
+        <location filename="../qthost.cpp" line="1107"/>
         <source>Do you want to install a BIOS file now?</source>
         <translation>Vill du installera en BIOS-fil nu?</translation>
-    </message>
-    <message>
-        <source>Startup was cancelled.</source>
-        <translation>Uppstarten avbröts.</translation>
-    </message>
-    <message>
-        <source>This save state was created with a different BIOS. This may cause stability issues.</source>
-        <translation>Detta sparade tillstånd skapades med ett annat BIOS. Detta kan orsaka stabilitetsproblem.</translation>
-    </message>
-    <message>
-        <source>System is not in correct state.</source>
-        <translation>Systemet är inte i ett korrekt tillstånd.</translation>
-    </message>
-    <message>
-        <source>Failed to open CD image &apos;{}&apos; used by save state:
-</source>
-        <translation>Misslyckades med att öppna cd-avbilden &apos;{}&apos; som används av sparat tillstånd:
-</translation>
-    </message>
-    <message>
-        <source>Save state is incompatible: minimum version is {0} but state is version {1}.</source>
-        <translation>Sparat tillstånd är inte kompatibelt: minimum version är {0} men tillståndet är version {1}.</translation>
-    </message>
-    <message>
-        <source>Save state is incompatible: maximum version is {0} but state is version {1}.</source>
-        <translation>Sparat tillstånd är inte kompatibelt: maximal version är {0} men tillståndet är version {1}.</translation>
-    </message>
-    <message>
-        <source>Cannot save state while memory card is being saved.</source>
-        <translation>Kan inte spara tillstånd under tiden minneskortet sparas.</translation>
-    </message>
-    <message>
-        <source>Using disc-specific memory card &apos;{}&apos; instead of per-game card.</source>
-        <translation>Använder skivspecifikt minneskort &apos;{}&apos; istället för kort per-spel.</translation>
-    </message>
-    <message>
-        <source>You are attempting to run a libcrypt protected game without an SBI file:
-
-{0}: {1}
-
-The game will likely not run properly.
-
-Please check the README for instructions on how to add an SBI file.
-
-Do you wish to continue?</source>
-        <translation>Du försöker att köra ett libcrypt-skyddat spel utan en SBI-fil:
-
-{0}: {1}
-
-Spelet kommer antagligen inte fungera korrekt.
-
-Ta en titt på README för instruktioner om hur man lägger till en SBI-fil.
-
-Vill du fortsätta?</translation>
-    </message>
-    <message>
-        <source>You are attempting to run a libcrypt protected game without an SBI file:
-
-{0}: {1}
-
-Your dump is incomplete, you must add the SBI file to run this game. 
-
-The name of the SBI file must match the name of the disc image.</source>
-        <translation>Du försöker att köra ett libcrypt-skyddat spel utan en SBI-fil:
-
-{0}: {1}
-
-Din dump är inte komplett och du måste lägga till SBI-filen för att köra spelet. 
-
-Namnet på SBI-filen måste matcha namnet på skivavbilden.</translation>
-    </message>
-    <message>
-        <source>Failed to switch to subimage {} in &apos;{}&apos;: {}.</source>
-        <translation>Misslyckades med att växla till underbild {} i &apos;{}&apos;: {}.</translation>
-    </message>
-    <message>
-        <source>Switched to sub-image {} ({}) in &apos;{}&apos;.</source>
-        <translation>Växlade till underbild {} ({}) i &apos;{}&apos;.</translation>
-    </message>
-    <message>
-        <source>CPU clock speed is set to {}% ({} / {}). This may crash games.</source>
-        <translation>CPU-klockfrekvensen är inställd till {}% ({} / {}). Detta kan krascha spel.</translation>
-    </message>
-    <message>
-        <source>CPU Overclock</source>
-        <comment>Taint</comment>
-        <translation>CPU-överklockning</translation>
-    </message>
-    <message>
-        <source>CD-ROM Read Speedup</source>
-        <comment>Taint</comment>
-        <translation>Uppsnabbad CD-ROM-läsning</translation>
-    </message>
-    <message>
-        <source>CD-ROM Seek Speedup</source>
-        <comment>Taint</comment>
-        <translation>Uppsnabbad CD-ROM-sökning</translation>
-    </message>
-    <message>
-        <source>Force Frame Timings</source>
-        <comment>Taint</comment>
-        <translation>Tvinga bildrutetider</translation>
-    </message>
-    <message>
-        <source>8MB RAM</source>
-        <comment>Taint</comment>
-        <translation>8 MB RAM</translation>
-    </message>
-    <message>
-        <source>Cheats</source>
-        <comment>Taint</comment>
-        <translation>Fusk</translation>
-    </message>
-    <message>
-        <source>Game Patches</source>
-        <comment>Taint</comment>
-        <translation>Spelpatchar</translation>
-    </message>
-    <message>
-        <source>CD-ROM read/seek speedup is enabled. This may crash games.</source>
-        <translation>Uppsnabbning av CD-ROM läsning/sökning är aktiverad. Detta kan krascha spel.</translation>
-    </message>
-    <message>
-        <source>Multisample anti-aliasing is enabled, some games may not render correctly.</source>
-        <translation>Antialiasing för multisamplingar är aktiverat. Vissa spel kanske inte renderas korrekt.</translation>
-    </message>
-    <message>
-        <source>Round upscaled texture coordinates is enabled. This may cause rendering errors.</source>
-        <translation>Runda uppskalade texturkoordinater är aktiverat. Detta kan orsaka fel i renderingen.</translation>
-    </message>
-    <message>
-        <source>8MB RAM is enabled, this may be incompatible with some games.</source>
-        <translation>8MB RAM är aktiverat och detta kan vara inkompatibelt med vissa spel.</translation>
-    </message>
-    <message>
-        <source>Cached interpreter is being used, this may be incompatible with some games.</source>
-        <translation>Cachad tolk används, detta kan vara inkompatibelt med vissa spel.</translation>
-    </message>
-    <message>
-        <source>Texture cache is enabled. This feature is experimental, some games may not render correctly.</source>
-        <translation>Texturcachen är aktiverad. Denna funktion är experimentell och vissa spel kanske inte renderas korrekt.</translation>
-    </message>
-    <message>
-        <source>Fastmem mode is set to {}, this will reduce performance.</source>
-        <translation>Fastmem-läget är inställt på {}, detta kommer att minska prestandan.</translation>
-    </message>
-    <message>
-        <source>Safe mode is enabled.</source>
-        <translation>Säkert läge är aktiverat.</translation>
-    </message>
-    <message>
-        <source>Overclock disabled.</source>
-        <translation>Överklockning inaktiverat.</translation>
-    </message>
-    <message>
-        <source>8MB RAM disabled.</source>
-        <translation>8MB RAM inaktiverat.</translation>
-    </message>
-    <message>
-        <source>Resolution scale set to 1x.</source>
-        <translation>Upplösningsskala inställd till 1x.</translation>
-    </message>
-    <message>
-        <source>Multisample anti-aliasing disabled.</source>
-        <translation>Antialiasing för multisamplingar inaktiverat.</translation>
-    </message>
-    <message>
-        <source>Texture filtering disabled.</source>
-        <translation>Texturfiltrering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Textures enabled.</source>
-        <translation>Texturer aktiverade.</translation>
-    </message>
-    <message>
-        <source>Vertex lighting enabled.</source>
-        <translation>Hörnbelysning aktiverad.</translation>
-    </message>
-    <message>
-        <source>Interlaced rendering enabled.</source>
-        <translation>Interlaced-rendering aktiverad.</translation>
-    </message>
-    <message>
-        <source>Video timings set to default.</source>
-        <translation>Videotider inställda till standard.</translation>
-    </message>
-    <message>
-        <source>Widescreen rendering disabled.</source>
-        <translation>Bredbildsrendering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>PGXP disabled.</source>
-        <translation>PGXP inaktiverat.</translation>
-    </message>
-    <message>
-        <source>GPU texture cache disabled.</source>
-        <translation>GPU-texturcache inaktiverad.</translation>
-    </message>
-    <message>
-        <source>FMV chroma smoothing disabled.</source>
-        <translation>Utjämning av FMV chroma inaktiverad.</translation>
-    </message>
-    <message>
-        <source>CD-ROM read speedup disabled.</source>
-        <translation>Ökad läshastighet för CD-ROM inaktiverad.</translation>
-    </message>
-    <message>
-        <source>CD-ROM seek speedup disabled.</source>
-        <translation>Ökad sökhastighet för CD-ROM inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Mute CD-ROM audio disabled.</source>
-        <translation>Tysta CD-ROM-ljud inaktiverat.</translation>
-    </message>
-    <message>
-        <source>VRAM write texture replacements disabled.</source>
-        <translation>Texturersättning för VRAM-skrivning inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Use old MDEC routines disabled.</source>
-        <translation>Användning av gamla MDEC-rutiner inaktiverat.</translation>
-    </message>
-    <message>
-        <source>PIO device removed.</source>
-        <translation>PIO-enhet togs bort.</translation>
-    </message>
-    <message>
-        <source>PCDrv disabled.</source>
-        <translation>PCDrv inaktiverad.</translation>
-    </message>
-    <message>
-        <source>PCSX Expansion Region disabled.</source>
-        <translation>PCSX-expansionsområde inaktiverat.</translation>
-    </message>
-    <message>
-        <source>Fast boot disabled.</source>
-        <translation>Snabb uppstart inaktiverat.</translation>
-    </message>
-    <message>
-        <source>Compatibility settings are not enabled. Some games may not function correctly.</source>
-        <translation>Kompatibilitetsinställningar är inte aktiverade. Vissa spel kanske inte fungerar korrekt.</translation>
-    </message>
-    <message>
-        <source>CD-ROM SubQ Skew is enabled. This will break games.</source>
-        <translation>CD-ROM SubQ Skew är aktiverat. Detta kommer att ge spelproblem.</translation>
-    </message>
-    <message>
-        <source>Failed to save resume state: {}</source>
-        <translation>Misslyckades med att spara återupptagningstillstånd: {}</translation>
-    </message>
-    <message>
-        <source>Failed to load undo state, restarting game.
-{}</source>
-        <translation>Det gick inte att läsa in ångringstillståndet. Startar om spelet.
-{}</translation>
-    </message>
-    <message>
-        <source>Loaded undo save state created {}.</source>
-        <translation>Läste in ångrat sparat tillstånd skapat {}.</translation>
-    </message>
-    <message>
-        <source>capturing audio and video</source>
-        <translation>fångar ljud och video</translation>
-    </message>
-    <message>
-        <source>capturing video</source>
-        <translation>fångar video</translation>
-    </message>
-    <message>
-        <source>capturing audio</source>
-        <translation>fångar ljud</translation>
-    </message>
-    <message>
-        <source>Failed to create media capture: {0}</source>
-        <translation>Misslyckades med att skapa mediafångst: {0}</translation>
-    </message>
-    <message>
-        <source>Starting {0} to &apos;{1}&apos;.</source>
-        <translation>Startar {0} till &apos;{1}&apos;.</translation>
-    </message>
-    <message>
-        <source>Stopped {0} to &apos;{1}&apos;.</source>
-        <translation>Stoppade {0} till &apos;{1}&apos;.</translation>
-    </message>
-    <message>
-        <source>Stopped {0}: {1}.</source>
-        <translation>Stoppade {0}: {1}.</translation>
-    </message>
-    <message>
-        <source>Failed to change GPU dump: {}</source>
-        <translation>Det gick inte att ändra GPU-dump: {}</translation>
-    </message>
-    <message>
-        <source>Failed to create render device:
-
-{0}
-
-This may be due to your GPU not supporting the chosen renderer ({1}), or because your graphics drivers need to be updated.</source>
-        <translation>Misslyckades med att skapa renderingsenhet:
-
-{0}
-
-Detta kan bero på att din GPU inte har stöd för vald renderare ({1}) eller på grund av att dina grafikdrivrutiner behöver uppdateras.</translation>
-    </message>
-    <message>
-        <source>Frame rate is not set to automatic. Games may run at incorrect speeds.</source>
-        <translation>Bildfrekvensen är inte inställd på automatisk. Spel kan köras med felaktiga hastigheter.</translation>
-    </message>
-    <message>
-        <source>Dithering set to unscaled.</source>
-        <translation>Dithering inställd till oskalad.</translation>
-    </message>
-    <message>
-        <source>Current game does not have multiple discs.</source>
-        <translation>Det aktuella spelet har inte flera skivor.</translation>
-    </message>
-    <message>
-        <source>Could not determine current disc for switching.</source>
-        <translation>Det gick inte att fastställa vilken skiva som ska bytas.</translation>
-    </message>
-    <message>
-        <source>There is no previous disc to switch to.</source>
-        <translation>Det finns ingen föregående skiva att byta till.</translation>
-    </message>
-    <message>
-        <source>There is no next disc to switch to.</source>
-        <translation>Det finns ingen nästa skiva att byta till.</translation>
-    </message>
-    <message>
-        <source>No disc found for serial {}.</source>
-        <translation>Ingen skiva hittades för serienummer {}.</translation>
-    </message>
-    <message>
-        <source>PGXP Geometry Tolerance is not set to default. This may cause rendering errors.</source>
-        <translation>PGXP-geometritoleransen är inte inställd på standardvärdet. Detta kan orsaka renderingsfel.</translation>
-    </message>
-    <message numerus="yes">
-        <source>You cannot pause until another %n second(s) have passed.</source>
-        <translation>
-            <numerusform>Du kan inte pausa förrän ytterligare %n sekund har gått.</numerusform>
-            <numerusform>Du kan inte pausa förrän ytterligare %n sekunder har gått.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>CPU Overclock Changed</source>
-        <translation>CPU-överklockning ändrad</translation>
-    </message>
-    <message>
-        <source>The save state does not match the current configuration.
-Save State: {0}%
-Configuration: {1}%</source>
-        <translation>Sparat tillstånd stämmer inte överens med den aktuella konfigurationen.
-Sparat tillstånd: {0}%
-Konfiguration: {1}%</translation>
-    </message>
-    <message>
-        <source>Failed to open CD image from save state.</source>
-        <translation>Det gick inte att öppna CD-avbildningen från sparat tillstånd.</translation>
-    </message>
-    <message>
-        <source>Path: {0}
-Error: {1}
-Using current CD image, this may result in instability.</source>
-        <translation>Sökväg: {0}
-Fel: {1}
-Om du använder den aktuella CD-avbildningen kan detta leda till instabilitet.</translation>
-    </message>
-    <message>
-        <source>Global Save Slot {}</source>
-        <translation>Global sparningsplats {}</translation>
-    </message>
-    <message>
-        <source>Save Slot {}</source>
-        <translation>Sparningsplats {}</translation>
-    </message>
-    <message>
-        <source>Save States Unavailable</source>
-        <translation>Sparade tillstånd inte tillgängliga</translation>
-    </message>
-    <message>
-        <source>Save states require a disc inserted with a valid serial.</source>
-        <translation>Sparade tillstånd kräver att en skiva med ett giltigt serienummer är isatt.</translation>
-    </message>
-    <message>
-        <source>No save state found in slot {}.</source>
-        <translation>Inget sparat tillstånd hittades i plats {}.</translation>
-    </message>
-    <message>
-        <source>Loaded save state from {}.</source>
-        <translation>Läste in sparat tillstånd från {}.</translation>
-    </message>
-    <message>
-        <source>Failed to load state from {0}:
-{1}</source>
-        <translation>Misslyckades med att läsa in tillstånd från {0}:
-{1}</translation>
-    </message>
-    <message>
-        <source>Saving state to {}...</source>
-        <translation>Sparar tillstånd till {}...</translation>
-    </message>
-    <message>
-        <source>State saved to {}.</source>
-        <translation>Tillstånd sparat till {}.</translation>
-    </message>
-    <message>
-        <source>Failed to save state to {0}:
-{1}</source>
-        <translation>Misslyckades med att spara tillstånd till {0}:
-{1}</translation>
-    </message>
-    <message>
-        <source>Memory Card Slot {}</source>
-        <translation>Minneskortsplats {}</translation>
-    </message>
-    <message>
-        <source>Card changed to {}.</source>
-        <translation>Kort ändrat till {}.</translation>
-    </message>
-    <message>
-        <source>One or more unsafe settings is enabled.</source>
-        <translation>En eller flera osäkra inställningar är aktiverade.</translation>
-    </message>
-    <message>
-        <source>Undo Load State</source>
-        <translation>Ångra inläst tillstånd</translation>
-    </message>
-    <message>
-        <source>Cannot use per-game memory card without a disc.
-Using shared card instead.</source>
-        <translation>Det går inte att använda minneskort per spel utan en skiva.
-Använder istället ett delat kort.</translation>
-    </message>
-    <message>
-        <source>Rewind has been disabled.</source>
-        <translation>Tillbakaspolning har inaktiverats.</translation>
-    </message>
-    <message>
-        <source>Rewind and runahead cannot be used at the same time.</source>
-        <translation>Tillbakaspolning och runahead kan inte användas samtidigt.</translation>
-    </message>
-    <message>
-        <source>Undo load state</source>
-        <translation>Ångra inläst tillstånd</translation>
-    </message>
-    <message>
-        <source>No valid game is running.</source>
-        <translation>Inget giltigt spel körs.</translation>
-    </message>
-    <message>
-        <source>Wireframe rendering disabled.</source>
-        <translation>Trådramsrendering inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Downsampling disabled.</source>
-        <translation>Nedsampling inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Texture modulation cropping disabled.</source>
-        <translation>Beskäring av texturmodulation inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Memory Card Mismatch</source>
-        <comment>Taint</comment>
-        <translation>Minneskortet stämmer inte</translation>
-    </message>
-    <message>
-        <source>Failed to inhibit screensaver</source>
-        <translation>Misslyckades med att förhindra skärmsläckaren</translation>
-    </message>
-    <message>
-        <source>Failed to allow screensaver</source>
-        <translation>Misslyckades med att tillåta skärmsläckaren</translation>
-    </message>
-    <message>
-        <source>This save state was created with the following tainted options, and may be unstable.
-You must save to a memory card and reset the game to clear any effects.</source>
-        <translation>Detta sparade tillståndet skapades med följande felaktiga alternativ och kan vara instabilt.
-Du måste spara till ett minneskort och starta om spelet för att ta bort eventuella effekter.</translation>
-    </message>
-    <message>
-        <source>No BIOS image found for {} region.
-
-DuckStation requires a PS1 or PS2 BIOS in order to run.
-
-For legal reasons, you must obtain a BIOS from an actual PS1/PS2 unit that you own (borrowing doesn&apos;t count).</source>
-        <translation>Ingen BIOS-avbild hittades för regionen {}.
-
-DuckStation kräver ett PS1- eller PS2-BIOS för att köras.
-
-Av juridiska skäl måste du skaffa ett BIOS från en faktisk PS1-/PS2-enhet som du äger (det räknas inte att låna en).</translation>
     </message>
 </context>
 <context>
     <name>TextureReplacementSettingsDialog</name>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="14"/>
         <source>Texture Replacement Settings</source>
         <translation>Inställningar för texturersättning</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="44"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Texture Replacement Settings&lt;/span&gt;&lt;br/&gt;These settings fine-tune the behavior of the texture replacement system. You can also export a game-specific configuration file. Each of the options is explained in the configuration file, and at &lt;a href=&quot;https://github.com/stenzek/duckstation/wiki/Texture-Replacement&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0078d4;&quot;&gt;https://github.com/stenzek/duckstation/wiki/Texture-Replacement&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Inställningar för texturersättningar&lt;/span&gt;&lt;br/&gt;Dessa inställningar finjusterar beteendet för texturersättningssystemet. Du kan även exportera en spelspecifik konfigurationsfil. Varje alternativ förklaras i konfigurationsfilen och på &lt;a href=&quot;https://github.com/stenzek/duckstation/wiki/Texture-Replacement&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0078d4;&quot;&gt;https://github.com/stenzek/duckstation/wiki/Texture-Replacement&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="65"/>
         <source>Texture Dumping Mode</source>
         <translation>Texturdumpningsläge</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="71"/>
         <source>Reduce Palette Range</source>
         <translation>Reducera palettomfång</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="78"/>
         <source>Dump Texture Pages</source>
         <translation>Dumpa textursidor</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="85"/>
         <source>Dump C16 Textures</source>
         <translation>Dumpa C16-texturer</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="92"/>
         <source>Dump Full Texture Pages</source>
         <translation>Dumpa fullständiga textursidor</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="99"/>
         <source>The texture dumping system can either operate in page mode, or write-tracking mode. Replacements can be loaded from either dump method.</source>
         <translation>Texturdumpningssystemet kan antingen jobba i sidläge eller skrivspårningsläge. Ersättningar kan läsas in från valfri dumpmetod.</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="112"/>
         <source>Write Tracking Options</source>
         <translation>Alternativ för skrivspårning</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="118"/>
         <source>Maximum Write Coalesce Size:</source>
         <translation>Maximal storlek på Write Coalesce:</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="127"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="150"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="221"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="241"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="291"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="311"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="143"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="234"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="304"/>
         <source>x</source>
         <translation>x</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="168"/>
         <source>Maximum Write Splits:</source>
         <translation>Maximalt antal uppdelade skrivningar:</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="187"/>
         <source>Convert Copies To Writes</source>
         <translation>Konvertera kopior till skrivningar</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="194"/>
         <source>Bilinear Replacement Scaling</source>
         <translation>Skalning för bilinjär ersättning</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="206"/>
         <source>Texture Dumping Options</source>
         <translation>Alternativ för texturdumpning</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="212"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="282"/>
         <source>Dump Size Threshold:</source>
         <translation>Tröskelvärde för dumpstorlek:</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="254"/>
+        <location filename="../texturereplacementsettingsdialog.ui" line="324"/>
         <source>Set Alpha Channel</source>
         <translation>Ställ in alfakanal</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="263"/>
         <source>Determines the minimum size of a texture that will be dumped. Textures with a size smaller than this value will be ignored.</source>
         <translation>Bestämmer minimal storlek för en textur som ska dumpas. Texturer med en storlek mindre än detta värde kommer att ignoreras.</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="276"/>
         <source>Background Dumping Options</source>
         <translation>Alternativ för bakgrundsdumpning</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="333"/>
         <source>Determines the minimum size of a VRAM write that will be dumped, in background dumping mode. Uploads smaller than this size will be ignored.</source>
         <translation>Bestämmer minimal storlek för a VRAM-skrivning som ska dumpas, i bakgrundsdumpningsläge. Inläsningar mindre än denna storlek kommer att ignoreras.</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="374"/>
         <source>Export...</source>
         <translation>Exportera...</translation>
     </message>
     <message>
+        <location filename="../texturereplacementsettingsdialog.ui" line="381"/>
         <source>Close</source>
         <translation>Stäng</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="1271"/>
         <source>Texture Replacement Configuration</source>
         <translation>Konfiguration för texturersättning</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="1274"/>
         <source>Texture Replacement Configuration (config.yaml)</source>
         <translation>Konfiguration för texturersättning (config.yaml)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="1276"/>
         <source>Save As...</source>
         <translation>Spara som...</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="1279"/>
         <source>Save Configuration</source>
         <translation>Spara konfiguration</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="1279"/>
         <source>Configuration Files (config.yaml)</source>
         <translation>Konfigurationsfiler (config.yaml)</translation>
     </message>
     <message>
+        <location filename="../graphicssettingswidget.cpp" line="1287"/>
         <source>Write Failed</source>
         <translation>Skrivning misslyckades</translation>
-    </message>
-</context>
-<context>
-    <name>XInputSource</name>
-    <message>
-        <source>LeftX</source>
-        <translation>LeftX</translation>
-    </message>
-    <message>
-        <source>LeftY</source>
-        <translation>LeftY</translation>
-    </message>
-    <message>
-        <source>RightX</source>
-        <translation>RightX</translation>
-    </message>
-    <message>
-        <source>RightY</source>
-        <translation>RightY</translation>
-    </message>
-    <message>
-        <source>LeftTrigger</source>
-        <translation>LeftTrigger</translation>
-    </message>
-    <message>
-        <source>RightTrigger</source>
-        <translation>RightTrigger</translation>
-    </message>
-    <message>
-        <source>DPadUp</source>
-        <translation>DPadUp</translation>
-    </message>
-    <message>
-        <source>DPadDown</source>
-        <translation>DPadDown</translation>
-    </message>
-    <message>
-        <source>DPadLeft</source>
-        <translation>DPadLeft</translation>
-    </message>
-    <message>
-        <source>DPadRight</source>
-        <translation>DPadRight</translation>
-    </message>
-    <message>
-        <source>Start</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <source>Back</source>
-        <translation>Back</translation>
-    </message>
-    <message>
-        <source>LeftStick</source>
-        <translation>LeftStick</translation>
-    </message>
-    <message>
-        <source>RightStick</source>
-        <translation>RightStick</translation>
-    </message>
-    <message>
-        <source>LeftShoulder</source>
-        <translation>LeftShoulder</translation>
-    </message>
-    <message>
-        <source>RightShoulder</source>
-        <translation>RightShoulder</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <source>X</source>
-        <translation>X</translation>
-    </message>
-    <message>
-        <source>Y</source>
-        <translation>Y</translation>
-    </message>
-    <message>
-        <source>Guide</source>
-        <translation>Guide</translation>
-    </message>
-    <message>
-        <source>XInput-{0}  {1}</source>
-        <translation>XInput-{0}  {1}</translation>
-    </message>
-    <message>
-        <source>XInput-{0}/{1}</source>
-        <translation>XInput-{0}/{1}</translation>
-    </message>
-    <message>
-        <source>XInput-{0}/{1}{2}</source>
-        <translation>XInput-{0}/{1}{2}</translation>
-    </message>
-    <message>
-        <source>SmallMotor</source>
-        <translation>SmallMotor</translation>
-    </message>
-    <message>
-        <source>LargeMotor</source>
-        <translation>LargeMotor</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Updated with Qt lupdate against current master. All 2,230 extracted Swedish messages are finished; lrelease and git diff --check pass.